### PR TITLE
fix: correct custom unit nutrition on delivery

### DIFF
--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -14,6 +14,7 @@ from src.api.schemas.response import (
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.domain.model.meal import Meal
 from src.domain.model.nutrition import FoodItem, Nutrition, Macros, Micros
+from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
 
 # Status mapping from domain to API
 STATUS_MAPPING = {
@@ -122,7 +123,12 @@ class MealMapper:
                         and item.is_custom
                         and item.quantity > 0
                     ):
-                        scale_factor = 100.0 / item.quantity
+                        quantity_grams = convert_quantity_to_grams(
+                            item.quantity,
+                            item.unit,
+                            item.name,
+                        )
+                        scale_factor = 100.0 / quantity_grams
                         custom_nutrition_dto = CustomNutritionResponse(
                             calories_per_100g=item.calories * scale_factor,
                             protein_per_100g=(

--- a/src/api/routes/v1/health.py
+++ b/src/api/routes/v1/health.py
@@ -19,10 +19,11 @@ from src.infra.database.config import (
 router = APIRouter(tags=["Health"])
 
 
-@router.get("/health")
+@router.api_route("/health", methods=["GET", "HEAD"])
 async def health_check():
     """
     Basic health check endpoint for uptime monitoring.
+    Supports HEAD for lightweight client connectivity probes.
     """
     return JSONResponse(
         status_code=200,

--- a/src/domain/services/meal_service.py
+++ b/src/domain/services/meal_service.py
@@ -4,13 +4,12 @@ Provides shared meal editing and management logic.
 """
 
 import logging
-from typing import List
 from uuid import uuid4
 
 from src.domain.model.meal import Meal
 from src.domain.model.meal.food_item_change import FoodItemChange
-from src.domain.model.nutrition import FoodItem
-from src.domain.model.nutrition import Nutrition
+from src.domain.model.nutrition import FoodItem, Nutrition
+from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ class MealService:
     """Service for meal operations."""
 
     def apply_food_item_changes(
-        self, meal: Meal, food_item_changes: List[FoodItemChange]
+        self, meal: Meal, food_item_changes: list[FoodItemChange]
     ) -> Meal:
         """Apply food item changes to a meal."""
         # Ensure meal.nutrition exists and food_items list is initialized
@@ -41,9 +40,10 @@ class MealService:
 
                 # Calculate calories and macros from custom_nutrition if provided
                 if change.custom_nutrition:
-                    scale_factor = (
-                        change.quantity / 100.0
-                    )  # Custom nutrition is per 100g
+                    quantity_grams = convert_quantity_to_grams(
+                        change.quantity, change.unit, change.name or ""
+                    )
+                    scale_factor = quantity_grams / 100.0
                     macros = Macros(
                         protein=change.custom_nutrition.protein_per_100g * scale_factor,
                         carbs=change.custom_nutrition.carbs_per_100g * scale_factor,
@@ -94,7 +94,13 @@ class MealService:
                             item.unit = change.unit
                         if change.custom_nutrition is not None:
                             # Recalculate macros from custom nutrition (calories derived automatically)
-                            scale_factor = (change.quantity or item.quantity) / 100.0
+                            item_name = change.name or item.name
+                            item_quantity = change.quantity or item.quantity
+                            item_unit = change.unit or item.unit
+                            quantity_grams = convert_quantity_to_grams(
+                                item_quantity, item_unit, item_name
+                            )
+                            scale_factor = quantity_grams / 100.0
                             item.macros = Macros(
                                 protein=change.custom_nutrition.protein_per_100g
                                 * scale_factor,

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -5,12 +5,10 @@ Provides a unified interface for calculating nutrition from various sources.
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Any
 
-from src.domain.constants.food_density import get_density, DEFAULT_DENSITY
-from src.domain.model.nutrition import FoodItem, Nutrition
-from src.domain.model.nutrition import Macros
-from src.domain.model.nutrition.serving_unit import ServingUnit
+from src.domain.constants.food_density import DEFAULT_DENSITY, get_density
+from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +93,6 @@ UNIT_TRANSLATION = {
     "小": "small",
     "块": "piece",
     "片": "slice",
-    "杯": "cup",
     "汤匙": "tablespoon",
     "茶匙": "teaspoon",
     "份": "serving",
@@ -152,7 +149,7 @@ def scale_per_100g_nutrition(
     quantity: float,
     unit: str,
     base_serving: float = 100.0,
-    allowed_units: Optional[List[Dict[str, Any]]] = None,
+    allowed_units: list[dict[str, Any]] | None = None,
     food_name: str = "",
 ) -> dict:
     """Scale per-100g nutrition values for a given quantity and unit.
@@ -190,7 +187,7 @@ def scale_per_100g_nutrition(
 def _convert_with_allowed_units(
     quantity: float,
     unit: str,
-    allowed_units: List[Dict[str, Any]],
+    allowed_units: list[dict[str, Any]],
     food_name: str = "",
 ) -> float:
     """Convert quantity to grams using food-specific allowed_units.
@@ -320,8 +317,8 @@ class NutritionCalculationService:
         pass
 
     def get_nutrition_for_ingredient(
-        self, name: str, quantity: float, unit: str, fdc_id: Optional[int] = None
-    ) -> Optional[ScaledNutritionResult]:
+        self, name: str, quantity: float, unit: str, fdc_id: int | None = None
+    ) -> ScaledNutritionResult | None:
         """
         Get nutrition data for an ingredient.
         Currently returns None — vector search removed, to be re-added later.
@@ -331,7 +328,7 @@ class NutritionCalculationService:
         )
         return None
 
-    def calculate_meal_total(self, food_items: List[FoodItem]) -> Nutrition:
+    def calculate_meal_total(self, food_items: list[FoodItem]) -> Nutrition:
         """
         Calculate total nutrition from a list of food items.
 
@@ -382,7 +379,11 @@ class NutritionCalculationService:
         for item in items:
             if not item.custom_nutrition:
                 continue
-            factor = item.quantity / 100.0
+            item_name = item.name or "Food Item"
+            quantity_grams = convert_quantity_to_grams(
+                item.quantity, item.unit, item_name
+            )
+            factor = quantity_grams / 100.0
             protein = item.custom_nutrition.protein_per_100g * factor
             carbs = item.custom_nutrition.carbs_per_100g * factor
             fat = item.custom_nutrition.fat_per_100g * factor
@@ -392,7 +393,7 @@ class NutritionCalculationService:
             food_items.append(
                 FoodItem(
                     id=uuid4(),
-                    name=item.name or "Food Item",
+                    name=item_name,
                     quantity=item.quantity,
                     unit=item.unit,
                     macros=Macros(protein=protein, carbs=carbs, fat=fat),

--- a/tests/unit/api/test_health_router.py
+++ b/tests/unit/api/test_health_router.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes.v1.health import router
+
+
+def test_health_accepts_head_requests():
+    app = FastAPI()
+    app.include_router(router)
+
+    response = TestClient(app).head("/health")
+
+    assert response.status_code == 200

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -203,6 +203,49 @@ class TestMealMapper:
             108.0
         )  # derived: (1*4+8*4+2*9) * (100/50)
 
+    def test_to_detailed_response_custom_nutrition_uses_grams_for_large_units(self):
+        """Custom nutrition is projected per 100g, not per serving count."""
+        food_items = [
+            FoodItem(
+                id="item-eggs",
+                name="Eggs",
+                quantity=20,
+                unit="large",
+                macros=Macros(protein=126, carbs=7, fat=96),
+                confidence=0.8,
+                fdc_id=None,
+                is_custom=True,
+            )
+        ]
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/eggs.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+                width=800,
+                height=600,
+            ),
+            dish_name="Omelette",
+            ready_at=datetime(2025, 1, 15, 15, 0),
+            created_at=datetime(2025, 1, 15, 14, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=126, carbs=7, fat=96),
+                food_items=food_items,
+            ),
+        )
+
+        result = MealMapper.to_detailed_response(meal)
+
+        custom = result.food_items[0].custom_nutrition
+        assert custom is not None
+        assert custom.protein_per_100g == pytest.approx(12.6)
+        assert custom.carbs_per_100g == pytest.approx(0.7)
+        assert custom.fat_per_100g == pytest.approx(9.6)
+
     def test_to_detailed_response_without_nutrition(self):
         """Test detailed response when nutrition is None."""
         image = MealImage(

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -1,0 +1,143 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from src.app.commands.meal.create_manual_meal_command import (
+    CustomNutrition,
+    ManualMealItem,
+)
+from src.domain.model.meal import Meal, MealImage, MealStatus
+from src.domain.model.meal.food_item_change import (
+    CustomNutritionData,
+    FoodItemChange,
+)
+from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+from src.domain.services.meal_service import MealService
+from src.domain.services.nutrition_calculation_service import (
+    NutritionCalculationService,
+)
+
+
+def test_manual_custom_nutrition_uses_unit_grams_for_large_eggs():
+    service = NutritionCalculationService()
+
+    nutrition, food_items = service.aggregate_from_command_items(
+        [
+            ManualMealItem(
+                name="Eggs",
+                quantity=2.0,
+                unit="large",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=143.0,
+                    protein_per_100g=12.6,
+                    carbs_per_100g=0.7,
+                    fat_per_100g=9.5,
+                ),
+            )
+        ]
+    )
+
+    assert nutrition.macros.protein == pytest.approx(12.6)
+    assert nutrition.macros.carbs == pytest.approx(0.7)
+    assert nutrition.macros.fat == pytest.approx(9.5)
+    assert food_items[0].calories == pytest.approx(138.7)
+
+
+def test_manual_custom_nutrition_uses_density_for_oil_ml():
+    service = NutritionCalculationService()
+
+    nutrition, food_items = service.aggregate_from_command_items(
+        [
+            ManualMealItem(
+                name="Cooking oil",
+                quantity=5.0,
+                unit="ml",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=828.0,
+                    protein_per_100g=0.0,
+                    carbs_per_100g=0.0,
+                    fat_per_100g=92.0,
+                ),
+            )
+        ]
+    )
+
+    assert nutrition.macros.protein == pytest.approx(0.0)
+    assert nutrition.macros.carbs == pytest.approx(0.0)
+    assert nutrition.macros.fat == pytest.approx(4.2)
+    assert food_items[0].macros.fat == pytest.approx(4.232)
+
+
+def test_meal_service_add_custom_nutrition_uses_unit_grams():
+    meal = _new_processing_meal()
+
+    updated = MealService().apply_food_item_changes(
+        meal,
+        [
+            FoodItemChange(
+                action="add",
+                name="Eggs",
+                quantity=2.0,
+                unit="large",
+                custom_nutrition=CustomNutritionData(
+                    calories_per_100g=143.0,
+                    protein_per_100g=12.6,
+                    carbs_per_100g=0.7,
+                    fat_per_100g=9.5,
+                ),
+            )
+        ],
+    )
+
+    assert updated.nutrition.macros.protein == pytest.approx(12.6)
+    assert updated.nutrition.macros.carbs == pytest.approx(0.7)
+    assert updated.nutrition.macros.fat == pytest.approx(9.5)
+
+
+def test_meal_service_update_custom_nutrition_uses_new_unit_grams():
+    food_item = FoodItem(
+        id="food-1",
+        name="Cooking oil",
+        quantity=1.0,
+        unit="ml",
+        macros=Macros(protein=0.0, carbs=0.0, fat=0.92),
+    )
+    meal = _new_processing_meal(
+        Nutrition(
+            macros=Macros(protein=0.0, carbs=0.0, fat=0.92),
+            food_items=[food_item],
+        )
+    )
+
+    updated = MealService().apply_food_item_changes(
+        meal,
+        [
+            FoodItemChange(
+                action="update",
+                id="food-1",
+                quantity=5.0,
+                unit="ml",
+                custom_nutrition=CustomNutritionData(
+                    calories_per_100g=828.0,
+                    protein_per_100g=0.0,
+                    carbs_per_100g=0.0,
+                    fat_per_100g=92.0,
+                ),
+            )
+        ],
+    )
+
+    assert updated.nutrition.food_items[0].macros.fat == pytest.approx(4.232)
+    assert updated.nutrition.macros.fat == pytest.approx(4.232)
+
+
+def _new_processing_meal(nutrition=None):
+    return Meal(
+        meal_id=str(uuid4()),
+        user_id=str(uuid4()),
+        status=MealStatus.PROCESSING,
+        created_at=datetime.now(UTC),
+        image=MealImage(image_id=str(uuid4()), format="jpeg", size_bytes=1),
+        nutrition=nutrition,
+    )


### PR DESCRIPTION
## Summary
- cherry-pick the custom-unit nutrition conversion fixes onto a delivery-based branch
- include the health HEAD route fix from the backend branch

## Verification
- uv run pytest tests/unit/api/test_meal_mapper.py tests/unit/domain/services/test_nutrition_calculation_service.py tests/unit/api/test_health_router.py