### PR TITLE
fix: standardize all datetime columns to TIMESTAMPTZ

### DIFF
--- a/migrations/versions/20260503113601_fix_datetime_timezone_columns_batch.py
+++ b/migrations/versions/20260503113601_fix_datetime_timezone_columns_batch.py
@@ -1,0 +1,63 @@
+"""Fix all remaining datetime columns to use TIMESTAMPTZ.
+
+Standardizes all datetime columns to TIMESTAMP WITH TIME ZONE for consistency
+with utc_now() which returns timezone-aware datetimes.
+
+Tables affected:
+- cheat_days.marked_at
+- weight_entries.recorded_at
+- feature_flags.created_at, updated_at
+- saved_suggestions.saved_at, created_at
+- barcode_products.created_at, updated_at
+- food_reference.created_at, updated_at
+- user_profiles.goal_started_at
+
+Revision ID: 059
+Revises: 058
+Create Date: 2026-05-03 11:36:01
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '059'
+down_revision: Union[str, None] = '058'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+COLUMNS_TO_FIX = [
+    ('cheat_days', 'marked_at', False),
+    ('weight_entries', 'recorded_at', False),
+    ('feature_flags', 'created_at', False),
+    ('feature_flags', 'updated_at', False),
+    ('saved_suggestions', 'saved_at', False),
+    ('saved_suggestions', 'created_at', False),
+    ('barcode_products', 'created_at', True),
+    ('barcode_products', 'updated_at', True),
+    ('food_reference', 'created_at', True),
+    ('food_reference', 'updated_at', True),
+    ('user_profiles', 'goal_started_at', True),
+]
+
+
+def upgrade() -> None:
+    for table, column, nullable in COLUMNS_TO_FIX:
+        op.alter_column(
+            table, column,
+            type_=sa.DateTime(timezone=True),
+            existing_type=sa.DateTime(timezone=False),
+            existing_nullable=nullable,
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+        )
+
+
+def downgrade() -> None:
+    for table, column, nullable in COLUMNS_TO_FIX:
+        op.alter_column(
+            table, column,
+            type_=sa.DateTime(timezone=False),
+            existing_type=sa.DateTime(timezone=True),
+            existing_nullable=nullable,
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+        )

--- a/src/infra/database/models/barcode_product_model.py
+++ b/src/infra/database/models/barcode_product_model.py
@@ -23,5 +23,5 @@ class BarcodeProductModel(Base):
     serving_size = Column(String(100))
     image_url = Column(Text)
     source = Column(String(50), default="fatsecret")
-    created_at = Column(DateTime, server_default=func.now())
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/src/infra/database/models/cheat_day/cheat_day.py
+++ b/src/infra/database/models/cheat_day/cheat_day.py
@@ -10,7 +10,7 @@ class CheatDayORM(Base):
     id = Column(String(36), primary_key=True)
     user_id = Column(String(36), nullable=False, index=True)
     date = Column(Date, nullable=False)
-    marked_at = Column(DateTime, nullable=False)
+    marked_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
         UniqueConstraint("user_id", "date", name="uq_user_cheat_date"),

--- a/src/infra/database/models/feature_flag.py
+++ b/src/infra/database/models/feature_flag.py
@@ -16,5 +16,5 @@ class FeatureFlag(Base):
     name = Column(String(255), primary_key=True, index=True)
     enabled = Column(Boolean, nullable=False, default=False)
     description = Column(String(500), nullable=True)
-    created_at = Column(DateTime, default=utc_now, nullable=False)
-    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)

--- a/src/infra/database/models/food_reference_model.py
+++ b/src/infra/database/models/food_reference_model.py
@@ -53,5 +53,5 @@ class FoodReferenceModel(Base):
     source = Column(String(50), nullable=False, default="fatsecret")
     is_verified = Column(Boolean, nullable=False, default=False)
     image_url = Column(Text, nullable=True)
-    created_at = Column(DateTime, server_default=func.now())
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/src/infra/database/models/meal/meal_translation_model.py
+++ b/src/infra/database/models/meal/meal_translation_model.py
@@ -27,8 +27,8 @@ class MealTranslationORM(Base):
         String(7), nullable=False
     )  # ISO 639-1: en, vi, es, fr, de, ja, zh
     dish_name = Column(String(255), nullable=False)
-    translated_at = Column(DateTime, nullable=False)
-    created_at = Column(DateTime, nullable=False)
+    translated_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False)
     meal_instruction = Column(JSON, nullable=True)
     meal_ingredients = Column(JSON, nullable=True)
 

--- a/src/infra/database/models/saved_suggestion.py
+++ b/src/infra/database/models/saved_suggestion.py
@@ -16,8 +16,8 @@ class SavedSuggestionModel(Base):
     meal_type = Column(String(20), nullable=False)
     portion_multiplier = Column(Integer, default=1)
     suggestion_data = Column(JSON, nullable=False)
-    saved_at = Column(DateTime, nullable=False)
-    created_at = Column(DateTime, nullable=False)
+    saved_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
         UniqueConstraint("user_id", "suggestion_id", name="uq_user_suggestion"),

--- a/src/infra/database/models/user/profile.py
+++ b/src/infra/database/models/user/profile.py
@@ -64,7 +64,7 @@ class UserProfile(Base, BaseMixin):
 
     # Goal progress tracking — tracks when user started current goal journey
     goal_start_weight_kg = Column(Float, nullable=True, default=None)
-    goal_started_at = Column(DateTime, nullable=True, default=None)
+    goal_started_at = Column(DateTime(timezone=True), nullable=True, default=None)
 
     @property
     def has_custom_macros(self) -> bool:

--- a/src/infra/database/models/weight_entry.py
+++ b/src/infra/database/models/weight_entry.py
@@ -14,7 +14,7 @@ class WeightEntryORM(Base, BaseMixin):
         String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     weight_kg = Column(Float, nullable=False)
-    recorded_at = Column(DateTime, nullable=False)
+    recorded_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
         UniqueConstraint("user_id", "recorded_at", name="uq_user_recorded_at"),


### PR DESCRIPTION
All datetime columns now use DateTime(timezone=True) for consistency with utc_now() which returns timezone-aware datetimes. This prevents the "can't subtract offset-naive and offset-aware datetimes" error.

Tables affected:
- cheat_days.marked_at
- weight_entries.recorded_at
- feature_flags.created_at, updated_at
- saved_suggestions.saved_at, created_at
- barcode_products.created_at, updated_at
- food_reference.created_at, updated_at
- user_profiles.goal_started_at