### PR TITLE
fix(users): register UpdateLanguageCommandHandler

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -29,6 +29,7 @@ from src.app.commands.user import (
     CompleteOnboardingCommand,
     DeleteUserCommand,
     UpdateCustomMacrosCommand,
+    UpdateLanguageCommand,
     UpdateTimezoneCommand,
 )
 from src.app.commands.user.sync_user_command import (
@@ -65,6 +66,7 @@ from src.app.handlers.command_handlers import (
 from src.app.handlers.command_handlers import (
     RegisterFcmTokenCommandHandler,
     DeleteFcmTokenCommandHandler,
+    UpdateLanguageCommandHandler,
     UpdateNotificationPreferencesCommandHandler,
     UpdateTimezoneCommandHandler,
 )
@@ -429,6 +431,10 @@ def get_configured_event_bus() -> EventBus:
     event_bus.register_handler(
         UpdateTimezoneCommand,
         UpdateTimezoneCommandHandler(),
+    )
+    event_bus.register_handler(
+        UpdateLanguageCommand,
+        UpdateLanguageCommandHandler(),
     )
     event_bus.register_handler(
         UpdateCustomMacrosCommand,


### PR DESCRIPTION
## Summary
`PATCH /v1/users/language` returned 500 `ValueError: No handler registered for UpdateLanguageCommand`. The handler existed and had `@handles(UpdateLanguageCommand)`, but was never imported or registered in `src/api/dependencies/event_bus.py`.

## Fix
Added the import and `event_bus.register_handler(UpdateLanguageCommand, UpdateLanguageCommandHandler())` mirroring the existing `UpdateTimezoneCommand` wiring.

## Test plan
- [x] Module import clean
- [x] 150/150 unit/api tests pass
- [ ] Manual: PATCH /v1/users/language returns 200