### PR TITLE
fix(i18n): resolve meal translation cache bugs

### DIFF
--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -149,8 +149,11 @@ class MealMapper:
             and meal.translations
         ):
             tr = meal.translations.get(target_language)
-            if tr and tr.is_fully_cached():
-                dish_name = tr.dish_name
+            if tr:
+                # Apply each translated field independently if it exists
+                # (lenient check - scanned meals may not have instructions)
+                if tr.dish_name:
+                    dish_name = tr.dish_name
                 if tr.meal_instruction:
                     instructions = tr.meal_instruction
                 if tr.meal_ingredients and len(tr.meal_ingredients) == len(food_items):

--- a/src/app/handlers/event_handlers/cache_invalidation_event_handler.py
+++ b/src/app/handlers/event_handlers/cache_invalidation_event_handler.py
@@ -32,10 +32,17 @@ class CacheInvalidationEventHandler(
         weekly_key, _ = CacheKeys.weekly_budget(user_id, week_start)
         breakdown_key, _ = CacheKeys.daily_breakdown(user_id, week_start)
         streak_key, _ = CacheKeys.user_streak(user_id)
-        activities_key, _ = CacheKeys.daily_activities(user_id, meal_date)
 
-        for key in (daily_key, weekly_key, breakdown_key, streak_key, activities_key):
+        # Invalidate specific keys
+        for key in (daily_key, weekly_key, breakdown_key, streak_key):
             try:
                 await self.cache.invalidate(key)
             except Exception as exc:
                 logger.warning("Cache invalidation failed for key=%s: %s", key, exc)
+
+        # Invalidate all language variants of daily activities using pattern
+        activities_pattern = f"user:{user_id}:activities:{meal_date.isoformat()}:*"
+        try:
+            await self.cache.invalidate_pattern(activities_pattern)
+        except Exception as exc:
+            logger.warning("Cache pattern invalidation failed for %s: %s", activities_pattern, exc)

--- a/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
@@ -27,7 +27,7 @@ class GetDailyActivitiesQueryHandler(EventHandler[GetDailyActivitiesQuery, List[
     async def handle(self, query: GetDailyActivitiesQuery) -> List[Dict[str, Any]]:
         """Get all activities for the specified date."""
         target_date = query.target_date.date() if hasattr(query.target_date, "date") else query.target_date
-        cache_key, ttl = CacheKeys.daily_activities(query.user_id, target_date)
+        cache_key, ttl = CacheKeys.daily_activities(query.user_id, target_date, query.language or "en")
         if self.cache_service:
             cached = await self.cache_service.get_json(cache_key)
             if cached is not None:

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -76,10 +76,10 @@ class CacheKeys:
         return (f"user:streak:{user_id}", CacheKeys.TTL_1_HOUR)
 
     @staticmethod
-    def daily_activities(user_id: str, target_date: date) -> tuple[str, int]:
-        """Cache key for daily activities list. 5min TTL."""
+    def daily_activities(user_id: str, target_date: date, language: str = "en") -> tuple[str, int]:
+        """Cache key for daily activities list. 5min TTL. Includes language to prevent cross-language cache pollution."""
         return (
-            f"user:{user_id}:activities:{target_date.isoformat()}",
+            f"user:{user_id}:activities:{target_date.isoformat()}:{language}",
             CacheKeys.TTL_5_MIN,
         )
 

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -137,6 +137,10 @@ class TestWebhookHandler:
                 mock_result.scalars.return_value.first.return_value = None
                 mock_uow.session.execute.return_value = mock_result
 
+                # Mock subscriptions repository (fallback lookup path)
+                mock_uow.subscriptions = MagicMock()
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+
                 with pytest.raises(HTTPException) as exc_info:
                     await revenuecat_webhook(mock_request, authorization="test_secret")
 

--- a/tests/unit/app/handlers/event_handlers/test_cache_invalidation_event_handler.py
+++ b/tests/unit/app/handlers/event_handlers/test_cache_invalidation_event_handler.py
@@ -14,6 +14,7 @@ from src.domain.cache.cache_keys import CacheKeys
 def cache_mock():
     mock = AsyncMock()
     mock.invalidate = AsyncMock()
+    mock.invalidate_pattern = AsyncMock(return_value=1)
     return mock
 
 
@@ -70,6 +71,8 @@ async def test_invalidates_streak_and_activities(handler, cache_mock):
     )
     await handler.handle(event)
     streak_key, _ = CacheKeys.user_streak("user-123")
-    activities_key, _ = CacheKeys.daily_activities("user-123", date(2026, 4, 18))
     cache_mock.invalidate.assert_any_await(streak_key)
-    cache_mock.invalidate.assert_any_await(activities_key)
+    # Activities now uses pattern invalidation to clear all language variants
+    cache_mock.invalidate_pattern.assert_any_await(
+        "user:user-123:activities:2026-04-18:*"
+    )

--- a/tests/unit/domain/test_cache_keys.py
+++ b/tests/unit/domain/test_cache_keys.py
@@ -11,8 +11,15 @@ class TestCacheKeysNewMethods:
 
     def test_daily_activities_key_format(self):
         key, ttl = CacheKeys.daily_activities("user-123", date(2026, 4, 14))
-        assert key == "user:user-123:activities:2026-04-14"
+        assert key == "user:user-123:activities:2026-04-14:en"  # Default language
         assert ttl == 300  # 5 minutes
+
+    def test_daily_activities_key_with_language(self):
+        key_en, _ = CacheKeys.daily_activities("user-123", date(2026, 4, 14), "en")
+        key_vi, _ = CacheKeys.daily_activities("user-123", date(2026, 4, 14), "vi")
+        assert key_en == "user:user-123:activities:2026-04-14:en"
+        assert key_vi == "user:user-123:activities:2026-04-14:vi"
+        assert key_en != key_vi  # Different languages produce different keys
 
     def test_saved_suggestions_key_format(self):
         key, ttl = CacheKeys.saved_suggestions("user-123")
@@ -32,4 +39,9 @@ class TestCacheKeysNewMethods:
     def test_activities_keys_are_distinct_per_date(self):
         key_a, _ = CacheKeys.daily_activities("user-1", date(2026, 4, 14))
         key_b, _ = CacheKeys.daily_activities("user-1", date(2026, 4, 15))
+        assert key_a != key_b
+
+    def test_activities_keys_are_distinct_per_language(self):
+        key_a, _ = CacheKeys.daily_activities("user-1", date(2026, 4, 14), "en")
+        key_b, _ = CacheKeys.daily_activities("user-1", date(2026, 4, 14), "vi")
         assert key_a != key_b


### PR DESCRIPTION
## Summary

Two bugs caused meal names to show English instead of user's locale (Vietnamese):

1. **Cache key missing language**: `daily_activities` cache key didn't include language, causing cross-language cache pollution
2. **`is_fully_cached()` too strict**: Meal details mapper required ALL translation fields, but scanned meals have no instructions

## Changes

- Add `language` param to `CacheKeys.daily_activities()` with "en" default
- Use `invalidate_pattern()` to clear all language variants on meal mutation
- Replace strict `is_fully_cached()` check with field-by-field application
- Update tests for new cache key format and pattern invalidation

## Files Changed

| File | Change |
|------|--------|
| `src/domain/cache/cache_keys.py` | Add `language` param |
| `src/app/handlers/query_handlers/get_daily_activities_query_handler.py` | Pass language to cache key |
| `src/app/handlers/event_handlers/cache_invalidation_event_handler.py` | Pattern-based invalidation |
| `src/api/mappers/meal_mapper.py` | Lenient translation check |
| `tests/unit/domain/test_cache_keys.py` | Updated + new language isolation tests |
| `tests/unit/app/handlers/event_handlers/test_cache_invalidation_event_handler.py` | Mock `invalidate_pattern` |

## Test Plan

- [ ] Verify Vietnamese meal names display correctly in Today's Meals list
- [ ] Verify Vietnamese meal names display correctly in Meal Detail view
- [ ] Confirm cache invalidates for all language variants on meal mutation
- [ ] All existing tests pass

## Known Issues (Out of Scope)

`RedisClient.delete_pattern` uses `KEYS` command which can block Redis. This is a pre-existing issue not introduced by this PR. Should be addressed separately by replacing with `SCAN`.