### PR TITLE
fix: strip sslmode from asyncpg database URLs

### DIFF
--- a/src/infra/database/config_async.py
+++ b/src/infra/database/config_async.py
@@ -1,6 +1,8 @@
 """Async database engine, session factory, and FastAPI dependency."""
 import logging
 import os
+from typing import Optional, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from dotenv import load_dotenv
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -9,6 +11,32 @@ from sqlalchemy.pool import NullPool, AsyncAdaptedQueuePool
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+def _extract_sslmode(url: str) -> Tuple[str, Optional[str]]:
+    """
+    asyncpg does not accept `sslmode` as a connect() kwarg.
+
+    SQLAlchemy's URL query params are forwarded as driver kwargs, so we strip
+    `sslmode` and return it so the caller can translate it into asyncpg's `ssl`.
+    """
+    try:
+        parts = urlsplit(url)
+        query_pairs = parse_qsl(parts.query, keep_blank_values=True)
+        sslmode: Optional[str] = None
+        filtered: list[tuple[str, str]] = []
+        for k, v in query_pairs:
+            if k == "sslmode":
+                sslmode = v
+                continue
+            filtered.append((k, v))
+        if sslmode is None:
+            return url, None
+        new_query = urlencode(filtered)
+        sanitized = urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
+        return sanitized, sslmode
+    except Exception:  # noqa: BLE001
+        # If parsing fails, keep original URL; engine init will surface any issues.
+        return url, None
 
 _raw_url = (
     os.getenv("DATABASE_URL_DIRECT")
@@ -32,6 +60,13 @@ elif _raw_url.startswith("postgresql+psycopg2://"):
 else:
     ASYNC_DATABASE_URL = _raw_url
 
+# Render/Neon style URLs may include `?sslmode=require`, which breaks asyncpg.
+ASYNC_DATABASE_URL, _sslmode = _extract_sslmode(ASYNC_DATABASE_URL)
+_connect_args: dict = {}
+if _sslmode and _sslmode.lower() not in {"disable", "allow", "prefer"}:
+    # asyncpg expects `ssl` instead of `sslmode`. `True` lets asyncpg create a default SSL context.
+    _connect_args["ssl"] = True
+
 # Detect Neon pooler — use NullPool (PgBouncer manages connections)
 _IS_NEON_POOLER = "-pooler" in ASYNC_DATABASE_URL and os.getenv("DATABASE_URL_DIRECT") is None
 
@@ -45,6 +80,7 @@ try:
             ASYNC_DATABASE_URL,
             echo=False,
             poolclass=NullPool,
+            connect_args=_connect_args,
         )
         logger.info("Async engine: NullPool (Neon pooler detected)")
     else:
@@ -56,6 +92,7 @@ try:
             max_overflow=_ASYNC_POOL_OVERFLOW,
             pool_recycle=120,
             pool_timeout=30,
+            connect_args=_connect_args,
         )
         logger.info(
             "Async engine: AsyncAdaptedQueuePool pool_size=%s max_overflow=%s",

--- a/src/infra/database/config_async.py
+++ b/src/infra/database/config_async.py
@@ -12,31 +12,41 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-def _extract_sslmode(url: str) -> Tuple[str, Optional[str]]:
+def _sanitize_asyncpg_url_and_connect_args(url: str) -> Tuple[str, dict]:
     """
-    asyncpg does not accept `sslmode` as a connect() kwarg.
+    Remove libpq-only URL params that asyncpg cannot accept as connect kwargs.
 
     SQLAlchemy's URL query params are forwarded as driver kwargs, so we strip
-    `sslmode` and return it so the caller can translate it into asyncpg's `ssl`.
+    unsupported options and translate compatible ones into asyncpg connect_args.
     """
     try:
         parts = urlsplit(url)
         query_pairs = parse_qsl(parts.query, keep_blank_values=True)
         sslmode: Optional[str] = None
         filtered: list[tuple[str, str]] = []
+        connect_args: dict = {}
         for k, v in query_pairs:
             if k == "sslmode":
                 sslmode = v
                 continue
+            if k == "channel_binding":
+                # libpq option; asyncpg.connect() doesn't accept it.
+                continue
             filtered.append((k, v))
-        if sslmode is None:
-            return url, None
+
+        if sslmode and sslmode.lower() not in {"disable", "allow", "prefer"}:
+            # asyncpg expects `ssl` instead of `sslmode`.
+            connect_args["ssl"] = True
+
+        if sslmode is None and len(filtered) == len(query_pairs):
+            return url, connect_args
+
         new_query = urlencode(filtered)
         sanitized = urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
-        return sanitized, sslmode
+        return sanitized, connect_args
     except Exception:  # noqa: BLE001
         # If parsing fails, keep original URL; engine init will surface any issues.
-        return url, None
+        return url, {}
 
 _raw_url = (
     os.getenv("DATABASE_URL_DIRECT")
@@ -60,12 +70,9 @@ elif _raw_url.startswith("postgresql+psycopg2://"):
 else:
     ASYNC_DATABASE_URL = _raw_url
 
-# Render/Neon style URLs may include `?sslmode=require`, which breaks asyncpg.
-ASYNC_DATABASE_URL, _sslmode = _extract_sslmode(ASYNC_DATABASE_URL)
-_connect_args: dict = {}
-if _sslmode and _sslmode.lower() not in {"disable", "allow", "prefer"}:
-    # asyncpg expects `ssl` instead of `sslmode`. `True` lets asyncpg create a default SSL context.
-    _connect_args["ssl"] = True
+# Render/Neon style URLs may include libpq params (sslmode/channel_binding),
+# which must be translated/removed for asyncpg.
+ASYNC_DATABASE_URL, _connect_args = _sanitize_asyncpg_url_and_connect_args(ASYNC_DATABASE_URL)
 
 # Detect Neon pooler — use NullPool (PgBouncer manages connections)
 _IS_NEON_POOLER = "-pooler" in ASYNC_DATABASE_URL and os.getenv("DATABASE_URL_DIRECT") is None

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -1,4 +1,5 @@
 """Meal cluster ORM <-> domain mapping functions."""
+from datetime import datetime, timezone
 from typing import Dict, Optional
 
 from src.domain.model.meal.meal import Meal as DomainMeal
@@ -16,6 +17,15 @@ from src.infra.database.models.meal.food_item_translation_model import FoodItemT
 from src.infra.database.models.nutrition.nutrition import NutritionORM
 from src.infra.database.models.nutrition.food_item import FoodItemORM
 from src.infra.mappers.status_mapper import MealStatusMapper
+
+
+def _to_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Convert aware datetime to naive UTC for TIMESTAMP WITHOUT TIME ZONE columns."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 # ---------------------------------------------------------------------------
@@ -192,8 +202,8 @@ def meal_translation_domain_to_orm(domain: DomainMealTranslation) -> MealTransla
         meal_id=domain.meal_id,
         language=domain.language,
         dish_name=domain.dish_name,
-        translated_at=domain.translated_at or now,
-        created_at=now,
+        translated_at=_to_naive_utc(domain.translated_at or now),
+        created_at=_to_naive_utc(now),
     )
     for fi in domain.food_items:
         translation.food_items.append(
@@ -215,10 +225,10 @@ def meal_domain_to_orm(domain: DomainMeal) -> MealORM:
         updated_at=getattr(domain, "updated_at", None) or utc_now(),
         dish_name=getattr(domain, "dish_name", None),
         meal_type=getattr(domain, "meal_type", None),
-        ready_at=getattr(domain, "ready_at", None),
+        ready_at=_to_naive_utc(getattr(domain, "ready_at", None)),
         error_message=getattr(domain, "error_message", None),
         raw_ai_response=getattr(domain, "raw_gpt_json", None),
-        last_edited_at=getattr(domain, "last_edited_at", None),
+        last_edited_at=_to_naive_utc(getattr(domain, "last_edited_at", None)),
         edit_count=getattr(domain, "edit_count", 0),
         is_manually_edited=getattr(domain, "is_manually_edited", False),
         source=getattr(domain, "source", None),

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -30,6 +30,16 @@ from src.infra.repositories.meal_repository import MealProjection
 
 logger = logging.getLogger(__name__)
 
+
+def _to_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Convert aware datetime to naive UTC for TIMESTAMP WITHOUT TIME ZONE columns."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 _PROJECTION_OPTS: dict = {
     MealProjection.MACROS_ONLY: (
         selectinload(MealORM.nutrition).selectinload(NutritionORM.food_items),
@@ -64,11 +74,11 @@ class AsyncMealRepository(MealRepositoryPort):
             existing_meal.status = MealStatusMapper.to_db(meal.status)
             existing_meal.dish_name = meal.dish_name
             existing_meal.meal_type = meal.meal_type
-            existing_meal.ready_at = meal.ready_at
+            existing_meal.ready_at = _to_naive_utc(meal.ready_at)
             existing_meal.error_message = meal.error_message
             existing_meal.raw_ai_response = meal.raw_gpt_json
             existing_meal.updated_at = meal.updated_at or utc_now()
-            existing_meal.last_edited_at = meal.last_edited_at
+            existing_meal.last_edited_at = _to_naive_utc(meal.last_edited_at)
             existing_meal.edit_count = meal.edit_count
             existing_meal.is_manually_edited = meal.is_manually_edited
             existing_meal.emoji = meal.emoji


### PR DESCRIPTION
Render/Neon DATABASE_URL values can include sslmode, which SQLAlchemy forwards as a driver kwarg. asyncpg rejects sslmode, so we remove it and enable SSL via connect_args when required.

Made-with: Cursor