### PR TITLE
fix(backend): make notification_sent_log drop conditional

### DIFF
--- a/migrations/versions/050_notification_optimization.py
+++ b/migrations/versions/050_notification_optimization.py
@@ -51,9 +51,11 @@ def upgrade() -> None:
         postgresql_where=sa.text("status != 'pending'"),
     )
 
-    # Drop old dedup table
-    op.drop_index('ix_sent_log_cleanup', table_name='notification_sent_log')
-    op.drop_table('notification_sent_log')
+    # Drop old dedup table (if exists — may not exist on fresh DBs)
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, 'notification_sent_log'):
+        op.drop_index('ix_sent_log_cleanup', table_name='notification_sent_log')
+        op.drop_table('notification_sent_log')
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Problem
Migration 050 fails on staging because it tries to drop `notification_sent_log` table which doesn't exist on fresh databases.

The entire migration transaction rolls back, including the `notifications` table creation, causing:
```
ERROR: relation "notifications" does not exist
```

## Fix
Check if table exists before dropping.

## After Merge
Reset staging DB migration version:
```sql
UPDATE alembic_version SET version_num = '049';
```
Then redeploy.