### PR TITLE
fix(notifications): skip users without active FCM tokens in reminder queries

### DIFF
--- a/src/infra/repositories/notification/reminder_query_builder.py
+++ b/src/infra/repositories/notification/reminder_query_builder.py
@@ -9,11 +9,21 @@ from src.domain.utils.timezone_utils import (
     DEFAULT_TIMEZONE
 )
 from src.infra.database.models.notification import NotificationPreferences as DBNotificationPreferences
+from src.infra.database.models.notification.user_fcm_token import UserFcmToken as DBUserFcmToken
 from src.infra.database.models.user.user import User
 
 
 class ReminderQueryBuilder:
     """Builds queries for finding users due for reminders."""
+
+    @staticmethod
+    def _active_token_users_subquery(db: Session):
+        """Subquery returning user_ids with at least one active FCM token."""
+        return (
+            db.query(DBUserFcmToken.user_id)
+            .filter(DBUserFcmToken.is_active == True)
+            .subquery()
+        )
 
     @staticmethod
     def find_users_for_meal_reminder(db: Session, meal_type: str, current_utc: datetime) -> List[str]:
@@ -39,6 +49,8 @@ class ReminderQueryBuilder:
         else:
             return []
 
+        active_token_users = ReminderQueryBuilder._active_token_users_subquery(db)
+
         results = (
             db.query(
                 DBNotificationPreferences.user_id,
@@ -48,7 +60,8 @@ class ReminderQueryBuilder:
             .join(User, DBNotificationPreferences.user_id == User.id)
             .filter(
                 DBNotificationPreferences.meal_reminders_enabled == True,
-                time_field.isnot(None)
+                time_field.isnot(None),
+                DBNotificationPreferences.user_id.in_(active_token_users)
             )
             .all()
         )
@@ -77,6 +90,8 @@ class ReminderQueryBuilder:
         Returns:
             List of user IDs who should receive daily summary at their configured time
         """
+        active_token_users = ReminderQueryBuilder._active_token_users_subquery(db)
+
         results = (
             db.query(
                 DBNotificationPreferences.user_id,
@@ -84,7 +99,10 @@ class ReminderQueryBuilder:
                 User.timezone
             )
             .join(User, DBNotificationPreferences.user_id == User.id)
-            .filter(DBNotificationPreferences.daily_summary_enabled == True)
+            .filter(
+                DBNotificationPreferences.daily_summary_enabled == True,
+                DBNotificationPreferences.user_id.in_(active_token_users)
+            )
             .all()
         )
 

--- a/tests/unit/test_notification_repository.py
+++ b/tests/unit/test_notification_repository.py
@@ -394,20 +394,23 @@ class TestNotificationRepository:
     
     # Utility Operations Tests
 
-    def test_find_users_for_meal_reminder_breakfast(self, repository, mock_db_session):
+    @patch('src.infra.repositories.notification.reminder_query_builder.ReminderQueryBuilder._active_token_users_subquery')
+    def test_find_users_for_meal_reminder_breakfast(self, mock_subquery_method, repository, mock_db_session):
         """Test finding users for breakfast reminder with timezone-aware query.
 
         Verifies the optimized query that includes time_field in initial query
         to avoid N+1 queries (no secondary query in loop).
         """
-        # Arrange - mock returns tuples of (user_id, timezone, pref_minutes)
-        # This is the optimized single-query pattern (no N+1)
+        # Arrange - patch subquery to return a real SQLAlchemy select
+        from sqlalchemy import select, literal_column
+        mock_subquery_method.return_value = select(literal_column("'dummy'")).subquery()
+
+        # Main query mock returns tuples of (user_id, timezone, pref_minutes)
         mock_query = Mock()
         mock_query.join = Mock(return_value=mock_query)
         mock_query.filter = Mock(return_value=mock_query)
-        # Both users have breakfast at 480 minutes (8:00 AM)
         mock_query.all = Mock(return_value=[
-            ("user-1", "UTC", 480),  # user_id, timezone, breakfast_time_minutes
+            ("user-1", "UTC", 480),
             ("user-2", "UTC", 480)
         ])
         mock_db_session.query = Mock(return_value=mock_query)
@@ -419,7 +422,6 @@ class TestNotificationRepository:
         # Assert - both users should match at 8:00 AM
         assert "user-1" in result
         assert "user-2" in result
-        # Verify only ONE query was made (no N+1 - no secondary query.first calls)
         mock_db_session.query.assert_called_once()
     
     def test_find_users_for_meal_reminder_invalid_meal_type(self, repository, mock_db_session):


### PR DESCRIPTION
## Summary
- Filter `ReminderQueryBuilder` to exclude users with no active FCM tokens via subquery join
- Eliminates wasted TDEE/budget computation and log noise for users who uninstalled the app
- Extracted shared `_active_token_users_subquery()` helper (DRY)

## Problem
Scheduler processes users every notification cycle (4x/day) even when they have zero active tokens, producing repeated WARNING logs and wasting compute on TDEE/budget calculations that get discarded.

## Test plan
- [ ] Deploy to staging, verify no more "No active FCM tokens found" warnings in logs
- [ ] Verify users WITH active tokens still receive notifications normally
- [ ] Check query performance with `EXPLAIN` on the new subquery