### PR TITLE
chore(infra): migrate docker-compose from mysql to postgres 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,22 @@
 version: '3.8'
 
 services:
-  mysql:
-    image: mysql:8.0
-    container_name: mealtrack_mysql
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: mealtrack_postgres
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: rootpassword123
-      MYSQL_DATABASE: mealtrack
-      MYSQL_USER: mealtrack_user
-      MYSQL_PASSWORD: mealtrack_pass123
+      POSTGRES_DB: nutree
+      POSTGRES_USER: nutree
+      POSTGRES_PASSWORD: nutree
     ports:
-      - "3306:3306"
+      - "5432:5432"
     volumes:
-      - mysql_data:/var/lib/mysql
-    command: 
-      - --default-authentication-plugin=mysql_native_password
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword123"]
-      timeout: 20s
+      test: ["CMD-SHELL", "pg_isready -U nutree -d nutree"]
+      interval: 10s
+      timeout: 5s
       retries: 10
 
   redis:
@@ -39,7 +35,7 @@ services:
       retries: 5
 
 volumes:
-  mysql_data:
-    name: mealtrack_mysql_data
+  postgres_data:
+    name: mealtrack_postgres_data
   redis_data:
     name: mealtrack_redis_data

--- a/src/infra/cache/cache_service.py
+++ b/src/infra/cache/cache_service.py
@@ -4,6 +4,7 @@ High-level cache service that handles serialization and metrics.
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Optional, TypeVar
 
@@ -12,6 +13,11 @@ from pydantic import BaseModel
 from src.domain.ports.cache_port import CachePort
 from src.infra.cache.metrics import CacheMonitor
 from src.infra.cache.redis_client import RedisClient
+
+# Strip the trailing 'Z' produced by an older serializer bug that wrote
+# tz-aware datetimes as '...+HH:MMZ' (offset + Z together is invalid ISO8601
+# and rejected by Pydantic v2). Heals existing Redis entries on read.
+_LEGACY_OFFSET_Z_RE = re.compile(r'([+-]\d{2}:\d{2})Z')
 
 T = TypeVar("T")
 
@@ -54,7 +60,8 @@ class CacheService(CachePort):
             self.monitor.record_hit()
 
         try:
-            return json.loads(raw)
+            sanitized = _LEGACY_OFFSET_Z_RE.sub(r'\1', raw) if isinstance(raw, str) else raw
+            return json.loads(sanitized)
         except json.JSONDecodeError:
             return None
 
@@ -107,6 +114,9 @@ def _json_serializer(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return value.model_dump()
     if isinstance(value, datetime):
-        return value.isoformat() + 'Z'
+        # tz-aware datetimes already encode the offset (e.g. +00:00); only
+        # append 'Z' for naive datetimes (assumed UTC) to avoid producing
+        # malformed strings like '...+00:00Z' that Pydantic rejects.
+        return value.isoformat() if value.tzinfo is not None else value.isoformat() + 'Z'
     raise TypeError(f"Object of type {value.__class__.__name__} is not JSON serializable")
 

--- a/tests/unit/infra/cache/test_cache_service.py
+++ b/tests/unit/infra/cache/test_cache_service.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for CacheService JSON (de)serialization, including the
+datetime-with-offset fix that prevented '+HH:MMZ' malformed strings.
+"""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.cache.cache_service import CacheService, _json_serializer
+
+
+# ---------- Serializer ----------
+
+def test_serializer_naive_datetime_appends_z():
+    """Naive datetimes are assumed UTC; legacy 'Z' suffix preserved."""
+    dt = datetime(2026, 4, 13, 10, 12, 43)
+    assert _json_serializer(dt) == "2026-04-13T10:12:43Z"
+
+
+def test_serializer_tz_aware_datetime_no_double_z():
+    """tz-aware datetimes must NOT get a trailing 'Z' (caused +00:00Z bug)."""
+    dt = datetime(2026, 4, 13, 10, 12, 43, 247633, tzinfo=timezone.utc)
+    out = _json_serializer(dt)
+    assert out == "2026-04-13T10:12:43.247633+00:00"
+    assert not out.endswith("Z")
+
+
+# ---------- Round-trip + legacy heal via get_json ----------
+
+@pytest.fixture
+def service():
+    redis = AsyncMock()
+    return CacheService(redis_client=redis, enabled=True)
+
+
+@pytest.mark.asyncio
+async def test_get_json_heals_legacy_offset_z(service):
+    """Legacy entries with '+00:00Z' should be sanitized on read."""
+    service.redis.get = AsyncMock(
+        return_value='{"updated_at": "2026-04-13T10:12:43.247633+00:00Z"}'
+    )
+    result = await service.get_json("k")
+    assert result == {"updated_at": "2026-04-13T10:12:43.247633+00:00"}
+
+
+@pytest.mark.asyncio
+async def test_get_json_heals_negative_offset_z(service):
+    """Sanitizer also fixes negative offsets (e.g. '-05:00Z')."""
+    service.redis.get = AsyncMock(
+        return_value='{"t": "2026-04-13T10:12:43-05:00Z"}'
+    )
+    result = await service.get_json("k")
+    assert result == {"t": "2026-04-13T10:12:43-05:00"}
+
+
+@pytest.mark.asyncio
+async def test_get_json_passthrough_when_clean(service):
+    """Well-formed payloads pass through unchanged."""
+    service.redis.get = AsyncMock(
+        return_value='{"updated_at": "2026-04-13T10:12:43.247633+00:00"}'
+    )
+    result = await service.get_json("k")
+    assert result == {"updated_at": "2026-04-13T10:12:43.247633+00:00"}
+
+
+@pytest.mark.asyncio
+async def test_get_json_returns_none_on_miss(service):
+    service.redis.get = AsyncMock(return_value=None)
+    assert await service.get_json("k") is None
+
+
+@pytest.mark.asyncio
+async def test_get_json_returns_none_on_invalid_json(service):
+    service.redis.get = AsyncMock(return_value="not-json")
+    assert await service.get_json("k") is None
+
+
+@pytest.mark.asyncio
+async def test_set_json_writes_clean_offset(service):
+    """End-to-end: set_json with tz-aware dt produces no '+00:00Z'."""
+    service.redis.set = AsyncMock(return_value=True)
+    dt = datetime(2026, 4, 13, 10, 12, 43, tzinfo=timezone.utc)
+    await service.set_json("k", {"updated_at": dt})
+    args, _ = service.redis.set.call_args
+    payload = args[1]
+    assert "+00:00" in payload
+    assert "+00:00Z" not in payload


### PR DESCRIPTION
## Summary
- Replace MySQL 8.0 with PostgreSQL 16 (pgvector) in docker-compose
- Update credentials to match backend .env defaults (nutree/nutree/nutree)
- Fix cache service ISO8601 datetime string sanitization for legacy tz-aware strings

## Test plan
- [ ] `docker-compose up -d postgres` starts successfully
- [ ] `pg_isready -U nutree -d nutree` returns accepting connections
- [ ] Backend connects without auth errors
- [ ] Cache datetime serialization handles `+HH:MMZ` malformed strings