### PR TITLE
Add Alembic merge migration 20260512162000 merging heads 059 and 20260509230545

### DIFF
--- a/migrations/versions/20260512162000_merge_heads_059_and_20260509230545.py
+++ b/migrations/versions/20260512162000_merge_heads_059_and_20260509230545.py
@@ -1,0 +1,22 @@
+"""Merge Alembic heads 059 and 20260509230545.
+
+Revision ID: 20260512162000
+Revises: 059, 20260509230545
+Create Date: 2026-05-12 16:20:00
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "20260512162000"
+down_revision: Union[str, Sequence[str], None] = ("059", "20260509230545")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
### Motivation
- Consolidate divergent Alembic heads into a single head so the database migration history is linear and future migrations apply cleanly.

### Description
- Add a new Alembic merge migration file `migrations/versions/20260512162000_merge_heads_059_and_20260509230545.py` that declares `revision = "20260512162000"` and `down_revision = ("059", "20260509230545")` with empty `upgrade()` and `downgrade()` stubs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03513f3afc832495cbd483362f10f4)