### PR TITLE
fix(webhooks): handle missed INITIAL_PURCHASE and fix timezone mismatch

### DIFF
--- a/migrations/versions/054_add_refunded_to_subscription_status.py
+++ b/migrations/versions/054_add_refunded_to_subscription_status.py
@@ -1,0 +1,69 @@
+"""add_refunded_to_subscription_status and fix datetime columns
+
+Revision ID: 054
+Revises: 053
+Create Date: 2026-04-25
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '054'
+down_revision: Union[str, None] = '053'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Note: subscription_status_enum type doesn't exist — status column uses VARCHAR with native_enum=False
+    # No ALTER TYPE needed; 'refunded' value works automatically with VARCHAR storage
+
+    # Fix subscription datetime columns to use TIMESTAMPTZ (same fix as migration 052)
+    op.alter_column(
+        'subscriptions', 'purchased_at',
+        type_=sa.DateTime(timezone=True),
+        existing_type=sa.DateTime(timezone=False),
+        existing_nullable=False,
+        postgresql_using="purchased_at AT TIME ZONE 'UTC'",
+    )
+    op.alter_column(
+        'subscriptions', 'expires_at',
+        type_=sa.DateTime(timezone=True),
+        existing_type=sa.DateTime(timezone=False),
+        existing_nullable=True,
+        postgresql_using="expires_at AT TIME ZONE 'UTC'",
+    )
+    op.alter_column(
+        'subscriptions', 'cancelled_at',
+        type_=sa.DateTime(timezone=True),
+        existing_type=sa.DateTime(timezone=False),
+        existing_nullable=True,
+        postgresql_using="cancelled_at AT TIME ZONE 'UTC'",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        'subscriptions', 'cancelled_at',
+        type_=sa.DateTime(timezone=False),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+        postgresql_using="cancelled_at AT TIME ZONE 'UTC'",
+    )
+    op.alter_column(
+        'subscriptions', 'expires_at',
+        type_=sa.DateTime(timezone=False),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+        postgresql_using="expires_at AT TIME ZONE 'UTC'",
+    )
+    op.alter_column(
+        'subscriptions', 'purchased_at',
+        type_=sa.DateTime(timezone=False),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+        postgresql_using="purchased_at AT TIME ZONE 'UTC'",
+    )

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -189,10 +189,7 @@ async def handle_renewal(uow, user, event):
 
 async def handle_cancellation(uow, user, event):
     """Handle subscription cancellation."""
-    subscription = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
-    )
+    subscription = await get_or_create_subscription(uow, user, event)
 
     if subscription:
         subscription.status = "cancelled"
@@ -204,10 +201,7 @@ async def handle_cancellation(uow, user, event):
 
 async def handle_expiration(uow, user, event):
     """Handle subscription expiration."""
-    subscription = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
-    )
+    subscription = await get_or_create_subscription(uow, user, event)
 
     if subscription:
         subscription.status = "expired"
@@ -217,10 +211,7 @@ async def handle_expiration(uow, user, event):
 
 async def handle_billing_issue(uow, user, event):
     """Handle billing issues."""
-    subscription = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
-    )
+    subscription = await get_or_create_subscription(uow, user, event)
 
     if subscription:
         subscription.status = "billing_issue"
@@ -230,10 +221,7 @@ async def handle_billing_issue(uow, user, event):
 
 async def handle_product_change(uow, user, event):
     """Handle product change (e.g., monthly to yearly)."""
-    subscription = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
-    )
+    subscription = await get_or_create_subscription(uow, user, event)
 
     if subscription:
         subscription.product_id = event.get("product_id")
@@ -245,10 +233,7 @@ async def handle_product_change(uow, user, event):
 
 async def handle_refund(uow, user, event):
     """Handle refund — update subscription status and revoke referral credit."""
-    subscription = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
-    )
+    subscription = await get_or_create_subscription(uow, user, event)
     if subscription:
         subscription.status = "refunded"
         subscription.updated_at = utc_now()
@@ -287,6 +272,30 @@ def _revoke_referral_on_refund(uow, user_id: str) -> None:
             conversion.referrer_user_id,
             conversion.commission_amount,
         )
+
+
+async def get_or_create_subscription(uow, user, event):
+    """Get existing subscription or create one if missing (handles missed INITIAL_PURCHASE)."""
+    subscription = await uow.subscriptions.find_by_revenuecat_id(event.get("app_user_id"))
+
+    if not subscription:
+        logger.warning(f"No subscription found for user {user.id}, creating record (missed INITIAL_PURCHASE)")
+        subscription = Subscription(
+            id=str(uuid.uuid4()),
+            user_id=user.id,
+            revenuecat_subscriber_id=event.get("app_user_id"),
+            product_id=event.get("product_id") or "unknown",
+            platform=parse_platform(event.get("store")),
+            status="active",
+            purchased_at=parse_timestamp(event.get("purchased_at_ms")) or utc_now(),
+            expires_at=parse_timestamp(event.get("expiration_at_ms")),
+            store_transaction_id=event.get("transaction_id"),
+            is_sandbox=event.get("environment") == "SANDBOX",
+        )
+        uow.session.add(subscription)
+        await uow.session.flush()
+
+    return subscription
 
 
 async def get_subscription_by_revenuecat_id(uow, revenuecat_id: str):

--- a/src/infra/database/models/subscription.py
+++ b/src/infra/database/models/subscription.py
@@ -28,13 +28,13 @@ class Subscription(Base, BaseMixin):
 
     # Subscription status
     status = Column(
-        Enum('active', 'expired', 'cancelled', 'billing_issue', native_enum=False),
+        Enum('active', 'expired', 'cancelled', 'billing_issue', 'refunded', native_enum=False),
         nullable=False,
         default='active'
     )
-    purchased_at = Column(DateTime, nullable=False)
-    expires_at = Column(DateTime, nullable=True)
-    cancelled_at = Column(DateTime, nullable=True)
+    purchased_at = Column(DateTime(timezone=True), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    cancelled_at = Column(DateTime(timezone=True), nullable=True)
     
     # Store metadata
     store_transaction_id = Column(String(255), nullable=True)

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -215,7 +215,7 @@ class TestWebhookHandler:
         event = {"app_user_id": "user_123"}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+        with patch('src.api.routes.v1.webhooks.get_or_create_subscription', new_callable=AsyncMock, return_value=subscription):
             await handle_cancellation(mock_uow, user, event)
 
         assert subscription.status == "cancelled"
@@ -228,7 +228,7 @@ class TestWebhookHandler:
         event = {"app_user_id": "user_123"}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+        with patch('src.api.routes.v1.webhooks.get_or_create_subscription', new_callable=AsyncMock, return_value=subscription):
             await handle_expiration(mock_uow, user, event)
 
         assert subscription.status == "expired"
@@ -240,7 +240,7 @@ class TestWebhookHandler:
         event = {"app_user_id": "user_123"}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+        with patch('src.api.routes.v1.webhooks.get_or_create_subscription', new_callable=AsyncMock, return_value=subscription):
             await handle_billing_issue(mock_uow, user, event)
 
         assert subscription.status == "billing_issue"


### PR DESCRIPTION
## Summary
- Add `get_or_create_subscription()` fallback — creates subscription if missing (handles missed INITIAL_PURCHASE webhooks)
- Fix subscription datetime columns to use TIMESTAMPTZ (asyncpg compatibility)
- Add 'refunded' status to subscription_status_enum

## Root Cause
1. `INITIAL_PURCHASE` webhooks failing silently → no subscription record created
2. Subsequent events (CANCELLATION, BILLING_ISSUE, etc.) tried to update non-existent records
3. Datetime columns were TIMESTAMP WITHOUT TIME ZONE but code uses timezone-aware datetimes

## Test Plan
- [ ] Run migration: `alembic upgrade head`
- [ ] Retry RevenueCat webhook
- [ ] Verify subscription record created in DB