### PR TITLE
feat(backend): add progress screen endpoints (streak + daily breakdown)

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -122,6 +122,8 @@ from src.app.handlers.query_handlers import (
     GetSingleMealForProfileQueryHandler,
     GetMealPlanningSummaryQueryHandler,
     GetUserMetricsQueryHandler,
+    GetStreakQueryHandler,
+    GetDailyBreakdownQueryHandler,
 )
 from src.app.handlers.query_handlers.chat import (
     GetThreadsQueryHandler,
@@ -147,6 +149,8 @@ from src.app.queries.meal import (
     GetMealByIdQuery,
     GetDailyMacrosQuery,
     GetMealsByDateQuery,
+    GetStreakQuery,
+    GetDailyBreakdownQuery,
 )
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
 from src.app.queries.notification import GetNotificationPreferencesQuery
@@ -361,6 +365,14 @@ def get_configured_event_bus() -> EventBus:
     event_bus.register_handler(
         GetWeeklyBudgetQuery,
         GetWeeklyBudgetQueryHandler(),
+    )
+    event_bus.register_handler(
+        GetStreakQuery,
+        GetStreakQueryHandler(),
+    )
+    event_bus.register_handler(
+        GetDailyBreakdownQuery,
+        GetDailyBreakdownQueryHandler(),
     )
 
     # Register activity query handlers

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -24,6 +24,7 @@ from src.api.schemas.request.meal_requests import (
 )
 from src.api.schemas.response import DetailedMealResponse, ManualMealCreationResponse
 from src.api.schemas.response.meal_responses import ParseMealTextResponse
+from src.api.schemas.progress_schemas import DailyBreakdownResponse, StreakResponse
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.api.schemas.response.weekly_budget_response import WeeklyBudgetResponse
 from src.app.commands.meal import EditMealCommand, FoodItemChange, CustomNutritionData
@@ -40,7 +41,7 @@ from src.app.commands.meal.upload_meal_image_immediately_command import (
 from src.app.commands.meal.analyze_meal_image_by_url_command import (
     AnalyzeMealImageByUrlCommand,
 )
-from src.app.queries.meal import GetMealByIdQuery, GetDailyMacrosQuery
+from src.app.queries.meal import GetMealByIdQuery, GetDailyMacrosQuery, GetStreakQuery, GetDailyBreakdownQuery
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
 from src.infra.event_bus import EventBus
 
@@ -404,6 +405,61 @@ async def parse_meal_text(
             total_fat=app_response.total_fat,
             emoji=app_response.emoji,
         )
+    except Exception as e:
+        raise handle_exception(e) from e
+
+
+@router.get("/streak", response_model=StreakResponse)
+async def get_streak(
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """
+    Get the user's current and best logging streak.
+
+    - current_streak: consecutive days logged up to today (streak not broken until end of day)
+    - best_streak: longest consecutive run ever
+    - last_logged_date: most recent date with a meal (YYYY-MM-DD), null if never logged
+    """
+    try:
+        header_tz = request.headers.get("X-Timezone")
+        query = GetStreakQuery(user_id=user_id, header_timezone=header_tz)
+        result = await event_bus.send(query)
+        return result
+    except Exception as e:
+        raise handle_exception(e) from e
+
+
+@router.get("/weekly/daily-breakdown", response_model=DailyBreakdownResponse)
+async def get_daily_breakdown(
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+    week_start: Optional[str] = Query(
+        None,
+        description="Week start date (Monday) in YYYY-MM-DD format. Defaults to current week.",
+    ),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """
+    Get 7-day macro breakdown (Mon–Sun) with consumed vs target per day.
+
+    Returns an array of 7 entries, one per day, with calories/protein/carbs/fat
+    consumed and base daily targets from the user's TDEE.
+    """
+    try:
+        parsed_week_start = None
+        if week_start:
+            parsed_week_start = datetime.strptime(week_start, "%Y-%m-%d").date()
+
+        header_tz = request.headers.get("X-Timezone")
+        query = GetDailyBreakdownQuery(
+            user_id=user_id,
+            week_start=parsed_week_start,
+            header_timezone=header_tz,
+        )
+        result = await event_bus.send(query)
+        return result
     except Exception as e:
         raise handle_exception(e) from e
 

--- a/src/api/schemas/progress_schemas.py
+++ b/src/api/schemas/progress_schemas.py
@@ -1,0 +1,38 @@
+"""
+Pydantic response schemas for progress screen endpoints.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class StreakResponse(BaseModel):
+    """Response for GET /v1/meals/streak."""
+
+    current_streak: int
+    best_streak: int
+    last_logged_date: Optional[str] = None  # YYYY-MM-DD, None if never logged
+
+
+class DailyBreakdownEntry(BaseModel):
+    """Macros consumed vs target for a single day."""
+
+    date: str  # YYYY-MM-DD
+    calories_consumed: float
+    calories_target: float
+    protein_consumed: float
+    protein_target: float
+    carbs_consumed: float
+    carbs_target: float
+    fat_consumed: float
+    fat_target: float
+    meal_count: int
+
+
+class DailyBreakdownResponse(BaseModel):
+    """Response for GET /v1/meals/weekly/daily-breakdown."""
+
+    days: List[DailyBreakdownEntry]
+    week_start: str  # YYYY-MM-DD (Monday)

--- a/src/app/handlers/query_handlers/__init__.py
+++ b/src/app/handlers/query_handlers/__init__.py
@@ -5,7 +5,9 @@ Each handler is in its own file for better maintainability.
 
 # Activity handlers
 from .get_daily_activities_query_handler import GetDailyActivitiesQueryHandler
+from .get_daily_breakdown_query_handler import GetDailyBreakdownQueryHandler
 from .get_daily_macros_query_handler import GetDailyMacrosQueryHandler
+from .get_streak_query_handler import GetStreakQueryHandler
 from .get_food_details_query_handler import GetFoodDetailsQueryHandler
 # Meal handlers
 from .get_meal_by_id_query_handler import GetMealByIdQueryHandler
@@ -51,6 +53,9 @@ __all__ = [
     "GetDailyActivitiesQueryHandler",
     # Meal Plan / Daily Meal
     "GetMealsByDateQueryHandler",
+    # Progress
+    "GetStreakQueryHandler",
+    "GetDailyBreakdownQueryHandler",
     # Daily Meal specific
     "GetMealSuggestionsForProfileQueryHandler",
     "GetSingleMealForProfileQueryHandler",

--- a/src/app/handlers/query_handlers/get_daily_breakdown_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_breakdown_query_handler.py
@@ -1,0 +1,117 @@
+"""
+GetDailyBreakdownQueryHandler — 7-day macro breakdown (actual vs target).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from src.app.events.base import EventHandler, handles
+from src.app.queries.meal.get_daily_breakdown_query import GetDailyBreakdownQuery
+from src.domain.model.meal import MealStatus
+from src.domain.model.nutrition.macros import Macros
+from src.domain.utils.timezone_utils import get_user_monday, get_zone_info, resolve_user_timezone
+from src.infra.database.uow import UnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+@handles(GetDailyBreakdownQuery)
+class GetDailyBreakdownQueryHandler(EventHandler[GetDailyBreakdownQuery, Dict[str, Any]]):
+    """Handler for 7-day per-day macro breakdown with consumed vs target."""
+
+    async def handle(self, query: GetDailyBreakdownQuery) -> Dict[str, Any]:
+        """Return 7 DailyBreakdownEntry dicts for Mon–Sun of the requested week."""
+        # Fetch TDEE targets first (async, outside UoW)
+        base_daily_cal, base_daily_protein, base_daily_carbs, base_daily_fat = (
+            await self._get_base_daily_targets(query.user_id)
+        )
+
+        with UnitOfWork() as uow:
+            user_tz_str = resolve_user_timezone(
+                query.user_id, uow, query.header_timezone
+            )
+            user_tz = get_zone_info(user_tz_str)
+            today = datetime.now(user_tz).date()
+
+            # Resolve week start (Monday)
+            if query.week_start:
+                week_start = query.week_start
+            else:
+                week_start = get_user_monday(today, query.user_id, uow)
+
+            days = [week_start + timedelta(days=i) for i in range(7)]
+
+            entries: List[Dict[str, Any]] = []
+            for day in days:
+                meals = uow.meals.find_by_date(
+                    day, user_id=query.user_id, user_timezone=user_tz_str
+                )
+
+                total_protein = 0.0
+                total_carbs = 0.0
+                total_fat = 0.0
+                total_fiber = 0.0
+                meal_count = 0
+
+                for meal in meals:
+                    if meal.status == MealStatus.INACTIVE:
+                        continue
+                    meal_count += 1
+                    if meal.nutrition and meal.status in [MealStatus.READY, MealStatus.ENRICHING]:
+                        if meal.nutrition.macros:
+                            total_protein += meal.nutrition.macros.protein or 0.0
+                            total_carbs += meal.nutrition.macros.carbs or 0.0
+                            total_fat += meal.nutrition.macros.fat or 0.0
+                            total_fiber += meal.nutrition.macros.fiber or 0.0
+
+                total_calories = Macros(
+                    protein=total_protein,
+                    carbs=total_carbs,
+                    fat=total_fat,
+                    fiber=total_fiber,
+                ).total_calories
+
+                entries.append({
+                    "date": day.isoformat(),
+                    "calories_consumed": round(total_calories, 1),
+                    "calories_target": round(base_daily_cal, 1),
+                    "protein_consumed": round(total_protein, 1),
+                    "protein_target": round(base_daily_protein, 1),
+                    "carbs_consumed": round(total_carbs, 1),
+                    "carbs_target": round(base_daily_carbs, 1),
+                    "fat_consumed": round(total_fat, 1),
+                    "fat_target": round(base_daily_fat, 1),
+                    "meal_count": meal_count,
+                })
+
+        return {
+            "days": entries,
+            "week_start": week_start.isoformat(),
+        }
+
+    async def _get_base_daily_targets(
+        self, user_id: str
+    ) -> tuple[float, float, float, float]:
+        """Return (calories, protein, carbs, fat) base daily targets from TDEE."""
+        try:
+            from src.app.handlers.query_handlers.get_user_tdee_query_handler import (
+                GetUserTdeeQueryHandler,
+            )
+            from src.app.queries.tdee import GetUserTdeeQuery
+
+            result = await GetUserTdeeQueryHandler().handle(
+                GetUserTdeeQuery(user_id=user_id)
+            )
+            cal = result.get("target_calories", 2000.0)
+            macros = result.get("macros", {})
+            return (
+                cal,
+                macros.get("protein", 70.0),
+                macros.get("carbs", 200.0),
+                macros.get("fat", 70.0),
+            )
+        except Exception as e:
+            logger.warning(f"Could not fetch TDEE targets for {user_id}: {e}")
+            return 2000.0, 70.0, 200.0, 70.0

--- a/src/app/handlers/query_handlers/get_streak_query_handler.py
+++ b/src/app/handlers/query_handlers/get_streak_query_handler.py
@@ -1,0 +1,82 @@
+"""
+GetStreakQueryHandler — computes current and best logging streak.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Optional
+
+from src.app.events.base import EventHandler, handles
+from src.app.queries.meal.get_streak_query import GetStreakQuery
+from src.domain.utils.timezone_utils import get_zone_info, resolve_user_timezone
+from src.infra.database.uow import UnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+@handles(GetStreakQuery)
+class GetStreakQueryHandler(EventHandler[GetStreakQuery, Dict[str, Any]]):
+    """Handler that calculates current + best logging streak for a user."""
+
+    async def handle(self, query: GetStreakQuery) -> Dict[str, Any]:
+        """Return current_streak, best_streak, and last_logged_date."""
+        with UnitOfWork() as uow:
+            user_tz_str = resolve_user_timezone(
+                query.user_id, uow, query.header_timezone
+            )
+            user_tz = get_zone_info(user_tz_str)
+            today = datetime.now(user_tz).date()
+
+            dates = uow.meals.get_dates_with_meals(
+                query.user_id, user_timezone=user_tz_str
+            )
+
+        if not dates:
+            return {"current_streak": 0, "best_streak": 0, "last_logged_date": None}
+
+        last_logged = dates[0]
+
+        current_streak = self._calculate_current_streak(dates, today)
+        best_streak = self._calculate_best_streak(dates)
+
+        return {
+            "current_streak": current_streak,
+            "best_streak": best_streak,
+            "last_logged_date": last_logged.isoformat(),
+        }
+
+    def _calculate_current_streak(self, dates: list[date], today: date) -> int:
+        """Walk backwards from today; streak not broken until day ends."""
+        if not dates:
+            return 0
+
+        # Allow streak to start from today or yesterday (streak not broken until day ends)
+        cursor = today if today in dates else today - timedelta(days=1)
+        if cursor not in dates:
+            return 0
+
+        date_set = set(dates)
+        streak = 0
+        while cursor in date_set:
+            streak += 1
+            cursor -= timedelta(days=1)
+        return streak
+
+    def _calculate_best_streak(self, dates: list[date]) -> int:
+        """Find the longest consecutive run across all logged dates."""
+        if not dates:
+            return 0
+
+        date_set = set(dates)
+        best = 0
+        for d in date_set:
+            # Only start counting from a "streak start" (day before not in set)
+            if (d - timedelta(days=1)) not in date_set:
+                length = 0
+                cursor = d
+                while cursor in date_set:
+                    length += 1
+                    cursor += timedelta(days=1)
+                best = max(best, length)
+        return best

--- a/src/app/queries/meal/__init__.py
+++ b/src/app/queries/meal/__init__.py
@@ -1,12 +1,16 @@
 """
 Meal queries.
 """
+from .get_daily_breakdown_query import GetDailyBreakdownQuery
 from .get_daily_macros_query import GetDailyMacrosQuery
 from .get_meal_by_id_query import GetMealByIdQuery
 from .get_meals_by_date_query import GetMealsByDateQuery
+from .get_streak_query import GetStreakQuery
 
 __all__ = [
     "GetMealByIdQuery",
     "GetDailyMacrosQuery",
     "GetMealsByDateQuery",
+    "GetStreakQuery",
+    "GetDailyBreakdownQuery",
 ]

--- a/src/app/queries/meal/get_daily_breakdown_query.py
+++ b/src/app/queries/meal/get_daily_breakdown_query.py
@@ -1,0 +1,19 @@
+"""
+Get daily breakdown query.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+from src.app.events.base import Query
+
+
+@dataclass
+class GetDailyBreakdownQuery(Query):
+    """Query to get 7-day macro breakdown (actual vs target per day)."""
+
+    user_id: str
+    week_start: Optional[date] = None
+    header_timezone: Optional[str] = None

--- a/src/app/queries/meal/get_streak_query.py
+++ b/src/app/queries/meal/get_streak_query.py
@@ -1,0 +1,17 @@
+"""
+Get streak query.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from src.app.events.base import Query
+
+
+@dataclass
+class GetStreakQuery(Query):
+    """Query to get user's current and best logging streak."""
+
+    user_id: str
+    header_timezone: Optional[str] = None

--- a/src/infra/repositories/meal_repository.py
+++ b/src/infra/repositories/meal_repository.py
@@ -277,6 +277,41 @@ class MealRepository(MealRepositoryPort):
             result[day_val] = count
         return result
 
+    def get_dates_with_meals(
+        self,
+        user_id: str,
+        user_timezone: Optional[str] = None,
+    ) -> List[date]:
+        """Return all distinct dates (descending) where user has ≥1 active meal.
+
+        Reuses timezone logic from get_daily_meal_counts().
+        """
+        tz = get_zone_info(user_timezone) if user_timezone else timezone.utc
+
+        if user_timezone and user_timezone != "UTC":
+            date_expr = func.date(func.convert_tz(DBMeal.created_at, "+00:00", self._tz_offset(tz)))
+        else:
+            date_expr = func.date(DBMeal.created_at)
+
+        rows = (
+            self.db.query(date_expr)
+            .filter(
+                DBMeal.user_id == user_id,
+                DBMeal.status != MealStatusEnum.INACTIVE,
+            )
+            .distinct()
+            .order_by(date_expr.desc())
+            .all()
+        )
+
+        result: List[date] = []
+        for (day_val,) in rows:
+            if isinstance(day_val, str):
+                day_val = date.fromisoformat(day_val)
+            if isinstance(day_val, date):
+                result.append(day_val)
+        return result
+
     @staticmethod
     def _tz_offset(tz) -> str:
         """Convert a timezone to a UTC offset string like '+07:00'."""


### PR DESCRIPTION
## Summary
- Add `GET /v1/meals/streak` endpoint returning current + best logging streak
- Add `GET /v1/meals/weekly/daily-breakdown` endpoint returning 7-day macro breakdown (consumed vs target per day)
- Add `get_dates_with_meals()` repository method with timezone-aware date grouping
- Both endpoints respect user timezone via `X-Timezone` header

## New Files
- `src/api/schemas/progress_schemas.py` — Pydantic response models
- `src/app/queries/meal/get_streak_query.py` — CQRS query
- `src/app/queries/meal/get_daily_breakdown_query.py` — CQRS query
- `src/app/handlers/query_handlers/get_streak_query_handler.py` — Streak calculation
- `src/app/handlers/query_handlers/get_daily_breakdown_query_handler.py` — 7-day breakdown

## Test plan
- [ ] Smoke test `GET /v1/meals/streak` via `/docs`
- [ ] Smoke test `GET /v1/meals/weekly/daily-breakdown` via `/docs`
- [ ] Verify timezone handling with `X-Timezone` header
- [ ] Verify streak counts correctly with gaps