### PR TITLE
fix(infra): restore auto-migration for Northflank and fix Redis init order

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,29 +1,38 @@
 #!/bin/bash
 set -e
 
-echo "🚀 MealTrack Backend - Starting initialization..."
+echo "🚀 MealTrack Backend - Starting application..."
 
 # Function to log messages
 log() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
 }
 
-# Run database migrations
-log "📦 Running database migrations..."
-python migrations/run.py
-
-if [ $? -eq 0 ]; then
-    log "✅ Migrations completed successfully"
-else
-    log "❌ Migrations failed!"
-    exit 1
+# Run database migrations (skip on Render where pre-deploy handles this)
+if [ "${RENDER:-}" != "true" ]; then
+    log "📦 Running database migrations..."
+    if python migrations/run.py; then
+        log "✅ Migrations completed successfully"
+    else
+        log "❌ Migrations failed!"
+        exit 1
+    fi
 fi
 
-# Railway (and others) inject PORT; default 8000 for local/Docker
-PORT="${PORT:-8000}"
+# Render defaults web services to port 10000 if a custom port is not configured.
+# Railway injects PORT; local Docker defaults to 8000.
+if [ -z "${PORT:-}" ]; then
+    if [ "${RENDER:-}" = "true" ]; then
+        PORT="10000"
+    else
+        PORT="8000"
+    fi
+fi
+
 # Start the application
 log "🚀 Starting FastAPI application on port ${PORT}..."
 WORKERS="${UVICORN_WORKERS:-4}"
+log "Uvicorn workers: ${WORKERS}"
 exec uvicorn src.api.main:app \
     --host 0.0.0.0 \
     --port "$PORT" \

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -158,6 +158,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Database connection warming failed: %s", e)
 
+    # Initialize Redis cache (must happen BEFORE notification service)
+    try:
+        await initialize_cache_layer()
+    except Exception as exc:
+        logger.error("Failed to initialize cache layer: %s", exc)
+        if os.getenv("FAIL_ON_CACHE_ERROR", "false").lower() == "true":
+            raise
+
     # Initialize and start scheduled notification service
     scheduled_service = None
     try:
@@ -168,14 +176,6 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to start scheduled notification service: {e}")
         # Continue running the API even if notification service fails
-
-    # Initialize Redis cache
-    try:
-        await initialize_cache_layer()
-    except Exception as exc:
-        logger.error("Failed to initialize cache layer: %s", exc)
-        if os.getenv("FAIL_ON_CACHE_ERROR", "false").lower() == "true":
-            raise
 
     logger.info("MealTrack API started successfully!")
     yield


### PR DESCRIPTION
## Summary
- Restore migrations in `docker-entrypoint.sh` for non-Render platforms (Northflank)
- Skip migrations on Render (`RENDER=true`) where pre-deploy handles it
- Move Redis initialization before notification service startup
- Fixes `'NoneType' has no attribute 'exists'` error on startup

## Root Cause
1. PR #172 removed auto-migration from entrypoint (intended for Render pre-deploy)
2. Redis was initialized AFTER notification service, causing `_redis_client` to be `None`

## Test Plan
- [ ] Deploy to Northflank staging
- [ ] Verify migrations run on startup
- [ ] Verify no `'NoneType'` errors in logs
- [ ] Verify notification service starts correctly