### PR TITLE
fix(translation): use English as DeepL source language

### DIFF
--- a/src/infra/adapters/deepl_translation_adapter.py
+++ b/src/infra/adapters/deepl_translation_adapter.py
@@ -59,6 +59,7 @@ class DeepLTranslationAdapter(DeepLTranslationPort):
             results = await asyncio.to_thread(
                 self._translator.translate_text,
                 texts,
+                source_lang="EN",
                 target_lang=deepl_lang,
             )
             # SDK returns a single TextResult when given a single string,


### PR DESCRIPTION
## Summary
- Force `source_lang="EN"` in DeepL translation adapter instead of relying on auto-detection
- Ensures consistent translation quality when source content is known to be English

## Changes
- `src/infra/adapters/deepl_translation_adapter.py`: Added `source_lang="EN"` parameter to `translate_text` call

## Test plan
- [ ] Verify translation requests include English as source language
- [ ] Confirm translation quality for EN→VI and other target languages