### PR TITLE
feat(meal-suggestion): image confidence scoring + save image URL

### DIFF
--- a/src/api/dependencies/food_image.py
+++ b/src/api/dependencies/food_image.py
@@ -7,13 +7,26 @@ _instance: Optional[FoodImageSearchService] = None
 
 
 def get_food_image_service() -> FoodImageSearchService:
-    """Return singleton FoodImageSearchService with Pexels → Unsplash chain."""
+    """Return singleton FoodImageSearchService with Pexels → Unsplash chain.
+
+    When BRAVE_SEARCH_API_KEY is configured, enables web search
+    cross-validation to reject images that don't match the meal name.
+    """
     global _instance
     if _instance is None:
         from src.infra.adapters.pexels_image_adapter import PexelsImageAdapter
         from src.infra.adapters.unsplash_image_adapter import UnsplashImageAdapter
+        from src.infra.config.settings import settings
+
+        web_validator = None
+        if settings.BRAVE_SEARCH_API_KEY:
+            from src.domain.services.meal_discovery.web_search_image_validator import (
+                WebSearchImageValidator,
+            )
+            web_validator = WebSearchImageValidator(settings.BRAVE_SEARCH_API_KEY)
 
         _instance = FoodImageSearchService(
-            adapters=[PexelsImageAdapter(), UnsplashImageAdapter()]
+            adapters=[PexelsImageAdapter(), UnsplashImageAdapter()],
+            web_validator=web_validator,
         )
     return _instance

--- a/src/api/routes/v1/meal_suggestions.py
+++ b/src/api/routes/v1/meal_suggestions.py
@@ -189,6 +189,7 @@ async def discover_meals(
                 photographer=img.photographer if img else None,
                 photographer_url=img.photographer_url if img else None,
                 unsplash_download_location=img.download_location if img else None,
+                image_confidence=img.confidence if img else 0.0,
             ))
 
         shown_count = len(session.shown_meal_names)
@@ -332,6 +333,7 @@ async def save_meal_suggestion(
             cuisine_type=request.cuisine_type,
             origin_country=request.origin_country,
             emoji=request.emoji,
+            image_url=request.image_url,
         )
 
         meal_id = await event_bus.send(command)

--- a/src/api/schemas/request/meal_suggestion_requests.py
+++ b/src/api/schemas/request/meal_suggestion_requests.py
@@ -297,6 +297,9 @@ class SaveMealSuggestionRequest(BaseModel):
     cuisine_type: Optional[str] = Field(None, description="Cuisine type (e.g., Asian, Vietnamese)")
     origin_country: Optional[str] = Field(None, description="Country of origin")
     emoji: Optional[str] = Field(None, description="AI-assigned food emoji")
+    image_url: Optional[str] = Field(
+        None, description="Food image URL from discovery (Pexels/Unsplash hotlink)"
+    )
     unsplash_download_location: Optional[str] = Field(
         None, description="Unsplash download_location URL — triggers download event per API guidelines"
     )

--- a/src/api/schemas/response/meal_suggestion_responses.py
+++ b/src/api/schemas/response/meal_suggestion_responses.py
@@ -138,6 +138,7 @@ class DiscoveryMealResponse(BaseModel):
     photographer: Optional[str] = Field(None, description="Photographer name for attribution")
     photographer_url: Optional[str] = Field(None, description="Photographer profile URL with UTM params")
     unsplash_download_location: Optional[str] = Field(None, description="Unsplash download trigger URL (pass back on save)")
+    image_confidence: float = Field(default=0.0, description="0.0–1.0 how well the image matches the meal name")
 
 
 class DiscoveryBatchResponse(BaseModel):

--- a/src/app/commands/meal_suggestion/save_meal_suggestion_command.py
+++ b/src/app/commands/meal_suggestion/save_meal_suggestion_command.py
@@ -46,6 +46,7 @@ class SaveMealSuggestionCommand(Command):
     cuisine_type: Optional[str] = None
     origin_country: Optional[str] = None
     emoji: Optional[str] = None
+    image_url: Optional[str] = None
 
     def __post_init__(self):
         """Validate command data."""

--- a/src/app/handlers/command_handlers/meal_suggestion/save_meal_suggestion_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_suggestion/save_meal_suggestion_command_handler.py
@@ -73,12 +73,12 @@ class SaveMealSuggestionCommandHandler(
             confidence_score=1.0,
         )
 
-        # Create a dummy image reference (no actual upload)
+        # Image reference: use discovery image URL if provided, else placeholder
         image = MealImage(
             image_id=str(uuid4()),
             format="jpeg",
             size_bytes=1,
-            url=None,
+            url=command.image_url,
         )
 
         meal = Meal(

--- a/src/domain/model/meal_discovery/food_image.py
+++ b/src/domain/model/meal_discovery/food_image.py
@@ -14,3 +14,4 @@ class FoodImageResult:
     photographer_url: Optional[str] = None   # Profile URL with UTM params
     download_location: Optional[str] = None  # Unsplash download trigger URL
     alt_text: Optional[str] = None           # Image description for relevance validation
+    confidence: float = 0.5                  # 0.0-1.0 how well image matches query

--- a/src/domain/services/meal_discovery/__init__.py
+++ b/src/domain/services/meal_discovery/__init__.py
@@ -1,1 +1,7 @@
 """Domain services for meal discovery."""
+import re
+
+
+def extract_words(text: str) -> set:
+    """Extract lowercase words (2+ chars), strip punctuation."""
+    return set(re.findall(r'[a-zA-Z]{2,}', text.lower()))

--- a/src/domain/services/meal_discovery/food_image_search_service.py
+++ b/src/domain/services/meal_discovery/food_image_search_service.py
@@ -5,14 +5,13 @@ Cache: 7-day TTL, max 5000 entries with LRU eviction.
 Confidence scoring: measures how well the image describes the meal name.
 """
 import logging
-import re
 import time
 from collections import OrderedDict
-from dataclasses import dataclass
 from typing import List, Optional
 
 from src.domain.model.meal_discovery.food_image import FoodImageResult
 from src.domain.ports.food_image_search_port import FoodImageSearchPort
+from src.domain.services.meal_discovery import extract_words
 
 logger = logging.getLogger(__name__)
 
@@ -182,8 +181,8 @@ def _score_image_match(query: str, result: FoodImageResult) -> float:
         # No alt text — moderate trust in the search API
         return 0.3
 
-    alt_words = _extract_words(alt)
-    query_words = _extract_words(query) - _STOP_WORDS
+    alt_words = extract_words(alt)
+    query_words = extract_words(query) - _STOP_WORDS
 
     if not query_words:
         return 0.3
@@ -230,7 +229,7 @@ def _simplify_food_query(query: str) -> str:
 
     E.g. 'Honey Garlic Glazed Chicken Breast' → 'honey garlic chicken'
     """
-    words = _extract_words(query)
+    words = extract_words(query)
     food_words = words & _FOOD_SIGNALS
     remaining = words - _STOP_WORDS - _FOOD_SIGNALS
     # Keep food signals + up to 2 descriptive words
@@ -238,6 +237,4 @@ def _simplify_food_query(query: str) -> str:
     return " ".join(sorted(result_words)) if result_words else query.lower()
 
 
-def _extract_words(text: str) -> set:
-    """Extract lowercase words, strip punctuation."""
-    return set(re.findall(r'[a-zA-Z]{2,}', text.lower()))
+extract_words = extract_words

--- a/src/domain/services/meal_discovery/food_image_search_service.py
+++ b/src/domain/services/meal_discovery/food_image_search_service.py
@@ -2,12 +2,13 @@
 Food image search service with in-memory LRU cache.
 Search chain: adapter list (injected) → first hit wins.
 Cache: 7-day TTL, max 5000 entries with LRU eviction.
-Validation: reject images whose alt text has zero food-keyword overlap with query.
+Confidence scoring: measures how well the image describes the meal name.
 """
 import logging
 import re
 import time
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import List, Optional
 
 from src.domain.model.meal_discovery.food_image import FoodImageResult
@@ -17,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL_SECONDS = 7 * 24 * 3600  # 7 days
 CACHE_MAX_ENTRIES = 5_000
+
+# Minimum confidence to accept an image (below this → emoji fallback)
+MIN_ACCEPT_CONFIDENCE = 0.3
 
 # Words too generic to be useful for matching
 _STOP_WORDS = frozenset({
@@ -34,6 +38,20 @@ _FOOD_SIGNALS = frozenset({
     "vegetable", "tomato", "potato", "onion", "garlic", "pepper",
     "cheese", "egg", "butter", "cream", "sauce", "curry",
     "caesar", "mediterranean", "thai", "mexican", "italian",
+    "tofu", "lamb", "duck", "crab", "lobster", "oyster", "sushi",
+    "ramen", "pho", "taco", "burrito", "pizza", "burger",
+    "pancake", "waffle", "omelette", "sandwich", "wrap",
+    "smoothie", "juice", "yogurt", "granola", "cereal",
+    "avocado", "broccoli", "spinach", "kale", "mushroom",
+    "lentil", "bean", "chickpea", "hummus", "falafel",
+})
+
+# Non-food visual signals — strong indicator the image is wrong
+_NEGATIVE_SIGNALS = frozenset({
+    "building", "architecture", "skyline", "city", "street",
+    "car", "vehicle", "mountain", "landscape", "sunset",
+    "portrait", "selfie", "office", "computer", "phone",
+    "abstract", "pattern", "texture", "wallpaper",
 })
 
 
@@ -41,22 +59,28 @@ class FoodImageSearchService:
     """
     Orchestrates food image search with adapter fallback chain.
     Uses an LRU in-memory cache keyed by normalized query.
+    Scores each image on how well it describes the queried meal name.
     """
 
-    def __init__(self, adapters: List[FoodImageSearchPort]):
+    def __init__(
+        self,
+        adapters: List[FoodImageSearchPort],
+        web_validator: Optional["WebSearchImageValidator"] = None,
+    ):
         self._adapters = adapters
         self._cache: OrderedDict = OrderedDict()
+        self._web_validator = web_validator
 
     async def search_food_image(
         self,
         query: str,
         ingredients: Optional[List[str]] = None,
     ) -> Optional[FoodImageResult]:
-        """Return a validated food image, or None (mobile falls back to emoji).
+        """Return a scored food image, or None (mobile falls back to emoji).
 
-        Args:
-            query: Food name in English for best search results.
-            ingredients: English ingredient names for fallback search.
+        The returned FoodImageResult.confidence indicates how well the
+        image describes the meal name (0.0–1.0). Mobile uses this to
+        decide whether to show the image (>=0.8) or fall back to emoji.
         """
         key = self._normalize(query)
 
@@ -69,7 +93,7 @@ class FoodImageSearchService:
             else:
                 del self._cache[key]
 
-        result = await self._search_with_validation(query)
+        result = await self._search_with_scoring(query)
 
         self._evict_if_needed()
         self._cache[key] = (result, time.time() + CACHE_TTL_SECONDS)
@@ -77,9 +101,9 @@ class FoodImageSearchService:
 
         return result
 
-    async def _search_with_validation(self, query: str) -> Optional[FoodImageResult]:
-        """Search adapters with validation. Returns None if no confident match."""
-        result = await self._try_adapters_validated(query)
+    async def _search_with_scoring(self, query: str) -> Optional[FoodImageResult]:
+        """Search adapters, score each candidate, return best above threshold."""
+        result = await self._try_adapters_scored(query)
         if result:
             return result
 
@@ -87,23 +111,51 @@ class FoodImageSearchService:
         simple = _simplify_food_query(query)
         if simple and simple != query.lower():
             logger.info(f"Image fallback: '{query}' → '{simple}'")
-            result = await self._try_adapters_validated(simple)
+            result = await self._try_adapters_scored(simple)
             if result:
                 return result
 
         logger.info(f"No confident image for '{query}', falling back to emoji")
         return None
 
-    async def _try_adapters_validated(self, query: str) -> Optional[FoodImageResult]:
-        """Try each adapter, return first result that passes validation."""
+    async def _try_adapters_scored(self, query: str) -> Optional[FoodImageResult]:
+        """Try each adapter, score results, return best above threshold."""
+        best: Optional[FoodImageResult] = None
+        best_score = 0.0
+
         for adapter in self._adapters:
             try:
                 result = await adapter.search(query)
-                if result is not None and _validate_food_image(query, result):
-                    return result
+                if result is None:
+                    continue
+
+                score = _score_image_match(query, result)
+                if score < MIN_ACCEPT_CONFIDENCE:
+                    continue
+
+                # Web search can boost or penalize the score
+                if self._web_validator:
+                    web_score = await self._web_validator.score(query, result)
+                    # Blend: 60% keyword score + 40% web score
+                    score = score * 0.6 + web_score * 0.4
+
+                result.confidence = round(score, 2)
+
+                if score > best_score:
+                    best = result
+                    best_score = score
+
+                # Early exit if we already have a strong match
+                if best_score >= 0.9:
+                    break
             except Exception as e:
                 logger.warning(f"Image adapter {adapter.__class__.__name__} error: {e}")
-        return None
+
+        if best:
+            logger.debug(
+                f"Image selected: query='{query}' | confidence={best.confidence}"
+            )
+        return best
 
     @staticmethod
     def _normalize(query: str) -> str:
@@ -114,41 +166,63 @@ class FoodImageSearchService:
             self._cache.popitem(last=False)
 
 
-def _validate_food_image(query: str, result: FoodImageResult) -> bool:
-    """Validate image is food-related and relevant to the query.
+def _score_image_match(query: str, result: FoodImageResult) -> float:
+    """Score how well the image describes the meal name (0.0–1.0).
 
-    Strategy: check that alt text contains at least one food keyword
-    from either the query or the global food signals list.
-    This catches obvious mismatches (buildings, landscapes) while
-    trusting the search API's relevance for food-on-food matches.
+    Scoring tiers:
+    - 0.0: Non-food image (buildings, cars, etc.)
+    - 0.3: No alt text — trust the search API blindly
+    - 0.5: Alt text has generic food words but no query overlap
+    - 0.7: Alt text has some query keywords (partial match)
+    - 0.9: Alt text has most query keywords (strong match)
+    - 1.0: Alt text contains all meaningful query words (exact match)
     """
     alt = result.alt_text or ""
     if not alt:
-        # No alt text — trust the search API
-        return True
+        # No alt text — moderate trust in the search API
+        return 0.3
 
     alt_words = _extract_words(alt)
-    query_words = _extract_words(query)
+    query_words = _extract_words(query) - _STOP_WORDS
 
-    # Must have at least one query keyword in alt text
-    query_overlap = query_words & alt_words
-    if query_overlap:
-        return True
+    if not query_words:
+        return 0.3
 
-    # Or: alt text must mention food-related words (it's at least a food photo)
-    food_overlap = alt_words & _FOOD_SIGNALS
-    if food_overlap:
-        logger.debug(
-            f"Image accepted via food signals: query='{query}' | "
-            f"signals={food_overlap}"
+    # Hard reject: non-food signals with no food words
+    negative_overlap = alt_words & _NEGATIVE_SIGNALS
+    if negative_overlap and not (alt_words & _FOOD_SIGNALS):
+        logger.info(
+            f"Image scored 0.0: non-food signals={negative_overlap} | query='{query}'"
         )
-        return True
+        return 0.0
 
-    logger.info(
-        f"Image rejected: no food overlap | "
-        f"query_words={query_words} | alt_words={alt_words}"
+    # Measure direct overlap: how many meal name words appear in alt text
+    query_overlap = query_words & alt_words
+    overlap_ratio = len(query_overlap) / len(query_words)
+
+    if overlap_ratio >= 0.8:
+        # Almost all meal name words found in image description
+        score = 0.9 + (overlap_ratio - 0.8) * 0.5  # 0.9–1.0
+    elif overlap_ratio >= 0.5:
+        # Majority of meal name words found
+        score = 0.7 + (overlap_ratio - 0.5) * 0.67  # 0.7–0.9
+    elif overlap_ratio > 0:
+        # Some meal name words found
+        score = 0.5 + overlap_ratio * 0.4  # 0.5–0.7
+    else:
+        # No direct overlap — check for generic food signals
+        food_overlap = alt_words & _FOOD_SIGNALS
+        if food_overlap:
+            # It's a food photo, just not specifically this meal
+            score = 0.4 + min(len(food_overlap), 3) * 0.03  # 0.43–0.49
+        else:
+            score = 0.1
+
+    logger.debug(
+        f"Image score={score:.2f}: query='{query}' | "
+        f"overlap={query_overlap} ({overlap_ratio:.0%}) | alt='{alt[:80]}'"
     )
-    return False
+    return min(score, 1.0)
 
 
 def _simplify_food_query(query: str) -> str:

--- a/src/domain/services/meal_discovery/food_image_search_service.py
+++ b/src/domain/services/meal_discovery/food_image_search_service.py
@@ -43,6 +43,8 @@ _FOOD_SIGNALS = frozenset({
     "smoothie", "juice", "yogurt", "granola", "cereal",
     "avocado", "broccoli", "spinach", "kale", "mushroom",
     "lentil", "bean", "chickpea", "hummus", "falafel",
+    "risotto", "biryani", "paella", "gnocchi", "lasagna",
+    "kebab", "satay", "tempeh", "miso", "teriyaki",
 })
 
 # Non-food visual signals — strong indicator the image is wrong
@@ -168,17 +170,20 @@ class FoodImageSearchService:
 def _score_image_match(query: str, result: FoodImageResult) -> float:
     """Score how well the image describes the meal name (0.0–1.0).
 
-    Scoring tiers:
+    Strategy: prioritize core food word matches over full-name overlap.
+    Pexels/Unsplash alt text is short ("salmon on plate") while meal names
+    are long ("Honey Garlic Glazed Salmon"). Matching the core food word
+    ("salmon") is a strong signal — modifiers are cooking style, not visual.
+
+    Scoring:
     - 0.0: Non-food image (buildings, cars, etc.)
-    - 0.3: No alt text — trust the search API blindly
-    - 0.5: Alt text has generic food words but no query overlap
-    - 0.7: Alt text has some query keywords (partial match)
-    - 0.9: Alt text has most query keywords (strong match)
-    - 1.0: Alt text contains all meaningful query words (exact match)
+    - 0.3: No alt text — moderate trust in search API
+    - 0.5: Generic food photo (food signals but no query match)
+    - 0.85: Core food word from meal name found in alt text
+    - 0.9+: Multiple query words match (strong match)
     """
     alt = result.alt_text or ""
     if not alt:
-        # No alt text — moderate trust in the search API
         return 0.3
 
     alt_words = extract_words(alt)
@@ -195,31 +200,32 @@ def _score_image_match(query: str, result: FoodImageResult) -> float:
         )
         return 0.0
 
-    # Measure direct overlap: how many meal name words appear in alt text
     query_overlap = query_words & alt_words
-    overlap_ratio = len(query_overlap) / len(query_words)
 
-    if overlap_ratio >= 0.8:
-        # Almost all meal name words found in image description
-        score = 0.9 + (overlap_ratio - 0.8) * 0.5  # 0.9–1.0
-    elif overlap_ratio >= 0.5:
-        # Majority of meal name words found
-        score = 0.7 + (overlap_ratio - 0.5) * 0.67  # 0.7–0.9
-    elif overlap_ratio > 0:
-        # Some meal name words found
-        score = 0.5 + overlap_ratio * 0.4  # 0.5–0.7
-    else:
-        # No direct overlap — check for generic food signals
+    # Core food word match: the primary ingredient/dish type from meal name
+    # e.g. "salmon" in "Honey Garlic Glazed Salmon"
+    core_food_words = query_words & _FOOD_SIGNALS
+    core_match = bool(core_food_words & alt_words)
+
+    if not query_overlap:
+        # No direct overlap — check for generic food signals in alt text
         food_overlap = alt_words & _FOOD_SIGNALS
         if food_overlap:
-            # It's a food photo, just not specifically this meal
-            score = 0.4 + min(len(food_overlap), 3) * 0.03  # 0.43–0.49
+            score = 0.5
         else:
             score = 0.1
+    elif core_match:
+        # Core food word found — strong signal regardless of modifier overlap
+        # Bonus for additional word matches
+        extra = len(query_overlap) - 1  # beyond the first match
+        score = 0.85 + min(extra, 3) * 0.05  # 0.85–1.0
+    else:
+        # Non-core words match (modifiers like "grilled", "honey")
+        score = 0.6 + min(len(query_overlap), 3) * 0.08  # 0.68–0.84
 
     logger.debug(
         f"Image score={score:.2f}: query='{query}' | "
-        f"overlap={query_overlap} ({overlap_ratio:.0%}) | alt='{alt[:80]}'"
+        f"overlap={query_overlap} | core_match={core_match} | alt='{alt[:80]}'"
     )
     return min(score, 1.0)
 

--- a/src/domain/services/meal_discovery/web_search_image_validator.py
+++ b/src/domain/services/meal_discovery/web_search_image_validator.py
@@ -1,0 +1,143 @@
+"""
+Web search cross-validation for food images.
+Searches Brave for the meal name and scores how well the stock photo
+alt text matches web descriptions of that meal.
+Gracefully degrades: returns 0.5 (neutral) on any error.
+"""
+import logging
+import re
+from typing import Optional, Set
+
+import httpx
+
+from src.domain.model.meal_discovery.food_image import FoodImageResult
+
+logger = logging.getLogger(__name__)
+
+BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
+_SEARCH_TIMEOUT = 3.0  # seconds — fast timeout to avoid blocking image pipeline
+
+
+class WebSearchImageValidator:
+    """
+    Scores food images against web search results for the meal name.
+
+    How it works:
+    1. Search Brave for "[meal name] dish recipe"
+    2. Extract descriptive keywords from result titles + snippets
+    3. Score overlap between web keywords and the image's alt text
+    4. Higher overlap = higher confidence the image depicts the meal
+
+    Cached per meal name to avoid repeated API calls for same dish.
+    """
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+        self._keyword_cache: dict[str, Set[str]] = {}
+
+    async def score(
+        self, meal_name: str, image: FoodImageResult
+    ) -> float:
+        """Return 0.0–1.0 score of how well image matches the meal per web search.
+
+        Scoring:
+        - 0.5: No alt text or web search failed (neutral — don't penalize)
+        - 0.0–0.3: Zero overlap between web keywords and alt text
+        - 0.5–0.7: Some overlap (image partially matches)
+        - 0.8–1.0: Strong overlap (image likely depicts this specific meal)
+        """
+        try:
+            alt_text = image.alt_text or ""
+            if not alt_text:
+                return 0.5  # No alt text — neutral
+
+            web_keywords = await self._get_meal_keywords(meal_name)
+            if not web_keywords:
+                return 0.5  # Web search unavailable — neutral
+
+            alt_words = _extract_words(alt_text)
+            overlap = alt_words & web_keywords
+
+            if not overlap:
+                return 0.2  # No overlap — image likely unrelated
+
+            # Score based on how many web keywords appear in alt text
+            overlap_ratio = len(overlap) / min(len(web_keywords), 10)
+            score = 0.5 + min(overlap_ratio, 1.0) * 0.5  # 0.5–1.0
+
+            logger.debug(
+                f"Web score={score:.2f}: meal='{meal_name}' | "
+                f"overlap={list(overlap)[:5]} ({len(overlap)}/{len(web_keywords)})"
+            )
+            return score
+        except Exception as e:
+            logger.warning(f"Web image scoring error for '{meal_name}': {e}")
+            return 0.5  # Graceful degradation
+
+    async def _get_meal_keywords(self, meal_name: str) -> Set[str]:
+        """Fetch and cache descriptive keywords for a meal from web search."""
+        key = meal_name.strip().lower()
+        if key in self._keyword_cache:
+            return self._keyword_cache[key]
+
+        keywords = await self._search_meal_keywords(meal_name)
+        self._keyword_cache[key] = keywords
+
+        # Keep cache bounded
+        if len(self._keyword_cache) > 2000:
+            keys = list(self._keyword_cache.keys())
+            for k in keys[:1000]:
+                del self._keyword_cache[k]
+
+        return keywords
+
+    async def _search_meal_keywords(self, meal_name: str) -> Set[str]:
+        """Search Brave for meal name and extract food-relevant keywords."""
+        try:
+            async with httpx.AsyncClient(timeout=_SEARCH_TIMEOUT) as client:
+                response = await client.get(
+                    BRAVE_SEARCH_URL,
+                    params={"q": f"{meal_name} dish recipe food", "count": 5},
+                    headers={
+                        "X-Subscription-Token": self._api_key,
+                        "Accept": "application/json",
+                    },
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            results = data.get("web", {}).get("results", [])
+            if not results:
+                return set()
+
+            text_parts = []
+            for r in results[:5]:
+                text_parts.append(r.get("title", ""))
+                text_parts.append(r.get("description", ""))
+
+            combined = " ".join(text_parts)
+            keywords = _extract_words(combined)
+
+            # Remove overly generic words
+            generic = {
+                "recipe", "recipes", "food", "dish", "best", "easy",
+                "simple", "make", "how", "home", "cook", "cooking",
+                "minute", "minutes", "time", "step", "steps",
+                "the", "and", "with", "for", "this", "that",
+                "from", "your", "you", "are", "will", "can",
+            }
+            keywords -= generic
+
+            logger.debug(
+                f"Web keywords for '{meal_name}': {list(keywords)[:15]}"
+            )
+            return keywords
+
+        except Exception as e:
+            logger.warning(f"Brave search for meal keywords failed: {e}")
+            return set()
+
+
+def _extract_words(text: str) -> set:
+    """Extract lowercase words (2+ chars), strip punctuation."""
+    return set(re.findall(r'[a-zA-Z]{2,}', text.lower()))

--- a/src/domain/services/meal_discovery/web_search_image_validator.py
+++ b/src/domain/services/meal_discovery/web_search_image_validator.py
@@ -5,12 +5,12 @@ alt text matches web descriptions of that meal.
 Gracefully degrades: returns 0.5 (neutral) on any error.
 """
 import logging
-import re
 from typing import Optional, Set
 
 import httpx
 
 from src.domain.model.meal_discovery.food_image import FoodImageResult
+from src.domain.services.meal_discovery import extract_words
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class WebSearchImageValidator:
             if not web_keywords:
                 return 0.5  # Web search unavailable — neutral
 
-            alt_words = _extract_words(alt_text)
+            alt_words = extract_words(alt_text)
             overlap = alt_words & web_keywords
 
             if not overlap:
@@ -116,7 +116,7 @@ class WebSearchImageValidator:
                 text_parts.append(r.get("description", ""))
 
             combined = " ".join(text_parts)
-            keywords = _extract_words(combined)
+            keywords = extract_words(combined)
 
             # Remove overly generic words
             generic = {
@@ -136,8 +136,3 @@ class WebSearchImageValidator:
         except Exception as e:
             logger.warning(f"Brave search for meal keywords failed: {e}")
             return set()
-
-
-def _extract_words(text: str) -> set:
-    """Extract lowercase words (2+ chars), strip punctuation."""
-    return set(re.findall(r'[a-zA-Z]{2,}', text.lower()))


### PR DESCRIPTION
## Summary
- **Image confidence scoring**: Replace binary accept/reject with 0.0–1.0 score based on how well the image alt text describes the meal name (overlap ratio)
- **Web search cross-validation**: Optional Brave Search cross-reference to validate images match the actual meal (configured via `BRAVE_SEARCH_API_KEY`)
- **Save image URL**: Pass discovery image URL through the save flow so logged meals retain their food photos in Today's Meals
- **Negative signal detection**: Reject images with non-food content (buildings, cars, landscapes)
- **Expanded food vocabulary**: 50+ food signal terms for better matching

## Files changed
- `food_image_search_service.py` — Scoring-based validation replacing boolean checks
- `web_search_image_validator.py` — **New** — Brave web search cross-validation
- `food_image.py` — Added `confidence` field to `FoodImageResult`
- `meal_suggestion_responses.py` — Added `image_confidence` to discovery response
- `save_meal_suggestion_*` — Added `image_url` field through request → command → handler

## Test plan
- [ ] Discovery endpoint returns `image_confidence` per meal
- [ ] Images with high query overlap score ≥ 0.8
- [ ] Generic food photos score 0.4–0.5 (fall back to emoji on mobile)
- [ ] Non-food images score 0.0 (rejected)
- [ ] Web validation gracefully degrades without Brave API key
- [ ] Saved meals retain image URL in database