### PR TITLE
fix(meal-suggestion): resolve AttributeError in recipe translation

### DIFF
--- a/src/api/routes/v1/meal_suggestions.py
+++ b/src/api/routes/v1/meal_suggestions.py
@@ -307,12 +307,12 @@ async def generate_recipes(
             min_acceptable_override=1,
         )
 
-        # Translate if non-English
+        # Translate if non-English (pass ISO code like "vi", not full name)
         if language != "en" and recipes:
-            from src.domain.services.meal_suggestion.parallel_recipe_generator import get_language_name
-            recipes, _ = await service._recipe_generator._phase3_translate(
-                session, recipes, get_language_name(language),
-            )
+            if service._recipe_generator._translation_service:
+                recipes = await service._recipe_generator._translation_service.translate_meal_suggestions_batch(
+                    recipes, language
+                )
 
         # Map to response
         from src.api.mappers.meal_suggestion_mapper import to_meal_suggestion_response


### PR DESCRIPTION
## Summary
- Fix 500 error when generating recipes for non-English users
- Replace removed `_phase3_translate` method with direct `translate_meal_suggestions_batch` call

## Root Cause
The `_phase3_translate()` method was removed during a refactor that pipelined translation with Phase 2 generation. The `/v1/meal-suggestions/recipes` endpoint still referenced the old method.

## Changes
- `src/api/routes/v1/meal_suggestions.py`: Use `_translation_service.translate_meal_suggestions_batch()` directly instead of the non-existent `_phase3_translate()`

## Test Plan
- [ ] Generate recipes for Vietnamese user
- [ ] Generate recipes for English user (should skip translation)
- [ ] Verify translated recipes return correctly