### PR TITLE
fix(user-profiles): add target_weight_kg support to update metrics endpoint

### DIFF
--- a/src/api/routes/v1/user_profiles.py
+++ b/src/api/routes/v1/user_profiles.py
@@ -194,6 +194,7 @@ async def update_user_metrics(
             body_fat_percent=request.body_fat_percent,
             fitness_goal=request.fitness_goal.value if request.fitness_goal else None,
             training_level=request.training_level.value if request.training_level else None,
+            target_weight_kg=request.target_weight_kg,
         )
 
         await event_bus.send(command)

--- a/src/api/schemas/request/user_profile_update_requests.py
+++ b/src/api/schemas/request/user_profile_update_requests.py
@@ -36,5 +36,6 @@ class UpdateMetricsRequest(BaseModel):
     body_fat_percent: float | None = Field(None, description="Body fat percentage", ge=0, le=70)
     fitness_goal: GoalEnum | None = Field(None, description="Fitness goal (cut, bulk, recomp)")
     training_level: TrainingLevelEnum | None = Field(None, description="Training level (beginner, intermediate, advanced)")
+    target_weight_kg: float | None = Field(None, description="Target weight in kg", gt=0)
 
 

--- a/src/app/commands/user/update_user_metrics_command.py
+++ b/src/app/commands/user/update_user_metrics_command.py
@@ -16,4 +16,5 @@ class UpdateUserMetricsCommand:
     body_fat_percent: Optional[float] = None
     fitness_goal: Optional[str] = None
     training_level: Optional[str] = None
+    target_weight_kg: Optional[float] = None
 

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -32,7 +32,7 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         # Validate at least one field is provided
         if not any([command.weight_kg, command.job_type, command.training_days_per_week,
                     command.training_minutes_per_session, command.body_fat_percent, command.fitness_goal,
-                    command.training_level]):
+                    command.training_level, command.target_weight_kg]):
             raise ValidationException("At least one metric must be provided")
 
         async with self.uow as uow:
@@ -87,6 +87,12 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 if command.training_level not in _VALID_TRAINING_LEVELS:
                     raise ValidationException(f"Training level must be one of: {sorted(_VALID_TRAINING_LEVELS)}")
                 profile.training_level = command.training_level
+
+            # Handle target weight update
+            if command.target_weight_kg is not None:
+                if command.target_weight_kg <= 0:
+                    raise ValidationException("Target weight must be greater than 0")
+                profile.target_weight_kg = command.target_weight_kg
 
             # Ensure this profile is marked as current
             profile.is_current = True


### PR DESCRIPTION
## Summary
- Fixes bug where users could not set target weight from weight progress card on home screen
- The `POST /user-profiles/metrics` endpoint was silently ignoring `target_weight_kg` sent by mobile clients
- Added support across all 4 layers: request schema, command, route handler, command handler

## Root Cause
Mobile sends `target_weight_kg` via `UpdateMetricsRequest`, but backend:
1. Request schema had no `target_weight_kg` field → Pydantic silently ignored it
2. `UpdateUserMetricsCommand` had no `target_weight_kg` field
3. Route handler didn't map `target_weight_kg` to command
4. Command handler had no logic to update `target_weight_kg`

## Changes
| File | Change |
|------|--------|
| `user_profile_update_requests.py` | Add `target_weight_kg` field to `UpdateMetricsRequest` |
| `update_user_metrics_command.py` | Add `target_weight_kg` field to command dataclass |
| `user_profiles.py` | Map `target_weight_kg` when creating command |
| `update_user_metrics_command_handler.py` | Validate (>0) and persist `target_weight_kg` |

## Test plan
- [x] Existing metrics tests pass (16/16)
- [x] Syntax and linting pass
- [ ] Manual test: update target weight from mobile weight progress card