### PR TITLE
docs: apply 200-line rule to all documentation files

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,9 +1,10 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** April 17, 2026  
-**Base URL:** `http://localhost:8000` (dev) or deployed host  
-**API Docs:** `/docs` (Swagger UI)  
-**50+ endpoints** across 12 route modules
+**Last Updated:** May 6, 2026
+**Base URL:** `http://localhost:8000` (dev) or deployed host
+**API Docs:** `/docs` (Swagger UI)
+**Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
+Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 
 ---
 
@@ -13,8 +14,9 @@
 |--------|----------|---------|
 | GET | `/health` | Basic health check |
 | GET | `/health/db-pool` | DB pool metrics |
-| GET | `/health/mysql-connections` | MySQL connection stats |
+| GET | `/health/db-connections` | MySQL connection stats |
 | GET | `/health/notifications` | FCM health |
+| GET | `/v1/monitoring/cache/metrics` | Redis cache metrics |
 
 ---
 
@@ -22,12 +24,16 @@
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/v1/meals/image/analyze` | Analyze meal from image |
+| POST | `/v1/meals/image/analyze` | Analyze meal from image (immediate upload) |
 | POST | `/v1/meals/manual` | Create meal from USDA foods |
-| GET | `/v1/meals/{id}` | Get meal details |
-| PUT | `/v1/meals/{id}` | Update meal (edit nutrition) |
-| DELETE | `/v1/meals/{id}` | Delete meal (soft delete) |
-| POST | `/v1/meals/image/immediate` | Upload meal image immediately |
+| POST | `/v1/meals/parse-text` | Parse meal from text description |
+| GET | `/v1/meals/streak` | Get meal logging streak |
+| GET | `/v1/meals/weekly/daily-breakdown` | Weekly daily nutrition breakdown |
+| GET | `/v1/meals/weekly/budget` | Weekly calorie budget |
+| GET | `/v1/meals/daily/macros` | Today's aggregated macros |
+| GET | `/v1/meals/{meal_id}` | Get meal details |
+| DELETE | `/v1/meals/{meal_id}` | Delete meal (soft delete) |
+| PUT | `/v1/meals/{meal_id}/ingredients` | Update meal ingredients |
 
 ---
 
@@ -35,64 +41,11 @@
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| GET | `/v1/user-profiles/me` | Get current user profile |
-| PUT | `/v1/user-profiles/me` | Update profile (health metrics) |
-| GET | `/v1/user-profiles/tdee` | Calculate TDEE |
-| GET | `/v1/user-profiles/{id}` | Get user profile by ID |
-
----
-
-## Meal Planning
-
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| POST | `/v1/meal-plans/weekly/ingredient-based` | Generate 7-day meal plan |
-| GET | `/v1/meal-plans/{id}` | Get meal plan |
-| PUT | `/v1/meal-plans/{id}` | Update meal plan |
-| DELETE | `/v1/meal-plans/{id}` | Delete meal plan |
-
----
-
-## Meal Suggestions
-
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| POST | `/v1/meal-suggestions/generate` | Generate 3 personalized suggestions |
-| POST | `/v1/meal-suggestions/discover` | Meal discovery (6 meals/batch) |
-
----
-
-## Chat (Real-Time)
-
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| WS | `/v1/chat/ws` | WebSocket chat connection |
-| POST | `/v1/chat/threads` | Create thread |
-| GET | `/v1/chat/threads` | List threads |
-| POST | `/v1/chat/threads/{id}/messages` | Send message |
-| GET | `/v1/chat/threads/{id}/messages` | Get thread messages |
-| DELETE | `/v1/chat/threads/{id}` | Delete thread |
-
----
-
-## Foods & Ingredients
-
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| GET | `/v1/foods/search` | Search USDA foods |
-| GET | `/v1/foods/{id}` | Get food details |
-| GET | `/v1/ingredients/recognize` | Recognize ingredients (image) |
-
----
-
-## Notifications
-
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| POST | `/v1/notifications/fcm/register` | Register FCM token |
-| DELETE | `/v1/notifications/fcm/{token}` | Unregister FCM token |
-| GET | `/v1/notifications/preferences` | Get notification preferences |
-| PUT | `/v1/notifications/preferences` | Update preferences |
+| POST | `/v1/user-profiles/` | Create user profile |
+| GET | `/v1/user-profiles/metrics` | Get current user metrics |
+| POST | `/v1/user-profiles/metrics` | Update metrics + recalculate TDEE |
+| GET | `/v1/user-profiles/tdee` | Get TDEE calculation |
+| PUT | `/v1/user-profiles/custom-macros` | Set custom macro targets |
 
 ---
 
@@ -101,9 +54,64 @@
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/users/sync` | Sync user from Firebase |
+| GET | `/v1/users/firebase/{firebase_uid}` | Get user profile by Firebase UID |
+| GET | `/v1/users/firebase/{firebase_uid}/status` | Get user status |
+| PUT | `/v1/users/firebase/{firebase_uid}/last-accessed` | Update last accessed |
 | PUT | `/v1/users/metrics` | Update user metrics |
-| POST | `/v1/users/onboarding` | Complete onboarding |
-| DELETE | `/v1/users/me` | Delete user account |
+| PUT | `/v1/users/timezone` | Update user timezone |
+| PATCH | `/v1/users/language` | Update user language |
+| DELETE | `/v1/users/firebase/{firebase_uid}` | Delete user account |
+
+---
+
+## Meal Suggestions
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/meal-suggestions/generate` | Generate 3 personalized suggestions |
+| POST | `/v1/meal-suggestions/discover` | Meal discovery (6 meals/batch with images) |
+| POST | `/v1/meal-suggestions/recipes` | Generate recipe batch |
+| POST | `/v1/meal-suggestions/save` | Save a meal suggestion |
+
+---
+
+## Saved Suggestions
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/saved-suggestions` | List saved suggestions |
+| POST | `/v1/saved-suggestions` | Save a suggestion |
+| DELETE | `/v1/saved-suggestions/{suggestion_id}` | Remove saved suggestion |
+
+---
+
+## Foods & Ingredients
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/foods/search` | Search USDA foods |
+| GET | `/v1/foods/{fdc_id}/details` | Get food details by FDC ID |
+| GET | `/v1/foods/barcode/{barcode}` | Barcode lookup (6-step cascade) |
+| POST | `/v1/ingredients/recognize` | Recognize ingredients from image |
+
+---
+
+## TDEE
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/tdee/preview` | Preview TDEE calculation without saving |
+
+---
+
+## Weight Entries
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/weight-entries` | List weight entries |
+| POST | `/v1/weight-entries` | Log weight entry |
+| DELETE | `/v1/weight-entries/{entry_id}` | Delete weight entry |
+| POST | `/v1/weight-entries/sync` | Sync weight entries |
 
 ---
 
@@ -111,17 +119,40 @@
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/v1/activities` | Create activity |
-| GET | `/v1/activities/{id}` | Get activity |
-| DELETE | `/v1/activities/{id}` | Delete activity |
+| GET | `/v1/activities/daily` | Get daily activities |
 
 ---
 
-## Webhooks
+## Notifications
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/v1/webhooks/revenucat` | RevenueCat subscription webhook |
+| POST | `/v1/notifications/tokens` | Register FCM token |
+| DELETE | `/v1/notifications/tokens` | Unregister FCM token |
+| GET | `/v1/notifications/preferences` | Get notification preferences |
+| PUT | `/v1/notifications/preferences` | Update preferences |
+
+---
+
+## Referrals
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/referrals/validate` | Validate referral code |
+| POST | `/v1/referrals/apply` | Apply referral code |
+| GET | `/v1/referrals/my-code` | Get user's referral code |
+| GET | `/v1/referrals/stats` | Get referral stats |
+| POST | `/v1/referrals/payout` | Request referral payout |
+
+---
+
+## Cheat Days
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/cheat-days` | List cheat days |
+| POST | `/v1/cheat-days` | Mark a cheat day |
+| DELETE | `/v1/cheat-days/{date_str}` | Remove cheat day |
 
 ---
 
@@ -129,44 +160,31 @@
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| GET | `/v1/feature-flags` | Get feature flags for user |
+| GET | `/v1/feature-flags/` | List all feature flags |
+| GET | `/v1/feature-flags/{feature_name}` | Get individual flag |
+| POST | `/v1/feature-flags/` | Create feature flag |
+| PUT | `/v1/feature-flags/{feature_name}` | Update feature flag |
+
+---
+
+## Webhooks
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/webhooks/revenuecat` | RevenueCat subscription webhook |
+| GET | `/v1/webhooks/revenuecat/health` | Webhook health check |
 
 ---
 
 ## Response Format
 
-### Success (2xx)
 ```json
-{
-  "data": {...},
-  "meta": {
-    "timestamp": "2026-04-17T12:00:00Z",
-    "version": "1.0"
-  }
-}
+// Success (2xx)
+{ "data": {...} }
+
+// Error (4xx, 5xx)
+{ "error": { "code": "MEAL_NOT_FOUND", "message": "Meal not found" } }
 ```
-
-### Error (4xx, 5xx)
-```json
-{
-  "error": {
-    "code": "MEAL_NOT_FOUND",
-    "message": "Meal not found",
-    "details": {...}
-  }
-}
-```
-
----
-
-## Authentication
-
-All protected endpoints require Firebase JWT:
-```
-Authorization: Bearer <firebase-id-token>
-```
-
-Dev mode supports `X-Dev-User-Id` header for testing (if `DEV_MODE=true`).
 
 ---
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,6 +1,6 @@
 # Backend Code Standards — Python Style & Conventions
 
-**Last Updated:** April 17, 2026  
+**Last Updated:** May 6, 2026
 **Scope:** All code in `src/` (430 files, ~38.5K LOC)  
 **Applies To:** Typing, naming, imports, code organization, error handling
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,12 +1,8 @@
 # Backend Codebase Summary
 
-**Generated:** April 17, 2026  
+**Generated:** May 6, 2026  
 **Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)  
 **Language:** Python 3.11+ | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
-
----
-
-## Quick Stats
 
 ---
 
@@ -23,7 +19,7 @@
 | Test Files | 92 files |
 | Total Test Cases | 681+ tests |
 | Test Coverage | 70%+ maintained |
-| API Endpoints | 50+ REST endpoints across 12 route modules |
+| API Endpoints | 60+ REST endpoints across 17 route modules |
 | CQRS Commands | 30 commands across 11 domains |
 | CQRS Queries | 31 query definitions |
 | Domain Events | 19 event definitions |
@@ -43,7 +39,7 @@
 
 | Directory | Files | Purpose |
 |-----------|-------|---------|
-| `src/api/routes/v1/` | 12 | 50+ REST endpoints |
+| `src/api/routes/v1/` | 17 | 60+ REST endpoints |
 | `src/api/schemas/` | 34 | Pydantic DTOs |
 | `src/app/commands/` | 30 | Write operations |
 | `src/app/queries/` | 31 | Read operations |

--- a/docs/cqrs-guide.md
+++ b/docs/cqrs-guide.md
@@ -1,8 +1,8 @@
 # Backend CQRS Pattern Guide
 
-**Last Updated:** April 17, 2026  
-**Event Bus:** PyMediator with singleton registry pattern  
-**Handlers:** 51+ across commands, queries, and events  
+**Last Updated:** May 6, 2026
+**Event Bus:** PyMediator with singleton registry pattern
+**Handlers:** 51+ across commands, queries, and events
 **Domains:** 11 (Chat, Meal, Daily Meal, Meal Plan, Meal Suggestion, User, Notification, Ingredient, TDEE, Activity, Food)
 
 ---
@@ -12,7 +12,7 @@
 ```
 API Layer (routes)
     ↓ commands/queries
-Application Layer (CQRS handlers)
+Application Layer (CQRS handlers + App Services)
     ↓ domain services
 Domain Layer (business logic)
     ↓ port implementations
@@ -25,9 +25,8 @@ Each layer has ZERO knowledge of layers above it. Domain layer is completely ind
 
 ## Commands (Write Operations)
 
-Commands represent user intent to change state. Named with imperative verbs.
+Named with imperative verbs. Validated in `__post_init__()`. Return domain entity or None.
 
-**Structure:**
 ```python
 @dataclass
 class UpdateUserMetricsCommand(Command):
@@ -40,33 +39,14 @@ class UpdateUserMetricsCommand(Command):
             raise ValidationException("Weight must be positive")
 ```
 
-**Naming**: Create, Update, Delete, Generate, Register, Upload, Sync
-
-**Validation**: In `__post_init__()` method
-
-**Return**: Domain entity or None
-
-**Handler Pattern:**
-```python
-@handles(UpdateUserMetricsCommand)
-class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, User]):
-    def __init__(self, user_repo: UserRepositoryPort):
-        self.user_repo = user_repo
-
-    async def handle(self, command: UpdateUserMetricsCommand) -> User:
-        # Execute business logic
-        # Publish events if needed
-        # Return result
-        pass
-```
+**Naming:** Create, Update, Delete, Generate, Register, Upload, Sync
 
 ---
 
 ## Queries (Read Operations)
 
-Queries retrieve data without side effects. Named with "Get" or "Search".
+Named with "Get" or "Search". No side effects. Return domain entity, list, or DTO.
 
-**Structure:**
 ```python
 @dataclass
 class GetMealByIdQuery(Query):
@@ -74,61 +54,43 @@ class GetMealByIdQuery(Query):
     user_id: str
 ```
 
-**Naming**: GetXById, SearchXBy, ListX
-
-**Validation**: Optional (simple only)
-
-**Return**: Domain entity, list, or DTO
-
-**Handler Pattern:**
-```python
-@handles(GetMealByIdQuery)
-class GetMealByIdQueryHandler(EventHandler[GetMealByIdQuery, Optional[Meal]]):
-    def __init__(self, meal_repo: MealRepositoryPort):
-        self.meal_repo = meal_repo
-
-    async def handle(self, query: GetMealByIdQuery) -> Optional[Meal]:
-        meal = self.meal_repo.find_by_id(query.meal_id)
-        if not meal:
-            return None
-        return meal
-```
+**Naming:** GetXById, SearchXBy, ListX
 
 ---
 
 ## Events (Domain Events)
 
-Events represent things that happened. Named with past tense verbs.
+Named with past tense verbs. Immutable historical facts for audit trail and downstream processing.
 
-**Structure:**
 ```python
 @dataclass
 class MealCreatedEvent(DomainEvent):
-    aggregate_id: str          # Required: meal_id
+    aggregate_id: str
     meal_id: str
     user_id: str
     event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     timestamp: datetime = field(default_factory=lambda: datetime.utcnow())
 ```
 
-**Naming**: Created, Updated, Deleted, Generated, Analyzed, Replaced
+**Naming:** Created, Updated, Deleted, Generated, Analyzed
 
-**Metadata**: Always include `event_id`, `timestamp`, optional `correlation_id`
+---
 
-**Purpose**: Historical facts for audit trail and downstream processing
+## Handler Pattern
 
-**Event Handler Pattern:**
+All three types share the same decorator and base class:
+
 ```python
-@handles(MealCreatedEvent)
-class MealCreatedEventHandler(EventHandler[MealCreatedEvent, None]):
-    def __init__(self, notification_service: NotificationServicePort):
-        self.notification_service = notification_service
+@handles(UpdateUserMetricsCommand)
+class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, User]):
+    def __init__(self, user_repo: UserRepositoryPort):
+        self.user_repo = user_repo
 
-    async def handle(self, event: MealCreatedEvent) -> None:
-        # Side effects only (send notifications, trigger jobs, etc.)
-        # Do not return data
-        pass
+    async def handle(self, command: UpdateUserMetricsCommand) -> User:
+        ...
 ```
+
+Event handlers return `None` (side effects only — notifications, jobs, etc.).
 
 ---
 
@@ -137,106 +99,30 @@ class MealCreatedEventHandler(EventHandler[MealCreatedEvent, None]):
 ### Singleton Registry Pattern
 
 ```python
-# Initialize once at app startup
+# Initialize once at app startup — prevents memory leaks from dynamic class generation
 event_bus = PyMediatorEventBus()
 
-# Reuse across requests (prevents memory leaks from dynamic class generation)
-result = await event_bus.send(CreateMealCommand(...))
-await event_bus.publish(MealCreatedEvent(...))
+result = await event_bus.send(CreateMealCommand(...))   # command/query
+await event_bus.publish(MealCreatedEvent(...))          # fire-and-forget
 ```
 
 ### Two Event Buses
 
-1. **Food Search Bus**: Lightweight, food queries only (no heavy services)
+1. **Food Search Bus**: Lightweight, food queries only
 2. **Configured Bus**: Full CQRS with 40+ handlers registered
-
----
-
-## Handler Registration
-
-Handlers are auto-discovered via `@handles` decorator:
-
-```python
-@handles(CreateMealCommand)
-class CreateMealCommandHandler:
-    pass
-
-@handles(GetMealByIdQuery)
-class GetMealByIdQueryHandler:
-    pass
-
-@handles(MealCreatedEvent)
-class MealCreatedEventHandler:
-    pass
-```
-
----
-
-## Dependency Injection
-
-### Constructor Injection
-```python
-class CreateMealCommandHandler:
-    def __init__(
-        self,
-        meal_repo: MealRepositoryPort,
-        image_store: ImageStorePort,
-        event_bus: EventBus,
-    ):
-        self.meal_repo = meal_repo
-        self.image_store = image_store
-        self.event_bus = event_bus
-
-    async def handle(self, command: CreateMealCommand) -> Meal:
-        # Use injected dependencies
-        pass
-```
-
-### Runtime Injection
-```python
-def set_dependencies(self, **kwargs):
-    self.meal_repo = kwargs.get('meal_repo', self.meal_repo)
-```
 
 ---
 
 ## Usage from Routes
 
-### Commands (Write)
 ```python
 @router.post("/meals")
 async def create_meal(
     request: CreateMealRequest,
     event_bus: EventBus = Depends(get_event_bus),
 ):
-    command = CreateMealCommand(
-        user_id=user.id,
-        image_data=request.image,
-    )
-    meal = await event_bus.send(command)
+    meal = await event_bus.send(CreateMealCommand(user_id=user.id, ...))
     return meal
-```
-
-### Queries (Read)
-```python
-@router.get("/meals/{id}")
-async def get_meal(
-    id: str,
-    event_bus: EventBus = Depends(get_event_bus),
-):
-    query = GetMealByIdQuery(meal_id=id)
-    meal = await event_bus.send(query)
-    return meal
-```
-
-### Events (Fire-and-Forget)
-```python
-# In a handler
-await self.event_bus.publish(MealCreatedEvent(
-    aggregate_id=meal.id,
-    meal_id=meal.id,
-    user_id=meal.user_id,
-))
 ```
 
 ---
@@ -245,30 +131,23 @@ await self.event_bus.publish(MealCreatedEvent(
 
 ```python
 class UnitOfWork:
-    async def __aenter__(self):
-        # Begin transaction
-        return self
-
+    async def __aenter__(self): ...   # Begin transaction
     async def __aexit__(self, exc_type, exc, tb):
-        if exc:
-            # Rollback on error
-        else:
-            # Commit on success
-        # Invalidate caches
+        if exc: ...   # Rollback
+        else: ...     # Commit + invalidate caches
 ```
 
 ---
 
-## Best Practices
+## Key Rules
 
-1. **Single Responsibility**: One command/query = one use case
-2. **Immutability**: Commands/queries/events are immutable
-3. **Validation**: In `__post_init__()` for commands, in handlers for queries
-4. **Error Handling**: Raise domain exceptions, handle at route level
-5. **Event Sourcing**: Events are immutable records of fact
-6. **Async**: All handlers are async for I/O operations
-7. **No Side Effects**: Queries never change state
-8. **Fire-and-Forget**: Events are published async, no wait for handlers
+| Rule | Applies To |
+|------|-----------|
+| Single responsibility: one use case per command/query | Commands, Queries |
+| Validation in `__post_init__()` | Commands |
+| Never change state | Queries, Events |
+| Always async | All handlers |
+| Fire-and-forget (no wait) | Events |
 
 ---
 

--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -1,9 +1,9 @@
 # Backend Database Guide
 
-**Last Updated:** April 17, 2026  
-**Engine:** MySQL 8.0 + SQLAlchemy 2.0  
-**Migrations:** Alembic with auto-migration on startup  
-**Tables:** 13+ core + notification_sent_log (dedup)
+**Last Updated:** May 6, 2026
+**Engine:** MySQL 8.0 + SQLAlchemy 2.0
+**Migrations:** Alembic with auto-migration on startup
+**Tables:** 15 (13 core + notification_sent_log + food_reference)
 
 ---
 
@@ -13,11 +13,10 @@
 # src/infra/database/config.py
 DATABASE_URL = "mysql+pymysql://user:pass@host/db"
 
-# Pool sizing
-pool_size = 20           # Base connections
-max_overflow = 10        # Additional under load
-pool_recycle = 3600      # Recycle connections hourly
-pool_pre_ping = True     # Verify before use
+pool_size = 20       # Base connections
+max_overflow = 10    # Additional under load
+pool_recycle = 3600  # Recycle hourly
+pool_pre_ping = True # Verify before use
 ```
 
 ---
@@ -26,13 +25,14 @@ pool_pre_ping = True     # Verify before use
 
 | Table | Purpose | Key Fields |
 |-------|---------|-----------|
-| **users** | Auth & identity | id, firebase_uid, email, is_active |
-| **user_profiles** | Health metrics | user_id, age, gender, height, weight, body_fat_percentage |
+| **users** | Auth & identity | id, firebase_uid, email, language_code, is_active |
+| **user_profiles** | Health metrics | user_id, age, gender, height, weight, body_fat_percentage, date_of_birth |
 | **subscriptions** | RevenueCat cache | user_id, product_id, platform, status, expires_at |
 | **meal** | Meal records | id, user_id, status (state machine), dish_name, ready_at |
 | **meal_image** | Cloudinary refs | meal_id, url, format, size, width, height |
 | **nutrition** | Macros | meal_id, calories, protein, carbs, fat, fiber, sugar, confidence_score |
 | **food_item** | Ingredients | meal_id, name, quantity, unit, fdc_id, is_custom, fiber, sugar |
+| **food_reference** | Barcode/food data | barcode, name, name_normalized, nutrition data |
 | **meal_plan** | Weekly plans | user_id, start_date, end_date, user_preferences |
 | **meal_plan_day** | Daily breakdown | meal_plan_id, day_index |
 | **planned_meal** | Individual meals | day_plan_id, meal_type, dish_name, nutrition |
@@ -40,32 +40,21 @@ pool_pre_ping = True     # Verify before use
 | **notification_preferences** | FCM settings | user_id, enabled, timing, interval |
 | **chat_threads** | Conversations | id, user_id, title, status, created_at |
 | **chat_messages** | Messages | thread_id, user_id, role (user/assistant), content, created_at |
-| **notification_sent_log** | Dedup (047) | user_id, notification_type, sent_minute, created_at |
+| **notification_sent_log** | FCM dedup | user_id, notification_type, sent_minute, created_at |
 
 ---
 
 ## Model Mixins
 
-```python
-# src/infra/database/models/base.py
+Three base mixins in `src/infra/database/models/base.py`:
 
-class PrimaryEntityMixin:
-    """GUID primary key (String(36)), timestamps"""
-    id: str = Column(String(36), primary_key=True)
-    created_at: datetime = Column(DateTime, default=utcnow)
-    updated_at: datetime = Column(DateTime, onupdate=utcnow)
+| Mixin | ID Type | Use Case |
+|-------|---------|---------|
+| `PrimaryEntityMixin` | GUID String(36) | Top-level aggregates (Meal, User) |
+| `SecondaryEntityMixin` | Auto-increment int | Child entities (Nutrition, FoodItem) |
+| `TimestampMixin` | No ID | Join tables or log tables |
 
-class SecondaryEntityMixin:
-    """Auto-increment integer ID, timestamps"""
-    id: int = Column(Integer, primary_key=True, autoincrement=True)
-    created_at: datetime = Column(DateTime, default=utcnow)
-    updated_at: datetime = Column(DateTime, onupdate=utcnow)
-
-class TimestampMixin:
-    """Only timestamps (no ID)"""
-    created_at: datetime = Column(DateTime, default=utcnow)
-    updated_at: datetime = Column(DateTime, onupdate=utcnow)
-```
+All mixins add `created_at` and `updated_at` timestamps.
 
 ---
 
@@ -95,110 +84,45 @@ PROCESSING → ANALYZING → ENRICHING → READY
 
 ## Migrations
 
-Managed via Alembic. Auto-migrate on startup with retry logic.
-
-**Run migrations:**
 ```bash
-# Apply latest
-alembic upgrade head
-
-# Create new migration
-alembic revision --autogenerate -m "description"
-
-# Rollback one
-alembic downgrade -1
+alembic upgrade head                              # Apply latest
+alembic revision --autogenerate -m "description"  # Create new
+alembic downgrade -1                              # Rollback one
 ```
 
+Auto-migrate runs on startup with retry logic. Use timestamp naming for new migrations.
+
 **Recent migrations:**
-| Version | Changes | Date |
-|---------|---------|------|
-| 047 | Add notification_sent_log for dedup | Apr 2026 |
-| 046 | Add name_normalized to food_reference | Apr 2026 |
-| 045 | Add challenge_duration, training_types (onboarding) | Apr 2026 |
-| 044 | Widen firebase_uid to 128 chars | Mar 2026 |
-| 043 | Add language_code to users | Mar 2026 |
-| 037 | Add custom_protein_g, custom_carbs_g, custom_fat_g | Mar 2026 |
-| 036 | Add date_of_birth to user_profiles | Mar 2026 |
-| 035 | Evolve barcode_products → food_reference | Mar 2026 |
-| 034 | Add fiber, sugar to food_item, nutrition | Mar 2026 |
+
+| Version | Changes |
+|---------|---------|
+| 047 | Add notification_sent_log for FCM deduplication |
+| 046 | Add name_normalized to food_reference |
+| 045 | Add challenge_duration, training_types (onboarding) |
+| 044 | Widen firebase_uid to 128 chars |
+| 043 | Add language_code to users |
+| 037 | Add custom_protein_g, custom_carbs_g, custom_fat_g |
+| 035 | Evolve barcode_products → food_reference |
+| 034 | Add fiber, sugar to food_item and nutrition |
 
 ---
 
 ## Repository Pattern
 
-**Smart Sync:** Update existing or create new
-```python
-def save(self, meal: Meal) -> Meal:
-    # If meal.id exists: update record
-    # If meal.id is new: insert record
-    # Handle nested entities (food items) with diff-based updates
-    pass
-```
+**Smart Sync:** Update existing or insert new record, with diff-based updates for nested entities.
 
-**Eager Loading:** Pre-defined options for consistent performance
-```python
-_load_options = [
-    joinedload(MealModel.image),
-    joinedload(MealModel.nutrition).joinedload(Nutrition.food_items),
-]
+**Eager Loading:** Pre-defined `joinedload` options per repository — avoids N+1 queries consistently.
 
-def find_by_id(self, meal_id: str) -> Optional[Meal]:
-    db_meal = self.session.query(MealModel).options(
-        *self._load_options
-    ).filter_by(meal_id=meal_id).first()
-    return db_meal.to_domain() if db_meal else None
-```
-
----
-
-## Domain ↔ DB Mapping
-
-```python
-class Meal(PrimaryEntityMixin, Base):
-    __tablename__ = "meal"
-    
-    # DB relationships with eager loading
-    image = relationship("MealImage", lazy="joined")
-    nutrition = relationship("Nutrition", lazy="joined")
-    
-    # Convert to domain
-    def to_domain(self) -> DomainMeal:
-        return DomainMeal(...)
-    
-    # Convert from domain
-    @staticmethod
-    def from_domain(meal: DomainMeal) -> "Meal":
-        return Meal(...)
-```
-
----
-
-## Session Management
-
-Request-scoped sessions via ContextVar (singleton-safe):
-
-```python
-# src/infra/database/config.py
-async_session = AsyncSessionLocal()
-
-# Request-scoped
-@app.middleware("http")
-async def add_session(request, call_next):
-    async with async_session() as session:
-        # Inject into request
-        request.state.session = session
-        return await call_next(request)
-```
+**Session Scope:** Request-scoped sessions via FastAPI dependency injection. One session per request, never shared across requests.
 
 ---
 
 ## Performance Optimization
 
-- **Eager Loading:** Pre-defined load options for known relationships
-- **Connection Pooling:** 20 base + 10 overflow, recycled hourly
-- **Indexes:** Firebase UID, status, dates, user_id foreign keys
-- **Queries:** Avoid N+1 with joinedload and selectinload
-- **Sessions:** Request-scoped (fresh per request, no global state)
+- Indexes on `firebase_uid`, `status`, date columns, and `user_id` foreign keys
+- `joinedload` / `selectinload` for known relationship paths
+- Connection pool: 20 base + 10 overflow, recycled hourly
+- Redis cache-aside for frequently read data (see `external-services.md`)
 
 ---
 

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,8 +1,8 @@
 # Backend External Services Integration
 
-**Last Updated:** April 17, 2026  
-**Services:** Firebase, Cloudinary, Google Gemini, Pinecone, RevenueCat, MySQL, Redis, Sentry  
-**All services gracefully degrade on failure** (except auth and DB which fail fast)
+**Last Updated:** May 6, 2026
+**Services:** Firebase, Cloudinary, Google Gemini, RevenueCat, Redis, Sentry
+**All services gracefully degrade on failure** (except Firebase Auth and DB which fail fast)
 
 ---
 
@@ -12,19 +12,14 @@
 
 ### Authentication
 - Firebase Admin SDK for JWT verification
-- Dev bypass middleware for local development
-- Token expiration and revocation checks
+- Dev bypass middleware enabled by `DEV_MODE=true` (`X-Dev-User-Id` header)
 - Maps Firebase UID to database UUID
 
-**Configuration:**
-```
-FIREBASE_CREDENTIALS=path/to/credentials.json
-```
+**Config:** `FIREBASE_CREDENTIALS=path/to/credentials.json`
 
 ### Firebase Cloud Messaging (FCM)
 - Platform-specific configs (Android high priority, APNS alert/badge/sound)
 - Multi-device support via `user_fcm_tokens` table
-- Failed token tracking with error codes
 - Deduplication across workers via `notification_sent_log` table (migration 047)
 
 ---
@@ -33,41 +28,36 @@ FIREBASE_CREDENTIALS=path/to/credentials.json
 
 **Purpose:** Image Storage + CDN
 
-**Features:**
-- Folder organization ("mealtrack")
-- Secure URL generation
-- Format support (JPEG, PNG)
-- Resource API with fallback to direct URL construction
+- Folder organization ("mealtrack"), secure URL generation
+- Format support: JPEG, PNG
+- Fallback to direct URL construction if Resource API unavailable
 
-**Configuration:**
-```
-CLOUDINARY_CLOUD_NAME=...
-CLOUDINARY_API_KEY=...
-CLOUDINARY_API_SECRET=...
-```
+**Config:** `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`
 
-**Used For:** Meal images, user avatars
+**Used for:** Meal images, user avatars
 
 ---
 
 ## Google Gemini
 
-**Purpose:** AI Meal Analysis + Chat + Content Generation
+**Purpose:** AI Meal Analysis + Content Generation
 
 ### Multi-Model Strategy (Rate Distribution)
-| Model | Purpose | Rate Limit |
-|-------|---------|------------|
-| gemini-2.5-flash-lite | Meal names | 10 RPM |
-| gemini-2.5-flash | Recipe primary | 5 RPM |
-| gemini-3-flash | Recipe secondary (load distribution) | — |
-| Default | General fallback | — |
+
+| Purpose | Model | Env Key |
+|---------|-------|---------|
+| General / Recipe / Barcode | `gemini-2.5-flash` | `GEMINI_MODEL` |
+| Meal names | `gemini-2.5-flash-lite` | `GEMINI_MODEL_NAMES` |
+| Recipe primary | `gemini-2.5-flash` | `GEMINI_MODEL_RECIPE_PRIMARY` |
+| Recipe secondary | `gemini-2.5-flash` | `GEMINI_MODEL_RECIPE_SECONDARY` |
 
 ### Vision AI (Meal Analysis)
 - 6 analysis strategies: basic, portion-aware, ingredient-aware, weight-aware, user-context, combined
 - JSON parsing with multiple fallbacks: direct, markdown extraction, regex, truncation recovery
 - Safety detection for blocked responses
 
-### Token Optimization
+### Token Limits by Use Case
+
 | Use Case | Tokens |
 |----------|--------|
 | Weekly meal plan | 8000 |
@@ -75,37 +65,7 @@ CLOUDINARY_API_SECRET=...
 | Daily multi-meal | 3000 |
 | Single meal | 1500 |
 
-**Configuration:**
-```
-GOOGLE_API_KEY=...
-```
-
-**Used For:** Meal image analysis, meal generation, chat responses
-
----
-
-## Pinecone
-
-**Purpose:** Vector Search for Ingredient Nutrition Data
-
-**Configuration:**
-- **Embedding Model:** llama-text-embed-v2 (1024 dimensions)
-- **Indexes:** "ingredients", "usda"
-- **Similarity Threshold:** 0.35
-
-**Features:**
-- Semantic ingredient search
-- Nutrition scaling by portion
-- Unit conversion (g, kg, oz, lb, ml, cup, tbsp, tsp, etc.)
-- Aggregate nutrition calculation
-
-**Configuration:**
-```
-PINECONE_API_KEY=...
-PINECONE_ENVIRONMENT=...
-```
-
-**Status:** Deprecated in favor of direct USDA/AI lookup (still available for fallback)
+**Config:** `GOOGLE_API_KEY`
 
 ---
 
@@ -113,59 +73,14 @@ PINECONE_ENVIRONMENT=...
 
 **Purpose:** Subscription Management
 
-**Features:**
 - Webhook sync to local `subscriptions` table
-- Premium status check with cache fallback
+- Premium status check with Redis cache fallback
 - Signature verification for webhooks
 - Webhook events: purchase, renewal, cancellation, expiration
 
-**Configuration:**
-```
-REVENUECAT_API_KEY=...
-REVENUECAT_WEBHOOK_SECRET=...
-```
+**Config:** `REVENUECAT_SECRET_API_KEY`, `REVENUECAT_WEBHOOK_SECRET`
 
-**Used For:** Premium feature gates (planned, not currently enforced)
-
----
-
-## MySQL Database
-
-**Engine:** MySQL 8.0 + SQLAlchemy 2.0
-
-**Configuration:**
-```
-DATABASE_URL=mysql+pymysql://user:pass@host/db
-```
-
-### Connection Pool
-- **Min connections:** 20
-- **Overflow:** 10 additional connections under load
-- **Timeout:** Connection timeout handling with retry logic
-
-### Schema
-| Table | Purpose |
-|-------|---------|
-| users | Firebase UID mapping, auth |
-| user_profiles | Health metrics, goals, preferences |
-| subscriptions | RevenueCat cache |
-| meal | Meal records with state machine |
-| meal_image | Cloudinary references |
-| nutrition | Macros + confidence score |
-| food_item | Ingredients with density conversion |
-| meal_plan | Weekly/daily plans |
-| meal_plan_day | Day details |
-| planned_meal | Individual planned meals |
-| notification_preferences | User notification settings |
-| user_fcm_tokens | Firebase Cloud Messaging tokens |
-| chat_threads | Conversation storage |
-| chat_messages | Message storage |
-| notification_sent_log | Deduplication for FCM (migration 047) |
-
-### Migrations
-- Managed via Alembic
-- Auto-migrate on startup with retry logic
-- Recent: notifications (047), onboarding (045), fiber/sugar (034), custom macros (037)
+**Status:** Premium feature gates planned, not currently enforced on routes
 
 ---
 
@@ -173,19 +88,14 @@ DATABASE_URL=mysql+pymysql://user:pass@host/db
 
 **Purpose:** Session caching, suggestion caching, performance optimization
 
-**Configuration:**
-```
-REDIS_URL=redis://host:port/db
-```
+- **Pattern:** Cache-aside (check → miss → fetch from DB → populate)
+- **Connection Pool:** 50 connections | **Default TTL:** 1 hour
+- **Error Handling:** Graceful degradation (continue on failure)
 
-### Cache Strategy
-- **Pattern:** Cache-aside (check cache → miss → fetch from DB → populate cache)
-- **Serialization:** JSON with Pydantic support
-- **Connection Pool:** 50 connections
-- **Default TTL:** 1 hour
-- **Error Handling:** Graceful degradation (continue on cache failure)
+**Config:** `REDIS_URL=redis://host:port/db`
 
-### TTL by Data Volatility
+### TTL by Data Type
+
 | Data | TTL |
 |------|-----|
 | User profile | 1 hour |
@@ -193,45 +103,34 @@ REDIS_URL=redis://host:port/db
 | TDEE calculations | 1 hour |
 | Food search results | 1 hour |
 
-**Used For:**
-- Session-based meal suggestions (4h)
-- User profile caching
-- TDEE calculation caching
-- Food reference caching
-
 ---
 
 ## Sentry Monitoring
 
 **Purpose:** Error tracking, performance profiling, crash reporting
 
-**Configuration:**
-```
-SENTRY_DSN=...
-SENTRY_ENVIRONMENT=production
-SENTRY_TRACES_SAMPLE_RATE=0.1
-SENTRY_PROFILES_SAMPLE_RATE=0.1
-```
+- FastAPI, Starlette, SQLAlchemy integrations built-in
+- Gracefully disabled if `SENTRY_DSN` not set
 
-### Features
-- Error tracking with context and breadcrumbs
-- Performance monitoring (traces)
-- Profiling (CPU, memory)
-- FastAPI, Starlette, SQLAlchemy integrations
-- Source map support
-- PII handling (disabled by default)
+**Config:** `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE=0.1`, `SENTRY_PROFILES_SAMPLE_RATE=0.0`, `SENTRY_SEND_PII=false`
 
-**Status:** NEW in Apr 2026, gracefully disabled if DSN not set
+---
+
+## Database (PostgreSQL/MySQL)
+
+See `database-guide.md` for schema, connection pool, and migration details.
+
+**Config:** `DATABASE_URL=mysql+pymysql://user:pass@host/db`
 
 ---
 
 ## Service Health Checks
 
-```bash
-GET /health               # Basic health (200 if running)
-GET /health/db-pool       # DB pool metrics
-GET /health/mysql-connections  # MySQL connection stats
-GET /health/notifications # FCM health
+```
+GET /health                    # Basic health (200 if running)
+GET /health/db-pool            # DB pool metrics
+GET /health/db-connections     # MySQL connection stats
+GET /health/notifications      # FCM health
 ```
 
 ---
@@ -241,11 +140,10 @@ GET /health/notifications # FCM health
 | Service | Failure Mode | Recovery |
 |---------|--------------|----------|
 | Firebase Auth | Fail fast (401) | Requests rejected |
-| Cloudinary | Degrade (use fallback URL) | Continue with best-effort image |
-| Gemini | Fail fast (503) | Return error to client |
-| Pinecone | Degrade (use USDA/AI fallback) | Continue with alternative source |
-| RevenueCat | Degrade (assume premium from cache) | Continue with last-known status |
 | MySQL | Fail fast (503) | Requests rejected |
+| Gemini | Fail fast (503) | Return error to client |
+| Cloudinary | Degrade (fallback URL) | Continue with best-effort image |
+| RevenueCat | Degrade (assume premium from cache) | Continue with last-known status |
 | Redis | Degrade (bypass cache) | Continue without caching |
 | Sentry | Degrade (log locally) | Continue with local logging |
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,7 +1,7 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
 **Version:** 0.6.1
-**Last Updated:** April 17, 2026
+**Last Updated:** May 6, 2026
 **Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: Sentry monitoring, meal discovery endpoint, notification deduplication, onboarding redesign (challenge_duration, training_types).
 
 ---
@@ -33,19 +33,24 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 - Gemini 2.5 Flash with strategy pattern for flexible context handling.
 - Returns results in <3 seconds through state machine (PROCESSING → ANALYZING → READY/FAILED).
 
-### 2. RESTful API (50+ Endpoints across 12 Route Modules)
-- **Meals**: image/analyze (POST), manual (POST), /{id} (GET/DELETE), ingredients (PUT), daily/macros (GET), streak, daily-breakdown.
-- **User Profiles**: POST/GET/PUT profiles, TDEE calculation.
-- **Meal Plans**: Weekly ingredient-based generation, meal retrieval by date.
-- **Meal Suggestions**: Session-based with 4h TTL, portion multipliers (1-4x), rejection feedback, discovery endpoint (6 meals).
-- **Chat**: Threads + Messages (REST + WebSocket), streaming AI responses via MessageOrchestrationService and AIResponseCoordinator.
-- **Notifications**: FCM token management, deduplication (notification_sent_log), preferences with timezone-aware scheduling.
-- **Foods**: USDA FDC search, barcode lookup with 6-step cascade (Nutritionix → Brave Search → AI fallback).
+### 2. RESTful API (60+ Endpoints across 17 Route Modules)
+- **Meals**: image/analyze, manual, parse-text, streak, weekly/daily-breakdown, weekly/budget, daily/macros, /{id} (GET/DELETE), ingredients (PUT).
+- **User Profiles**: create, metrics (GET/POST), TDEE, custom-macros.
+- **Users**: sync, Firebase UID lookups, metrics, timezone, language, delete.
+- **Meal Suggestions**: generate (3/session, 4h TTL), discover (6 meals + images), recipes, save.
+- **Saved Suggestions**: list, save, delete.
+- **Foods**: USDA FDC search, details by FDC ID, barcode lookup (6-step cascade).
+- **Ingredients**: image-based recognition.
+- **TDEE**: preview calculation.
+- **Weight Entries**: list, log, delete, sync.
+- **Activities**: daily activities.
+- **Notifications**: FCM token management, deduplication (notification_sent_log), preferences.
+- **Referrals**: validate, apply, my-code, stats, payout.
+- **Cheat Days**: list, mark, delete.
+- **Feature Flags**: CRUD for feature toggles.
 - **Webhooks**: RevenueCat subscription sync.
-- **Activities**: Activity tracking and management.
-- **Ingredients**: Ingredient recognition and analysis.
-- **Monitoring**: Health checks, Sentry error/performance tracking, observability endpoints.
-- **Feature Flags**: Feature toggle management.
+- **Monitoring**: cache metrics.
+- **Health**: health, db-pool, db-connections, notifications.
 
 ### 3. Session-Based Meal Suggestions & Discovery
 - Generates 3 personalized suggestions per session with Redis 4h TTL.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -75,10 +75,11 @@
 ---
 
 ## Current Priorities (Q2 2026)
-1. **Performance**: Optimize suggestion generation (target <10s from ~45s).
-2. **Rate Limiting**: Tune rate limits on meal_suggestions endpoints (discover, generate).
-3. **Security**: Restrict CORS in production, implement request body logging with PII redaction.
-4. **Testing**: Increase coverage for new meal discovery and notification dedup logic.
+1. **Performance**: Optimize suggestion generation (target <10s from ~45s) — in progress.
+2. **Security**: Restrict CORS in production (`allow_origins=["*"]` currently wide open), add PII redaction to request logging — open.
+3. **Rate Limiting**: Tune rate limits on `meal_suggestions` endpoints (discover, generate) — open.
+4. **Testing**: Increase coverage for meal discovery and notification dedup logic — open.
+5. **Premium Gating**: Apply `require_premium` dependency to premium-only routes — open.
 
 ---
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,13 +1,13 @@
 # Backend System Architecture Overview
 
-**Last Updated:** April 17, 2026  
-**Architecture:** 4-Layer Clean + CQRS + Event-Driven  
-**Event Bus:** PyMediator (singleton registry pattern)  
+**Last Updated:** May 6, 2026
+**Architecture:** 4-Layer Clean + CQRS + Event-Driven
+**Event Bus:** PyMediator (singleton registry pattern)
 **Codebase:** 430 files, ~38.5K LOC across 4 layers
 
 ---
 
-## Architecture Overview
+## Architecture Diagram
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -33,175 +33,75 @@
 
 ---
 
-## Layer Statistics & Responsibilities
+## Layer Statistics
 
-| Layer | Files | LOC | Purpose |
-|-------|-------|-----|---------|
-| API | 76 | ~8,605 | HTTP presentation + routing |
-| App | 140 | ~6,229 | CQRS orchestration (commands/queries/events) |
-| Domain | 133 | ~14,556 | Business logic (ZERO external dependencies) |
-| Infra | 80 | ~8,895 | DB, cache, external services, event bus |
+| Layer | Files | LOC | Key Contents |
+|-------|-------|-----|-------------|
+| API | 76 | ~8,605 | 17 route modules, 34 Pydantic schemas, 8 mappers, 3 middleware |
+| App | 140 | ~6,229 | 30 commands, 31 queries, 19 events, 51+ handlers, 3 app services |
+| Domain | 133 | ~14,556 | 8 bounded contexts, 30+ entities, 50+ services, 17 port interfaces |
+| Infra | 80 | ~8,895 | 13+ DB tables, 10+ repos, Redis, PyMediator, external adapters |
 | **Total** | **430** | **~38,300** | |
 
----
-
-## Layer Responsibilities
-
-### 1. API Layer (`src/api/`)
-**Responsibility:** HTTP request/response handling
-
-- **12 Route Modules**: 50+ REST endpoints (health, meals, users, profiles, chat, notifications, etc.)
-- **34 Pydantic Schemas**: Request/response DTOs with validation
-- **8 Mappers**: API ↔ Domain transformations
-- **3 Middleware Layers**: CORS, request logging, dev auth bypass
-- **Firebase JWT Auth**: Token verification with dev bypass
-- **WebSocket Support**: ConnectionManager for real-time chat
-
-**Flow:**
-1. Receive HTTP request
-2. Validate via Pydantic
-3. Create command/query
-4. Dispatch to event bus
-5. Map result to response DTO
-6. Return response
-
-### 2. Application Layer (`src/app/`)
-**Responsibility:** CQRS command/query/event orchestration
-
-- **30 Commands**: Write operations across 11 domains
-- **31 Queries**: Read operations
-- **19 Domain Events**: Historical facts
-- **51+ Handlers**: Command, query, event handlers with @handles decorator
-- **3 App Services**: MessageOrchestrationService, AIResponseCoordinator, ChatNotificationService
-- **UnitOfWork**: Transaction management
-
-**Key Concept:** Handlers are dependency-injected with repositories and domain services, never directly manipulate DB.
-
-### 3. Domain Layer (`src/domain/`)
-**Responsibility:** Pure business logic (ZERO infrastructure dependencies)
-
-- **8 Bounded Contexts**: Meal, Nutrition, User, Meal Planning, Conversation, Notification, AI, Chat
-- **30+ Domain Entities**: Rich models with validation
-- **50+ Domain Services**: TDEE, nutrition, meal planning, suggestions, translation, notifications
-- **6 Analysis Strategies**: Strategy Pattern for flexible meal analysis
-- **17 Port Interfaces**: Dependency inversion for repositories and services
-
-**Key Concept:** Domain layer knows nothing about HTTP, databases, or external APIs. It only knows business rules.
-
-### 4. Infrastructure Layer (`src/infra/`)
-**Responsibility:** Technical implementation details
-
-- **MySQL + SQLAlchemy 2.0**: 13+ tables, connection pooling (20 + 10 overflow)
-- **Alembic Migrations**: Database version control
-- **10+ Repositories**: Smart sync, eager loading, request-scoped sessions
-- **Redis Cache**: Cache-aside pattern, graceful degradation
-- **PyMediator Event Bus**: Singleton registry, async handler execution
-- **External Services**: Firebase FCM, Cloudinary, Gemini, Pinecone, RevenueCat, Sentry
-- **WebSocket**: ConnectionManager for real-time connections
+**Layer rule:** Domain has ZERO external dependencies. See `cqrs-guide.md` for handler patterns.
 
 ---
 
 ## Key Architectural Patterns
 
 ### Dependency Inversion
+Domain defines port interfaces; infrastructure implements them. Handlers depend on abstractions.
 
-Domain layer defines ports (interfaces); infrastructure implements them.
+### CQRS
+- **Commands** — write operations, publish events (CreateMeal, UpdateUserMetrics)
+- **Queries** — read-only, return immediately (GetMealById, SearchFoods)
+- **Events** — fire-and-forget, processed async (MealCreated, UserOnboarded)
 
-```
-Domain (defines interface)
-    ↓
-Infrastructure (implements interface)
-    ↓
-Handler (depends on abstraction, not concrete impl)
-```
-
-### CQRS (Command Query Responsibility Segregation)
-
-Separates write (commands) from read (queries) operations:
-
-- **Commands**: CreateMealCommand, UpdateUserMetricsCommand (execute business logic, publish events)
-- **Queries**: GetMealByIdQuery, SearchFoodsQuery (read-only, return immediately)
-- **Events**: MealCreatedEvent, UserOnboardedEvent (fire-and-forget, processed async)
-
-See `docs/cqrs-guide.md` for detailed patterns.
-
-### Event Bus (PyMediator)
-
-Singleton registry pattern prevents memory leaks:
-
+### Event Bus (PyMediator Singleton)
 ```python
-# Commands/Queries (synchronous)
-result = await event_bus.send(CreateMealCommand(...))
-
-# Events (asynchronous, fire-and-forget)
-await event_bus.publish(MealCreatedEvent(...))
+result = await event_bus.send(CreateMealCommand(...))    # synchronous
+await event_bus.publish(MealCreatedEvent(...))           # fire-and-forget
 ```
 
 ### Repository Pattern
-
-Repositories encapsulate data access with smart sync and eager loading:
-
-```python
-def save(self, meal: Meal) -> Meal:
-    # Smart sync: update existing or create new
-    # Diff-based updates for nested entities
-    pass
-
-def find_by_id(self, meal_id: str) -> Optional[Meal]:
-    # Eager loading with joinedload
-    # Convert DB model to domain entity
-    pass
-```
+Smart sync (diff-based updates), eager loading via pre-defined `joinedload` options.
 
 ---
 
 ## Bounded Contexts (Domain)
 
-| Context | Purpose | Key Entities |
-|---------|---------|--------------|
-| Meal | Core meal operations | Meal (state machine), MealImage, Ingredient |
-| Nutrition | Macro/micro data | Nutrition, FoodItem, Macros, Micros |
-| User | User profiles & metrics | User, UserProfile, Activity, TdeeRequest |
-| Meal Planning | Weekly/daily plans | MealPlan, PlannedMeal, DayPlan, UserPreferences |
-| Conversation | Chat state | Conversation, Message, ConversationState |
-| Notification | Push notifications | UserFcmToken, NotificationPreferences, PushNotification |
-| AI | AI response models | GPTAnalysisResponse, GPTFoodItem, GPTResponseError |
-| Chat | Real-time messaging | Thread, Message, ThreadStatus, MessageRole |
+| Context | Key Entities |
+|---------|-------------|
+| Meal | Meal (state machine), MealImage, Ingredient |
+| Nutrition | Nutrition, FoodItem, Macros, Micros |
+| User | User, UserProfile, Activity, TdeeRequest |
+| Meal Planning | MealPlan, PlannedMeal, DayPlan, UserPreferences |
+| Conversation | Conversation, Message, ConversationState |
+| Notification | UserFcmToken, NotificationPreferences, PushNotification |
+| AI | GPTAnalysisResponse, GPTFoodItem, GPTResponseError |
+| Chat | Thread, Message, ThreadStatus, MessageRole |
 
 ---
 
 ## Data Flow Example: Meal Analysis
 
-1. API POST `/v1/meals/image/analyze` receives image
+1. `POST /v1/meals/image/analyze` receives image
 2. Route creates `UploadMealImageImmediatelyCommand`
-3. EventBus.send() → `UploadMealImageImmediatelyCommandHandler`
-4. Handler uploads image to Cloudinary, creates Meal with PROCESSING status, publishes `MealImageUploadedEvent`
-5. EventBus.publish() → `MealAnalysisEventHandler` (background)
-6. Background handler calls `VisionAIService` (Gemini), parses nutrition, updates Meal to READY
-7. Handler returns Meal to API layer immediately (step 4)
-
-**Result:** Synchronous response to client, async analysis in background.
-
----
-
-## Architectural Strengths
-
-1. **Clear Separation of Concerns**: 4 distinct layers
-2. **CQRS Flexibility**: Independent scaling of reads/writes
-3. **Event-Driven Scalability**: Async background processing
-4. **Dependency Inversion**: Domain has zero infrastructure dependencies
-5. **Testability**: 681+ tests, 70%+ coverage (isolated handlers, injected deps)
-6. **Graceful Degradation**: Cache/service failures handled gracefully
+3. `EventBus.send()` → `UploadMealImageImmediatelyHandler`
+4. Handler uploads to Cloudinary, creates Meal (PROCESSING), publishes `MealImageUploadedEvent`
+5. Handler returns Meal immediately to API (synchronous response to client)
+6. `EventBus.publish()` → `MealAnalysisEventHandler` (background)
+7. Background: calls `VisionAIService` (Gemini), parses nutrition, updates Meal to READY
 
 ---
 
 ## Known Issues
 
-1. CORS wide open in production (`allow_origins=["*"]`)
-2. Premium features not restricted on routes
-3. No API versioning strategy (only v1)
-4. Hardcoded constants not in config
-5. CloudinaryImageStore created directly in routes (not DI)
+- CORS `allow_origins=["*"]` wide open in production (security risk)
+- Premium features not restricted on routes (`require_premium` dependency not applied)
+- No API versioning strategy beyond v1
+- `CloudinaryImageStore` instantiated directly in routes (not via DI)
+- Hardcoded constants (MAX_FILE_SIZE, SLOW_REQUEST_THRESHOLD) not in config
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Backend Troubleshooting Guide
 
-**Last Updated:** April 17, 2026
+**Last Updated:** May 6, 2026
 
 ---
 
@@ -20,36 +20,22 @@ python -c "from src.app.commands.meal import CreateMealCommand"
 2. Verify relative imports use `.` notation
 3. Check for circular dependencies: A imports B imports A
 
-**Prevention:** Run type checker before commit:
-```bash
-mypy src/
-```
-
 ---
 
 ### Database Connection Errors
 
-**Problem:** `OperationalError: (pymysql.err.OperationalError) (2003, "Can't connect to MySQL server..."`
+**Problem:** `OperationalError: Can't connect to MySQL server`
 
 **Diagnosis:**
 ```bash
-# Check DATABASE_URL format
 echo $DATABASE_URL
 # Should be: mysql+pymysql://user:pass@host:3306/dbname
 ```
 
 **Solutions:**
-1. Verify MySQL is running
-2. Check `DATABASE_URL` format (user, pass, host, port, dbname)
-3. Verify credentials and network access
-4. Check firewall rules
-
-**Prevention:** Test connection on startup:
-```bash
-# In settings.py
-if not test_db_connection():
-    raise RuntimeError("Database connection failed")
-```
+1. Verify `DATABASE_URL` format (user, pass, host, port, dbname)
+2. Verify MySQL is running and credentials are correct
+3. Check firewall/network access rules
 
 ---
 
@@ -57,25 +43,12 @@ if not test_db_connection():
 
 **Problem:** `alembic upgrade head` fails with "heads are not equal"
 
-**Diagnosis:**
-```bash
-alembic heads
-# Shows multiple head revisions
-```
-
 **Solutions:**
-1. List all heads: `alembic heads`
-2. Merge conflicts manually or use merge command:
-   ```bash
-   alembic merge -m "Merge heads"
-   ```
-3. Resolve conflicts in merged migration file
-4. Apply: `alembic upgrade head`
+1. `alembic heads` — list all head revisions
+2. Merge: `alembic merge -m "Merge heads"`
+3. Resolve conflicts in merged migration file, then `alembic upgrade head`
 
-**Prevention:**
-- Pull before creating new migrations
-- Use feature branches for parallel work
-- Review migration conflicts in code review
+**Prevention:** Pull before creating new migrations; use feature branches.
 
 ---
 
@@ -85,47 +58,14 @@ alembic heads
 
 **Diagnosis:**
 ```bash
-# Check Firebase credentials file
 ls -la $FIREBASE_CREDENTIALS
-cat $FIREBASE_CREDENTIALS | head -5
-
-# Test token verification
-python -c "from src.api.dependencies.auth import verify_firebase_token; verify_firebase_token('test-token')"
 ```
 
 **Solutions:**
 1. Verify Firebase credentials file path and content
-2. Check Firebase project ID matches
-3. Verify token is valid JWT format
-4. Check token expiration (use `jwt.decode(..., options={"verify_exp": False})`)
-5. In dev, use `dev_auth_bypass_middleware` (enabled by `DEV_MODE=true`)
-
-**Prevention:**
-- Test Firebase SDK initialization on app startup
-- Log token verification errors (redact token)
-- Use dev bypass for local development
-
----
-
-### Type Errors
-
-**Problem:** `error: Argument 1 to "X" has incompatible type` from mypy
-
-**Diagnosis:**
-```bash
-mypy src/ --show-column-numbers --show-error-codes
-```
-
-**Solutions:**
-1. Add type hints to function signature
-2. Use `Optional[T]` for nullable values
-3. Use `Union[T1, T2]` for multiple types
-4. Check if using `Any` (too permissive)
-
-**Prevention:** Run before commit:
-```bash
-mypy src/ && black src/ && flake8 src/
-```
+2. Check Firebase project ID matches environment
+3. Verify token is valid and not expired
+4. In dev: use `DEV_MODE=true` to enable `X-Dev-User-Id` header bypass
 
 ---
 
@@ -137,22 +77,12 @@ mypy src/ && black src/ && flake8 src/
 ```bash
 redis-cli ping
 # Should return: PONG
-
-# Check REDIS_URL
-echo $REDIS_URL
-# Should be: redis://host:port/db
 ```
 
 **Solutions:**
-1. Verify Redis is running
-2. Check `REDIS_URL` format (host, port, db number)
-3. Verify firewall/network access
-4. Cache is optional: app continues without Redis (graceful degradation)
-
-**Prevention:**
-- Test Redis connection on startup
-- Log cache errors but don't fail the request
-- Monitor cache hit rates in Sentry
+1. Check `REDIS_URL` format: `redis://host:port/db`
+2. Verify Redis is running
+3. Cache is optional — app continues without Redis (graceful degradation)
 
 ---
 
@@ -162,29 +92,14 @@ echo $REDIS_URL
 
 **Diagnosis:**
 ```bash
-# Enable query logging
 SQLALCHEMY_ECHO=true python src/api/main.py
-
-# Check slow logs
-mysql> SET GLOBAL slow_query_log='ON';
-mysql> SET GLOBAL long_query_time=1;
 ```
 
 **Solutions:**
 1. Add indexes on frequently filtered columns
-2. Use eager loading (joinedload) instead of lazy loading
-3. Check N+1 queries: is one query spawning many?
-4. Profile with `explain()`:
-   ```python
-   from sqlalchemy import text
-   result = session.execute(text("EXPLAIN ANALYZE SELECT ..."))
-   ```
-5. Consider caching (Redis) for frequently read data
-
-**Prevention:**
-- Monitor request durations in logs
-- Set slow query alerts in Sentry
-- Profile critical paths in tests
+2. Use `joinedload` to avoid N+1 queries
+3. Profile with `EXPLAIN ANALYZE` via SQLAlchemy `text()`
+4. Consider Redis caching for frequently read data
 
 ---
 
@@ -194,24 +109,14 @@ mysql> SET GLOBAL long_query_time=1;
 
 **Diagnosis:**
 ```bash
-# Check handler is registered
 grep -r "@handles" src/app/handlers/
-
-# Check event_bus initialization
-python -c "from src.infra.event_bus import get_event_bus; bus = get_event_bus(); print(bus._handlers.keys())"
 ```
 
 **Solutions:**
 1. Verify `@handles` decorator on handler class
-2. Check handler is imported in `src/infra/event_bus/` init
+2. Check handler is imported in the event bus init
 3. Verify command/query class name matches exactly
-4. Check handler `async def handle()` signature
-5. Ensure event bus is singleton (not recreated per request)
-
-**Prevention:**
-- Add unit tests for all handlers
-- Log handler registration on startup
-- Use type hints to catch mismatches
+4. Ensure event bus is singleton (not recreated per request)
 
 ---
 
@@ -219,53 +124,11 @@ python -c "from src.infra.event_bus import get_event_bus; bus = get_event_bus();
 
 **Problem:** Gemini/Cloudinary/Firebase requests timeout
 
-**Diagnosis:**
-```bash
-# Check timeout settings
-grep -r "timeout" src/infra/services/
-
-# Monitor latency in Sentry
-# Check service status pages
-```
-
 **Solutions:**
-1. Increase timeout (but don't exceed 30s for FastAPI)
+1. Increase timeout (max 30s for FastAPI)
 2. Implement retry logic with exponential backoff
-3. Cache responses when possible
-4. Use request-level timeout handling
-5. Add circuit breaker for repeated failures
-
-**Prevention:**
-- Set reasonable timeouts (10-30s based on service)
-- Implement graceful degradation
-- Monitor P95/P99 latencies in Sentry
-- Add alerts for service degradation
-
----
-
-### File Size Limit Exceeded
-
-**Problem:** `FileTooLargeError` when uploading meal image
-
-**Diagnosis:**
-```bash
-# Check file size limit
-grep -r "MAX_FILE_SIZE\|10.*1024\*1024" src/
-
-# Check actual file size
-ls -lh /path/to/image
-```
-
-**Solutions:**
-1. Reduce image size before upload (client-side)
-2. Increase limit if needed (default 10MB)
-3. Compress image on upload
-4. Add client-side validation
-
-**Prevention:**
-- Document max file size in API docs
-- Provide clear error message to client
-- Move limit to config (not hardcoded)
+3. Cache responses where possible
+4. Add circuit breaker for repeated failures
 
 ---
 
@@ -275,58 +138,28 @@ ls -lh /path/to/image
 
 **Diagnosis:**
 ```bash
-# Check CORS headers in response
 curl -i -X OPTIONS "http://localhost:8000/v1/meals"
-
-# Check CORS config
-grep -r "allow_origins\|CORS" src/api/
 ```
 
 **Solutions:**
-1. In development: `allow_origins=["*"]` (already set)
-2. In production: Restrict to known origins
-3. Add `allow_credentials=True` if needed
-4. Verify preflight request (OPTIONS) returns 200
-
-**Prevention:**
-- Use environment-based CORS config
-- Document allowed origins
-- Test with real client origins
+1. Development: `allow_origins=["*"]` (already set)
+2. Production: Restrict to known origins via environment config
+3. Verify preflight (OPTIONS) returns 200
 
 ---
 
 ## Testing & Debugging
 
-**Run tests with output:**
 ```bash
+# Run specific test with output
 pytest -v -s tests/unit/domain/services/test_meal_service.py
-```
 
-**Run specific test:**
-```bash
+# Run by name pattern
 pytest -k "test_tdee_calculation_with_body_fat" -v
-```
 
-**Debug with breakpoint:**
-```python
+# Debug breakpoint
 import pdb; pdb.set_trace()
 ```
-
-**Profile memory:**
-```bash
-pip install memory_profiler
-python -m memory_profiler src/api/main.py
-```
-
----
-
-## Getting Help
-
-1. **Check logs:** `tail -f logs/app.log`
-2. **Check Sentry:** https://sentry.io/organizations/...
-3. **Run tests:** `pytest -v` to isolate issue
-4. **Ask team:** Post in #backend Slack channel with error + context
-5. **Check docs:** `docs/` folder for architecture/patterns
 
 ---
 


### PR DESCRIPTION
## Summary
- Trimmed 5 oversized docs to under 200 lines following progressive disclosure principles
- Updated api-endpoints.md with 7 missing route groups (weight-entries, referrals, saved-suggestions, cheat-days, TDEE, monitoring, expanded users)
- Removed duplicate content, cross-referenced instead
- Fixed stale references (Gemini model names, config keys)

## Changes

| File | Before | After | Delta |
|------|--------|-------|-------|
| troubleshooting.md | 333 | 166 | -167 |
| cqrs-guide.md | 275 | 154 | -121 |
| external-services.md | 254 | 152 | -102 |
| system-architecture.md | 208 | 108 | -100 |
| database-guide.md | 205 | 129 | -76 |
| api-endpoints.md | 173 | 191 | +18 |
| **Total** | **2063** | **1517** | **-546 (-26%)** |

## Principles Applied
Based on [200-line rule](https://thieunv.substack.com/p/ce-02-quy-tac-200-dong):
- Max 200 lines per doc file
- Progressive disclosure (metadata → entry point → references)
- >80% content relevance (remove inferable-from-code content)
- Cross-reference instead of duplicate

## Test Plan
- [x] All docs under 200 lines
- [x] Documentation validator passed (16 code refs + 16 config keys verified)
- [x] No broken internal links