### PR TITLE
feat(backend): support variable-length referral codes (3-15 chars)

### DIFF
--- a/migrations/versions/059_extend_referral_code_length.py
+++ b/migrations/versions/059_extend_referral_code_length.py
@@ -1,0 +1,49 @@
+"""Extend referral code columns from VARCHAR(6) to VARCHAR(15).
+
+Supports admin-created promo codes from 3-15 characters.
+Auto-generated user codes remain 6 chars.
+
+Revision ID: 059
+Revises: 058
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "059"
+down_revision = "058"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "referral_codes",
+        "code",
+        existing_type=sa.String(6),
+        type_=sa.String(15),
+        nullable=False,
+    )
+    op.alter_column(
+        "referral_conversions",
+        "code_used",
+        existing_type=sa.String(6),
+        type_=sa.String(15),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "referral_conversions",
+        "code_used",
+        existing_type=sa.String(15),
+        type_=sa.String(6),
+        nullable=False,
+    )
+    op.alter_column(
+        "referral_codes",
+        "code",
+        existing_type=sa.String(15),
+        type_=sa.String(6),
+        nullable=False,
+    )

--- a/src/api/routes/v1/referrals.py
+++ b/src/api/routes/v1/referrals.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from src.api.dependencies.auth import get_current_user_id
 from src.app.commands.referral.apply_referral_code_command import ApplyReferralCodeCommand
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # ── Request / Response Schemas ────────────────────────────────────────────────
 
 class ValidateCodeRequest(BaseModel):
-    code: str
+    code: str = Field(..., min_length=3, max_length=15)
 
     @field_validator("code")
     @classmethod
@@ -51,7 +51,7 @@ class ValidateCodeResponse(BaseModel):
 
 
 class ApplyCodeRequest(BaseModel):
-    code: str
+    code: str = Field(..., min_length=3, max_length=15)
     discount_applied: int
 
     @field_validator("code")

--- a/src/infra/database/models/referral/referral_code.py
+++ b/src/infra/database/models/referral/referral_code.py
@@ -9,7 +9,7 @@ class ReferralCode(Base):
     __tablename__ = "referral_codes"
 
     user_id = Column(String(36), ForeignKey("users.id"), primary_key=True)
-    code = Column(String(6), nullable=False)
+    code = Column(String(15), nullable=False)
     created_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (

--- a/src/infra/database/models/referral/referral_conversion.py
+++ b/src/infra/database/models/referral/referral_conversion.py
@@ -11,7 +11,7 @@ class ReferralConversion(Base, PrimaryEntityMixin):
 
     referrer_user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
     referred_user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
-    code_used = Column(String(6), nullable=False)
+    code_used = Column(String(15), nullable=False)
     # status: pending | converted | revoked
     status = Column(String(20), nullable=False, default="pending")
     discount_applied = Column(Integer, nullable=True)


### PR DESCRIPTION
## Summary
Support admin-created promo codes from 3-15 characters (auto-generated user codes remain 6 chars).

## Changes
- **Migration 059**: Widen `referral_codes.code` and `referral_conversions.code_used` from VARCHAR(6) to VARCHAR(15)
- **ORM models**: Update String(6) → String(15)
- **API validation**: Add `Field(min_length=3, max_length=15)` to `ValidateCodeRequest` and `ApplyCodeRequest`

## Files Changed
- `migrations/versions/059_extend_referral_code_length.py` (new)
- `src/infra/database/models/referral/referral_code.py`
- `src/infra/database/models/referral/referral_conversion.py`
- `src/api/routes/v1/referrals.py`

## Test Plan
- [ ] Run `alembic upgrade head` - exits 0
- [ ] Run `alembic downgrade -1` - exits 0 (rollback safe)
- [ ] Verify existing 6-char codes unchanged
- [ ] Test API validation rejects codes <3 or >15 chars

## Notes
- Downgrade will truncate any codes >6 chars - only safe before admin creates long codes
- Non-destructive change for existing data