### PR TITLE
fix(notifications): prevent duplicate sends from multi-worker scheduling

### DIFF
--- a/migrations/versions/047_add_notification_sent_log.py
+++ b/migrations/versions/047_add_notification_sent_log.py
@@ -1,0 +1,36 @@
+"""Add notification_sent_log table for cross-worker deduplication.
+
+Revision ID: 047
+Revises: 046
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "047"
+down_revision = "046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_sent_log",
+        sa.Column("user_id", sa.String(36), nullable=False),
+        sa.Column("notification_type", sa.String(50), nullable=False),
+        sa.Column("sent_minute", sa.String(16), nullable=False),
+        sa.Column(
+            "sent_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("user_id", "notification_type", "sent_minute"),
+    )
+    op.create_index(
+        "ix_sent_log_cleanup", "notification_sent_log", ["sent_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sent_log_cleanup", table_name="notification_sent_log")
+    op.drop_table("notification_sent_log")

--- a/src/domain/services/notification_service.py
+++ b/src/domain/services/notification_service.py
@@ -1,8 +1,12 @@
 """
 Notification service for sending push notifications.
+
+Includes deduplication guard so multiple workers (uvicorn --workers N)
+don't send the same scheduled notification twice in the same minute.
 """
 
 import logging
+from datetime import datetime
 from typing import Dict, List, Optional, Any
 
 from src.domain.model.notification import (
@@ -12,6 +16,7 @@ from src.domain.model.notification import (
 )
 from src.domain.ports.notification_repository_port import NotificationRepositoryPort
 from src.domain.services.notification_messages import get_messages
+from src.domain.utils.timezone_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +86,14 @@ class NotificationService:
                 )
                 return {"success": False, "reason": "disabled"}
 
-            # 3. Send notification via Firebase
+            # 3. Dedup guard — prevent duplicate sends from multiple workers
+            if self._is_already_sent(user_id, notification_type):
+                logger.info(
+                    f"Skipping duplicate {notification_type} for user {user_id}"
+                )
+                return {"success": True, "reason": "deduplicated"}
+
+            # 4. Send notification via Firebase
             fcm_tokens = [token.fcm_token for token in tokens]
             for t in tokens:
                 logger.info(
@@ -100,7 +112,7 @@ class NotificationService:
                 tokens=fcm_tokens,
             )
 
-            # 4. Handle invalid tokens
+            # 5. Handle invalid tokens
             if result.get("success") and result.get("failed_tokens"):
                 await self._handle_failed_tokens(
                     result["failed_tokens"],
@@ -265,6 +277,68 @@ class NotificationService:
             logger.info(
                 f"Deactivated {deactivated_count} invalid FCM tokens ({context})"
             )
+
+    def _minute_key(self) -> str:
+        """Current UTC minute as string key for dedup window."""
+        return utc_now().strftime("%Y%m%d%H%M")
+
+    def _is_already_sent(
+        self, user_id: str, notification_type: NotificationType
+    ) -> bool:
+        """Atomically check-and-mark a notification as sent.
+
+        Uses INSERT with duplicate-key ignore so only the first worker
+        to reach this point records the row; all others get False.
+        """
+        from src.infra.database.config import ScopedSession
+        from src.infra.database.models.notification.notification_sent_log import (
+            NotificationSentLog,
+        )
+        from sqlalchemy.exc import IntegrityError
+
+        minute_key = self._minute_key()
+        db = ScopedSession()
+        try:
+            db.add(NotificationSentLog(
+                user_id=user_id,
+                notification_type=str(notification_type),
+                sent_minute=minute_key,
+            ))
+            db.commit()
+            return False  # We claimed it — proceed to send
+        except IntegrityError:
+            db.rollback()
+            return True  # Another worker already claimed it
+        except Exception as e:
+            db.rollback()
+            logger.warning(f"Dedup check failed, allowing send: {e}")
+            return False  # Fail-open: send rather than silently drop
+        finally:
+            db.close()
+
+    def cleanup_old_sent_logs(self, older_than_hours: int = 24) -> int:
+        """Delete sent-log rows older than N hours to prevent table bloat."""
+        from src.infra.database.config import ScopedSession
+        from src.infra.database.models.notification.notification_sent_log import (
+            NotificationSentLog,
+        )
+        from datetime import timedelta
+
+        cutoff = utc_now() - timedelta(hours=older_than_hours)
+        db = ScopedSession()
+        try:
+            deleted = db.query(NotificationSentLog).filter(
+                NotificationSentLog.sent_at < cutoff
+            ).delete()
+            db.commit()
+            logger.info(f"Cleaned up {deleted} old notification sent logs")
+            return deleted
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Error cleaning up sent logs: {e}")
+            return 0
+        finally:
+            db.close()
 
     def get_notification_preferences(
         self, user_id: str

--- a/src/infra/database/models/__init__.py
+++ b/src/infra/database/models/__init__.py
@@ -24,7 +24,7 @@ from .meal.meal_image import MealImage
 from .meal.meal_translation_model import MealTranslation
 from .meal.food_item_translation_model import FoodItemTranslation
 # Notification models
-from .notification import NotificationPreferences, UserFcmToken
+from .notification import NotificationPreferences, NotificationSentLog, UserFcmToken
 from .nutrition.food_item import FoodItem
 # Nutrition models
 from .nutrition.nutrition import Nutrition
@@ -86,6 +86,7 @@ __all__ = [
     
     # Notification models
     "NotificationPreferences",
+    "NotificationSentLog",
     "UserFcmToken",
 
     # Feature flags

--- a/src/infra/database/models/notification/__init__.py
+++ b/src/infra/database/models/notification/__init__.py
@@ -2,9 +2,11 @@
 Notification database models.
 """
 from .notification_preferences import NotificationPreferences
+from .notification_sent_log import NotificationSentLog
 from .user_fcm_token import UserFcmToken
 
 __all__ = [
     'NotificationPreferences',
+    'NotificationSentLog',
     'UserFcmToken',
 ]

--- a/src/infra/database/models/notification/notification_sent_log.py
+++ b/src/infra/database/models/notification/notification_sent_log.py
@@ -1,0 +1,20 @@
+"""Notification sent log for deduplication across workers."""
+from sqlalchemy import Column, String, DateTime, Index
+
+from src.infra.database.config import Base
+from src.domain.utils.timezone_utils import utc_now
+
+
+class NotificationSentLog(Base):
+    """Tracks sent notifications to prevent duplicates from multiple workers."""
+    __tablename__ = 'notification_sent_log'
+
+    # Composite natural key: user + type + minute window
+    user_id = Column(String(36), nullable=False, primary_key=True)
+    notification_type = Column(String(50), nullable=False, primary_key=True)
+    sent_minute = Column(String(16), nullable=False, primary_key=True)
+    sent_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+
+    __table_args__ = (
+        Index('ix_sent_log_cleanup', 'sent_at'),
+    )

--- a/src/infra/services/scheduled_notification_service.py
+++ b/src/infra/services/scheduled_notification_service.py
@@ -35,6 +35,7 @@ class ScheduledNotificationService:
         self._tdee_service = TdeeCalculationService()
         self._running = False
         self._tasks: List[asyncio.Task] = []
+        self._cleanup_counter = 0  # Clean sent logs every ~60 loop ticks (~1h)
     
     async def start(self):
         """Start the scheduled notification service."""
@@ -78,6 +79,12 @@ class ScheduledNotificationService:
             try:
                 current_time = datetime.now(timezone.utc)
                 await self._check_and_send_notifications(current_time)
+
+                # Periodically clean old dedup logs (~every hour)
+                self._cleanup_counter += 1
+                if self._cleanup_counter >= 60:
+                    self._cleanup_counter = 0
+                    self.notification_service.cleanup_old_sent_logs()
 
                 # Wait for next check
                 await asyncio.sleep(self.SCHEDULING_LOOP_INTERVAL_SECONDS)


### PR DESCRIPTION
## Summary
- **Root cause**: `uvicorn --workers 2` starts 2 scheduling loops, both fire in the same minute → same user gets 2 identical notifications
- **Fix**: `notification_sent_log` table as cross-worker dedup lock — first worker INSERTs `(user, type, minute)` composite PK, second gets IntegrityError and skips
- Hourly cleanup of rows >24h old prevents table bloat
- Fail-open design: if dedup check errors, notification still sends (no silent drops)

## Changes
- `notification_sent_log` table + migration 047
- `NotificationService.send_notification()` — dedup guard before Firebase send
- `ScheduledNotificationService` — periodic cleanup of old dedup rows

## Test plan
- [ ] Deploy to staging with `UVICORN_WORKERS=2`
- [ ] Trigger meal reminder at scheduled time, verify only 1 notification received
- [ ] Check logs for `Skipping duplicate` entries from the second worker
- [ ] Verify cleanup runs (~hourly) via `Cleaned up N old notification sent logs` log
- [ ] Confirm fail-open: if DB is temporarily unreachable, notifications still send