### PR TITLE
fix(users): use timezone-aware datetime for last_accessed column

### DIFF
--- a/migrations/versions/055_fix_users_last_accessed_timezone.py
+++ b/migrations/versions/055_fix_users_last_accessed_timezone.py
@@ -1,0 +1,36 @@
+"""Fix users.last_accessed to use TIMESTAMPTZ.
+
+The last_accessed column was declared as TIMESTAMP WITHOUT TIME ZONE while
+the code uses utc_now() which returns timezone-aware datetimes. asyncpg
+rejects mixing naive and aware datetimes.
+
+Revision ID: 055
+Revises: 054
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '055'
+down_revision = '054'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'users', 'last_accessed',
+        type_=sa.DateTime(timezone=True),
+        existing_type=sa.DateTime(timezone=False),
+        existing_nullable=False,
+        postgresql_using="last_accessed AT TIME ZONE 'UTC'",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        'users', 'last_accessed',
+        type_=sa.DateTime(timezone=False),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=False,
+        postgresql_using="last_accessed AT TIME ZONE 'UTC'",
+    )

--- a/src/domain/model/user/core_user.py
+++ b/src/domain/model/user/core_user.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from src.domain.model.auth.auth_provider import AuthProvider
 from src.domain.model.base import BaseDomainModel
+from src.domain.utils.timezone_utils import utc_now
 
 
 @dataclass(kw_only=True)
@@ -54,7 +55,7 @@ class UserDomainModel(BaseDomainModel):
     provider: AuthProvider
     is_active: bool = True
     onboarding_completed: bool = False
-    last_accessed: datetime = field(default_factory=datetime.now)
+    last_accessed: datetime = field(default_factory=utc_now)
     timezone: str = 'UTC'
     first_name: Optional[str] = None
     last_name: Optional[str] = None

--- a/src/infra/database/models/user/user.py
+++ b/src/infra/database/models/user/user.py
@@ -1,12 +1,11 @@
 """
 Core user model for authentication and account management.
 """
-from datetime import datetime
-
 from sqlalchemy import Column, String, Boolean, DateTime, Text, Index, Enum
 from sqlalchemy.orm import relationship
 
 from src.api.schemas.common.auth_enums import AuthProviderEnum
+from src.domain.utils.timezone_utils import utc_now
 from src.infra.database.config import Base
 from src.infra.database.models.base import BaseMixin
 
@@ -34,7 +33,7 @@ class User(Base, BaseMixin):
     # Status & Activity
     is_active = Column(Boolean, default=True, nullable=False)
     onboarding_completed = Column(Boolean, default=False, nullable=False)
-    last_accessed = Column(DateTime, default=datetime.now, nullable=False)
+    last_accessed = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     deleted_at = Column(DateTime(timezone=True), nullable=True)
     
     # Timezone (IANA format, e.g., "America/Los_Angeles")


### PR DESCRIPTION
## Summary
- asyncpg rejects mixing naive and aware datetimes
- `users.last_accessed` was `TIMESTAMP WITHOUT TIME ZONE` but code uses `utc_now()` which returns timezone-aware datetime

## Changes
- Migration 055: ALTER `users.last_accessed` to `TIMESTAMPTZ`
- User model: `DateTime(timezone=True)` + `utc_now` default
- Domain model: `utc_now` default for consistency

## Deploy
Run `alembic upgrade head` after merge