### PR TITLE
perf: add noload(image) to MACROS_ONLY projection

### DIFF
--- a/src/infra/repositories/meal_repository.py
+++ b/src/infra/repositories/meal_repository.py
@@ -4,7 +4,7 @@ from enum import Enum, auto
 from typing import Dict, List, Optional
 
 from sqlalchemy import func, update
-from sqlalchemy.orm import Session, joinedload, selectinload
+from sqlalchemy.orm import Session, joinedload, selectinload, noload
 
 from src.domain.model.meal import Meal, MealStatus
 from src.domain.model.nutrition import Nutrition
@@ -40,6 +40,7 @@ class MealProjection(Enum):
 
 _PROJECTION_OPTS: dict = {
     MealProjection.MACROS_ONLY: (
+        noload(MealORM.image),
         selectinload(MealORM.nutrition).selectinload(NutritionORM.food_items),
     ),
     MealProjection.FULL: (

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 from sqlalchemy import func, update, select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload, joinedload
+from sqlalchemy.orm import selectinload, joinedload, noload
 
 from src.domain.model.meal import Meal, MealStatus
 from src.domain.model.nutrition import Nutrition
@@ -42,6 +42,7 @@ def _to_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
 
 _PROJECTION_OPTS: dict = {
     MealProjection.MACROS_ONLY: (
+        noload(MealORM.image),
         selectinload(MealORM.nutrition).selectinload(NutritionORM.food_items),
     ),
     MealProjection.FULL: (

--- a/tests/unit/repositories/test_meal_repository_projections.py
+++ b/tests/unit/repositories/test_meal_repository_projections.py
@@ -44,9 +44,9 @@ def test_projection_opt_counts():
     """Each projection must have the correct number of load options."""
     from src.infra.repositories.meal_repository import _PROJECTION_OPTS, MealProjection
 
-    # MACROS_ONLY: nutrition + food_items selectinload (counts as 1 chained option)
-    assert len(_PROJECTION_OPTS[MealProjection.MACROS_ONLY]) == 1, (
-        "MACROS_ONLY must have 1 load option (nutrition chain)"
+    # MACROS_ONLY: noload(image) + nutrition chain selectinload
+    assert len(_PROJECTION_OPTS[MealProjection.MACROS_ONLY]) == 2, (
+        "MACROS_ONLY must have 2 load options (noload image, nutrition chain)"
     )
     # FULL: image + nutrition chain
     assert len(_PROJECTION_OPTS[MealProjection.FULL]) == 2, (


### PR DESCRIPTION
Prevents unnecessary LEFT JOIN to mealimage table in daily-breakdown endpoint, reducing query overhead for /v1/meals/weekly/daily-breakdown.