### PR TITLE
fix(i18n): add meal_instruction and meal_ingredients to ORM and mapper

### DIFF
--- a/src/infra/database/models/meal/meal_translation_model.py
+++ b/src/infra/database/models/meal/meal_translation_model.py
@@ -4,7 +4,7 @@ Meal translation database models.
 Stores translated content separately from original English to support
 multiple languages.
 """
-from sqlalchemy import Column, String, DateTime, Integer, ForeignKey, Boolean
+from sqlalchemy import Column, String, DateTime, Integer, ForeignKey, Boolean, JSON
 from sqlalchemy.orm import relationship
 
 from src.infra.database.config import Base
@@ -25,6 +25,8 @@ class MealTranslationORM(Base):
     dish_name = Column(String(255), nullable=False)
     translated_at = Column(DateTime, nullable=False)
     created_at = Column(DateTime, nullable=False)
+    meal_instruction = Column(JSON, nullable=True)
+    meal_ingredients = Column(JSON, nullable=True)
 
     # Soft delete
     is_deleted = Column(Boolean, default=False, nullable=False, server_default='false')

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -206,6 +206,8 @@ def meal_translation_domain_to_orm(domain: DomainMealTranslation) -> MealTransla
         dish_name=domain.dish_name,
         translated_at=_to_naive_utc(domain.translated_at or now),
         created_at=_to_naive_utc(now),
+        meal_instruction=domain.meal_instruction,
+        meal_ingredients=domain.meal_ingredients,
     )
     for fi in domain.food_items:
         translation.food_items.append(

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -97,6 +97,8 @@ def meal_translation_orm_to_domain(orm: MealTranslationORM) -> DomainMealTransla
             for fi in orm.food_items
         ],
         translated_at=orm.translated_at,
+        meal_instruction=orm.meal_instruction,
+        meal_ingredients=orm.meal_ingredients,
     )
 
 

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -138,7 +138,8 @@ class AsyncMealRepository(MealRepositoryPort):
         result = await self.session.execute(
             select(MealORM).options(*_PROJECTION_OPTS[projection]).where(MealORM.meal_id == meal_id)
         )
-        db_meal = result.scalars().first()
+        # .unique() required for joinedload to properly consolidate joined rows
+        db_meal = result.unique().scalars().first()
         return meal_orm_to_domain(db_meal) if db_meal else None
 
     async def find_by_status(self, status: MealStatus, limit: int = 10) -> List[Meal]:


### PR DESCRIPTION
## Summary
- Add `meal_instruction` and `meal_ingredients` JSON columns to `MealTranslationORM`
- Update `meal_translation_orm_to_domain` mapper to load these fields from DB
- Update `meal_translation_domain_to_orm` mapper to persist these fields when saving
- Add `.unique()` call in `find_by_id` for proper joinedload consolidation

## Root Cause
Multiple issues preventing meal translations from showing:

1. **ORM model missing columns**: Migration 051 added `meal_instruction` and `meal_ingredients` to the DB, but the ORM model was missing these column definitions

2. **Mapper not loading fields**: `meal_translation_orm_to_domain` wasn't mapping `meal_instruction` and `meal_ingredients` to the domain model

3. **Mapper not persisting fields**: `meal_translation_domain_to_orm` wasn't setting these fields when creating new translation records

4. **joinedload without .unique()**: When using `joinedload(MealORM.translations)`, SQLAlchemy requires `.unique()` on the result to properly consolidate joined rows. Without it, relationships may not load correctly.

## Changes
| File | Change |
|------|--------|
| `meal_translation_model.py` | Add `meal_instruction` and `meal_ingredients` columns |
| `infra/mappers/meal_mapper.py` | Map fields in both directions (ORM↔Domain) |
| `meal_repository_async.py` | Add `.unique()` to `find_by_id` |

## Test Plan
- [x] All 1124 unit tests pass
- [ ] Deploy to staging and verify Vietnamese meal names appear in meal detail