### PR TITLE
fix(auth): guard notification preferences creation in user sync

### DIFF
--- a/src/app/handlers/command_handlers/sync_user_command_handler.py
+++ b/src/app/handlers/command_handlers/sync_user_command_handler.py
@@ -216,18 +216,26 @@ class SyncUserCommandHandler(EventHandler[SyncUserCommand, Dict[str, Any]]):
 
         return first_name, last_name
     
-    def _create_default_notification_preferences(self, user_id: Any, uow: UnitOfWorkPort):
-        """Create default notification preferences using repository."""
+    def _create_default_notification_preferences(self, user_id, uow: UnitOfWorkPort):
+        """Create default notification preferences. Non-fatal: logs and skips on error."""
         if not user_id:
             logger.warning("Cannot create notification preferences: user_id is None")
             return
-        
-        # Create default preferences domain model
-        # Using string ID for user_id because domain model uses UUID but repo handles string conversion if needed?
-        # UserDomainModel.id is UUID. NotificationPreferences.user_id is str (from previous check).
-        # Let's ensure type compatibility.
+
         user_id_str = str(user_id)
-        
-        default_prefs = NotificationPreferences.create_default(user_id_str)
-        uow.notifications.save_notification_preferences(default_prefs)
-        logger.info(f"Added default notification preferences for user {user_id}")
+
+        # Validate UUID format before constructing domain model (NUTREE-44)
+        try:
+            import uuid
+            uuid.UUID(user_id_str)
+        except ValueError:
+            logger.error(f"Skipping notification prefs: invalid UUID {user_id_str!r}")
+            return
+
+        try:
+            default_prefs = NotificationPreferences.create_default(user_id_str)
+            uow.notifications.save_notification_preferences(default_prefs)
+            logger.info(f"Added default notification preferences for user {user_id}")
+        except Exception as e:
+            # Non-fatal: notification prefs failure should not crash user sync
+            logger.error(f"Failed to create notification preferences for {user_id}: {e}")


### PR DESCRIPTION
## Summary
- `_create_default_notification_preferences` in `SyncUserCommandHandler` could crash the entire user sync if `user_id` wasn't a valid UUID string, causing HTTP 500
- Added UUID format validation before constructing the domain model
- Wrapped entire notification preferences creation in try/except so failures are non-fatal (logged, not raised)

Fixes NUTREE-44

## Test plan
- [x] Python syntax validated
- [ ] Manual: new user sync → should succeed even if notification prefs creation fails
- [ ] Verify in Sentry: no new NUTREE-44 occurrences after deploy