### PR TITLE
fix(webhooks): resolve user lookup for anonymous RevenueCat renewals

### DIFF
--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -92,6 +92,20 @@ async def revenuecat_webhook(
                     if user:
                         break
 
+        # Fallback: lookup via existing Subscription record (handles anonymous ID renewals)
+        if not user:
+            subscription = await uow.subscriptions.find_by_revenuecat_id(app_user_id)
+            if subscription:
+                result = await uow.session.execute(
+                    select(User).where(User.id == subscription.user_id)
+                )
+                user = result.scalars().first()
+                if user:
+                    logger.info(
+                        f"RevenueCat webhook: found user via subscription record — "
+                        f"app_user_id={app_user_id}, user_id={user.id}"
+                    )
+
         if not user:
             logger.error(
                 f"RevenueCat webhook: user not found — "


### PR DESCRIPTION
## Summary
- Add fallback lookup via Subscription.revenuecat_subscriber_id when firebase_uid lookup fails
- Handles RENEWAL events for users who purchased with anonymous RevenueCat ID
- Logs successful subscription-based user resolution for observability

## Context
RevenueCat webhooks for renewals were returning 404 when `app_user_id` is an anonymous ID (`$RCAnonymousID:...`) that doesn't match any firebase_uid. This occurs when users purchase before Firebase sign-in.

## Test plan
- [ ] Deploy to staging
- [ ] Trigger test RENEWAL webhook with anonymous ID
- [ ] Verify user found via subscription record lookup