### PR TITLE
fix(referral): convert to async SQLAlchemy for AsyncSession compatibility

### DIFF
--- a/src/api/routes/v1/referrals.py
+++ b/src/api/routes/v1/referrals.py
@@ -26,7 +26,6 @@ from src.app.handlers.query_handlers.referral.validate_referral_code_handler imp
 from src.app.queries.referral.get_my_referral_code_query import GetMyReferralCodeQuery
 from src.app.queries.referral.get_referral_stats_query import GetReferralStatsQuery
 from src.app.queries.referral.validate_referral_code_query import ValidateReferralCodeQuery
-from src.infra.database.uow import UnitOfWork
 
 router = APIRouter(prefix="/v1/referrals", tags=["Referrals"])
 logger = logging.getLogger(__name__)
@@ -93,57 +92,51 @@ class PayoutRequest(BaseModel):
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 @router.post("/validate", response_model=ValidateCodeResponse)
-def validate_code(
+async def validate_code(
     request: ValidateCodeRequest,
     user_id: str = Depends(get_current_user_id),
 ):
     """Validate a referral code before the user completes their purchase."""
-    with UnitOfWork() as uow:
-        handler = ValidateReferralCodeQueryHandler()
-        result = handler.handle(
-            ValidateReferralCodeQuery(code=request.code, user_id=user_id),
-            uow,
-        )
+    handler = ValidateReferralCodeQueryHandler()
+    result = await handler.handle(
+        ValidateReferralCodeQuery(code=request.code, user_id=user_id),
+    )
     return ValidateCodeResponse(**result.__dict__)
 
 
 @router.post("/apply", status_code=status.HTTP_201_CREATED)
-def apply_code(
+async def apply_code(
     request: ApplyCodeRequest,
     user_id: str = Depends(get_current_user_id),
 ):
     """Record the referred user's code application (call after purchase confirmation)."""
     try:
-        with UnitOfWork() as uow:
-            handler = ApplyReferralCodeCommandHandler()
-            handler.handle(
-                ApplyReferralCodeCommand(
-                    user_id=user_id,
-                    code=request.code,
-                    discount_applied=request.discount_applied,
-                ),
-                uow,
-            )
+        handler = ApplyReferralCodeCommandHandler()
+        await handler.handle(
+            ApplyReferralCodeCommand(
+                user_id=user_id,
+                code=request.code,
+                discount_applied=request.discount_applied,
+            ),
+        )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return {"success": True}
 
 
 @router.get("/my-code", response_model=MyCodeResponse)
-def get_my_code(user_id: str = Depends(get_current_user_id)):
+async def get_my_code(user_id: str = Depends(get_current_user_id)):
     """Return (or lazily create) the authenticated user's personal referral code."""
-    with UnitOfWork() as uow:
-        handler = GetMyReferralCodeQueryHandler()
-        result = handler.handle(GetMyReferralCodeQuery(user_id=user_id), uow)
+    handler = GetMyReferralCodeQueryHandler()
+    result = await handler.handle(GetMyReferralCodeQuery(user_id=user_id))
     return MyCodeResponse(**result.__dict__)
 
 
 @router.get("/stats", response_model=StatsResponse)
-def get_stats(user_id: str = Depends(get_current_user_id)):
+async def get_stats(user_id: str = Depends(get_current_user_id)):
     """Return wallet balance, lifetime totals, and per-conversion history."""
-    with UnitOfWork() as uow:
-        handler = GetReferralStatsQueryHandler()
-        result = handler.handle(GetReferralStatsQuery(user_id=user_id), uow)
+    handler = GetReferralStatsQueryHandler()
+    result = await handler.handle(GetReferralStatsQuery(user_id=user_id))
     return StatsResponse(
         code=result.code,
         wallet_balance=result.wallet_balance,
@@ -157,23 +150,21 @@ def get_stats(user_id: str = Depends(get_current_user_id)):
 
 
 @router.post("/payout", status_code=status.HTTP_201_CREATED)
-def request_payout(
+async def request_payout(
     request: PayoutRequest,
     user_id: str = Depends(get_current_user_id),
 ):
     """Request a withdrawal of referral wallet balance (minimum ₫100,000)."""
-    with UnitOfWork() as uow:
-        handler = RequestPayoutCommandHandler()
-        try:
-            handler.handle(
-                RequestPayoutCommand(
-                    user_id=user_id,
-                    amount=request.amount,
-                    payment_method=request.payment_method,
-                    payment_details=request.payment_details,
-                ),
-                uow,
-            )
-        except ValueError as exc:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    handler = RequestPayoutCommandHandler()
+    try:
+        await handler.handle(
+            RequestPayoutCommand(
+                user_id=user_id,
+                amount=request.amount,
+                payment_method=request.payment_method,
+                payment_details=request.payment_details,
+            ),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return {"success": True}

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -167,7 +167,7 @@ async def handle_purchase(uow, user, event):
     logger.info(f"User {user.id} purchased {subscription.product_id}")
 
     # Credit referrer if this user has a pending referral conversion
-    _credit_referral_on_purchase(uow, str(user.id))
+    await _credit_referral_on_purchase(uow, str(user.id))
 
 
 async def handle_renewal(uow, user, event):
@@ -239,18 +239,18 @@ async def handle_refund(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} subscription refunded")
 
-    _revoke_referral_on_refund(uow, str(user.id))
+    await _revoke_referral_on_refund(uow, str(user.id))
 
 
-def _credit_referral_on_purchase(uow, user_id: str) -> None:
+async def _credit_referral_on_purchase(uow, user_id: str) -> None:
     """Credit the referrer's wallet when a referred user completes their first purchase."""
     from src.infra.repositories.referral_repository import ReferralRepository
     repo = ReferralRepository(uow.session)
-    conversion = repo.get_conversion_by_referred_user(user_id)
+    conversion = await repo.get_conversion_by_referred_user(user_id)
     if conversion and conversion.status == "pending":
         conversion.status = "converted"
         conversion.converted_at = utc_now()
-        repo.credit_wallet(conversion.referrer_user_id, conversion.commission_amount)
+        await repo.credit_wallet(conversion.referrer_user_id, conversion.commission_amount)
         logger.info(
             "Referral credited: referrer=%s amount=%d",
             conversion.referrer_user_id,
@@ -258,15 +258,15 @@ def _credit_referral_on_purchase(uow, user_id: str) -> None:
         )
 
 
-def _revoke_referral_on_refund(uow, user_id: str) -> None:
+async def _revoke_referral_on_refund(uow, user_id: str) -> None:
     """Revoke the referrer's wallet credit when a referred user is refunded."""
     from src.infra.repositories.referral_repository import ReferralRepository
     repo = ReferralRepository(uow.session)
-    conversion = repo.get_conversion_by_referred_user(user_id)
+    conversion = await repo.get_conversion_by_referred_user(user_id)
     if conversion and conversion.status == "converted":
         conversion.status = "revoked"
         conversion.revoked_at = utc_now()
-        repo.revoke_from_wallet(conversion.referrer_user_id, conversion.commission_amount)
+        await repo.revoke_from_wallet(conversion.referrer_user_id, conversion.commission_amount)
         logger.info(
             "Referral revoked: referrer=%s amount=%d",
             conversion.referrer_user_id,

--- a/src/app/handlers/command_handlers/referral/apply_referral_code_handler.py
+++ b/src/app/handlers/command_handlers/referral/apply_referral_code_handler.py
@@ -2,35 +2,36 @@
 import logging
 
 from src.app.commands.referral.apply_referral_code_command import ApplyReferralCodeCommand
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
 
 logger = logging.getLogger(__name__)
 
 
 class ApplyReferralCodeCommandHandler:
-    def handle(self, command: ApplyReferralCodeCommand, uow) -> None:
-        repo = ReferralRepository(uow.session)
+    async def handle(self, command: ApplyReferralCodeCommand) -> None:
+        async with AsyncUnitOfWork() as uow:
+            repo = ReferralRepository(uow.session)
 
-        code = repo.get_code_by_code(command.code)
-        if not code:
-            raise ValueError("invalid_code")
+            code = await repo.get_code_by_code(command.code)
+            if not code:
+                raise ValueError("invalid_code")
 
-        if code.user_id == command.user_id:
-            raise ValueError("self_referral")
+            if code.user_id == command.user_id:
+                raise ValueError("self_referral")
 
-        existing = repo.get_conversion_by_referred_user(command.user_id)
-        if existing:
-            raise ValueError("already_referred")
+            existing = await repo.get_conversion_by_referred_user(command.user_id)
+            if existing:
+                raise ValueError("already_referred")
 
-        repo.create_conversion(
-            referrer_user_id=code.user_id,
-            referred_user_id=command.user_id,
-            code=command.code,
-            discount=command.discount_applied,
-        )
-        uow.commit()
-        logger.info(
-            "Referral conversion created: referrer=%s referred=%s",
-            code.user_id,
-            command.user_id,
-        )
+            await repo.create_conversion(
+                referrer_user_id=code.user_id,
+                referred_user_id=command.user_id,
+                code=command.code,
+                discount=command.discount_applied,
+            )
+            logger.info(
+                "Referral conversion created: referrer=%s referred=%s",
+                code.user_id,
+                command.user_id,
+            )

--- a/src/app/handlers/command_handlers/referral/request_payout_handler.py
+++ b/src/app/handlers/command_handlers/referral/request_payout_handler.py
@@ -2,6 +2,7 @@
 import logging
 
 from src.app.commands.referral.request_payout_command import RequestPayoutCommand
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
 
 logger = logging.getLogger(__name__)
@@ -10,37 +11,37 @@ MIN_WITHDRAWAL = 100_000  # ₫100,000
 
 
 class RequestPayoutCommandHandler:
-    def handle(self, command: RequestPayoutCommand, uow) -> None:
-        repo = ReferralRepository(uow.session)
+    async def handle(self, command: RequestPayoutCommand) -> None:
+        async with AsyncUnitOfWork() as uow:
+            repo = ReferralRepository(uow.session)
 
-        pending = repo.get_pending_payout(command.user_id)
-        if pending:
-            raise ValueError("pending_payout_exists")
+            pending = await repo.get_pending_payout(command.user_id)
+            if pending:
+                raise ValueError("pending_payout_exists")
 
-        wallet = repo.get_or_create_wallet(command.user_id)
-        if wallet.balance < MIN_WITHDRAWAL:
-            raise ValueError(f"minimum_withdrawal_{MIN_WITHDRAWAL}")
+            wallet = await repo.get_or_create_wallet(command.user_id)
+            if wallet.balance < MIN_WITHDRAWAL:
+                raise ValueError(f"minimum_withdrawal_{MIN_WITHDRAWAL}")
 
-        if command.amount > wallet.balance:
-            raise ValueError("insufficient_balance")
+            if command.amount > wallet.balance:
+                raise ValueError("insufficient_balance")
 
-        if command.amount < MIN_WITHDRAWAL:
-            raise ValueError(f"minimum_withdrawal_{MIN_WITHDRAWAL}")
+            if command.amount < MIN_WITHDRAWAL:
+                raise ValueError(f"minimum_withdrawal_{MIN_WITHDRAWAL}")
 
-        repo.create_payout_request(
-            user_id=command.user_id,
-            amount=command.amount,
-            method=command.payment_method,
-            details=command.payment_details,
-        )
+            await repo.create_payout_request(
+                user_id=command.user_id,
+                amount=command.amount,
+                method=command.payment_method,
+                details=command.payment_details,
+            )
 
-        wallet.balance -= command.amount
-        wallet.total_withdrawn += command.amount
+            wallet.balance -= command.amount
+            wallet.total_withdrawn += command.amount
 
-        uow.commit()
-        logger.info(
-            "Payout request created: user=%s amount=%d method=%s",
-            command.user_id,
-            command.amount,
-            command.payment_method,
-        )
+            logger.info(
+                "Payout request created: user=%s amount=%d method=%s",
+                command.user_id,
+                command.amount,
+                command.payment_method,
+            )

--- a/src/app/handlers/query_handlers/referral/get_my_referral_code_handler.py
+++ b/src/app/handlers/query_handlers/referral/get_my_referral_code_handler.py
@@ -5,22 +5,23 @@ from src.app.queries.referral.get_my_referral_code_query import (
     GetMyReferralCodeQuery,
     ReferralCodeResult,
 )
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
 
 logger = logging.getLogger(__name__)
 
 
 class GetMyReferralCodeQueryHandler:
-    def handle(self, query: GetMyReferralCodeQuery, uow) -> ReferralCodeResult:
-        repo = ReferralRepository(uow.session)
+    async def handle(self, query: GetMyReferralCodeQuery) -> ReferralCodeResult:
+        async with AsyncUnitOfWork() as uow:
+            repo = ReferralRepository(uow.session)
 
-        code = repo.get_code_by_user_id(query.user_id)
-        if not code:
-            code = repo.create_code(query.user_id)
-            uow.commit()
-            logger.info("Created new referral code for user %s", query.user_id)
+            code = await repo.get_code_by_user_id(query.user_id)
+            if not code:
+                code = await repo.create_code(query.user_id)
+                logger.info("Created new referral code for user %s", query.user_id)
 
-        return ReferralCodeResult(
-            code=code.code,
-            created_at=code.created_at.isoformat(),
-        )
+            return ReferralCodeResult(
+                code=code.code,
+                created_at=code.created_at.isoformat(),
+            )

--- a/src/app/handlers/query_handlers/referral/get_referral_stats_handler.py
+++ b/src/app/handlers/query_handlers/referral/get_referral_stats_handler.py
@@ -10,52 +10,53 @@ from src.app.queries.referral.get_referral_stats_query import (
     ReferralStatsResult,
 )
 from src.infra.database.models.user.user import User
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
 
 logger = logging.getLogger(__name__)
 
 
 class GetReferralStatsQueryHandler:
-    def handle(self, query: GetReferralStatsQuery, uow) -> ReferralStatsResult:
-        repo = ReferralRepository(uow.session)
+    async def handle(self, query: GetReferralStatsQuery) -> ReferralStatsResult:
+        async with AsyncUnitOfWork() as uow:
+            repo = ReferralRepository(uow.session)
 
-        # Ensure code exists (lazy-create so stats endpoint never errors on first call)
-        code = repo.get_code_by_user_id(query.user_id)
-        if not code:
-            code = repo.create_code(query.user_id)
-            uow.commit()
+            # Ensure code exists (lazy-create so stats endpoint never errors on first call)
+            code = await repo.get_code_by_user_id(query.user_id)
+            if not code:
+                code = await repo.create_code(query.user_id)
 
-        wallet = repo.get_or_create_wallet(query.user_id)
-        conversions = repo.get_conversions_by_referrer(query.user_id)
-        pending_payout = repo.get_pending_payout(query.user_id)
+            wallet = await repo.get_or_create_wallet(query.user_id)
+            conversions = await repo.get_conversions_by_referrer(query.user_id)
+            pending_payout = await repo.get_pending_payout(query.user_id)
 
-        total_converted = sum(1 for c in conversions if c.status == "converted")
+            total_converted = sum(1 for c in conversions if c.status == "converted")
 
-        conversion_dtos: List[ReferralConversionDTO] = []
-        for conv in conversions:
-            referred_name = self._get_first_name(uow, conv.referred_user_id)
-            conversion_dtos.append(
-                ReferralConversionDTO(
-                    referred_name=referred_name,
-                    status=conv.status,
-                    amount=conv.commission_amount,
-                    date=conv.created_at.isoformat(),
+            conversion_dtos: List[ReferralConversionDTO] = []
+            for conv in conversions:
+                referred_name = await self._get_first_name(uow, conv.referred_user_id)
+                conversion_dtos.append(
+                    ReferralConversionDTO(
+                        referred_name=referred_name,
+                        status=conv.status,
+                        amount=conv.commission_amount,
+                        date=conv.created_at.isoformat(),
+                    )
                 )
+
+            return ReferralStatsResult(
+                code=code.code,
+                wallet_balance=wallet.balance,
+                total_earned=wallet.total_earned,
+                total_withdrawn=wallet.total_withdrawn,
+                total_invited=len(conversions),
+                total_converted=total_converted,
+                conversions=conversion_dtos,
+                has_pending_payout=pending_payout is not None,
             )
 
-        return ReferralStatsResult(
-            code=code.code,
-            wallet_balance=wallet.balance,
-            total_earned=wallet.total_earned,
-            total_withdrawn=wallet.total_withdrawn,
-            total_invited=len(conversions),
-            total_converted=total_converted,
-            conversions=conversion_dtos,
-            has_pending_payout=pending_payout is not None,
-        )
-
-    def _get_first_name(self, uow, user_id: str) -> str:
-        result = uow.session.execute(
+    async def _get_first_name(self, uow, user_id: str) -> str:
+        result = await uow.session.execute(
             select(User.first_name, User.display_name).where(User.id == user_id)
         )
         row = result.first()

--- a/src/app/handlers/query_handlers/referral/validate_referral_code_handler.py
+++ b/src/app/handlers/query_handlers/referral/validate_referral_code_handler.py
@@ -8,39 +8,41 @@ from src.app.queries.referral.validate_referral_code_query import (
     ValidateReferralCodeQuery,
 )
 from src.infra.database.models.user.user import User
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
 
 logger = logging.getLogger(__name__)
 
 
 class ValidateReferralCodeQueryHandler:
-    def handle(self, query: ValidateReferralCodeQuery, uow) -> ValidateCodeResult:
-        repo = ReferralRepository(uow.session)
+    async def handle(self, query: ValidateReferralCodeQuery) -> ValidateCodeResult:
+        async with AsyncUnitOfWork() as uow:
+            repo = ReferralRepository(uow.session)
 
-        code = repo.get_code_by_code(query.code)
-        if not code:
-            return ValidateCodeResult(valid=False, error="invalid_code")
+            code = await repo.get_code_by_code(query.code)
+            if not code:
+                return ValidateCodeResult(valid=False, error="invalid_code")
 
-        if code.user_id == query.user_id:
-            return ValidateCodeResult(valid=False, error="self_referral")
+            if code.user_id == query.user_id:
+                return ValidateCodeResult(valid=False, error="self_referral")
 
-        existing = repo.get_conversion_by_referred_user(query.user_id)
-        if existing:
-            return ValidateCodeResult(valid=False, error="already_referred")
+            existing = await repo.get_conversion_by_referred_user(query.user_id)
+            if existing:
+                return ValidateCodeResult(valid=False, error="already_referred")
 
-        # Fetch referrer's first name for personalised UI copy
-        result = uow.session.execute(
-            select(User.first_name, User.display_name).where(User.id == code.user_id)
-        )
-        row = result.first()
-        referrer_name = "Friend"
-        if row:
-            raw = row.first_name or row.display_name or ""
-            referrer_name = raw.split()[0] if raw.strip() else "Friend"
+            # Fetch referrer's first name for personalised UI copy
+            result = await uow.session.execute(
+                select(User.first_name, User.display_name).where(User.id == code.user_id)
+            )
+            row = result.first()
+            referrer_name = "Friend"
+            if row:
+                raw = row.first_name or row.display_name or ""
+                referrer_name = raw.split()[0] if raw.strip() else "Friend"
 
-        return ValidateCodeResult(
-            valid=True,
-            referrer_name=referrer_name,
-            discount_monthly=199000,
-            discount_annual=499000,
-        )
+            return ValidateCodeResult(
+                valid=True,
+                referrer_name=referrer_name,
+                discount_monthly=199000,
+                discount_annual=499000,
+            )

--- a/src/infra/repositories/referral_repository.py
+++ b/src/infra/repositories/referral_repository.py
@@ -1,9 +1,10 @@
-"""Repository for referral system persistence — codes, conversions, wallets, payouts."""
+"""Async repository for referral system — codes, conversions, wallets, payouts."""
 import random
 import string
 from typing import List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.domain.utils.timezone_utils import utc_now
 from src.infra.database.models.referral import (
@@ -15,60 +16,59 @@ from src.infra.database.models.referral import (
 
 
 class ReferralRepository:
-    def __init__(self, db: Session):
-        self.db = db
+    """Async SQLAlchemy referral repository. Never calls session.commit()."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
 
     # === Code Operations ===
 
-    def get_code_by_user_id(self, user_id: str) -> Optional[ReferralCode]:
-        return (
-            self.db.query(ReferralCode)
-            .filter(ReferralCode.user_id == user_id)
-            .first()
+    async def get_code_by_user_id(self, user_id: str) -> Optional[ReferralCode]:
+        result = await self.session.execute(
+            select(ReferralCode).where(ReferralCode.user_id == user_id)
         )
+        return result.scalars().first()
 
-    def get_code_by_code(self, code: str) -> Optional[ReferralCode]:
-        return (
-            self.db.query(ReferralCode)
-            .filter(ReferralCode.code == code.upper())
-            .first()
+    async def get_code_by_code(self, code: str) -> Optional[ReferralCode]:
+        result = await self.session.execute(
+            select(ReferralCode).where(ReferralCode.code == code.upper())
         )
+        return result.scalars().first()
 
-    def create_code(self, user_id: str) -> ReferralCode:
-        code = self._generate_unique_code()
+    async def create_code(self, user_id: str) -> ReferralCode:
+        code = await self._generate_unique_code()
         referral_code = ReferralCode(
             user_id=user_id,
             code=code,
             created_at=utc_now(),
         )
-        self.db.add(referral_code)
+        self.session.add(referral_code)
         return referral_code
 
-    def _generate_unique_code(self) -> str:
+    async def _generate_unique_code(self) -> str:
         for _ in range(10):
             code = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
-            if not self.get_code_by_code(code):
+            if not await self.get_code_by_code(code):
                 return code
         raise RuntimeError("Failed to generate unique referral code after 10 attempts")
 
     # === Conversion Operations ===
 
-    def get_conversion_by_referred_user(self, user_id: str) -> Optional[ReferralConversion]:
-        return (
-            self.db.query(ReferralConversion)
-            .filter(ReferralConversion.referred_user_id == user_id)
-            .first()
+    async def get_conversion_by_referred_user(self, user_id: str) -> Optional[ReferralConversion]:
+        result = await self.session.execute(
+            select(ReferralConversion).where(ReferralConversion.referred_user_id == user_id)
         )
+        return result.scalars().first()
 
-    def get_conversions_by_referrer(self, user_id: str) -> List[ReferralConversion]:
-        return (
-            self.db.query(ReferralConversion)
-            .filter(ReferralConversion.referrer_user_id == user_id)
+    async def get_conversions_by_referrer(self, user_id: str) -> List[ReferralConversion]:
+        result = await self.session.execute(
+            select(ReferralConversion)
+            .where(ReferralConversion.referrer_user_id == user_id)
             .order_by(ReferralConversion.created_at.desc())
-            .all()
         )
+        return list(result.scalars().all())
 
-    def create_conversion(
+    async def create_conversion(
         self,
         referrer_user_id: str,
         referred_user_id: str,
@@ -83,17 +83,16 @@ class ReferralRepository:
             discount_applied=discount,
             commission_amount=50000,
         )
-        self.db.add(conversion)
+        self.session.add(conversion)
         return conversion
 
     # === Wallet Operations ===
 
-    def get_or_create_wallet(self, user_id: str) -> ReferralWallet:
-        wallet = (
-            self.db.query(ReferralWallet)
-            .filter(ReferralWallet.user_id == user_id)
-            .first()
+    async def get_or_create_wallet(self, user_id: str) -> ReferralWallet:
+        result = await self.session.execute(
+            select(ReferralWallet).where(ReferralWallet.user_id == user_id)
         )
+        wallet = result.scalars().first()
         if not wallet:
             wallet = ReferralWallet(
                 user_id=user_id,
@@ -103,18 +102,18 @@ class ReferralRepository:
                 total_withdrawn=0,
                 updated_at=utc_now(),
             )
-            self.db.add(wallet)
+            self.session.add(wallet)
         return wallet
 
-    def credit_wallet(self, user_id: str, amount: int) -> ReferralWallet:
-        wallet = self.get_or_create_wallet(user_id)
+    async def credit_wallet(self, user_id: str, amount: int) -> ReferralWallet:
+        wallet = await self.get_or_create_wallet(user_id)
         wallet.balance += amount
         wallet.total_earned += amount
         wallet.updated_at = utc_now()
         return wallet
 
-    def revoke_from_wallet(self, user_id: str, amount: int) -> ReferralWallet:
-        wallet = self.get_or_create_wallet(user_id)
+    async def revoke_from_wallet(self, user_id: str, amount: int) -> ReferralWallet:
+        wallet = await self.get_or_create_wallet(user_id)
         wallet.balance = max(0, wallet.balance - amount)
         wallet.total_revoked += amount
         wallet.updated_at = utc_now()
@@ -122,7 +121,7 @@ class ReferralRepository:
 
     # === Payout Operations ===
 
-    def create_payout_request(
+    async def create_payout_request(
         self, user_id: str, amount: int, method: str, details: dict
     ) -> PayoutRequest:
         request = PayoutRequest(
@@ -133,15 +132,14 @@ class ReferralRepository:
             status="pending",
             requested_at=utc_now(),
         )
-        self.db.add(request)
+        self.session.add(request)
         return request
 
-    def get_pending_payout(self, user_id: str) -> Optional[PayoutRequest]:
-        return (
-            self.db.query(PayoutRequest)
-            .filter(
+    async def get_pending_payout(self, user_id: str) -> Optional[PayoutRequest]:
+        result = await self.session.execute(
+            select(PayoutRequest).where(
                 PayoutRequest.user_id == user_id,
                 PayoutRequest.status.in_(["pending", "processing"]),
             )
-            .first()
         )
+        return result.scalars().first()


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'AsyncSession' object has no attribute 'query'` in RevenueCat webhook
- ReferralRepository was using sync `session.query()` but webhooks pass `AsyncSession`
- Converted entire referral system to async SQLAlchemy 2.0 pattern

## Changes
- `referral_repository.py`: Use `select()` + `await session.execute()` instead of `session.query()`
- All referral handlers: Use `async with AsyncUnitOfWork()` pattern
- `referrals.py` routes: Convert to `async def` + `await handler.handle()`
- `webhooks.py`: Convert referral helper functions to async

## Test plan
- [ ] Verify RevenueCat webhook handles INITIAL_PURCHASE without error
- [ ] Test referral code validation endpoint
- [ ] Test referral stats endpoint
- [ ] Test payout request endpoint