### PR TITLE
fix(migrations): surface silent errors + enforce sequential revision IDs

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -10,6 +10,7 @@ script_location = migrations
 # see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
 # for all available tokens
 # file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+file_template = %%(rev)s_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -12,6 +12,7 @@ from sqlalchemy import pool
 from alembic import context
 
 # Import our database configuration
+from alembic.script import ScriptDirectory
 from src.infra.database.config import Base, SQLALCHEMY_DATABASE_URL, engine
 
 # this is the Alembic Config object, which provides
@@ -21,16 +22,22 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
 target_metadata = Base.metadata
 
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
+
+def _next_sequential_rev_id(context, revision, directives):
+    """Auto-assign sequential numeric revision IDs (048, 049, ...)."""
+    if not directives:
+        return
+    script = directives[0]
+    head = ScriptDirectory.from_config(config).get_current_head()
+    next_id = str(int(head) + 1).zfill(3) if head and head.isdigit() else None
+    if next_id:
+        script.rev_id = next_id
 
 
 def run_migrations_offline() -> None:
@@ -51,6 +58,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        process_revision_directives=_next_sequential_rev_id,
     )
 
     with context.begin_transaction():
@@ -74,7 +82,9 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=_next_sequential_rev_id,
         )
 
         with context.begin_transaction():

--- a/migrations/run.py
+++ b/migrations/run.py
@@ -190,6 +190,9 @@ def run_migrations() -> bool:
         return True
         
     except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"❌ Migration failed: {e}", file=sys.stderr, flush=True)
         logger.error(f"❌ Migration failed: {e}", exc_info=True)
         return False
 
@@ -202,6 +205,7 @@ if __name__ == "__main__":
         if success:
             logger.info("🎉 Migration process completed successfully")
         else:
+            print("💥 Migration process failed", file=sys.stderr, flush=True)
             logger.error("💥 Migration process failed")
         
         sys.exit(exit_code)
@@ -210,5 +214,8 @@ if __name__ == "__main__":
         logger.warning("⚠️ Migration interrupted by user")
         sys.exit(130)  # Standard exit code for SIGINT
     except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"💥 Unexpected error: {e}", file=sys.stderr, flush=True)
         logger.error(f"💥 Unexpected error: {e}", exc_info=True)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- **Fix invisible migration errors**: `fileConfig()` in `env.py` was called with `disable_existing_loggers=True` (default), which silently killed the migration runner's logger — all errors after Alembic ran were dropped. Added `disable_existing_loggers=False` and `print()` fallbacks to stderr.
- **Enforce sequential revision IDs**: Added `process_revision_directives` hook so `alembic revision --autogenerate` generates `048`, `049`, etc. instead of hex hashes. Prevents future revision mismatch issues like the one that caused today's deployment failure.

## Changes
- `migrations/env.py`: `disable_existing_loggers=False`, `_next_sequential_rev_id` hook
- `migrations/run.py`: `print()` + `traceback` fallback for error visibility
- `alembic.ini`: `file_template` set to `%(rev)s_%(slug)s`

## Test plan
- [ ] Deploy to staging and verify migration logs show success/failure messages
- [ ] Run `alembic revision --autogenerate -m "test"` locally and confirm file is named `048_test.py` with `revision = "048"`
- [ ] Delete test migration after verification