### PR TITLE
fix(meal-suggestion): preserve submission order for /recipes batch generation

### DIFF
--- a/src/domain/services/meal_suggestion/parallel_recipe_generator.py
+++ b/src/domain/services/meal_suggestion/parallel_recipe_generator.py
@@ -69,7 +69,10 @@ class ParallelRecipeGenerator:
         meal_names = await self._phase1_generate_names(session, exclude_meal_names, target_lang, count)
         phase1_elapsed = time.time() - start_time
 
-        suggestions = await self._phase2_generate_recipes(session, meal_names, target_lang, count)
+        # Discovery flow: more names than needed (headroom), use as_completed for early-stop benefit.
+        suggestions = await self._phase2_generate_recipes(
+            session, meal_names, target_lang, count, preserve_order=False
+        )
         phase2_elapsed = time.time() - start_time - phase1_elapsed
 
         phase3_elapsed = 0.0
@@ -229,12 +232,13 @@ class ParallelRecipeGenerator:
         self, session: SuggestionSession, meal_names: List[str], target_lang: str,
         suggestion_count: int = 3,
         min_acceptable_override: int = 0,
+        preserve_order: bool = True,
     ) -> List[MealSuggestion]:
         from src.domain.services.meal_suggestion.suggestion_prompt_builder import build_recipe_details_prompt
 
         total_attempts = len(meal_names)
         min_acceptable = min_acceptable_override or max(suggestion_count - 1, self.MIN_ACCEPTABLE_RESULTS)
-        logger.info(f"[PHASE-2-START] session={session.id} | recipes for {meal_names}")
+        logger.info(f"[PHASE-2-START] session={session.id} | recipes for {meal_names} | preserve_order={preserve_order}")
         recipe_system = (
             "You are a professional chef and nutritionist. Return ONLY this exact JSON structure:\n"
             '{{"ingredients":[{{"name":"...","amount":0.0,"unit":"g"}}],'
@@ -253,17 +257,31 @@ class ParallelRecipeGenerator:
 
         gen_start = time.time()
         successful: List[MealSuggestion] = []
-        for coro in asyncio.as_completed(tasks):
-            try:
-                result = await coro
-                if result is not None:
+
+        if preserve_order:
+            # gather preserves submission order — required for /recipes endpoint where mobile
+            # pairs results to selected meal names by index position.
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.warning(f"[RECIPE-ERROR] {type(result).__name__}: {result}")
+                elif result is not None:
                     successful.append(result)
-                    if len(successful) >= suggestion_count:
-                        cancelled = sum(1 for t in tasks if not t.done() and t.cancel())
-                        logger.info(f"[EARLY-STOP] Got {suggestion_count} meals, cancelled {cancelled} tasks")
-                        break
-            except Exception as e:
-                logger.warning(f"[RECIPE-ERROR] {type(e).__name__}: {e}")
+        else:
+            # as_completed yields in completion-time order, enabling early-stop once
+            # suggestion_count successes arrive. Used by the discovery flow which spawns
+            # total_attempts > suggestion_count tasks for headroom.
+            for coro in asyncio.as_completed(tasks):
+                try:
+                    result = await coro
+                    if result is not None:
+                        successful.append(result)
+                        if len(successful) >= suggestion_count:
+                            cancelled = sum(1 for t in tasks if not t.done() and t.cancel())
+                            logger.info(f"[EARLY-STOP] Got {suggestion_count} meals, cancelled {cancelled} tasks")
+                            break
+                except Exception as e:
+                    logger.warning(f"[RECIPE-ERROR] {type(e).__name__}: {e}")
 
         logger.info(
             f"[PHASE-2-COMPLETE] session={session.id} | "

--- a/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
+++ b/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
@@ -1,0 +1,253 @@
+"""
+Unit tests verifying that _phase2_generate_recipes preserves submission order
+when preserve_order=True (the default used by the /recipes endpoint).
+
+Regression test for: asyncio.as_completed yielding results in completion-time
+order, causing mobile index-based pairing to mismatch meal names with recipes.
+"""
+import asyncio
+import uuid
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.domain.model.meal_suggestion.meal_suggestion import (
+    Ingredient,
+    MacroEstimate,
+    MealSuggestion,
+    MealType,
+    RecipeStep,
+    SuggestionStatus,
+)
+from src.domain.model.meal_suggestion.suggestion_session import SuggestionSession
+from src.domain.services.meal_suggestion.parallel_recipe_generator import ParallelRecipeGenerator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_session() -> SuggestionSession:
+    return SuggestionSession(
+        id="test-session",
+        user_id="user-1",
+        meal_type="lunch",
+        meal_portion_type="main",
+        target_calories=600,
+        ingredients=[],
+        language="en",
+    )
+
+
+def make_meal_suggestion(meal_name: str, index: int) -> MealSuggestion:
+    return MealSuggestion(
+        id=str(uuid.uuid4()),
+        session_id="test-session",
+        user_id="user-1",
+        meal_name=meal_name,
+        description=f"Description for {meal_name}",
+        meal_type=MealType.LUNCH,
+        macros=MacroEstimate(calories=600, protein=40.0, carbs=60.0, fat=15.0),
+        ingredients=[Ingredient(name="chicken", amount=200.0, unit="g")],
+        recipe_steps=[RecipeStep(step=1, instruction="Cook it", duration_minutes=10)],
+        prep_time_minutes=20,
+        confidence_score=0.9,
+    )
+
+
+def make_generator() -> ParallelRecipeGenerator:
+    """Build a ParallelRecipeGenerator with mock dependencies."""
+    generation_service = MagicMock()
+    translation_service = MagicMock()
+    macro_validator = MagicMock()
+    return ParallelRecipeGenerator(generation_service, translation_service, macro_validator)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPhase2PreservesSubmissionOrder:
+    """_phase2_generate_recipes with preserve_order=True must return results in
+    submission order regardless of which task completes first."""
+
+    @pytest.mark.asyncio
+    async def test_order_preserved_when_index1_fastest(self):
+        """
+        Setup: index=1 (Caesar Salad) finishes first, index=0 (Chicken Curry) last,
+               index=2 (Teriyaki Bowl) in the middle.
+        Expect: returned list is [Chicken Curry, Caesar Salad, Teriyaki Bowl] — submission order.
+        """
+        meal_names = ["Chicken Curry", "Caesar Salad", "Teriyaki Bowl"]
+        session = make_session()
+
+        # Delays simulate: index=1 fastest, index=2 middle, index=0 slowest.
+        delays = {0: 0.05, 1: 0.01, 2: 0.03}
+
+        async def fake_generate_with_retry(prompt: str, meal_name: str, index: int,
+                                            recipe_system: str, session: SuggestionSession
+                                            ) -> Optional[MealSuggestion]:
+            await asyncio.sleep(delays[index])
+            return make_meal_suggestion(meal_name, index)
+
+        generator = make_generator()
+
+        with patch.object(
+            generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+        ):
+            with patch(
+                "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+                ".build_recipe_details_prompt",
+                return_value="mock-prompt",
+            ):
+                results = await generator._phase2_generate_recipes(
+                    session, meal_names, "English",
+                    suggestion_count=3,
+                    preserve_order=True,
+                )
+
+        assert len(results) == 3
+        assert results[0].meal_name == "Chicken Curry"
+        assert results[1].meal_name == "Caesar Salad"
+        assert results[2].meal_name == "Teriyaki Bowl"
+
+    @pytest.mark.asyncio
+    async def test_order_matches_submitted_names_exactly(self):
+        """Each result's meal_name must match the name at the same submission index."""
+        meal_names = ["Pasta Bolognese", "Miso Soup", "Greek Salad"]
+        session = make_session()
+
+        # Reverse completion order: index=2 fastest, index=0 slowest.
+        delays = {0: 0.06, 1: 0.03, 2: 0.01}
+
+        async def fake_generate_with_retry(prompt: str, meal_name: str, index: int,
+                                            recipe_system: str, session: SuggestionSession
+                                            ) -> Optional[MealSuggestion]:
+            await asyncio.sleep(delays[index])
+            return make_meal_suggestion(meal_name, index)
+
+        generator = make_generator()
+
+        with patch.object(
+            generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+        ):
+            with patch(
+                "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+                ".build_recipe_details_prompt",
+                return_value="mock-prompt",
+            ):
+                results = await generator._phase2_generate_recipes(
+                    session, meal_names, "English",
+                    suggestion_count=3,
+                    preserve_order=True,
+                )
+
+        for i, (result, expected_name) in enumerate(zip(results, meal_names)):
+            assert result.meal_name == expected_name, (
+                f"Index {i}: expected '{expected_name}', got '{result.meal_name}'"
+            )
+
+    @pytest.mark.asyncio
+    async def test_none_results_filtered_out_and_order_preserved(self):
+        """When one task returns None (failure), remaining results keep submission order."""
+        meal_names = ["Burger", "Salad", "Soup"]
+        session = make_session()
+
+        async def fake_generate_with_retry(prompt: str, meal_name: str, index: int,
+                                            recipe_system: str, session: SuggestionSession
+                                            ) -> Optional[MealSuggestion]:
+            if index == 1:
+                return None  # Salad generation fails
+            return make_meal_suggestion(meal_name, index)
+
+        generator = make_generator()
+
+        with patch.object(
+            generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+        ):
+            with patch(
+                "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+                ".build_recipe_details_prompt",
+                return_value="mock-prompt",
+            ):
+                results = await generator._phase2_generate_recipes(
+                    session, meal_names, "English",
+                    suggestion_count=3,
+                    min_acceptable_override=1,
+                    preserve_order=True,
+                )
+
+        assert len(results) == 2
+        assert results[0].meal_name == "Burger"
+        assert results[1].meal_name == "Soup"
+
+    @pytest.mark.asyncio
+    async def test_exception_in_task_logged_and_skipped(self):
+        """Exceptions from tasks are logged as warnings, not raised; other results preserved."""
+        meal_names = ["Steak", "Ramen", "Tacos"]
+        session = make_session()
+
+        async def fake_generate_with_retry(prompt: str, meal_name: str, index: int,
+                                            recipe_system: str, session: SuggestionSession
+                                            ) -> Optional[MealSuggestion]:
+            if index == 0:
+                raise ValueError("AI service timeout")
+            return make_meal_suggestion(meal_name, index)
+
+        generator = make_generator()
+
+        with patch.object(
+            generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+        ):
+            with patch(
+                "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+                ".build_recipe_details_prompt",
+                return_value="mock-prompt",
+            ):
+                results = await generator._phase2_generate_recipes(
+                    session, meal_names, "English",
+                    suggestion_count=3,
+                    min_acceptable_override=1,
+                    preserve_order=True,
+                )
+
+        # Steak (index=0) failed; Ramen and Tacos succeed in submission order.
+        assert len(results) == 2
+        assert results[0].meal_name == "Ramen"
+        assert results[1].meal_name == "Tacos"
+
+    @pytest.mark.asyncio
+    async def test_preserve_order_false_does_not_guarantee_order(self):
+        """preserve_order=False (discovery flow) uses as_completed — order is non-deterministic.
+        This test just verifies the path executes without error and returns correct count."""
+        meal_names = ["Meal A", "Meal B", "Meal C", "Meal D"]
+        session = make_session()
+
+        async def fake_generate_with_retry(prompt: str, meal_name: str, index: int,
+                                            recipe_system: str, session: SuggestionSession
+                                            ) -> Optional[MealSuggestion]:
+            return make_meal_suggestion(meal_name, index)
+
+        generator = make_generator()
+
+        with patch.object(
+            generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+        ):
+            with patch(
+                "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+                ".build_recipe_details_prompt",
+                return_value="mock-prompt",
+            ):
+                results = await generator._phase2_generate_recipes(
+                    session, meal_names, "English",
+                    suggestion_count=3,
+                    preserve_order=False,
+                )
+
+        # Should stop after 3 successes (early-stop).
+        assert len(results) == 3
+        # All results should be valid MealSuggestion objects.
+        for r in results:
+            assert isinstance(r, MealSuggestion)
+            assert r.meal_name in meal_names


### PR DESCRIPTION
## Summary

- `asyncio.as_completed` in `_phase2_generate_recipes` yielded results in completion-time order instead of submission order, breaking the contract that `recipes[i]` corresponds to `meal_names[i]`
- Mobile (`selected_meals_screen.dart`) pairs by index — when AI latency varied across 3 concurrent tasks, meal names were systematically mismatched with wrong recipe bodies and images

## Repro

Described in debug report: `mobile/plans/reports/debugger-260413-1445-meal-swap-bug.md`

> User selects [Teriyaki, Curry, Caesar]; backend spawns 3 parallel tasks; Caesar finishes first → `successful[0]` = CaesarRecipe; mobile maps index 0 → Teriyaki name + Caesar recipe body.

## Fix

Option A from debug report: replaced `asyncio.as_completed` loop with `asyncio.gather(*tasks, return_exceptions=True)` for the `/recipes` endpoint path (order-preserving by spec).

Implemented via `preserve_order: bool = True` parameter on `_phase2_generate_recipes`:
- `/recipes` endpoint: uses default `preserve_order=True` → `gather` → submission order guaranteed
- `generate()` discovery flow: passes `preserve_order=False` → `as_completed` → early-stop after N successes preserved (discovery spawns 7 tasks for 3 needed)

## Test Plan

- [x] `test_order_preserved_when_index1_fastest` — index=1 finishes first, asserts result order is [0,1,2]
- [x] `test_order_matches_submitted_names_exactly` — reverse completion order, asserts name-at-index contract
- [x] `test_none_results_filtered_out_and_order_preserved` — None task removed, remaining two in order
- [x] `test_exception_in_task_logged_and_skipped` — exception task skipped, rest in submission order
- [x] `test_preserve_order_false_does_not_guarantee_order` — discovery path executes, returns early after 3
- [x] Full unit suite: 857 passed, 0 failures