### PR TITLE
fix(migrations): renumber 053-055 to 052-054 to fix broken chain

### DIFF
--- a/migrations/versions/052_add_referral_tables.py
+++ b/migrations/versions/052_add_referral_tables.py
@@ -1,14 +1,14 @@
 """Add referral system tables.
 
-Revision ID: 053
-Revises: 052
+Revision ID: 052
+Revises: 051
 """
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSON
 
-revision = "053"
-down_revision = "052"
+revision = "052"
+down_revision = "051"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/053_add_refunded_to_subscription_status.py
+++ b/migrations/versions/053_add_refunded_to_subscription_status.py
@@ -1,7 +1,7 @@
 """add_refunded_to_subscription_status and fix datetime columns
 
-Revision ID: 054
-Revises: 053
+Revision ID: 053
+Revises: 052
 Create Date: 2026-04-25
 
 """
@@ -11,8 +11,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = '054'
-down_revision: Union[str, None] = '053'
+revision: str = '053'
+down_revision: Union[str, None] = '052'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/054_fix_users_last_accessed_timezone.py
+++ b/migrations/versions/054_fix_users_last_accessed_timezone.py
@@ -4,14 +4,14 @@ The last_accessed column was declared as TIMESTAMP WITHOUT TIME ZONE while
 the code uses utc_now() which returns timezone-aware datetimes. asyncpg
 rejects mixing naive and aware datetimes.
 
-Revision ID: 055
-Revises: 054
+Revision ID: 054
+Revises: 053
 """
 from alembic import op
 import sqlalchemy as sa
 
-revision = '055'
-down_revision = '054'
+revision = '054'
+down_revision = '053'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Fix production deploy failure caused by missing migration 052
- Renumbered migrations: 053→052, 054→053, 055→054
- Updated revision chains: 051→052→053→054

## Root Cause
Migration 053 referenced non-existent 052 as `down_revision`, causing `KeyError: '052'` during Alembic upgrade.

## Test Plan
- [x] Verify migration chain integrity
- [ ] Redeploy to production