### PR TITLE
fix(meal-suggestion): expose english_name in recipe response

### DIFF
--- a/src/api/mappers/meal_suggestion_mapper.py
+++ b/src/api/mappers/meal_suggestion_mapper.py
@@ -19,6 +19,7 @@ def to_meal_suggestion_response(suggestion: MealSuggestion) -> MealSuggestionRes
     return MealSuggestionResponse(
         id=suggestion.id,
         meal_name=suggestion.meal_name,
+        english_name=suggestion.english_name,
         emoji=suggestion.emoji,
         description=suggestion.description,
         macros=MacroEstimateResponse(

--- a/src/api/schemas/response/meal_suggestion_responses.py
+++ b/src/api/schemas/response/meal_suggestion_responses.py
@@ -48,7 +48,11 @@ class MealSuggestionResponse(BaseModel):
     """
 
     id: str = Field(..., description="Unique identifier for this suggestion")
-    meal_name: str = Field(..., description="Name of the meal")
+    meal_name: str = Field(..., description="Name of the meal (possibly translated)")
+    english_name: Optional[str] = Field(
+        None,
+        description="Original English name — stable reconciliation key across locales",
+    )
     emoji: Optional[str] = Field(None, description="AI-assigned food emoji")
     description: str = Field(..., description="Brief description of the meal")
     macros: MacroEstimateResponse = Field(


### PR DESCRIPTION
## Summary
- Add `english_name` to `MealSuggestionResponse` schema
- Map `MealSuggestion.english_name` through `to_meal_suggestion_response`

## Why
Mobile reconciler swaps recipes between meals for non-EN users (VI/ES/…)
because phase-3 translates `meal_name`. `english_name` is preserved
untranslated (already in `_SKIP_FIELDS`) but was not exposed in the
recipe response. Adds a stable reconciliation key.

## Compatibility
Additive optional field — zero risk to existing mobile clients.

## Test plan
- [ ] Verify response contains `english_name` for EN + VI locales
- [ ] Confirm field survives phase-3 translation unchanged