### PR TITLE
feat(barcode): 6-step cascade with Nutritionix, Brave Search, AI fallback

### DIFF
--- a/env.example
+++ b/env.example
@@ -93,3 +93,10 @@ DEV_USER_USERNAME=your_dev_username
 # FatSecret API (barcode lookup + food search) - OAuth 2.0
 FATSECRET_CLIENT_ID=your_client_id
 FATSECRET_CLIENT_SECRET=your_client_secret
+
+# Nutritionix API (barcode nutrition lookup) - free 50 req/day
+NUTRITIONIX_APP_ID=
+NUTRITIONIX_API_KEY=
+
+# Brave Search API (web search for barcode nutrition) - free $5/mo credits = ~1000 searches
+BRAVE_SEARCH_API_KEY=

--- a/env.example
+++ b/env.example
@@ -94,6 +94,9 @@ DEV_USER_USERNAME=your_dev_username
 FATSECRET_CLIENT_ID=your_client_id
 FATSECRET_CLIENT_SECRET=your_client_secret
 
+# DeepL
+DEEPL_API_KEY=
+
 # Nutritionix API (barcode nutrition lookup) - free 50 req/day
 NUTRITIONIX_APP_ID=
 NUTRITIONIX_API_KEY=

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -237,6 +237,34 @@ def get_fat_secret_service_instance():
     return get_fat_secret_service()
 
 
+# Nutritionix Service
+def get_nutritionix_service_instance():
+    """Get the Nutritionix service instance, or None if not configured."""
+    from src.infra.adapters.nutritionix_service import get_nutritionix_service
+    return get_nutritionix_service()
+
+
+# BraveSearch Nutrition Service (singleton — None when API key not configured)
+_brave_search_nutrition_service = None
+
+
+def get_brave_search_nutrition_service_instance():
+    """Get the BraveSearch nutrition service singleton, or None if unconfigured."""
+    global _brave_search_nutrition_service
+    if _brave_search_nutrition_service is None:
+        from src.infra.adapters.brave_search_nutrition_service import get_brave_search_nutrition_service
+        from src.infra.adapters.meal_generation_service import MealGenerationService
+        from src.domain.services.meal_suggestion.macro_validation_service import MacroValidationService
+
+        meal_gen = MealGenerationService()
+        macro_validator = MacroValidationService()
+        _brave_search_nutrition_service = get_brave_search_nutrition_service(
+            meal_generation_service=meal_gen,
+            macro_validation_service=macro_validator,
+        )
+    return _brave_search_nutrition_service
+
+
 # Food Reference Repository (replaces barcode_product_repository)
 _food_reference_repository = None
 

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -190,6 +190,9 @@ def get_food_search_event_bus() -> EventBus:
 
     from src.infra.adapters.meal_generation_service import MealGenerationService
     from src.domain.services.food_search_translation_service import FoodSearchTranslationService
+    from src.infra.adapters.nutritionix_service import get_nutritionix_service
+    from src.infra.adapters.brave_search_nutrition_service import get_brave_search_nutrition_service
+    from src.domain.services.meal_suggestion.macro_validation_service import MacroValidationService
 
     event_bus = PyMediatorEventBus()
 
@@ -202,7 +205,16 @@ def get_food_search_event_bus() -> EventBus:
     food_reference_repository = get_food_reference_repository()
 
     # Translation service for localized food search
-    food_translation_service = FoodSearchTranslationService(MealGenerationService())
+    meal_generation_service = MealGenerationService()
+    food_translation_service = FoodSearchTranslationService(meal_generation_service)
+
+    # Barcode cascade: Nutritionix + Brave Search (optional — None if keys not set)
+    nutritionix_service = get_nutritionix_service()
+    macro_validation_service = MacroValidationService()
+    brave_search_service = get_brave_search_nutrition_service(
+        meal_generation_service=meal_generation_service,
+        macro_validation_service=macro_validation_service,
+    )
 
     event_bus.register_handler(
         SearchFoodsQuery,
@@ -225,6 +237,10 @@ def get_food_search_event_bus() -> EventBus:
             fat_secret_service=fat_secret_service,
             food_reference_repository=food_reference_repository,
             translation_service=food_translation_service,
+            nutritionix_service=nutritionix_service,
+            brave_search_service=brave_search_service,
+            meal_generation_service=meal_generation_service,
+            macro_validation_service=macro_validation_service,
         ),
     )
 

--- a/src/api/schemas/response/barcode_product_response.py
+++ b/src/api/schemas/response/barcode_product_response.py
@@ -19,7 +19,8 @@ class BarcodeProductResponse(BaseModel):
     sugar_100g: float = Field(0, description="Sugar per 100g")
     serving_size: Optional[str] = Field(None, description="Serving size description")
     image_url: Optional[str] = Field(None, description="Product image URL")
-    source: Optional[str] = Field(None, description="Data source: cache, fatsecret, openfoodfacts")
+    source: Optional[str] = Field(None, description="Data source: cache, fatsecret, openfoodfacts, nutritionix, brave_search, ai_estimate")
     food_reference_id: Optional[int] = Field(None, description="Food reference table ID")
+    is_estimate: bool = Field(False, description="True when macros are AI-estimated, user should verify")
 
     model_config = {"from_attributes": True}

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -176,7 +176,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             )
             result = self.meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",
-                max_tokens=500, model_purpose="recipe_primary",
+                max_tokens=500, model_purpose="barcode",
             )
             if not result or not isinstance(result, dict):
                 return None
@@ -193,6 +193,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             result["barcode"] = barcode
             result["source"] = "ai_estimate"
             result["is_estimate"] = True
+            # Ensure name is never null (required by response schema)
+            if not result.get("name"):
+                result["name"] = partial_name or f"Unknown product ({country})"
             return result
         except Exception as e:
             logger.warning(f"AI estimation failed for barcode {barcode}: {e}")

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -71,57 +71,80 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
 
     async def handle(self, query: LookupBarcodeQuery) -> Optional[Dict[str, Any]]:
         """Look up product by barcode with 6-step cascade."""
+        # Track product name from partial matches (has name but no nutrition)
+        partial_name: Optional[str] = None
 
         # Step 1: Check local cache (DB)
         cached = self.repo.get_by_barcode(query.barcode)
-        if cached:
+        if cached and self._has_nutrition(cached):
             cached["source"] = "cache"
             return await self._maybe_translate(cached, query.language)
+        if cached:
+            partial_name = cached.get("name")
 
         # Step 2: Try FatSecret
         region = LANGUAGE_TO_REGION.get(query.language, "US")
         fat_secret_result = await self.fat_secret.get_product(
             query.barcode, region=region, language=query.language,
         )
-        if fat_secret_result:
+        if fat_secret_result and self._has_nutrition(fat_secret_result):
             fat_secret_result["source"] = "fatsecret"
             self._cache_result(fat_secret_result)
             return await self._maybe_translate(fat_secret_result, query.language)
+        if fat_secret_result:
+            partial_name = partial_name or fat_secret_result.get("name")
 
         # Step 3: Try OpenFoodFacts
         off_result = await self.off.get_product(query.barcode)
-        if off_result:
+        if off_result and self._has_nutrition(off_result):
             off_result["source"] = "openfoodfacts"
             self._cache_result(off_result)
             return await self._maybe_translate(off_result, query.language)
+        if off_result:
+            partial_name = partial_name or off_result.get("name")
 
         # Step 4: Try Nutritionix
         if self.nutritionix:
             nx_result = await self.nutritionix.get_product(query.barcode)
-            if nx_result:
+            if nx_result and self._has_nutrition(nx_result):
                 nx_result["source"] = "nutritionix"
                 self._cache_result(nx_result)
                 return await self._maybe_translate(nx_result, query.language)
+            if nx_result:
+                partial_name = partial_name or nx_result.get("name")
 
         # Step 5: Try Brave Search + Gemini extraction
         if self.brave_search:
             brave_result = await self.brave_search.get_product(
                 query.barcode, query.language,
             )
-            if brave_result:
+            if brave_result and self._has_nutrition(brave_result):
                 brave_result["source"] = "brave_search"
                 self._cache_result(brave_result)
                 return await self._maybe_translate(brave_result, query.language)
 
         # Step 6: AI estimation (last resort — don't cache unreliable data)
-        estimate = await self._ai_estimate(query.barcode, query.language)
+        # Pass partial_name so AI can make a better guess
+        estimate = await self._ai_estimate(query.barcode, query.language, partial_name)
         if estimate:
             return estimate
 
         return None
 
+    @staticmethod
+    def _has_nutrition(result: Dict[str, Any]) -> bool:
+        """Check if result has meaningful macro data (not all zeros/None)."""
+        protein = result.get("protein_100g")
+        carbs = result.get("carbs_100g")
+        fat = result.get("fat_100g")
+        # At least one macro must be a positive number
+        for val in (protein, carbs, fat):
+            if val is not None and val > 0:
+                return True
+        return False
+
     async def _ai_estimate(
-        self, barcode: str, language: str,
+        self, barcode: str, language: str, partial_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Estimate nutrition via Gemini when all other sources fail."""
         if not self.meal_gen:
@@ -129,17 +152,19 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
         try:
             country = _get_country_from_barcode(barcode)
             system_prompt = (
-                "You are a nutrition expert. A barcode was scanned but not found "
-                "in any food database. Based on the barcode prefix (country of origin) "
-                "and your knowledge, provide your best estimate of what this product "
-                "might be and its approximate nutrition per 100g. "
+                "You are a nutrition expert. A barcode was scanned but nutrition data "
+                "was not found in any food database. Based on the product name (if known), "
+                "barcode prefix (country of origin), and your knowledge, provide your best "
+                "estimate of approximate nutrition per 100g. "
                 "Be conservative with estimates. "
                 "Return ONLY valid JSON: "
-                '{"name": "estimated product name", "brand": null, '
+                '{"name": "product name", "brand": null, '
                 '"protein_100g": float, "carbs_100g": float, "fat_100g": float, '
                 '"fiber_100g": float, "sugar_100g": float}'
             )
+            name_hint = f"Product name: {partial_name}\n" if partial_name else ""
             user_prompt = (
+                f"{name_hint}"
                 f"Barcode: {barcode}\n"
                 f"Country of origin: {country}\n"
                 f"Language: {language}"

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -172,7 +172,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                 f"Country of origin: {country}\n"
                 f"Language: {language}"
             )
-            result = await self.meal_gen.generate_meal_plan(
+            result = self.meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",
             )
             if not result or not isinstance(result, dict):

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -131,7 +131,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
         # Step 5: Try Brave Search + Gemini extraction
         if self.brave_search:
             brave_result = await self.brave_search.get_product(
-                query.barcode, query.language,
+                query.barcode, query.language, product_name=partial_name,
             )
             if brave_result and self._has_nutrition(brave_result):
                 logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 HIT (brave): {brave_result.get('name')}")

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -23,6 +23,8 @@ GS1_COUNTRY_PREFIXES = {
     "400": "Germany", "300": "France",
     "500": "United Kingdom", "800": "Italy",
     "450": "Japan", "840": "Spain",
+    "528": "Lebanon", "529": "Cyprus",
+    "460": "Russia", "470": "Kyrgyzstan",
 }
 
 
@@ -152,15 +154,15 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
         try:
             country = _get_country_from_barcode(barcode)
             system_prompt = (
-                "You are a nutrition expert. A barcode was scanned but nutrition data "
-                "was not found in any food database. Based on the product name (if known), "
-                "barcode prefix (country of origin), and your knowledge, provide your best "
-                "estimate of approximate nutrition per 100g. "
+                "You are a nutrition expert. This barcode was scanned in a food tracking app. "
+                "Assume it IS a food product unless the product name clearly indicates otherwise "
+                "(e.g. 'Dettol Soap', 'iPhone Charger', 'Paracetamol'). "
+                "Based on the product name (if known), barcode prefix (country of origin), "
+                "and your knowledge, estimate approximate nutrition per 100g. "
                 "Be conservative with estimates. "
-                "IMPORTANT: If the product is clearly NOT a food item (e.g. electronics, "
-                "cleaning products, cosmetics, medicine, household items), return "
-                '{"is_food": false} instead. '
-                "Return ONLY valid JSON: "
+                "If the product name clearly indicates a non-food item, return "
+                '{"is_food": false}. '
+                "Otherwise return ONLY valid JSON: "
                 '{"is_food": true, "name": "product name", "brand": null, '
                 '"protein_100g": float, "carbs_100g": float, "fat_100g": float, '
                 '"fiber_100g": float, "sugar_100g": float}'

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -158,8 +158,10 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                             logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5b HIT (fatsecret name): {fs_item.get('name')}")
                             fs_item["source"] = "fatsecret"
                             fs_item["barcode"] = query.barcode
+                            # Use brave_name as the display name (original brand name)
+                            fs_item["name"] = brave_name
                             self._cache_result(fs_item)
-                            return await self._maybe_translate(fs_item, query.language)
+                            return fs_item  # Don't translate — brand names should stay as-is
             except Exception as e:
                 logger.warning(f"FatSecret name search failed for '{brave_name}': {e}")
 
@@ -169,7 +171,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             brave_result["source"] = "brave_search"
             brave_result["barcode"] = query.barcode
             self._cache_result(brave_result)
-            return await self._maybe_translate(brave_result, query.language)
+            return brave_result  # Don't translate — brand names should stay as-is
         elif brave_result:
             logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 MISS (brave, no nutrition)")
         else:

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -129,19 +129,48 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 4 SKIP (nutritionix not configured)")
 
         # Step 5: Try Brave Search + Gemini extraction
+        brave_name: Optional[str] = None
         if self.brave_search:
             brave_result = await self.brave_search.get_product(
                 query.barcode, query.language, product_name=partial_name,
             )
-            if brave_result and self._has_nutrition(brave_result):
-                logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 HIT (brave): {brave_result.get('name')}")
-                brave_result["source"] = "brave_search"
-                self._cache_result(brave_result)
-                return await self._maybe_translate(brave_result, query.language)
-            else:
-                logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 MISS (brave search)")
+            if brave_result:
+                brave_name = brave_result.get("name")
+                partial_name = partial_name or brave_name
         else:
             logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 SKIP (brave not configured)")
+
+        # Step 5b: If Brave found a product name, search FatSecret by name for verified nutrition
+        if brave_name:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5b FatSecret name search: {brave_name}")
+            region = LANGUAGE_TO_REGION.get(query.language, "US")
+            try:
+                fs_results = await self.fat_secret.search_foods(
+                    brave_name, max_results=3, region=region, language=query.language,
+                )
+                if fs_results:
+                    # Use first result with nutrition
+                    for fs_item in fs_results:
+                        if self._has_nutrition(fs_item):
+                            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5b HIT (fatsecret name): {fs_item.get('name')}")
+                            fs_item["source"] = "fatsecret"
+                            fs_item["barcode"] = query.barcode
+                            self._cache_result(fs_item)
+                            return await self._maybe_translate(fs_item, query.language)
+            except Exception as e:
+                logger.warning(f"FatSecret name search failed for '{brave_name}': {e}")
+
+        # Step 5c: Return Brave estimate if available (editable)
+        if brave_result and self._has_nutrition(brave_result):
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5c using Brave estimate: {brave_name}")
+            brave_result["source"] = "brave_search"
+            brave_result["barcode"] = query.barcode
+            self._cache_result(brave_result)
+            return await self._maybe_translate(brave_result, query.language)
+        elif brave_result:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 MISS (brave, no nutrition)")
+        else:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 MISS (brave search)")
 
         # Step 6: AI estimation (last resort — don't cache unreliable data)
         logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 6 AI estimation (partial_name={partial_name})")

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -1,5 +1,6 @@
 """
-LookupBarcodeQueryHandler - Handle barcode lookup with cascade: DB -> FatSecret -> OpenFoodFacts.
+LookupBarcodeQueryHandler - Handle barcode lookup with cascade:
+DB -> FatSecret -> OpenFoodFacts -> Nutritionix -> Brave+AI -> AI estimate.
 """
 import logging
 from typing import Optional, Dict, Any
@@ -12,10 +13,41 @@ from src.infra.repositories.food_reference_repository import FoodReferenceReposi
 
 logger = logging.getLogger(__name__)
 
+# GS1 barcode prefixes → country of origin (common entries)
+GS1_COUNTRY_PREFIXES = {
+    "890": "Vietnam", "893": "Vietnam",
+    "880": "South Korea", "885": "Thailand",
+    "888": "Singapore", "884": "Cambodia",
+    "899": "Indonesia", "489": "Hong Kong",
+    "471": "Taiwan", "480": "Philippines",
+    "400": "Germany", "300": "France",
+    "500": "United Kingdom", "800": "Italy",
+    "450": "Japan", "840": "Spain",
+}
+
+
+def _get_country_from_barcode(barcode: str) -> str:
+    """Determine country of origin from GS1 barcode prefix."""
+    prefix3 = barcode[:3]
+    if prefix3 in GS1_COUNTRY_PREFIXES:
+        return GS1_COUNTRY_PREFIXES[prefix3]
+    # Range-based prefixes
+    if "690" <= prefix3 <= "699":
+        return "China"
+    if "000" <= prefix3 <= "019":
+        return "United States"
+    if "030" <= prefix3 <= "039":
+        return "United States"
+    if "300" <= prefix3 <= "379":
+        return "France"
+    if "400" <= prefix3 <= "440":
+        return "Germany"
+    return "Unknown"
+
 
 @handles(LookupBarcodeQuery)
 class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[str, Any]]]):
-    """Handler for looking up product by barcode with cascade logic."""
+    """Handler for looking up product by barcode with 6-step cascade."""
 
     def __init__(
         self,
@@ -23,14 +55,22 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
         fat_secret_service: FatSecretService,
         food_reference_repository: FoodReferenceRepository,
         translation_service: Optional[Any] = None,
+        nutritionix_service: Optional[Any] = None,
+        brave_search_service: Optional[Any] = None,
+        meal_generation_service: Optional[Any] = None,
+        macro_validation_service: Optional[Any] = None,
     ):
         self.off = open_food_facts_service
         self.fat_secret = fat_secret_service
         self.repo = food_reference_repository
         self.translation_service = translation_service
+        self.nutritionix = nutritionix_service
+        self.brave_search = brave_search_service
+        self.meal_gen = meal_generation_service
+        self.macro_validator = macro_validation_service
 
     async def handle(self, query: LookupBarcodeQuery) -> Optional[Dict[str, Any]]:
-        """Look up product by barcode with cascade: DB -> FatSecret -> OpenFoodFacts."""
+        """Look up product by barcode with 6-step cascade."""
 
         # Step 1: Check local cache (DB)
         cached = self.repo.get_by_barcode(query.barcode)
@@ -38,7 +78,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             cached["source"] = "cache"
             return await self._maybe_translate(cached, query.language)
 
-        # Step 2: Try FatSecret (with region/language for localized results)
+        # Step 2: Try FatSecret
         region = LANGUAGE_TO_REGION.get(query.language, "US")
         fat_secret_result = await self.fat_secret.get_product(
             query.barcode, region=region, language=query.language,
@@ -55,8 +95,72 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             self._cache_result(off_result)
             return await self._maybe_translate(off_result, query.language)
 
-        # Step 4: Not found
+        # Step 4: Try Nutritionix
+        if self.nutritionix:
+            nx_result = await self.nutritionix.get_product(query.barcode)
+            if nx_result:
+                nx_result["source"] = "nutritionix"
+                self._cache_result(nx_result)
+                return await self._maybe_translate(nx_result, query.language)
+
+        # Step 5: Try Brave Search + Gemini extraction
+        if self.brave_search:
+            brave_result = await self.brave_search.get_product(
+                query.barcode, query.language,
+            )
+            if brave_result:
+                brave_result["source"] = "brave_search"
+                self._cache_result(brave_result)
+                return await self._maybe_translate(brave_result, query.language)
+
+        # Step 6: AI estimation (last resort — don't cache unreliable data)
+        estimate = await self._ai_estimate(query.barcode, query.language)
+        if estimate:
+            return estimate
+
         return None
+
+    async def _ai_estimate(
+        self, barcode: str, language: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Estimate nutrition via Gemini when all other sources fail."""
+        if not self.meal_gen:
+            return None
+        try:
+            country = _get_country_from_barcode(barcode)
+            system_prompt = (
+                "You are a nutrition expert. A barcode was scanned but not found "
+                "in any food database. Based on the barcode prefix (country of origin) "
+                "and your knowledge, provide your best estimate of what this product "
+                "might be and its approximate nutrition per 100g. "
+                "Be conservative with estimates. "
+                "Return ONLY valid JSON: "
+                '{"name": "estimated product name", "brand": null, '
+                '"protein_100g": float, "carbs_100g": float, "fat_100g": float, '
+                '"fiber_100g": float, "sugar_100g": float}'
+            )
+            user_prompt = (
+                f"Barcode: {barcode}\n"
+                f"Country of origin: {country}\n"
+                f"Language: {language}"
+            )
+            result = await self.meal_gen.generate_meal_plan(
+                user_prompt, system_prompt, response_type="json",
+            )
+            if not result or not isinstance(result, dict):
+                return None
+
+            # Validate with macro validator if available
+            if self.macro_validator:
+                result = self.macro_validator.validate_and_correct(result)
+
+            result["barcode"] = barcode
+            result["source"] = "ai_estimate"
+            result["is_estimate"] = True
+            return result
+        except Exception as e:
+            logger.warning(f"AI estimation failed for barcode {barcode}: {e}")
+            return None
 
     async def _maybe_translate(
         self, result: Dict[str, Any], language: str

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -157,8 +157,11 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                 "barcode prefix (country of origin), and your knowledge, provide your best "
                 "estimate of approximate nutrition per 100g. "
                 "Be conservative with estimates. "
+                "IMPORTANT: If the product is clearly NOT a food item (e.g. electronics, "
+                "cleaning products, cosmetics, medicine, household items), return "
+                '{"is_food": false} instead. '
                 "Return ONLY valid JSON: "
-                '{"name": "product name", "brand": null, '
+                '{"is_food": true, "name": "product name", "brand": null, '
                 '"protein_100g": float, "carbs_100g": float, "fat_100g": float, '
                 '"fiber_100g": float, "sugar_100g": float}'
             )
@@ -173,6 +176,11 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                 user_prompt, system_prompt, response_type="json",
             )
             if not result or not isinstance(result, dict):
+                return None
+
+            # Non-food item detected by AI
+            if not result.get("is_food", True):
+                logger.info(f"Non-food item detected for barcode {barcode}")
                 return None
 
             # Validate with macro validator if available

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -149,9 +149,12 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                     brave_name, max_results=3, region=region, language=query.language,
                 )
                 if fs_results:
-                    # Use first result with nutrition
+                    # Use first result with nutrition and a valid name
                     for fs_item in fs_results:
                         if self._has_nutrition(fs_item):
+                            # Ensure name is set (FatSecret search can return null names)
+                            if not fs_item.get("name"):
+                                fs_item["name"] = brave_name
                             logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5b HIT (fatsecret name): {fs_item.get('name')}")
                             fs_item["source"] = "fatsecret"
                             fs_item["barcode"] = query.barcode
@@ -269,6 +272,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
 
     def _cache_result(self, result: Dict[str, Any]) -> None:
         """Cache API result to food_reference table (fail silently on error)."""
+        if not result.get("name"):
+            logger.warning(f"Skipping cache for barcode {result.get('barcode')}: name is required")
+            return
         try:
             self.repo.upsert(result)
         except Exception as e:

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -79,10 +79,12 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
         # Step 1: Check local cache (DB)
         cached = self.repo.get_by_barcode(query.barcode)
         if cached and self._has_nutrition(cached):
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 1 HIT (cache)")
             cached["source"] = "cache"
             return await self._maybe_translate(cached, query.language)
         if cached:
             partial_name = cached.get("name")
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 1 partial (name={partial_name}, no nutrition)")
 
         # Step 2: Try FatSecret
         region = LANGUAGE_TO_REGION.get(query.language, "US")
@@ -90,30 +92,41 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             query.barcode, region=region, language=query.language,
         )
         if fat_secret_result and self._has_nutrition(fat_secret_result):
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 2 HIT (fatsecret): {fat_secret_result.get('name')}")
             fat_secret_result["source"] = "fatsecret"
             self._cache_result(fat_secret_result)
             return await self._maybe_translate(fat_secret_result, query.language)
         if fat_secret_result:
             partial_name = partial_name or fat_secret_result.get("name")
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 2 partial (name={partial_name}, no nutrition)")
+        else:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 2 MISS (fatsecret)")
 
         # Step 3: Try OpenFoodFacts
         off_result = await self.off.get_product(query.barcode)
         if off_result and self._has_nutrition(off_result):
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 3 HIT (openfoodfacts): {off_result.get('name')}")
             off_result["source"] = "openfoodfacts"
             self._cache_result(off_result)
             return await self._maybe_translate(off_result, query.language)
         if off_result:
             partial_name = partial_name or off_result.get("name")
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 3 partial (name={partial_name}, no nutrition)")
+        else:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 3 MISS (openfoodfacts)")
 
         # Step 4: Try Nutritionix
         if self.nutritionix:
             nx_result = await self.nutritionix.get_product(query.barcode)
             if nx_result and self._has_nutrition(nx_result):
+                logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 4 HIT (nutritionix): {nx_result.get('name')}")
                 nx_result["source"] = "nutritionix"
                 self._cache_result(nx_result)
                 return await self._maybe_translate(nx_result, query.language)
             if nx_result:
                 partial_name = partial_name or nx_result.get("name")
+        else:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 4 SKIP (nutritionix not configured)")
 
         # Step 5: Try Brave Search + Gemini extraction
         if self.brave_search:
@@ -121,12 +134,17 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                 query.barcode, query.language,
             )
             if brave_result and self._has_nutrition(brave_result):
+                logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 HIT (brave): {brave_result.get('name')}")
                 brave_result["source"] = "brave_search"
                 self._cache_result(brave_result)
                 return await self._maybe_translate(brave_result, query.language)
+            else:
+                logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 MISS (brave search)")
+        else:
+            logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 5 SKIP (brave not configured)")
 
         # Step 6: AI estimation (last resort — don't cache unreliable data)
-        # Pass partial_name so AI can make a better guess
+        logger.info(f"[BARCODE-CASCADE] {query.barcode} → step 6 AI estimation (partial_name={partial_name})")
         estimate = await self._ai_estimate(query.barcode, query.language, partial_name)
         if estimate:
             return estimate
@@ -173,6 +191,10 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
                 f"Barcode: {barcode}\n"
                 f"Country of origin: {country}\n"
                 f"Language: {language}"
+            )
+            logger.info(
+                f"AI estimation for {barcode}: country={country}, "
+                f"partial_name={partial_name}, prompt_len={len(user_prompt)}"
             )
             result = self.meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -176,6 +176,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             )
             result = self.meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",
+                max_tokens=500,
             )
             if not result or not isinstance(result, dict):
                 return None

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -176,7 +176,7 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, Optional[Dict[s
             )
             result = self.meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",
-                max_tokens=500,
+                max_tokens=500, model_purpose="recipe_primary",
             )
             if not result or not isinstance(result, dict):
                 return None

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -98,7 +98,7 @@ class BraveSearchNutritionService:
 
             result = self._meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",
-                max_tokens=500, model_purpose="recipe_primary",
+                max_tokens=500, model_purpose="barcode",
             )
 
             if not result or not isinstance(result, dict):

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -94,7 +94,7 @@ class BraveSearchNutritionService:
                 f"Barcode: {barcode}\nLanguage: {language}\n\nWeb search snippets:\n{snippets}"
             )
 
-            result = await self._meal_gen.generate_meal_plan(
+            result = self._meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json"
             )
 

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -97,7 +97,8 @@ class BraveSearchNutritionService:
             )
 
             result = self._meal_gen.generate_meal_plan(
-                user_prompt, system_prompt, response_type="json"
+                user_prompt, system_prompt, response_type="json",
+                max_tokens=500,
             )
 
             if not result or not isinstance(result, dict):

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -98,7 +98,7 @@ class BraveSearchNutritionService:
 
             result = self._meal_gen.generate_meal_plan(
                 user_prompt, system_prompt, response_type="json",
-                max_tokens=500,
+                max_tokens=500, model_purpose="recipe_primary",
             )
 
             if not result or not isinstance(result, dict):

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -25,10 +25,12 @@ class BraveSearchNutritionService:
             self._client = httpx.AsyncClient(timeout=5.0)
         return self._client
 
-    async def get_product(self, barcode: str, language: str = "en") -> Optional[Dict[str, Any]]:
+    async def get_product(
+        self, barcode: str, language: str = "en", product_name: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Search barcode nutrition via web search + AI extraction."""
         try:
-            snippets = await self._search_barcode(barcode)
+            snippets = await self._search_barcode(barcode, product_name)
             if not snippets:
                 return None
 
@@ -43,13 +45,15 @@ class BraveSearchNutritionService:
             logger.warning(f"Brave search failed for barcode {barcode}: {e}")
             return None
 
-    async def _search_barcode(self, barcode: str) -> Optional[str]:
+    async def _search_barcode(self, barcode: str, product_name: Optional[str] = None) -> Optional[str]:
         """Search Brave for barcode nutrition info, return combined snippets."""
         try:
+            # Search with barcode + product name if available, otherwise just barcode
+            query = f"{barcode} {product_name} nutrition" if product_name else f"{barcode} barcode product"
             client = self._get_client()
             response = await client.get(
                 self.SEARCH_URL,
-                params={"q": f"{barcode} nutrition facts", "count": 5},
+                params={"q": query, "count": 5},
                 headers={
                     "X-Subscription-Token": self._api_key,
                     "Accept": "application/json",

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -1,0 +1,137 @@
+"""
+BraveSearchNutritionService - Search barcode nutrition via Brave Search + Gemini extraction.
+"""
+import logging
+from typing import Optional, Dict, Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class BraveSearchNutritionService:
+    """Search for barcode nutrition info via Brave Search, extract macros via Gemini."""
+
+    SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
+
+    def __init__(self, api_key: str, meal_generation_service: Any, macro_validation_service: Any):
+        self._api_key = api_key
+        self._meal_gen = meal_generation_service
+        self._macro_validator = macro_validation_service
+        self._client: Optional[httpx.AsyncClient] = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if not self._client:
+            self._client = httpx.AsyncClient(timeout=5.0)
+        return self._client
+
+    async def get_product(self, barcode: str, language: str = "en") -> Optional[Dict[str, Any]]:
+        """Search barcode nutrition via web search + AI extraction."""
+        try:
+            snippets = await self._search_barcode(barcode)
+            if not snippets:
+                return None
+
+            extracted = await self._extract_nutrition(barcode, snippets, language)
+            if not extracted:
+                return None
+
+            validated = self._macro_validator.validate_and_correct(extracted)
+            validated["barcode"] = barcode
+            return validated
+        except Exception as e:
+            logger.warning(f"Brave search failed for barcode {barcode}: {e}")
+            return None
+
+    async def _search_barcode(self, barcode: str) -> Optional[str]:
+        """Search Brave for barcode nutrition info, return combined snippets."""
+        try:
+            client = self._get_client()
+            response = await client.get(
+                self.SEARCH_URL,
+                params={"q": f"{barcode} nutrition facts", "count": 5},
+                headers={
+                    "X-Subscription-Token": self._api_key,
+                    "Accept": "application/json",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            results = data.get("web", {}).get("results", [])
+            if not results:
+                return None
+
+            snippets = []
+            for r in results[:5]:
+                title = r.get("title", "")
+                description = r.get("description", "")
+                snippets.append(f"{title}: {description}")
+
+            return "\n\n".join(snippets)
+        except Exception as e:
+            logger.warning(f"Brave search API error for {barcode}: {e}")
+            return None
+
+    async def _extract_nutrition(
+        self, barcode: str, snippets: str, language: str
+    ) -> Optional[Dict[str, Any]]:
+        """Use Gemini to extract structured nutrition from search snippets."""
+        try:
+            system_prompt = (
+                "You are a nutrition data extraction expert. "
+                "Extract nutrition information per 100g from web search snippets about a food product. "
+                "Return ONLY valid JSON with these fields: "
+                '{"name": "product name", "brand": "brand or null", '
+                '"protein_100g": float, "carbs_100g": float, "fat_100g": float, '
+                '"fiber_100g": float, "sugar_100g": float, "serving_size": "description or null", '
+                '"confidence": "high|medium|low"} '
+                "If snippets don't contain enough nutrition data, return null. "
+                "Be precise — only extract values explicitly stated in the snippets."
+            )
+
+            user_prompt = (
+                f"Barcode: {barcode}\nLanguage: {language}\n\nWeb search snippets:\n{snippets}"
+            )
+
+            result = await self._meal_gen.generate_meal_plan(
+                user_prompt, system_prompt, response_type="json"
+            )
+
+            if not result or not isinstance(result, dict):
+                return None
+
+            confidence = result.get("confidence", "low")
+            if confidence == "low":
+                logger.info(f"Brave+AI extraction low confidence for {barcode}, skipping")
+                return None
+
+            required = ["protein_100g", "carbs_100g", "fat_100g"]
+            if not all(result.get(f) is not None for f in required):
+                return None
+
+            return result
+        except Exception as e:
+            logger.warning(f"Gemini extraction failed for barcode {barcode}: {e}")
+            return None
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+
+def get_brave_search_nutrition_service(
+    meal_generation_service: Any = None,
+    macro_validation_service: Any = None,
+) -> Optional[BraveSearchNutritionService]:
+    """Return a BraveSearchNutritionService if API key is configured, else None."""
+    from src.infra.config.settings import settings
+
+    if not settings.BRAVE_SEARCH_API_KEY:
+        return None
+    if not meal_generation_service or not macro_validation_service:
+        return None
+    return BraveSearchNutritionService(
+        settings.BRAVE_SEARCH_API_KEY, meal_generation_service, macro_validation_service
+    )

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -66,9 +66,13 @@ class BraveSearchNutritionService:
             for r in results[:5]:
                 title = r.get("title", "")
                 description = r.get("description", "")
+                url = r.get("url", "")
                 snippets.append(f"{title}: {description}")
+                logger.info(f"Brave result for {barcode}: {title} | {url}")
 
-            return "\n\n".join(snippets)
+            combined = "\n\n".join(snippets)
+            logger.info(f"Brave snippets for {barcode} ({len(results)} results, {len(combined)} chars)")
+            return combined
         except Exception as e:
             logger.warning(f"Brave search API error for {barcode}: {e}")
             return None

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -81,13 +81,15 @@ class BraveSearchNutritionService:
             system_prompt = (
                 "You are a nutrition data extraction expert. "
                 "Extract nutrition information per 100g from web search snippets about a food product. "
+                "If snippets mention nutrition values per serving, convert to per 100g. "
+                "If snippets identify the product but lack exact macros, estimate based on "
+                "your knowledge of similar products and set confidence to medium. "
                 "Return ONLY valid JSON with these fields: "
                 '{"name": "product name", "brand": "brand or null", '
                 '"protein_100g": float, "carbs_100g": float, "fat_100g": float, '
                 '"fiber_100g": float, "sugar_100g": float, "serving_size": "description or null", '
                 '"confidence": "high|medium|low"} '
-                "If snippets don't contain enough nutrition data, return null. "
-                "Be precise — only extract values explicitly stated in the snippets."
+                "Return null ONLY if you cannot identify the product at all from the snippets."
             )
 
             user_prompt = (

--- a/src/infra/adapters/brave_search_nutrition_service.py
+++ b/src/infra/adapters/brave_search_nutrition_service.py
@@ -112,10 +112,12 @@ class BraveSearchNutritionService:
             if not result or not isinstance(result, dict):
                 return None
 
+            # Accept all confidence levels — the data is from web search,
+            # user will verify in editable UI. Only reject if macros are missing.
             confidence = result.get("confidence", "low")
             if confidence == "low":
-                logger.info(f"Brave+AI extraction low confidence for {barcode}, skipping")
-                return None
+                result["is_estimate"] = True  # Mark low-confidence as estimate
+                logger.info(f"Brave+AI extraction low confidence for {barcode}, marking as estimate")
 
             required = ["protein_100g", "carbs_100g", "fat_100g"]
             if not all(result.get(f) is not None for f in required):

--- a/src/infra/adapters/nutritionix_service.py
+++ b/src/infra/adapters/nutritionix_service.py
@@ -1,0 +1,128 @@
+"""
+Nutritionix API HTTP client.
+Provides product lookup by barcode (UPC) for packaged foods.
+"""
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class NutritionixService:
+    """HTTP client for Nutritionix Track API."""
+
+    BASE_URL = "https://trackapi.nutritionix.com/v2"
+    BARCODE_PATTERN = re.compile(r'^\d{8,14}$')
+
+    def __init__(self, app_id: str, api_key: str):
+        self._app_id = app_id
+        self._api_key = api_key
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create lazy async HTTP client with auth headers."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                timeout=5.0,
+                headers={
+                    "x-app-id": self._app_id,
+                    "x-app-key": self._api_key,
+                },
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def get_product(self, barcode: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch product by UPC barcode from Nutritionix.
+
+        Args:
+            barcode: Product barcode (EAN-8 to EAN-14 / UPC)
+
+        Returns:
+            Product dict with name, brand, nutrition per 100g, serving size, image URL.
+            Returns None if product not found or API error.
+        """
+        if not self.BARCODE_PATTERN.match(barcode):
+            return None
+
+        try:
+            client = await self._get_client()
+            response = await client.get(
+                f"{self.BASE_URL}/search/item",
+                params={"upc": barcode},
+            )
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+
+            data = response.json()
+            foods = data.get("foods")
+            if not foods:
+                return None
+
+            return self._map_product(foods[0], barcode)
+        except httpx.HTTPError as exc:
+            logger.warning("Nutritionix HTTP error for barcode %s: %s", barcode, exc)
+            return None
+        except Exception as exc:
+            logger.warning("Nutritionix unexpected error for barcode %s: %s", barcode, exc)
+            return None
+
+    def _map_product(self, item: dict, barcode: str) -> Dict[str, Any]:
+        """Map Nutritionix foods item to clean per-100g dict."""
+        serving_weight = item.get("nf_serving_weight_grams") or 0.0
+        use_per_100 = serving_weight <= 0
+
+        def per_100(value: Optional[float]) -> Optional[float]:
+            if value is None:
+                return None
+            if use_per_100:
+                return value
+            return round(value * 100.0 / serving_weight, 2)
+
+        serving_qty = item.get("serving_qty")
+        serving_unit = item.get("serving_unit")
+        serving_size: Optional[str] = None
+        if serving_qty is not None and serving_unit:
+            serving_size = f"{serving_qty} {serving_unit}"
+
+        return {
+            "name": item.get("food_name"),
+            "brand": item.get("brand_name"),
+            "barcode": item.get("nix_item_id") or barcode,
+            "protein_100g": per_100(item.get("nf_protein")),
+            "carbs_100g": per_100(item.get("nf_total_carbohydrate")),
+            "fat_100g": per_100(item.get("nf_total_fat")),
+            "fiber_100g": per_100(item.get("nf_dietary_fiber")),
+            "sugar_100g": per_100(item.get("nf_sugars")),
+            "serving_size": serving_size,
+            "image_url": (item.get("photo") or {}).get("thumb"),
+        }
+
+
+_nutritionix_service: Optional[NutritionixService] = None
+
+
+def get_nutritionix_service() -> Optional[NutritionixService]:
+    """Get singleton NutritionixService, or None if credentials not configured."""
+    global _nutritionix_service
+    if _nutritionix_service is not None:
+        return _nutritionix_service
+
+    from src.infra.config.settings import settings
+    app_id = settings.NUTRITIONIX_APP_ID
+    api_key = settings.NUTRITIONIX_API_KEY
+    if not app_id or not api_key:
+        return None
+
+    _nutritionix_service = NutritionixService(app_id=app_id, api_key=api_key)
+    return _nutritionix_service

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -72,6 +72,9 @@ class Settings(BaseSettings):
     PINECONE_API_KEY: str | None = Field(default=None)
     FATSECRET_CLIENT_ID: str | None = Field(default=None, description="FatSecret OAuth 2.0 client ID")
     FATSECRET_CLIENT_SECRET: str | None = Field(default=None, description="FatSecret OAuth 2.0 client secret")
+    NUTRITIONIX_APP_ID: str | None = Field(default=None, description="Nutritionix API app ID")
+    NUTRITIONIX_API_KEY: str | None = Field(default=None, description="Nutritionix API key")
+    BRAVE_SEARCH_API_KEY: str | None = Field(default=None, description="Brave Search API key (free tier: 2K/mo)")
 
     # LLM Provider configuration
     LLM_PROVIDER: str | None = Field(

--- a/src/infra/services/ai/gemini_model_config.py
+++ b/src/infra/services/ai/gemini_model_config.py
@@ -18,6 +18,7 @@ class GeminiModelPurpose(str, Enum):
     MEAL_NAMES = "meal_names"  # High RPM (10/min) for fast name generation
     RECIPE_PRIMARY = "recipe_primary"  # Recipe gen pool 1 (5 RPM)
     RECIPE_SECONDARY = "recipe_secondary"  # Recipe gen pool 2 (5 RPM)
+    BARCODE = "barcode"  # Barcode nutrition extraction (no thinking needed)
 
 
 # Default cache settings
@@ -31,6 +32,7 @@ PURPOSE_MODEL_DEFAULTS = {
     GeminiModelPurpose.MEAL_NAMES: "gemini-2.5-flash-lite",
     GeminiModelPurpose.RECIPE_PRIMARY: "gemini-2.5-flash",
     GeminiModelPurpose.RECIPE_SECONDARY: "gemini-2.5-flash",
+    GeminiModelPurpose.BARCODE: "gemini-2.5-flash",
 }
 
 # Env var names per purpose
@@ -39,6 +41,7 @@ PURPOSE_ENV_VARS = {
     GeminiModelPurpose.MEAL_NAMES: "GEMINI_MODEL_NAMES",
     GeminiModelPurpose.RECIPE_PRIMARY: "GEMINI_MODEL_RECIPE_PRIMARY",
     GeminiModelPurpose.RECIPE_SECONDARY: "GEMINI_MODEL_RECIPE_SECONDARY",
+    GeminiModelPurpose.BARCODE: "GEMINI_MODEL",
 }
 
 

--- a/src/infra/services/ai/gemini_model_manager.py
+++ b/src/infra/services/ai/gemini_model_manager.py
@@ -138,7 +138,7 @@ class GeminiModelManager:
         env_var = PURPOSE_ENV_VARS.get(purpose, "GEMINI_MODEL")
         model_name = os.getenv(env_var, PURPOSE_MODEL_DEFAULTS.get(purpose, self.model_name))
 
-        if purpose in (GeminiModelPurpose.RECIPE_PRIMARY, GeminiModelPurpose.RECIPE_SECONDARY):
+        if purpose in (GeminiModelPurpose.RECIPE_PRIMARY, GeminiModelPurpose.RECIPE_SECONDARY, GeminiModelPurpose.BARCODE):
             kwargs.setdefault("thinking_budget", 0)
 
         config_key = self._get_config_key(


### PR DESCRIPTION
## Summary
- Extend barcode lookup from 3-step (DB→FatSecret→OFF→404) to 6-step cascade
- **Step 4: Nutritionix** — structured nutrition API (free 50 req/day)
- **Step 5: Brave Search + Gemini** — web search with AI macro extraction (free 2K/mo)
- **Step 6: AI estimation** — Gemini estimates macros from GS1 country prefix (always returns a result)
- All new services optional — graceful degradation when API keys not configured
- AI estimates marked `is_estimate=True`, NOT cached in `food_reference` table

## Env Vars Needed
```
NUTRITIONIX_APP_ID=...       # Optional
NUTRITIONIX_API_KEY=...      # Optional
BRAVE_SEARCH_API_KEY=...     # Optional
```

## Test Plan
- [ ] Barcode lookup with known product → existing behavior unchanged
- [ ] Barcode lookup without new API keys → falls through to AI estimate
- [ ] AI estimate response has `is_estimate: true` and `source: ai_estimate`
- [ ] Nutritionix/Brave results cached; AI estimates NOT cached