### PR TITLE
feat(backend): add goal progress tracking with weight sync

### DIFF
--- a/migrations/versions/057_add_weight_entries_table.py
+++ b/migrations/versions/057_add_weight_entries_table.py
@@ -1,0 +1,53 @@
+"""Add weight_entries table for progress tracking.
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-05-01
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "057"
+down_revision = "056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "weight_entries",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(36),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("weight_kg", sa.Float, nullable=False),
+        sa.Column("recorded_at", sa.DateTime, nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("user_id", "recorded_at", name="uq_user_recorded_at"),
+    )
+    op.create_index(
+        "idx_weight_entries_user_recorded",
+        "weight_entries",
+        ["user_id", "recorded_at"],
+    )
+    op.create_index("idx_weight_entries_user_id", "weight_entries", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_weight_entries_user_id", table_name="weight_entries")
+    op.drop_index("idx_weight_entries_user_recorded", table_name="weight_entries")
+    op.drop_table("weight_entries")

--- a/migrations/versions/058_add_goal_start_fields.py
+++ b/migrations/versions/058_add_goal_start_fields.py
@@ -1,0 +1,31 @@
+"""Add goal_start_weight_kg and goal_started_at to user_profiles.
+
+Revision ID: 058
+Revises: 057
+Create Date: 2026-05-01
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "058"
+down_revision = "057"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_profiles",
+        sa.Column("goal_start_weight_kg", sa.Float, nullable=True),
+    )
+    op.add_column(
+        "user_profiles",
+        sa.Column("goal_started_at", sa.DateTime, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_profiles", "goal_started_at")
+    op.drop_column("user_profiles", "goal_start_weight_kg")

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -85,6 +85,24 @@ from src.app.queries.saved_suggestion import GetSavedSuggestionsQuery
 from src.app.handlers.query_handlers import GetSavedSuggestionsQueryHandler
 from src.app.commands.cheat_day import MarkCheatDayCommand, UnmarkCheatDayCommand
 from src.app.queries.cheat_day import GetCheatDaysQuery
+from src.app.commands.weight import (
+    AddWeightEntryCommand,
+    DeleteWeightEntryCommand,
+    SyncWeightEntriesCommand,
+)
+from src.app.queries.weight import GetWeightEntriesQuery
+from src.app.handlers.command_handlers.add_weight_entry_command_handler import (
+    AddWeightEntryCommandHandler,
+)
+from src.app.handlers.command_handlers.delete_weight_entry_command_handler import (
+    DeleteWeightEntryCommandHandler,
+)
+from src.app.handlers.command_handlers.sync_weight_entries_command_handler import (
+    SyncWeightEntriesCommandHandler,
+)
+from src.app.handlers.query_handlers.get_weight_entries_query_handler import (
+    GetWeightEntriesQueryHandler,
+)
 from src.app.handlers.command_handlers.mark_cheat_day_command_handler import (
     MarkCheatDayCommandHandler,
 )
@@ -486,6 +504,16 @@ def get_configured_event_bus() -> EventBus:
     event_bus.register_handler(MarkCheatDayCommand, MarkCheatDayCommandHandler())
     event_bus.register_handler(UnmarkCheatDayCommand, UnmarkCheatDayCommandHandler())
     event_bus.register_handler(GetCheatDaysQuery, GetCheatDaysQueryHandler())
+
+    # Register weight entry handlers
+    event_bus.register_handler(AddWeightEntryCommand, AddWeightEntryCommandHandler())
+    event_bus.register_handler(
+        DeleteWeightEntryCommand, DeleteWeightEntryCommandHandler()
+    )
+    event_bus.register_handler(
+        SyncWeightEntriesCommand, SyncWeightEntriesCommandHandler()
+    )
+    event_bus.register_handler(GetWeightEntriesQuery, GetWeightEntriesQueryHandler())
 
     # Register saved suggestion handlers
     event_bus.register_handler(

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -56,6 +56,7 @@ from src.api.routes.v1.tdee import router as tdee_router
 from src.api.routes.v1.user_profiles import router as user_profiles_router
 from src.api.routes.v1.users import router as users_router
 from src.api.routes.v1.webhooks import router as webhooks_router
+from src.api.routes.v1.weight_entries import router as weight_entries_router
 from src.infra.config.settings import settings
 from src.infra.database.config import engine
 from src.infra.monitoring.sentry import initialize_sentry
@@ -251,6 +252,7 @@ app.include_router(tdee_router)
 app.include_router(saved_suggestions_router)
 app.include_router(cheat_days_router)
 app.include_router(referrals_router)
+app.include_router(weight_entries_router)
 
 # Serve static files from uploads directory (development)
 if os.environ.get("ENVIRONMENT") == "development":

--- a/src/api/routes/v1/user_profiles.py
+++ b/src/api/routes/v1/user_profiles.py
@@ -183,8 +183,16 @@ async def update_user_metrics(
 
     Authentication required: User ID is automatically extracted from the Firebase token.
     """
+    import logging
+    logger = logging.getLogger(__name__)
     try:
-        # Update metrics (including optional fitness goal)
+        # Debug: log incoming request values
+        logger.info(
+            f"update_user_metrics: goal={request.fitness_goal}, "
+            f"target_weight_kg={request.target_weight_kg}, "
+            f"weight_kg={request.weight_kg}"
+        )
+        # Update metrics (including optional fitness goal and target weight)
         command = UpdateUserMetricsCommand(
             user_id=user_id,
             weight_kg=request.weight_kg,
@@ -196,6 +204,9 @@ async def update_user_metrics(
             training_level=(
                 request.training_level.value if request.training_level else None
             ),
+            target_weight_kg=request.target_weight_kg,
+            goal_start_weight_kg=request.goal_start_weight_kg,
+            goal_started_at=request.goal_started_at,
         )
 
         await event_bus.send(command)

--- a/src/api/routes/v1/weight_entries.py
+++ b/src/api/routes/v1/weight_entries.py
@@ -1,0 +1,86 @@
+"""Weight entries API endpoints."""
+
+from fastapi import APIRouter, Depends
+
+from src.api.dependencies.auth import get_current_user_id
+from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.exceptions import handle_exception
+from src.api.schemas.request.weight_entry_requests import (
+    AddWeightEntryRequest,
+    SyncWeightEntriesRequest,
+)
+from src.app.commands.weight import (
+    AddWeightEntryCommand,
+    DeleteWeightEntryCommand,
+    SyncWeightEntriesCommand,
+)
+from src.app.commands.weight.sync_weight_entries_command import WeightEntryData
+from src.app.queries.weight import GetWeightEntriesQuery
+from src.infra.event_bus import EventBus
+
+router = APIRouter(prefix="/v1/weight-entries", tags=["Weight Entries"])
+
+
+@router.get("")
+async def get_weight_entries(
+    limit: int = 100,
+    offset: int = 0,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """Get user's weight entry history."""
+    try:
+        query = GetWeightEntriesQuery(user_id=user_id, limit=limit, offset=offset)
+        return await event_bus.send(query)
+    except Exception as e:
+        raise handle_exception(e) from e
+
+
+@router.post("")
+async def add_weight_entry(
+    request: AddWeightEntryRequest,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """Add a single weight entry."""
+    try:
+        command = AddWeightEntryCommand(
+            user_id=user_id,
+            weight_kg=request.weight_kg,
+            recorded_at=request.recorded_at,
+        )
+        return await event_bus.send(command)
+    except Exception as e:
+        raise handle_exception(e) from e
+
+
+@router.delete("/{entry_id}")
+async def delete_weight_entry(
+    entry_id: str,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """Delete a weight entry."""
+    try:
+        command = DeleteWeightEntryCommand(user_id=user_id, entry_id=entry_id)
+        return await event_bus.send(command)
+    except Exception as e:
+        raise handle_exception(e) from e
+
+
+@router.post("/sync")
+async def sync_weight_entries(
+    request: SyncWeightEntriesRequest,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """Bulk sync weight entries from mobile."""
+    try:
+        entries = [
+            WeightEntryData(weight_kg=e.weight_kg, recorded_at=e.recorded_at)
+            for e in request.entries
+        ]
+        command = SyncWeightEntriesCommand(user_id=user_id, entries=entries)
+        return await event_bus.send(command)
+    except Exception as e:
+        raise handle_exception(e) from e

--- a/src/api/schemas/request/user_profile_update_requests.py
+++ b/src/api/schemas/request/user_profile_update_requests.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel, Field
@@ -30,7 +31,7 @@ class UpdateFitnessGoalRequest(BaseModel):
 
 
 class UpdateMetricsRequest(BaseModel):
-    """Unified update for weight, job type, training, body fat, and fitness goal."""
+    """Unified update for weight, job type, training, body fat, fitness goal, and target weight."""
 
     weight_kg: float | None = Field(None, description="Weight in kg", gt=0)
     job_type: str | None = Field(None, description="Job type (desk, on_feet, physical)")
@@ -48,4 +49,13 @@ class UpdateMetricsRequest(BaseModel):
     )
     training_level: TrainingLevelEnum | None = Field(
         None, description="Training level (beginner, intermediate, advanced)"
+    )
+    target_weight_kg: float | None = Field(
+        None, description="Target weight in kg", gt=0
+    )
+    goal_start_weight_kg: float | None = Field(
+        None, description="Weight when goal journey started", gt=0
+    )
+    goal_started_at: datetime | None = Field(
+        None, description="Timestamp when goal journey started"
     )

--- a/src/api/schemas/request/weight_entry_requests.py
+++ b/src/api/schemas/request/weight_entry_requests.py
@@ -1,0 +1,21 @@
+"""Weight entry request schemas."""
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class AddWeightEntryRequest(BaseModel):
+    """Request to add a single weight entry."""
+
+    weight_kg: float = Field(..., gt=0, description="Weight in kilograms")
+    recorded_at: datetime = Field(..., description="When the weight was recorded")
+
+
+class SyncWeightEntriesRequest(BaseModel):
+    """Request to bulk sync weight entries from mobile."""
+
+    entries: List[AddWeightEntryRequest] = Field(
+        ..., description="List of weight entries to sync"
+    )

--- a/src/api/schemas/response/user_responses.py
+++ b/src/api/schemas/response/user_responses.py
@@ -126,6 +126,12 @@ class UserMetricsResponse(BaseModel):
     target_weight_kg: Optional[float] = Field(
         None, description="Target weight in kilograms"
     )
+    goal_start_weight_kg: Optional[float] = Field(
+        None, description="Weight when goal journey started"
+    )
+    goal_started_at: Optional[datetime] = Field(
+        None, description="Timestamp when goal journey started"
+    )
     updated_at: datetime = Field(..., description="Last update timestamp")
 
 

--- a/src/api/schemas/response/weight_entry_responses.py
+++ b/src/api/schemas/response/weight_entry_responses.py
@@ -1,0 +1,29 @@
+"""Weight entry response schemas."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class WeightEntryResponse(BaseModel):
+    """Response for a single weight entry."""
+
+    id: str = Field(..., description="Entry ID")
+    weight_kg: float = Field(..., description="Weight in kilograms")
+    recorded_at: datetime = Field(..., description="When the weight was recorded")
+    created_at: Optional[datetime] = Field(None, description="When entry was created")
+
+
+class WeightEntriesListResponse(BaseModel):
+    """Response containing list of weight entries."""
+
+    entries: List[WeightEntryResponse] = Field(..., description="Weight entries")
+    count: int = Field(..., description="Total count of entries")
+
+
+class SyncWeightEntriesResponse(BaseModel):
+    """Response from bulk sync operation."""
+
+    synced_count: int = Field(..., description="Number of entries synced")
+    message: str = Field(..., description="Operation result message")

--- a/src/app/commands/user/update_user_metrics_command.py
+++ b/src/app/commands/user/update_user_metrics_command.py
@@ -3,12 +3,13 @@ Command to update user metrics (weight, job type, training, body fat).
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 
 @dataclass
 class UpdateUserMetricsCommand:
-    """Update user metrics (including fitness goal) and trigger TDEE recalculation."""
+    """Update user metrics (including fitness goal and target weight) and trigger TDEE recalculation."""
 
     user_id: str
     weight_kg: Optional[float] = None
@@ -18,3 +19,6 @@ class UpdateUserMetricsCommand:
     body_fat_percent: Optional[float] = None
     fitness_goal: Optional[str] = None
     training_level: Optional[str] = None
+    target_weight_kg: Optional[float] = None
+    goal_start_weight_kg: Optional[float] = None
+    goal_started_at: Optional[datetime] = None

--- a/src/app/commands/weight/__init__.py
+++ b/src/app/commands/weight/__init__.py
@@ -1,0 +1,11 @@
+"""Weight commands."""
+
+from .add_weight_entry_command import AddWeightEntryCommand
+from .delete_weight_entry_command import DeleteWeightEntryCommand
+from .sync_weight_entries_command import SyncWeightEntriesCommand
+
+__all__ = [
+    "AddWeightEntryCommand",
+    "DeleteWeightEntryCommand",
+    "SyncWeightEntriesCommand",
+]

--- a/src/app/commands/weight/add_weight_entry_command.py
+++ b/src/app/commands/weight/add_weight_entry_command.py
@@ -1,0 +1,13 @@
+"""Command to add a weight entry."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class AddWeightEntryCommand:
+    """Add a single weight entry."""
+
+    user_id: str
+    weight_kg: float
+    recorded_at: datetime

--- a/src/app/commands/weight/delete_weight_entry_command.py
+++ b/src/app/commands/weight/delete_weight_entry_command.py
@@ -1,0 +1,11 @@
+"""Command to delete a weight entry."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DeleteWeightEntryCommand:
+    """Delete a weight entry."""
+
+    user_id: str
+    entry_id: str

--- a/src/app/commands/weight/sync_weight_entries_command.py
+++ b/src/app/commands/weight/sync_weight_entries_command.py
@@ -1,0 +1,21 @@
+"""Command to sync weight entries from mobile."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class WeightEntryData:
+    """Single weight entry for sync."""
+
+    weight_kg: float
+    recorded_at: datetime
+
+
+@dataclass
+class SyncWeightEntriesCommand:
+    """Bulk sync weight entries from mobile."""
+
+    user_id: str
+    entries: List[WeightEntryData]

--- a/src/app/handlers/command_handlers/add_weight_entry_command_handler.py
+++ b/src/app/handlers/command_handlers/add_weight_entry_command_handler.py
@@ -1,0 +1,37 @@
+"""Handler for adding a weight entry."""
+
+import logging
+import uuid
+from typing import Dict, Any
+
+from src.app.commands.weight import AddWeightEntryCommand
+from src.app.events.base import EventHandler, handles
+from src.domain.model.weight import WeightEntry
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+@handles(AddWeightEntryCommand)
+class AddWeightEntryCommandHandler(EventHandler[AddWeightEntryCommand, Dict[str, Any]]):
+    """Handler for adding a weight entry."""
+
+    async def handle(self, command: AddWeightEntryCommand) -> Dict[str, Any]:
+        async with AsyncUnitOfWork() as uow:
+            entry = WeightEntry(
+                id=str(uuid.uuid4()),
+                user_id=command.user_id,
+                weight_kg=command.weight_kg,
+                recorded_at=command.recorded_at,
+            )
+
+            saved = await uow.weight_entries.add(entry)
+            await uow.commit()
+
+            return {
+                "id": saved.id,
+                "weight_kg": saved.weight_kg,
+                "recorded_at": saved.recorded_at.isoformat() if saved.recorded_at else None,
+                "created_at": saved.created_at.isoformat() if saved.created_at else None,
+                "message": "Weight entry added",
+            }

--- a/src/app/handlers/command_handlers/delete_weight_entry_command_handler.py
+++ b/src/app/handlers/command_handlers/delete_weight_entry_command_handler.py
@@ -1,0 +1,35 @@
+"""Handler for deleting a weight entry."""
+
+import logging
+from typing import Dict, Any
+
+from src.api.exceptions import ResourceNotFoundException
+from src.app.commands.weight import DeleteWeightEntryCommand
+from src.app.events.base import EventHandler, handles
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+@handles(DeleteWeightEntryCommand)
+class DeleteWeightEntryCommandHandler(
+    EventHandler[DeleteWeightEntryCommand, Dict[str, Any]]
+):
+    """Handler for deleting a weight entry."""
+
+    async def handle(self, command: DeleteWeightEntryCommand) -> Dict[str, Any]:
+        async with AsyncUnitOfWork() as uow:
+            deleted = await uow.weight_entries.delete(command.user_id, command.entry_id)
+
+            if not deleted:
+                raise ResourceNotFoundException(
+                    f"Weight entry {command.entry_id} not found"
+                )
+
+            await uow.commit()
+
+            return {
+                "id": command.entry_id,
+                "deleted": True,
+                "message": "Weight entry deleted",
+            }

--- a/src/app/handlers/command_handlers/sync_weight_entries_command_handler.py
+++ b/src/app/handlers/command_handlers/sync_weight_entries_command_handler.py
@@ -1,0 +1,39 @@
+"""Handler for syncing weight entries from mobile."""
+
+import logging
+import uuid
+from typing import Dict, Any
+
+from src.app.commands.weight import SyncWeightEntriesCommand
+from src.app.events.base import EventHandler, handles
+from src.domain.model.weight import WeightEntry
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+@handles(SyncWeightEntriesCommand)
+class SyncWeightEntriesCommandHandler(
+    EventHandler[SyncWeightEntriesCommand, Dict[str, Any]]
+):
+    """Handler for bulk syncing weight entries."""
+
+    async def handle(self, command: SyncWeightEntriesCommand) -> Dict[str, Any]:
+        async with AsyncUnitOfWork() as uow:
+            entries = [
+                WeightEntry(
+                    id=str(uuid.uuid4()),
+                    user_id=command.user_id,
+                    weight_kg=e.weight_kg,
+                    recorded_at=e.recorded_at,
+                )
+                for e in command.entries
+            ]
+
+            synced = await uow.weight_entries.bulk_upsert(command.user_id, entries)
+            await uow.commit()
+
+            return {
+                "synced_count": synced,
+                "message": f"Synced {synced} weight entries",
+            }

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -40,6 +40,9 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 command.body_fat_percent,
                 command.fitness_goal,
                 command.training_level,
+                command.target_weight_kg,
+                command.goal_start_weight_kg,
+                command.goal_started_at,
             ]
         ):
             raise ValidationException("At least one metric must be provided")
@@ -118,6 +121,35 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                         f"Training level must be one of: {sorted(_VALID_TRAINING_LEVELS)}"
                     )
                 profile.training_level = command.training_level
+
+            # Handle target weight update
+            if command.target_weight_kg is not None:
+                if command.target_weight_kg <= 0:
+                    raise ValidationException("Target weight must be greater than 0")
+                logger.info(
+                    f"Updating target_weight_kg for user {command.user_id}: "
+                    f"{profile.target_weight_kg} -> {command.target_weight_kg}"
+                )
+                profile.target_weight_kg = command.target_weight_kg
+
+            # Handle goal start fields (for progress tracking reset)
+            if command.goal_start_weight_kg is not None:
+                if command.goal_start_weight_kg <= 0:
+                    raise ValidationException(
+                        "Goal start weight must be greater than 0"
+                    )
+                logger.info(
+                    f"Updating goal_start_weight_kg for user {command.user_id}: "
+                    f"{profile.goal_start_weight_kg} -> {command.goal_start_weight_kg}"
+                )
+                profile.goal_start_weight_kg = command.goal_start_weight_kg
+
+            if command.goal_started_at is not None:
+                logger.info(
+                    f"Updating goal_started_at for user {command.user_id}: "
+                    f"{profile.goal_started_at} -> {command.goal_started_at}"
+                )
+                profile.goal_started_at = command.goal_started_at
 
             # Ensure this profile is marked as current
             profile.is_current = True

--- a/src/app/handlers/query_handlers/get_user_metrics_query_handler.py
+++ b/src/app/handlers/query_handlers/get_user_metrics_query_handler.py
@@ -67,5 +67,7 @@ class GetUserMetricsQueryHandler(EventHandler[GetUserMetricsQuery, Dict[str, Any
                 "training_level": profile.training_level,
                 "fitness_goal": profile.fitness_goal,
                 "target_weight_kg": profile.target_weight_kg,
+                "goal_start_weight_kg": profile.goal_start_weight_kg,
+                "goal_started_at": profile.goal_started_at,
                 "updated_at": profile.updated_at,
             }

--- a/src/app/handlers/query_handlers/get_weight_entries_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weight_entries_query_handler.py
@@ -1,0 +1,34 @@
+"""Handler for getting weight entries."""
+
+import logging
+from typing import Dict, Any, List
+
+from src.app.events.base import EventHandler, handles
+from src.app.queries.weight import GetWeightEntriesQuery
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+logger = logging.getLogger(__name__)
+
+
+@handles(GetWeightEntriesQuery)
+class GetWeightEntriesQueryHandler(EventHandler[GetWeightEntriesQuery, Dict[str, Any]]):
+    """Handler for getting user's weight entries."""
+
+    async def handle(self, query: GetWeightEntriesQuery) -> Dict[str, Any]:
+        async with AsyncUnitOfWork() as uow:
+            entries = await uow.weight_entries.find_by_user(
+                query.user_id, query.limit, query.offset
+            )
+
+            return {
+                "entries": [
+                    {
+                        "id": e.id,
+                        "weight_kg": e.weight_kg,
+                        "recorded_at": e.recorded_at.isoformat() if e.recorded_at else None,
+                        "created_at": e.created_at.isoformat() if e.created_at else None,
+                    }
+                    for e in entries
+                ],
+                "count": len(entries),
+            }

--- a/src/app/queries/weight/__init__.py
+++ b/src/app/queries/weight/__init__.py
@@ -1,0 +1,5 @@
+"""Weight queries."""
+
+from .get_weight_entries_query import GetWeightEntriesQuery
+
+__all__ = ["GetWeightEntriesQuery"]

--- a/src/app/queries/weight/get_weight_entries_query.py
+++ b/src/app/queries/weight/get_weight_entries_query.py
@@ -1,0 +1,13 @@
+"""Query to get user's weight entries."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class GetWeightEntriesQuery:
+    """Get weight entries for a user."""
+
+    user_id: str
+    limit: int = 100
+    offset: int = 0

--- a/src/domain/model/__init__.py
+++ b/src/domain/model/__init__.py
@@ -47,3 +47,4 @@ from .user import (
     UserMacros,
     MacroTargets,
 )
+from .weight import WeightEntry

--- a/src/domain/model/user/core_user.py
+++ b/src/domain/model/user/core_user.py
@@ -45,6 +45,8 @@ class UserProfileDomainModel(BaseDomainModel):
     custom_protein_g: Optional[float] = None
     custom_carbs_g: Optional[float] = None
     custom_fat_g: Optional[float] = None
+    goal_start_weight_kg: Optional[float] = None
+    goal_started_at: Optional[datetime] = None
 
 
 @dataclass(kw_only=True)

--- a/src/domain/model/weight/__init__.py
+++ b/src/domain/model/weight/__init__.py
@@ -1,0 +1,5 @@
+"""Weight domain models."""
+
+from .weight_entry import WeightEntry
+
+__all__ = ["WeightEntry"]

--- a/src/domain/model/weight/weight_entry.py
+++ b/src/domain/model/weight/weight_entry.py
@@ -1,0 +1,17 @@
+"""Weight entry domain entity."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+import uuid
+
+
+@dataclass
+class WeightEntry:
+    """A single weight log entry for a user."""
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    user_id: str = ""
+    weight_kg: float = 0.0
+    recorded_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: Optional[datetime] = None

--- a/src/infra/database/models/__init__.py
+++ b/src/infra/database/models/__init__.py
@@ -61,6 +61,9 @@ BarcodeProductModel = FoodReferenceModel
 # Referral system
 from .referral import ReferralCode, ReferralConversion, ReferralWallet, PayoutRequest
 
+# Weight tracking
+from .weight_entry import WeightEntryORM
+
 __all__ = [
     # Base
     "BaseMixin",
@@ -109,4 +112,6 @@ __all__ = [
     "ReferralConversion",
     "ReferralWallet",
     "PayoutRequest",
+    # Weight tracking
+    "WeightEntryORM",
 ]

--- a/src/infra/database/models/user/profile.py
+++ b/src/infra/database/models/user/profile.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     CheckConstraint,
     JSON,
     Date,
+    DateTime,
 )
 from sqlalchemy.orm import relationship
 
@@ -60,6 +61,10 @@ class UserProfile(Base, BaseMixin):
     custom_protein_g = Column(Float, nullable=True, default=None)
     custom_carbs_g = Column(Float, nullable=True, default=None)
     custom_fat_g = Column(Float, nullable=True, default=None)
+
+    # Goal progress tracking — tracks when user started current goal journey
+    goal_start_weight_kg = Column(Float, nullable=True, default=None)
+    goal_started_at = Column(DateTime, nullable=True, default=None)
 
     @property
     def has_custom_macros(self) -> bool:

--- a/src/infra/database/models/weight_entry.py
+++ b/src/infra/database/models/weight_entry.py
@@ -1,0 +1,22 @@
+"""Weight entry database model."""
+
+from sqlalchemy import Column, String, Float, DateTime, UniqueConstraint, Index, ForeignKey
+from src.infra.database.config import Base
+from src.infra.database.models.base import BaseMixin
+
+
+class WeightEntryORM(Base, BaseMixin):
+    """Stores user weight history for progress tracking."""
+
+    __tablename__ = "weight_entries"
+
+    user_id = Column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    weight_kg = Column(Float, nullable=False)
+    recorded_at = Column(DateTime, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "recorded_at", name="uq_user_recorded_at"),
+        Index("idx_weight_entries_user_recorded", "user_id", "recorded_at"),
+    )

--- a/src/infra/database/uow_async.py
+++ b/src/infra/database/uow_async.py
@@ -20,6 +20,7 @@ from src.infra.repositories.notification_repository_async import (
 from src.infra.repositories.saved_suggestion_db_repository_async import (
     AsyncSavedSuggestionDbRepository,
 )
+from src.infra.repositories.weight_repository_async import AsyncWeightRepository
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ class AsyncUnitOfWork(AsyncUnitOfWorkPort):
         self.saved_suggestions_db = (
             self.saved_suggestions
         )  # alias for handlers using this name
+        self.weight_entries = AsyncWeightRepository(session)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         session = self.session

--- a/src/infra/mappers/user_mapper.py
+++ b/src/infra/mappers/user_mapper.py
@@ -90,6 +90,8 @@ class UserProfileMapper:
             custom_protein_g=profile_entity.custom_protein_g,
             custom_carbs_g=profile_entity.custom_carbs_g,
             custom_fat_g=profile_entity.custom_fat_g,
+            goal_start_weight_kg=profile_entity.goal_start_weight_kg,
+            goal_started_at=profile_entity.goal_started_at,
             created_at=profile_entity.created_at,
             updated_at=profile_entity.updated_at,
         )
@@ -125,4 +127,6 @@ class UserProfileMapper:
             custom_protein_g=profile_domain.custom_protein_g,
             custom_carbs_g=profile_domain.custom_carbs_g,
             custom_fat_g=profile_domain.custom_fat_g,
+            goal_start_weight_kg=profile_domain.goal_start_weight_kg,
+            goal_started_at=profile_domain.goal_started_at,
         )

--- a/src/infra/mappers/weight_entry_mapper.py
+++ b/src/infra/mappers/weight_entry_mapper.py
@@ -1,0 +1,23 @@
+"""WeightEntry ORM <-> domain mapping functions."""
+
+from src.domain.model.weight import WeightEntry
+from src.infra.database.models.weight_entry import WeightEntryORM
+
+
+def weight_entry_orm_to_domain(orm: WeightEntryORM) -> WeightEntry:
+    return WeightEntry(
+        id=orm.id,
+        user_id=orm.user_id,
+        weight_kg=orm.weight_kg,
+        recorded_at=orm.recorded_at,
+        created_at=orm.created_at,
+    )
+
+
+def weight_entry_domain_to_orm(domain: WeightEntry) -> WeightEntryORM:
+    return WeightEntryORM(
+        id=domain.id,
+        user_id=domain.user_id,
+        weight_kg=domain.weight_kg,
+        recorded_at=domain.recorded_at,
+    )

--- a/src/infra/repositories/weight_repository_async.py
+++ b/src/infra/repositories/weight_repository_async.py
@@ -1,0 +1,92 @@
+"""Async weight entry repository."""
+
+import logging
+from typing import List, Optional
+
+from sqlalchemy import select, delete
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.model.weight import WeightEntry
+from src.infra.database.models.weight_entry import WeightEntryORM
+from src.infra.mappers.weight_entry_mapper import (
+    weight_entry_orm_to_domain,
+    weight_entry_domain_to_orm,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncWeightRepository:
+    """Async weight entry repository. Never calls session.commit()."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def add(self, entry: WeightEntry) -> WeightEntry:
+        """Add a weight entry. Returns the entry with created_at populated."""
+        db = weight_entry_domain_to_orm(entry)
+        self.session.add(db)
+        await self.session.flush()
+        await self.session.refresh(db)
+        return weight_entry_orm_to_domain(db)
+
+    async def find_by_id(self, user_id: str, entry_id: str) -> Optional[WeightEntry]:
+        """Find entry by ID for a specific user."""
+        result = await self.session.execute(
+            select(WeightEntryORM).where(
+                WeightEntryORM.id == entry_id,
+                WeightEntryORM.user_id == user_id,
+            )
+        )
+        db = result.scalars().first()
+        return weight_entry_orm_to_domain(db) if db else None
+
+    async def find_by_user(
+        self, user_id: str, limit: int = 100, offset: int = 0
+    ) -> List[WeightEntry]:
+        """Get weight entries for a user, ordered by recorded_at desc."""
+        result = await self.session.execute(
+            select(WeightEntryORM)
+            .where(WeightEntryORM.user_id == user_id)
+            .order_by(WeightEntryORM.recorded_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return [weight_entry_orm_to_domain(r) for r in result.scalars().all()]
+
+    async def delete(self, user_id: str, entry_id: str) -> bool:
+        """Delete entry by ID. Returns True if deleted."""
+        result = await self.session.execute(
+            delete(WeightEntryORM).where(
+                WeightEntryORM.id == entry_id,
+                WeightEntryORM.user_id == user_id,
+            )
+        )
+        return result.rowcount > 0
+
+    async def bulk_upsert(self, user_id: str, entries: List[WeightEntry]) -> int:
+        """Bulk upsert entries. Returns count of affected rows."""
+        if not entries:
+            return 0
+
+        values = [
+            {
+                "id": e.id,
+                "user_id": user_id,
+                "weight_kg": e.weight_kg,
+                "recorded_at": e.recorded_at,
+            }
+            for e in entries
+        ]
+
+        stmt = insert(WeightEntryORM).values(values)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_user_recorded_at",
+            set_={
+                "weight_kg": stmt.excluded.weight_kg,
+            },
+        )
+
+        result = await self.session.execute(stmt)
+        return result.rowcount

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -60,6 +60,7 @@ class TestUpdateUserMetricsCommand:
             training_minutes_per_session=60,
             body_fat_percent=15.0,
             fitness_goal="cut",
+            target_weight_kg=70.0,
         )
 
         assert command.user_id == "test_user"
@@ -69,6 +70,7 @@ class TestUpdateUserMetricsCommand:
         assert command.training_minutes_per_session == 60
         assert command.body_fat_percent == 15.0
         assert command.fitness_goal == "cut"
+        assert command.target_weight_kg == 70.0
 
     def test_create_command_with_partial_fields(self):
         """Test creating command with only some metrics."""
@@ -81,6 +83,7 @@ class TestUpdateUserMetricsCommand:
         assert command.training_minutes_per_session is None
         assert command.body_fat_percent is None
         assert command.fitness_goal is None
+        assert command.target_weight_kg is None
 
 
 @pytest.mark.asyncio
@@ -239,3 +242,30 @@ class TestUpdateUserMetricsCommandHandler:
             await handler.handle(command)
 
         assert "Fitness goal must be one of" in str(exc_info.value)
+
+    async def test_update_target_weight(self):
+        """Test updating target weight."""
+        profile = _make_profile()
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(user_id="test_user", target_weight_kg=65.0)
+
+        await handler.handle(command)
+
+        assert profile.target_weight_kg == 65.0
+        assert profile.is_current is True
+        mock_uow.users.update_profile.assert_called_once_with(profile)
+
+    async def test_invalid_target_weight(self):
+        """Test validation for invalid target weight."""
+        profile = _make_profile()
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(user_id="test_user", target_weight_kg=-10.0)
+
+        with pytest.raises(ValidationException) as exc_info:
+            await handler.handle(command)
+
+        assert "Target weight must be greater than 0" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Add weight_entries table (migration 057) with full CRUD + bulk sync API
- Extend user_profiles with goal_start_weight_kg/goal_started_at (migration 058)
- Implement WeightEntry domain model, repository, commands, and query handlers
- Register event bus handlers for weight entry operations

## Test plan
- [ ] Run migrations 057/058 on staging
- [ ] POST/GET/DELETE /weight-entries endpoints
- [ ] POST /weight-entries/sync bulk upsert
- [ ] Verify goal start fields persist via profile update
- [ ] Unit tests pass (`test_update_user_metrics.py`)