### PR TITLE
fix(webhooks): make RevenueCat handlers async to fix coroutine error

### DIFF
--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -98,23 +98,23 @@ async def revenuecat_webhook(
         # Handle events
         try:
             if event_type == "INITIAL_PURCHASE":
-                handle_purchase(uow, user, event)
-                
+                await handle_purchase(uow, user, event)
+
             elif event_type == "RENEWAL":
-                handle_renewal(uow, user, event)
-                
+                await handle_renewal(uow, user, event)
+
             elif event_type == "CANCELLATION":
-                handle_cancellation(uow, user, event)
-                
+                await handle_cancellation(uow, user, event)
+
             elif event_type == "EXPIRATION":
-                handle_expiration(uow, user, event)
-                
+                await handle_expiration(uow, user, event)
+
             elif event_type == "BILLING_ISSUE":
-                handle_billing_issue(uow, user, event)
-                
+                await handle_billing_issue(uow, user, event)
+
             elif event_type == "PRODUCT_CHANGE":
-                handle_product_change(uow, user, event)
-            
+                await handle_product_change(uow, user, event)
+
             else:
                 logger.info(f"Unhandled event type: {event_type}")
 
@@ -131,19 +131,19 @@ async def revenuecat_webhook(
     return {"status": "success"}
 
 
-def handle_purchase(uow, user, event):
+async def handle_purchase(uow, user, event):
     """Handle initial purchase."""
     logger.info(f"Creating subscription for user {user.id}")
-    
+
     # Check if subscription already exists
-    existing = get_subscription_by_revenuecat_id(
-        uow, 
+    existing = await get_subscription_by_revenuecat_id(
+        uow,
         event.get("app_user_id")
     )
-    
+
     if existing:
         logger.warning(f"Subscription already exists for {user.id}, updating instead")
-        handle_renewal(uow, user, event)
+        await handle_renewal(uow, user, event)
         return
     
     # Create new subscription record
@@ -164,13 +164,13 @@ def handle_purchase(uow, user, event):
     logger.info(f"User {user.id} purchased {subscription.product_id}")
 
 
-def handle_renewal(uow, user, event):
+async def handle_renewal(uow, user, event):
     """Handle subscription renewal."""
-    subscription = get_subscription_by_revenuecat_id(
+    subscription = await get_subscription_by_revenuecat_id(
         uow,
         event.get("app_user_id")
     )
-    
+
     if subscription:
         subscription.expires_at = parse_timestamp(event.get("expiration_at_ms"))
         subscription.status = "active"
@@ -178,16 +178,16 @@ def handle_renewal(uow, user, event):
         logger.info(f"User {user.id} renewed subscription until {subscription.expires_at}")
     else:
         logger.warning(f"Subscription not found for renewal, creating new one")
-        handle_purchase(uow, user, event)
+        await handle_purchase(uow, user, event)
 
 
-def handle_cancellation(uow, user, event):
+async def handle_cancellation(uow, user, event):
     """Handle subscription cancellation."""
-    subscription = get_subscription_by_revenuecat_id(
+    subscription = await get_subscription_by_revenuecat_id(
         uow,
         event.get("app_user_id")
     )
-    
+
     if subscription:
         subscription.status = "cancelled"
         subscription.cancelled_at = utc_now()
@@ -196,40 +196,39 @@ def handle_cancellation(uow, user, event):
         logger.info(f"User {user.id} cancelled subscription (expires {subscription.expires_at})")
 
 
-def handle_expiration(uow, user, event):
+async def handle_expiration(uow, user, event):
     """Handle subscription expiration."""
-    subscription = get_subscription_by_revenuecat_id(
+    subscription = await get_subscription_by_revenuecat_id(
         uow,
         event.get("app_user_id")
     )
-    
+
     if subscription:
         subscription.status = "expired"
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} subscription expired")
 
 
-def handle_billing_issue(uow, user, event):
+async def handle_billing_issue(uow, user, event):
     """Handle billing issues."""
-    subscription = get_subscription_by_revenuecat_id(
+    subscription = await get_subscription_by_revenuecat_id(
         uow,
         event.get("app_user_id")
     )
-    
+
     if subscription:
         subscription.status = "billing_issue"
         subscription.updated_at = utc_now()
         logger.warning(f"Billing issue for user {user.id}")
-        # TODO: Send notification to user
 
 
-def handle_product_change(uow, user, event):
+async def handle_product_change(uow, user, event):
     """Handle product change (e.g., monthly to yearly)."""
-    subscription = get_subscription_by_revenuecat_id(
+    subscription = await get_subscription_by_revenuecat_id(
         uow,
         event.get("app_user_id")
     )
-    
+
     if subscription:
         subscription.product_id = event.get("product_id")
         subscription.expires_at = parse_timestamp(event.get("expiration_at_ms"))
@@ -238,9 +237,9 @@ def handle_product_change(uow, user, event):
         logger.info(f"User {user.id} changed to {subscription.product_id}")
 
 
-def get_subscription_by_revenuecat_id(uow, revenuecat_id: str):
+async def get_subscription_by_revenuecat_id(uow, revenuecat_id: str):
     """Get subscription by RevenueCat subscriber ID."""
-    return uow.subscriptions.find_by_revenuecat_id(revenuecat_id)
+    return await uow.subscriptions.find_by_revenuecat_id(revenuecat_id)
 
 
 def parse_platform(store: str) -> str:

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -110,8 +110,8 @@ class TestWebhookHandler:
                 mock_result.scalars.return_value.first.return_value = mock_user
                 mock_uow.session.execute.return_value = mock_result
                 
-                # Mock no existing subscription
-                with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', return_value=None):
+                # Mock no existing subscription (async)
+                with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=None):
                     result = await revenuecat_webhook(mock_request, authorization="test_secret")
                 
                 assert result == {"status": "success"}
@@ -168,7 +168,7 @@ class TestWebhookHandler:
             assert exc_info.value.status_code == 401
             assert exc_info.value.detail == "Unauthorized"
     
-    def test_handle_purchase(self, mock_uow):
+    async def test_handle_purchase(self, mock_uow):
         """Test handling initial purchase event."""
         user = MagicMock(id="user_123")
         event = {
@@ -180,11 +180,11 @@ class TestWebhookHandler:
             "transaction_id": "123456",
             "environment": "PRODUCTION"
         }
-        
-        # Mock no existing subscription
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', return_value=None):
-            handle_purchase(mock_uow, user, event)
-        
+
+        # Mock no existing subscription (async)
+        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=None):
+            await handle_purchase(mock_uow, user, event)
+
         # Verify subscription was added
         mock_uow.session.add.assert_called_once()
         added_subscription = mock_uow.session.add.call_args[0][0]
@@ -192,7 +192,7 @@ class TestWebhookHandler:
         assert added_subscription.product_id == "premium_monthly"
         assert added_subscription.status == "active"
     
-    def test_handle_renewal(self, mock_uow):
+    async def test_handle_renewal(self, mock_uow):
         """Test handling renewal event."""
         user = MagicMock(id="user_123")
         subscription = MagicMock()
@@ -200,47 +200,47 @@ class TestWebhookHandler:
             "app_user_id": "user_123",
             "expiration_at_ms": 1699478400000
         }
-        
-        # Mock existing subscription
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', return_value=subscription):
-            handle_renewal(mock_uow, user, event)
-        
+
+        # Mock existing subscription (async)
+        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+            await handle_renewal(mock_uow, user, event)
+
         assert subscription.status == "active"
         assert subscription.expires_at is not None
     
-    def test_handle_cancellation(self, mock_uow):
+    async def test_handle_cancellation(self, mock_uow):
         """Test handling cancellation event."""
         user = MagicMock(id="user_123")
         subscription = MagicMock()
         event = {"app_user_id": "user_123"}
-        
-        # Mock existing subscription
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', return_value=subscription):
-            handle_cancellation(mock_uow, user, event)
-        
+
+        # Mock existing subscription (async)
+        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+            await handle_cancellation(mock_uow, user, event)
+
         assert subscription.status == "cancelled"
         assert subscription.cancelled_at is not None
     
-    def test_handle_expiration(self, mock_uow):
+    async def test_handle_expiration(self, mock_uow):
         """Test handling expiration event."""
         user = MagicMock(id="user_123")
         subscription = MagicMock()
         event = {"app_user_id": "user_123"}
-        
-        # Mock existing subscription
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', return_value=subscription):
-            handle_expiration(mock_uow, user, event)
-        
+
+        # Mock existing subscription (async)
+        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+            await handle_expiration(mock_uow, user, event)
+
         assert subscription.status == "expired"
     
-    def test_handle_billing_issue(self, mock_uow):
+    async def test_handle_billing_issue(self, mock_uow):
         """Test handling billing issue event."""
         user = MagicMock(id="user_123")
         subscription = MagicMock()
         event = {"app_user_id": "user_123"}
-        
-        # Mock existing subscription
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', return_value=subscription):
-            handle_billing_issue(mock_uow, user, event)
-        
+
+        # Mock existing subscription (async)
+        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+            await handle_billing_issue(mock_uow, user, event)
+
         assert subscription.status == "billing_issue"


### PR DESCRIPTION
## Summary
- Made all 6 RevenueCat webhook handler functions `async`
- Made `get_subscription_by_revenuecat_id` helper `async`
- Added `await` to all repository and cross-handler calls

## Problem
`AsyncUnitOfWork` uses async repository methods, but handler functions were sync and never awaited the coroutines, causing:
```
AttributeError: 'coroutine' object has no attribute 'status'
```

## Test plan
- [ ] Trigger RevenueCat webhook event (EXPIRATION, RENEWAL, etc.)
- [ ] Verify no coroutine errors in logs
- [ ] Verify subscription status updates correctly in DB