### PR TITLE
Implement distributed job queue infrastructure

### DIFF
--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -27,6 +27,7 @@ from src.infra.cache.metrics import CacheMonitor
 from src.infra.cache.redis_client import RedisClient
 from src.infra.config.settings import settings
 from src.infra.database.config import get_db as get_db_from_config
+from src.infra.queue import RedisJobQueue, create_queue_redis_client
 from src.infra.repositories.meal_repository import MealRepository
 from src.infra.repositories.notification_repository import NotificationRepository
 from src.infra.services.firebase_service import FirebaseService
@@ -40,7 +41,9 @@ from src.infra.services.scheduled_notification_service import ScheduledNotificat
 # Globals
 logger = logging.getLogger(__name__)
 _redis_client: Optional[RedisClient] = None
+_queue_redis_client: Optional[RedisClient] = None
 _cache_service: Optional[CacheService] = None
+_job_queue: Optional[RedisJobQueue] = None
 _cache_monitor = CacheMonitor()
 
 # Singleton service instances (initialized once, reused across requests)
@@ -73,13 +76,43 @@ async def initialize_cache_layer() -> None:
 
 async def shutdown_cache_layer() -> None:
     """Gracefully close Redis connections."""
-    global _redis_client, _cache_service
+    global _redis_client, _cache_service, _job_queue
 
     if _cache_service:
         _cache_service = None
+    if _job_queue:
+        _job_queue = None
     if _redis_client:
         await _redis_client.disconnect()
         _redis_client = None
+
+
+async def initialize_queue_layer() -> None:
+    """Initialize queue Redis client when QUEUE_ENABLED. Uses factory for provider selection."""
+    global _queue_redis_client
+
+    if not settings.QUEUE_ENABLED:
+        logger.info("Queue disabled via settings")
+        return
+
+    try:
+        _queue_redis_client = create_queue_redis_client()
+        await _queue_redis_client.connect()
+        logger.info("Queue Redis client initialized (provider=%s)", settings.QUEUE_PROVIDER)
+    except ValueError as exc:
+        logger.error("Queue configuration error: %s", exc)
+        raise
+
+
+async def shutdown_queue_layer() -> None:
+    """Disconnect queue Redis client."""
+    global _queue_redis_client, _job_queue
+
+    if _job_queue:
+        _job_queue = None
+    if _queue_redis_client:
+        await _queue_redis_client.disconnect()
+        _queue_redis_client = None
 
 
 # Database
@@ -346,6 +379,36 @@ def initialize_scheduled_notification_service() -> ScheduledNotificationService:
 def get_redis_client() -> Optional[RedisClient]:
     """Get Redis client for meal suggestions repository."""
     return _redis_client
+
+
+def get_job_queue() -> Optional[RedisJobQueue]:
+    """
+    Get the Redis-backed distributed job queue instance.
+
+    Uses queue-specific Redis client (Upstash or dedicated per QUEUE_PROVIDER).
+    No automatic fallback.
+
+    Returns:
+        Optional[RedisJobQueue]: Queue instance if enabled and client is initialized,
+        otherwise None.
+    """
+    global _job_queue
+
+    if not settings.QUEUE_ENABLED:
+        return None
+    if _queue_redis_client is None:
+        return None
+    if _job_queue is not None:
+        return _job_queue
+
+    _job_queue = RedisJobQueue(
+        redis_client=_queue_redis_client,
+        stream_name=settings.QUEUE_STREAM_NAME,
+        dead_letter_stream=settings.QUEUE_DEAD_LETTER_STREAM_NAME,
+        consumer_group=settings.QUEUE_CONSUMER_GROUP,
+        max_retries=settings.QUEUE_MAX_RETRIES,
+    )
+    return _job_queue
 
 
 def get_meal_suggestion_repository():

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -28,8 +28,10 @@ from firebase_admin import credentials
 
 from src.api.base_dependencies import (
     initialize_cache_layer,
+    initialize_queue_layer,
     initialize_scheduled_notification_service,
     shutdown_cache_layer,
+    shutdown_queue_layer,
 )
 from src.api.middleware.accept_language import AcceptLanguageMiddleware
 from src.api.middleware.dev_auth_bypass import add_dev_auth_bypass
@@ -49,6 +51,7 @@ from src.api.routes.v1.notifications import router as notifications_router
 from src.api.routes.v1.user_profiles import router as user_profiles_router
 from src.api.routes.v1.users import router as users_router
 from src.api.routes.v1.webhooks import router as webhooks_router
+from src.infra.config.settings import settings
 from src.infra.database.config import engine
 
 load_dotenv()
@@ -160,6 +163,14 @@ async def lifespan(app: FastAPI):
         if os.getenv("FAIL_ON_CACHE_ERROR", "false").lower() == "true":
             raise
 
+    # Initialize queue layer (Upstash or dedicated per QUEUE_PROVIDER)
+    try:
+        await initialize_queue_layer()
+    except Exception as exc:
+        logger.error("Failed to initialize queue layer: %s", exc)
+        if settings.QUEUE_ENABLED:
+            raise
+
     logger.info("MealTrack API started successfully!")
     yield
 
@@ -175,7 +186,8 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error(f"Error stopping scheduled notification service: {e}")
 
-    # Disconnect cache
+    # Disconnect queue and cache
+    await shutdown_queue_layer()
     await shutdown_cache_layer()
 
 

--- a/src/domain/model/job_queue.py
+++ b/src/domain/model/job_queue.py
@@ -1,0 +1,38 @@
+"""
+Domain models for distributed background jobs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+
+class JobStatus(str, Enum):
+    """Status values for background jobs."""
+
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    DEAD = "dead"
+
+
+@dataclass
+class JobPayload:
+    """
+    Canonical payload used for queue producer/consumer communication.
+    """
+
+    job_type: str
+    user_id: str
+    payload: dict[str, Any]
+    priority: int = 0
+    max_retries: int = 3
+    retry_count: int = 0
+    job_id: str = field(default_factory=lambda: str(uuid4()))
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+

--- a/src/domain/ports/__init__.py
+++ b/src/domain/ports/__init__.py
@@ -1,11 +1,13 @@
 """Domain ports package."""
 
 from src.domain.ports.image_store_port import ImageStorePort
+from src.domain.ports.job_queue_port import JobQueuePort
 from src.domain.ports.meal_repository_port import MealRepositoryPort
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
 
 __all__ = [
-    'MealRepositoryPort', 
-    'ImageStorePort', 
-    'VisionAIServicePort'
-] 
+    'MealRepositoryPort',
+    'ImageStorePort',
+    'VisionAIServicePort',
+    'JobQueuePort',
+]

--- a/src/domain/ports/job_queue_port.py
+++ b/src/domain/ports/job_queue_port.py
@@ -1,0 +1,42 @@
+"""
+Port interface for distributed job queue operations.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from src.domain.model.job_queue import JobPayload, JobStatus
+
+
+class JobQueuePort(ABC):
+    """Port interface for queueing and consuming background jobs."""
+
+    @abstractmethod
+    async def enqueue(self, payload: JobPayload) -> str:
+        """Enqueue a job and return its job_id."""
+        pass
+
+    @abstractmethod
+    async def dequeue(
+        self, job_types: list[str], block_ms: int = 5000
+    ) -> Optional[JobPayload]:
+        """Consume the next available job."""
+        pass
+
+    @abstractmethod
+    async def ack(self, job_id: str) -> None:
+        """Acknowledge successful processing."""
+        pass
+
+    @abstractmethod
+    async def nack(self, job_id: str, error: str) -> None:
+        """Mark processing failure and trigger retry/DLQ logic."""
+        pass
+
+    @abstractmethod
+    async def get_status(self, job_id: str) -> Optional[JobStatus]:
+        """Return the current status of a job."""
+        pass
+

--- a/src/infra/cache/redis_client.py
+++ b/src/infra/cache/redis_client.py
@@ -4,8 +4,9 @@ Async Redis client with connection pooling.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
+import certifi
 import redis.asyncio as redis
 from redis.exceptions import RedisError
 
@@ -17,11 +18,15 @@ class RedisClient:
 
     def __init__(self, redis_url: str, max_connections: int = 50):
         self._redis_url = redis_url
-        self.pool = redis.ConnectionPool.from_url(
-            redis_url,
-            max_connections=max_connections,
-            decode_responses=True,
-        )
+
+        pool_kwargs: dict[str, Any] = {
+            "max_connections": max_connections,
+            "decode_responses": True,
+        }
+        if redis_url.startswith("rediss://"):
+            pool_kwargs["ssl_ca_certs"] = certifi.where()
+
+        self.pool = redis.ConnectionPool.from_url(redis_url, **pool_kwargs)
         self.client: Optional[redis.Redis] = None
 
     async def connect(self) -> None:

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -61,6 +61,26 @@ class Settings(BaseSettings):
     CACHE_ENABLED: bool = Field(default=True)
     CACHE_DEFAULT_TTL: int = Field(default=3600)  # 1 hour
 
+    # Queue configuration
+    QUEUE_ENABLED: bool = Field(default=False)
+    QUEUE_PROVIDER: str = Field(
+        default="upstash",
+        description="Queue backend: 'upstash' or 'dedicated'",
+    )
+    UPSTASH_REDIS_URL: str | None = Field(
+        default=None,
+        description="Full Redis URL for Upstash (required when QUEUE_PROVIDER=upstash)",
+    )
+    DEDICATED_REDIS_URL: str | None = Field(
+        default=None,
+        description="Override Redis URL for dedicated provider; else uses redis_url",
+    )
+    QUEUE_STREAM_NAME: str = Field(default="jobs:stream")
+    QUEUE_DEAD_LETTER_STREAM_NAME: str = Field(default="jobs:dead")
+    QUEUE_CONSUMER_GROUP: str = Field(default="jobs:workers")
+    QUEUE_MAX_RETRIES: int = Field(default=3)
+    QUEUE_BLOCK_MS: int = Field(default=5000)
+
     # Firebase
     FIREBASE_CREDENTIALS: str | None = Field(default=None)
     FIREBASE_SERVICE_ACCOUNT_JSON: str | None = Field(default=None)

--- a/src/infra/queue/__init__.py
+++ b/src/infra/queue/__init__.py
@@ -1,0 +1,7 @@
+"""Distributed job queue infrastructure."""
+
+from src.infra.queue.queue_client_factory import create_queue_redis_client
+from src.infra.queue.redis_job_queue import RedisJobQueue
+
+__all__ = ["RedisJobQueue", "create_queue_redis_client"]
+

--- a/src/infra/queue/queue_client_factory.py
+++ b/src/infra/queue/queue_client_factory.py
@@ -1,0 +1,72 @@
+"""
+Factory for creating Redis clients used by the job queue.
+
+Resolves provider from settings (upstash | dedicated) and builds
+a RedisClient with the appropriate URL. No automatic fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from src.infra.cache.redis_client import RedisClient
+from src.infra.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+VALID_PROVIDERS = ("upstash", "dedicated")
+
+
+def _add_ssl_cert_reqs_none(url: str) -> str:
+    """Append ssl_cert_reqs=none to URL to avoid CERTIFICATE_VERIFY_FAILED with Upstash."""
+    parsed = urlparse(url)
+    query = parsed.query
+    params = dict(p.split("=", 1) for p in query.split("&") if p) if query else {}
+    params["ssl_cert_reqs"] = "none"
+    new_query = urlencode(params)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def create_queue_redis_client() -> RedisClient:
+    """
+    Build a RedisClient for the job queue based on QUEUE_PROVIDER.
+
+    Returns:
+        RedisClient configured for the selected provider.
+
+    Raises:
+        ValueError: If provider is invalid or required URL is missing.
+    """
+    provider = (settings.QUEUE_PROVIDER or "upstash").strip().lower()
+    if provider not in VALID_PROVIDERS:
+        raise ValueError(
+            f"Invalid QUEUE_PROVIDER '{settings.QUEUE_PROVIDER}'. "
+            f"Must be one of: {', '.join(VALID_PROVIDERS)}"
+        )
+
+    if provider == "upstash":
+        url = settings.UPSTASH_REDIS_URL
+        if not url or not url.strip():
+            raise ValueError(
+                "QUEUE_PROVIDER=upstash requires UPSTASH_REDIS_URL to be set. "
+                "Add UPSTASH_REDIS_URL to your environment."
+            )
+        url = url.strip()
+        url = _add_ssl_cert_reqs_none(url)
+        max_connections = min(10, settings.REDIS_MAX_CONNECTIONS)
+        logger.info("Queue using Upstash Redis (URL configured)")
+        return RedisClient(redis_url=url, max_connections=max_connections)
+
+    # dedicated
+    url = settings.DEDICATED_REDIS_URL
+    if url and url.strip():
+        url = url.strip()
+        logger.info("Queue using dedicated Redis (DEDICATED_REDIS_URL)")
+    else:
+        url = settings.redis_url
+        logger.info("Queue using dedicated Redis (redis_url from REDIS_* vars)")
+    return RedisClient(
+        redis_url=url,
+        max_connections=settings.REDIS_MAX_CONNECTIONS,
+    )

--- a/src/infra/queue/queue_client_factory.py
+++ b/src/infra/queue/queue_client_factory.py
@@ -19,13 +19,15 @@ VALID_PROVIDERS = ("upstash", "dedicated")
 
 
 def _add_ssl_cert_reqs_none(url: str) -> str:
-    """Append ssl_cert_reqs=none to URL to avoid CERTIFICATE_VERIFY_FAILED with Upstash."""
-    parsed = urlparse(url)
-    query = parsed.query
-    params = dict(p.split("=", 1) for p in query.split("&") if p) if query else {}
-    params["ssl_cert_reqs"] = "none"
-    new_query = urlencode(params)
-    return urlunparse(parsed._replace(query=new_query))
+    """
+    Legacy helper kept for backwards compatibility.
+
+    TLS certificate verification is no longer disabled here. Upstash should
+    work with the default CA trust store; if you encounter CERTIFICATE_VERIFY_FAILED
+    in local or development environments, prefer fixing your CA configuration
+    or making insecure TLS explicitly opt-in elsewhere.
+    """
+    return url
 
 
 def create_queue_redis_client() -> RedisClient:

--- a/src/infra/queue/redis_job_queue.py
+++ b/src/infra/queue/redis_job_queue.py
@@ -189,14 +189,24 @@ class RedisJobQueue(JobQueuePort):
     async def _promote_due_retries(self) -> None:
         client = self._require_client()
         now = time.time()
-        due_ids = await client.zrangebyscore(self._retry_zset, 0, now)
-        if not due_ids:
-            return
 
-        for job_id in due_ids:
+        while True:
+            # Atomically pop the job with the smallest retry timestamp.
+            items = await client.zpopmin(self._retry_zset, 1)
+            if not items:
+                # No more jobs in the retry set.
+                break
+
+            job_id, score = items[0]
+
+            # If the earliest job is not yet due, put it back and stop.
+            if score > now:
+                await client.zadd(self._retry_zset, {job_id: score})
+                break
+
             state = await client.hgetall(self._job_state_key(job_id))
             if not state:
-                await client.zrem(self._retry_zset, job_id)
+                # Job state no longer exists; nothing to re-enqueue.
                 continue
 
             payload = self._payload_from_state(job_id, state)
@@ -209,7 +219,6 @@ class RedisJobQueue(JobQueuePort):
                     "stream_id": "",
                 },
             )
-            await client.zrem(self._retry_zset, job_id)
 
     async def _set_job_state(
         self,

--- a/src/infra/queue/redis_job_queue.py
+++ b/src/infra/queue/redis_job_queue.py
@@ -1,0 +1,316 @@
+"""
+Redis Streams implementation of JobQueuePort.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+from uuid import uuid4
+
+from redis.exceptions import RedisError, ResponseError
+
+from src.domain.model.job_queue import JobPayload, JobStatus
+from src.domain.ports.job_queue_port import JobQueuePort
+from src.infra.cache.redis_client import RedisClient
+
+logger = logging.getLogger(__name__)
+
+
+class RedisJobQueue(JobQueuePort):
+    """Queue implementation backed by Redis Streams + consumer groups."""
+
+    def __init__(
+        self,
+        redis_client: RedisClient,
+        stream_name: str = "jobs:stream",
+        dead_letter_stream: str = "jobs:dead",
+        consumer_group: str = "jobs:workers",
+        consumer_name: Optional[str] = None,
+        max_retries: int = 3,
+        retry_schedule_seconds: tuple[int, ...] = (5, 15),
+    ):
+        self._redis = redis_client
+        self._stream_name = stream_name
+        self._dead_letter_stream = dead_letter_stream
+        self._consumer_group = consumer_group
+        self._consumer_name = consumer_name or f"consumer-{uuid4()}"
+        self._max_retries = max_retries
+        self._retry_schedule_seconds = retry_schedule_seconds
+        self._retry_zset = f"{stream_name}:retry_schedule"
+        self._group_initialized = False
+
+    async def enqueue(self, payload: JobPayload) -> str:
+        client = self._require_client()
+        await self._ensure_group()
+
+        payload.max_retries = payload.max_retries or self._max_retries
+
+        fields = self._serialize_payload(payload)
+        await client.xadd(self._stream_name, fields)
+        await self._set_job_state(
+            payload,
+            status=JobStatus.QUEUED,
+            extra={"queued_at": self._utc_now_iso()},
+        )
+        await self._increment_metric("jobs_enqueued_total")
+        return payload.job_id
+
+    async def dequeue(
+        self, job_types: list[str], block_ms: int = 5000
+    ) -> Optional[JobPayload]:
+        del job_types  # Router-level filtering will be handled by worker layer.
+
+        client = self._require_client()
+        await self._ensure_group()
+        await self._promote_due_retries()
+
+        response = await client.xreadgroup(
+            groupname=self._consumer_group,
+            consumername=self._consumer_name,
+            streams={self._stream_name: ">"},
+            count=1,
+            block=block_ms,
+        )
+        if not response:
+            return None
+
+        stream_entries = response[0][1]
+        stream_id, fields = stream_entries[0]
+        payload = self._deserialize_payload(fields)
+        await self._set_job_state(
+            payload,
+            status=JobStatus.PROCESSING,
+            extra={
+                "stream_id": stream_id,
+                "started_at": self._utc_now_iso(),
+                "consumer_name": self._consumer_name,
+            },
+        )
+        return payload
+
+    async def ack(self, job_id: str) -> None:
+        client = self._require_client()
+
+        state = await client.hgetall(self._job_state_key(job_id))
+        stream_id = state.get("stream_id")
+
+        if stream_id:
+            await client.xack(self._stream_name, self._consumer_group, stream_id)
+            await client.xdel(self._stream_name, stream_id)
+
+        payload = self._payload_from_state(job_id, state)
+        await self._set_job_state(
+            payload,
+            status=JobStatus.COMPLETED,
+            extra={"completed_at": self._utc_now_iso()},
+        )
+        await client.zrem(self._retry_zset, job_id)
+
+    async def nack(self, job_id: str, error: str) -> None:
+        client = self._require_client()
+        state = await client.hgetall(self._job_state_key(job_id))
+        if not state:
+            return
+
+        payload = self._payload_from_state(job_id, state)
+        payload.retry_count += 1
+
+        stream_id = state.get("stream_id")
+        if stream_id:
+            await client.xack(self._stream_name, self._consumer_group, stream_id)
+            await client.xdel(self._stream_name, stream_id)
+
+        if payload.retry_count > payload.max_retries:
+            await self._move_to_dead_letter(payload, error)
+            await self._set_job_state(
+                payload,
+                status=JobStatus.DEAD,
+                extra={
+                    "failed_at": self._utc_now_iso(),
+                    "last_error": error,
+                },
+            )
+            await self._increment_metric("jobs_dead_total")
+            return
+
+        delay = self._retry_delay_seconds(payload.retry_count)
+        due_at_epoch = time.time() + delay
+
+        await self._set_job_state(
+            payload,
+            status=JobStatus.FAILED,
+            extra={
+                "failed_at": self._utc_now_iso(),
+                "last_error": error,
+                "retry_count": str(payload.retry_count),
+                "next_retry_at_epoch": str(due_at_epoch),
+            },
+        )
+
+        await client.zadd(self._retry_zset, {job_id: due_at_epoch})
+        await self._increment_metric("jobs_nacked_total")
+
+    async def get_status(self, job_id: str) -> Optional[JobStatus]:
+        client = self._require_client()
+        state = await client.hgetall(self._job_state_key(job_id))
+        if not state:
+            return None
+        value = state.get("status")
+        if not value:
+            return None
+        return JobStatus(value)
+
+    async def _ensure_group(self) -> None:
+        if self._group_initialized:
+            return
+
+        client = self._require_client()
+        try:
+            await client.xgroup_create(
+                name=self._stream_name,
+                groupname=self._consumer_group,
+                id="$",
+                mkstream=True,
+            )
+            logger.info(
+                "Created Redis stream group '%s' on '%s'",
+                self._consumer_group,
+                self._stream_name,
+            )
+        except ResponseError as exc:
+            if "BUSYGROUP" not in str(exc):
+                raise
+        self._group_initialized = True
+
+    async def _promote_due_retries(self) -> None:
+        client = self._require_client()
+        now = time.time()
+        due_ids = await client.zrangebyscore(self._retry_zset, 0, now)
+        if not due_ids:
+            return
+
+        for job_id in due_ids:
+            state = await client.hgetall(self._job_state_key(job_id))
+            if not state:
+                await client.zrem(self._retry_zset, job_id)
+                continue
+
+            payload = self._payload_from_state(job_id, state)
+            await client.xadd(self._stream_name, self._serialize_payload(payload))
+            await self._set_job_state(
+                payload,
+                status=JobStatus.QUEUED,
+                extra={
+                    "queued_at": self._utc_now_iso(),
+                    "stream_id": "",
+                },
+            )
+            await client.zrem(self._retry_zset, job_id)
+
+    async def _set_job_state(
+        self,
+        payload: JobPayload,
+        status: JobStatus,
+        extra: Optional[dict[str, str]] = None,
+    ) -> None:
+        client = self._require_client()
+
+        state: dict[str, str] = {
+            "job_id": payload.job_id,
+            "job_type": payload.job_type,
+            "user_id": payload.user_id,
+            "status": status.value,
+            "priority": str(payload.priority),
+            "max_retries": str(payload.max_retries),
+            "retry_count": str(payload.retry_count),
+            "created_at": payload.created_at.isoformat(),
+            "payload_json": json.dumps(payload.payload),
+            "updated_at": self._utc_now_iso(),
+        }
+        if extra:
+            state.update(extra)
+
+        await client.hset(self._job_state_key(payload.job_id), mapping=state)
+
+    async def _move_to_dead_letter(self, payload: JobPayload, error: str) -> None:
+        client = self._require_client()
+        fields = self._serialize_payload(payload)
+        fields["error"] = error
+        fields["dead_at"] = self._utc_now_iso()
+        await client.xadd(self._dead_letter_stream, fields)
+
+    async def _increment_metric(self, metric_name: str) -> None:
+        try:
+            client = self._require_client()
+            await client.incr(f"metrics:{metric_name}")
+        except RedisError:
+            logger.debug("Could not increment metric '%s'", metric_name, exc_info=True)
+
+    def _serialize_payload(self, payload: JobPayload) -> dict[str, str]:
+        return {
+            "job_id": payload.job_id,
+            "job_type": payload.job_type,
+            "user_id": payload.user_id,
+            "created_at": payload.created_at.isoformat(),
+            "priority": str(payload.priority),
+            "max_retries": str(payload.max_retries),
+            "retry_count": str(payload.retry_count),
+            "payload_json": json.dumps(payload.payload),
+        }
+
+    def _deserialize_payload(self, fields: dict[str, Any]) -> JobPayload:
+        created_at_raw = fields.get("created_at")
+        if created_at_raw:
+            created_at = datetime.fromisoformat(created_at_raw)
+        else:
+            created_at = datetime.now(timezone.utc)
+
+        return JobPayload(
+            job_id=fields["job_id"],
+            job_type=fields["job_type"],
+            user_id=fields["user_id"],
+            created_at=created_at,
+            priority=int(fields.get("priority", 0)),
+            max_retries=int(fields.get("max_retries", self._max_retries)),
+            retry_count=int(fields.get("retry_count", 0)),
+            payload=json.loads(fields.get("payload_json", "{}")),
+        )
+
+    def _payload_from_state(self, job_id: str, state: dict[str, str]) -> JobPayload:
+        created_at = datetime.fromisoformat(state["created_at"])
+        payload_json = json.loads(state.get("payload_json", "{}"))
+        return JobPayload(
+            job_id=job_id,
+            job_type=state["job_type"],
+            user_id=state["user_id"],
+            payload=payload_json,
+            priority=int(state.get("priority", 0)),
+            max_retries=int(state.get("max_retries", self._max_retries)),
+            retry_count=int(state.get("retry_count", 0)),
+            created_at=created_at,
+        )
+
+    def _retry_delay_seconds(self, retry_count: int) -> int:
+        if retry_count <= 0:
+            return 0
+        if retry_count <= len(self._retry_schedule_seconds):
+            return self._retry_schedule_seconds[retry_count - 1]
+        return self._retry_schedule_seconds[-1]
+
+    def _job_state_key(self, job_id: str) -> str:
+        return f"jobs:state:{job_id}"
+
+    def _require_client(self):
+        client = self._redis.client
+        if client is None:
+            raise RuntimeError("Redis client is not connected")
+        return client
+
+    @staticmethod
+    def _utc_now_iso() -> str:
+        return datetime.now(timezone.utc).isoformat()
+

--- a/src/infra/queue/redis_job_queue.py
+++ b/src/infra/queue/redis_job_queue.py
@@ -62,35 +62,50 @@ class RedisJobQueue(JobQueuePort):
     async def dequeue(
         self, job_types: list[str], block_ms: int = 5000
     ) -> Optional[JobPayload]:
-        del job_types  # Router-level filtering will be handled by worker layer.
-
         client = self._require_client()
         await self._ensure_group()
         await self._promote_due_retries()
 
-        response = await client.xreadgroup(
-            groupname=self._consumer_group,
-            consumername=self._consumer_name,
-            streams={self._stream_name: ">"},
-            count=1,
-            block=block_ms,
-        )
-        if not response:
-            return None
+        # Continue reading until we either get a matching job type or hit the block timeout.
+        while True:
+            response = await client.xreadgroup(
+                groupname=self._consumer_group,
+                consumername=self._consumer_name,
+                streams={self._stream_name: ">"},
+                count=1,
+                block=block_ms,
+            )
+            if not response:
+                return None
 
-        stream_entries = response[0][1]
-        stream_id, fields = stream_entries[0]
-        payload = self._deserialize_payload(fields)
-        await self._set_job_state(
-            payload,
-            status=JobStatus.PROCESSING,
-            extra={
-                "stream_id": stream_id,
-                "started_at": self._utc_now_iso(),
-                "consumer_name": self._consumer_name,
-            },
-        )
-        return payload
+            stream_entries = response[0][1]
+            stream_id, fields = stream_entries[0]
+            payload = self._deserialize_payload(fields)
+
+            # If job_types is specified, only return matching jobs.
+            payload_job_type = getattr(payload, "job_type", None)
+            if job_types and payload_job_type not in job_types:
+                # Re-queue the non-matching job back onto the stream and ack the original entry
+                # so it can be picked up by an appropriate worker without getting stuck pending.
+                try:
+                    await client.xadd(self._stream_name, fields)
+                    await client.xack(self._stream_name, self._consumer_group, stream_id)
+                    await self._increment_metric("jobs_requeued_mismatched_type_total")
+                except RedisError:
+                    logger.exception("Failed to re-queue non-matching job %s", getattr(payload, "job_id", None))
+                # Try reading the next job.
+                continue
+
+            await self._set_job_state(
+                payload,
+                status=JobStatus.PROCESSING,
+                extra={
+                    "stream_id": stream_id,
+                    "started_at": self._utc_now_iso(),
+                    "consumer_name": self._consumer_name,
+                },
+            )
+            return payload
 
     async def ack(self, job_id: str) -> None:
         client = self._require_client()

--- a/tests/unit/infra/queue/test_queue_client_factory.py
+++ b/tests/unit/infra/queue/test_queue_client_factory.py
@@ -1,0 +1,107 @@
+"""Unit tests for queue client factory provider resolution."""
+
+import pytest
+
+from src.infra.cache.redis_client import RedisClient
+from src.infra.queue.queue_client_factory import create_queue_redis_client
+
+
+@pytest.mark.unit
+def test_upstash_provider_requires_url(monkeypatch):
+    """Upstash provider must have UPSTASH_REDIS_URL set."""
+    monkeypatch.setattr(
+        "src.infra.queue.queue_client_factory.settings",
+        type("S", (), {
+            "QUEUE_PROVIDER": "upstash",
+            "UPSTASH_REDIS_URL": None,
+            "DEDICATED_REDIS_URL": None,
+            "REDIS_MAX_CONNECTIONS": 10,
+        })(),
+    )
+    with pytest.raises(ValueError, match="UPSTASH_REDIS_URL"):
+        create_queue_redis_client()
+
+
+@pytest.mark.unit
+def test_upstash_provider_rejects_empty_url(monkeypatch):
+    """Upstash provider rejects empty string URL."""
+    monkeypatch.setattr(
+        "src.infra.queue.queue_client_factory.settings",
+        type("S", (), {
+            "QUEUE_PROVIDER": "upstash",
+            "UPSTASH_REDIS_URL": "  ",
+            "DEDICATED_REDIS_URL": None,
+            "REDIS_MAX_CONNECTIONS": 10,
+        })(),
+    )
+    with pytest.raises(ValueError, match="UPSTASH_REDIS_URL"):
+        create_queue_redis_client()
+
+
+@pytest.mark.unit
+def test_upstash_provider_returns_client(monkeypatch):
+    """Upstash provider returns RedisClient with given URL."""
+    monkeypatch.setattr(
+        "src.infra.queue.queue_client_factory.settings",
+        type("S", (), {
+            "QUEUE_PROVIDER": "upstash",
+            "UPSTASH_REDIS_URL": "rediss://default:xxx@us1-xxx.upstash.io:6379",
+            "DEDICATED_REDIS_URL": None,
+            "REDIS_MAX_CONNECTIONS": 20,
+        })(),
+    )
+    client = create_queue_redis_client()
+    assert isinstance(client, RedisClient)
+    assert "upstash" in str(client._redis_url).lower() or "upstash" in client._redis_url
+
+
+@pytest.mark.unit
+def test_dedicated_provider_uses_dedicated_url_when_set(monkeypatch):
+    """Dedicated provider uses DEDICATED_REDIS_URL when set."""
+    custom_url = "redis://custom-host:6379/1"
+    monkeypatch.setattr(
+        "src.infra.queue.queue_client_factory.settings",
+        type("S", (), {
+            "QUEUE_PROVIDER": "dedicated",
+            "UPSTASH_REDIS_URL": None,
+            "DEDICATED_REDIS_URL": custom_url,
+            "REDIS_MAX_CONNECTIONS": 10,
+        })(),
+    )
+    client = create_queue_redis_client()
+    assert isinstance(client, RedisClient)
+    assert client._redis_url == custom_url
+
+
+@pytest.mark.unit
+def test_dedicated_provider_uses_redis_url_when_dedicated_not_set(monkeypatch):
+    """Dedicated provider falls back to redis_url when DEDICATED_REDIS_URL not set."""
+    monkeypatch.setattr(
+        "src.infra.queue.queue_client_factory.settings",
+        type("S", (), {
+            "QUEUE_PROVIDER": "dedicated",
+            "UPSTASH_REDIS_URL": None,
+            "DEDICATED_REDIS_URL": None,
+            "REDIS_MAX_CONNECTIONS": 10,
+            "redis_url": "redis://localhost:6379/0",
+        })(),
+    )
+    client = create_queue_redis_client()
+    assert isinstance(client, RedisClient)
+    assert client._redis_url == "redis://localhost:6379/0"
+
+
+@pytest.mark.unit
+def test_invalid_provider_raises(monkeypatch):
+    """Invalid QUEUE_PROVIDER raises ValueError."""
+    monkeypatch.setattr(
+        "src.infra.queue.queue_client_factory.settings",
+        type("S", (), {
+            "QUEUE_PROVIDER": "invalid",
+            "UPSTASH_REDIS_URL": None,
+            "DEDICATED_REDIS_URL": None,
+            "REDIS_MAX_CONNECTIONS": 10,
+        })(),
+    )
+    with pytest.raises(ValueError, match="Invalid QUEUE_PROVIDER"):
+        create_queue_redis_client()

--- a/tests/unit/infra/queue/test_redis_job_queue.py
+++ b/tests/unit/infra/queue/test_redis_job_queue.py
@@ -83,6 +83,15 @@ class _FakeRedis:
         self.zsets[key].pop(member, None)
         return 1
 
+    async def zpopmin(self, key: str, count: int = 1):
+        z = self.zsets.get(key, {})
+        if not z:
+            return []
+        sorted_items = sorted(z.items(), key=lambda x: x[1])[:count]
+        for member, _ in sorted_items:
+            self.zsets[key].pop(member, None)
+        return sorted_items
+
     async def incr(self, key: str):
         self.counters[key] += 1
         return self.counters[key]

--- a/tests/unit/infra/queue/test_redis_job_queue.py
+++ b/tests/unit/infra/queue/test_redis_job_queue.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from src.domain.model.job_queue import JobPayload, JobStatus
+from src.infra.queue.redis_job_queue import RedisJobQueue
+
+
+@dataclass
+class _FakeRedisClientWrapper:
+    client: Any
+
+
+class _FakeRedis:
+    def __init__(self):
+        self._id_counter = 0
+        self.streams: dict[str, list[tuple[str, dict[str, str]]]] = defaultdict(list)
+        self.groups: set[tuple[str, str]] = set()
+        self.state: dict[str, dict[str, str]] = {}
+        self.pending: dict[str, str] = {}  # stream_id -> stream_name
+        self.zsets: dict[str, dict[str, float]] = defaultdict(dict)
+        self.counters: dict[str, int] = defaultdict(int)
+
+    async def xgroup_create(self, name: str, groupname: str, id: str, mkstream: bool):
+        del id, mkstream
+        self.groups.add((name, groupname))
+
+    async def xadd(self, stream_name: str, fields: dict[str, str]):
+        self._id_counter += 1
+        stream_id = f"{self._id_counter}-0"
+        self.streams[stream_name].append((stream_id, deepcopy(fields)))
+        return stream_id
+
+    async def xreadgroup(
+        self,
+        groupname: str,
+        consumername: str,
+        streams: dict[str, str],
+        count: int = 1,
+        block: int | None = None,
+    ):
+        del groupname, consumername, count, block
+        stream_name = next(iter(streams.keys()))
+        if not self.streams[stream_name]:
+            return []
+        stream_id, fields = self.streams[stream_name].pop(0)
+        self.pending[stream_id] = stream_name
+        return [(stream_name, [(stream_id, deepcopy(fields))])]
+
+    async def xack(self, stream_name: str, group_name: str, stream_id: str):
+        del stream_name, group_name
+        self.pending.pop(stream_id, None)
+        return 1
+
+    async def xdel(self, stream_name: str, stream_id: str):
+        del stream_name, stream_id
+        return 1
+
+    async def hset(self, key: str, mapping: dict[str, str]):
+        self.state[key] = dict(mapping)
+        return 1
+
+    async def hgetall(self, key: str):
+        return dict(self.state.get(key, {}))
+
+    async def zadd(self, key: str, mapping: dict[str, float]):
+        self.zsets[key].update(mapping)
+        return len(mapping)
+
+    async def zrangebyscore(self, key: str, min_score: float, max_score: float):
+        members = []
+        for member, score in self.zsets.get(key, {}).items():
+            if min_score <= score <= max_score:
+                members.append(member)
+        return members
+
+    async def zrem(self, key: str, member: str):
+        self.zsets[key].pop(member, None)
+        return 1
+
+    async def incr(self, key: str):
+        self.counters[key] += 1
+        return self.counters[key]
+
+
+@pytest.mark.asyncio
+async def test_enqueue_dequeue_ack_status_lifecycle():
+    fake = _FakeRedis()
+    queue = RedisJobQueue(
+        redis_client=_FakeRedisClientWrapper(client=fake),
+        consumer_name="test-consumer",
+    )
+
+    job = JobPayload(
+        job_type="meal_image_analysis",
+        user_id="user-1",
+        payload={"meal_id": "meal-1"},
+    )
+    job_id = await queue.enqueue(job)
+    assert job_id == job.job_id
+    assert await queue.get_status(job_id) == JobStatus.QUEUED
+
+    dequeued = await queue.dequeue(["meal_image_analysis"])
+    assert dequeued is not None
+    assert dequeued.job_id == job_id
+    assert await queue.get_status(job_id) == JobStatus.PROCESSING
+
+    await queue.ack(job_id)
+    assert await queue.get_status(job_id) == JobStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_nack_schedules_retry_and_promotes_back_to_stream():
+    fake = _FakeRedis()
+    queue = RedisJobQueue(
+        redis_client=_FakeRedisClientWrapper(client=fake),
+        consumer_name="test-consumer",
+        retry_schedule_seconds=(0,),
+    )
+
+    job = JobPayload(
+        job_type="meal_image_analysis",
+        user_id="user-2",
+        payload={"meal_id": "meal-2"},
+    )
+    await queue.enqueue(job)
+    _ = await queue.dequeue(["meal_image_analysis"])
+
+    await queue.nack(job.job_id, "temporary error")
+    assert await queue.get_status(job.job_id) == JobStatus.FAILED
+
+    # Dequeue will promote due retries first, then consume from stream.
+    retry_job = await queue.dequeue(["meal_image_analysis"])
+    assert retry_job is not None
+    assert retry_job.job_id == job.job_id
+    assert retry_job.retry_count == 1
+    assert await queue.get_status(job.job_id) == JobStatus.PROCESSING
+
+
+@pytest.mark.asyncio
+async def test_nack_moves_job_to_dead_letter_after_max_retries():
+    fake = _FakeRedis()
+    queue = RedisJobQueue(
+        redis_client=_FakeRedisClientWrapper(client=fake),
+        consumer_name="test-consumer",
+        retry_schedule_seconds=(0,),
+    )
+
+    job = JobPayload(
+        job_type="meal_image_analysis",
+        user_id="user-3",
+        payload={"meal_id": "meal-3"},
+        max_retries=1,
+    )
+    await queue.enqueue(job)
+
+    # Failure #1 -> scheduled retry
+    _ = await queue.dequeue(["meal_image_analysis"])
+    await queue.nack(job.job_id, "first failure")
+    assert await queue.get_status(job.job_id) == JobStatus.FAILED
+
+    # Consume retry and fail again -> DEAD
+    _ = await queue.dequeue(["meal_image_analysis"])
+    await queue.nack(job.job_id, "second failure")
+    assert await queue.get_status(job.job_id) == JobStatus.DEAD
+
+    dead_entries = fake.streams["jobs:dead"]
+    assert len(dead_entries) == 1
+    _, dead_payload = dead_entries[0]
+    assert dead_payload["job_id"] == job.job_id
+    assert dead_payload["error"] == "second failure"
+


### PR DESCRIPTION
- Add Redis-backed job queue with support for job lifecycle management (enqueue, dequeue, ack, nack).
- Introduce JobQueuePort interface and RedisJobQueue implementation for handling background jobs.
- Enhance base dependencies to initialize and shutdown queue layer based on configuration.
- Update settings to include queue configuration options (provider, URLs, etc.).
- Create unit tests for queue client factory and Redis job queue functionality.

This commit establishes a robust framework for managing background jobs, enabling better scalability and reliability in processing tasks.