### PR TITLE
fix(backend): cache invalidation and datetime serialization

### DIFF
--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -96,7 +96,7 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         await self._invalidate_user_profile(command.user_id)
 
     async def _invalidate_user_profile(self, user_id: str):
-        """Invalidate user profile, TDEE, and daily macros cache."""
+        """Invalidate user profile, TDEE, metrics, and daily macros cache."""
         if not self.cache_service:
             return
 
@@ -107,6 +107,10 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         # Invalidate TDEE cache
         tdee_key, _ = CacheKeys.user_tdee(user_id)
         await self.cache_service.invalidate(tdee_key)
+
+        # Invalidate user metrics cache
+        metrics_key, _ = CacheKeys.user_metrics(user_id)
+        await self.cache_service.invalidate(metrics_key)
 
         # Invalidate today's daily macros (contains target goals from TDEE)
         daily_macros_key, _ = CacheKeys.daily_macros(user_id, date.today())

--- a/src/infra/cache/cache_service.py
+++ b/src/infra/cache/cache_service.py
@@ -107,6 +107,8 @@ def _json_serializer(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return value.model_dump()
     if isinstance(value, datetime):
-        return value.isoformat() + 'Z'
+        # isoformat() already includes timezone offset for aware datetimes
+        # Don't append 'Z' - it creates invalid "+00:00Z" format
+        return value.isoformat()
     raise TypeError(f"Object of type {value.__class__.__name__} is not JSON serializable")
 


### PR DESCRIPTION
## Summary
- Add user metrics cache invalidation when updating metrics via `UpdateUserMetricsCommandHandler`
- Fix datetime serialization in `CacheService` to avoid invalid "+00:00Z" format (isoformat() already includes timezone)

## Changes
- `update_user_metrics_command_handler.py`: Invalidate `user_metrics` cache key on update
- `cache_service.py`: Remove redundant 'Z' suffix from datetime serialization

## Test Plan
- [ ] Verify metrics update invalidates cache correctly
- [ ] Verify datetime values serialize without format errors