### PR TITLE
docs(backend): update documentation for May 2026 features

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -14,9 +14,16 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 |--------|----------|---------|
 | GET | `/health` | Basic health check |
 | GET | `/health/db-pool` | DB pool metrics |
-| GET | `/health/db-connections` | MySQL connection stats |
+| GET | `/health/db-connections` | DB connection stats |
 | GET | `/health/notifications` | FCM health |
 | GET | `/v1/monitoring/cache/metrics` | Redis cache metrics |
+
+## App & Universal Links
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/app-download` | Redirect to App Store with `?source=` campaign tracking |
+| GET | `/.well-known/apple-app-site-association` | iOS Universal Links config (paths: /log, /dashboard, /upgrade, /feedback, /settings) |
 
 ---
 
@@ -136,9 +143,11 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 
 ## Referrals
 
+Referral codes are 3–15 characters. Commission rates are configurable via `REFERRAL_COMMISSIONS` env var (per-currency JSON; default: `{"USD": 2, "VND": 50000, "EUR": 1.8, "default": 2}`).
+
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/v1/referrals/validate` | Validate referral code |
+| POST | `/v1/referrals/validate` | Validate referral code (3–15 chars) |
 | POST | `/v1/referrals/apply` | Apply referral code |
 | GET | `/v1/referrals/my-code` | Get user's referral code |
 | GET | `/v1/referrals/stats` | Get referral stats |

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,6 +1,6 @@
 # Backend Codebase Summary
 
-**Generated:** May 6, 2026  
+**Generated:** May 15, 2026  
 **Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)  
 **Language:** Python 3.11+ | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
 
@@ -53,13 +53,14 @@
 
 ---
 
-## Recent Features (Apr 2026)
+## Recent Features (May 2026)
 
-- **Sentry Monitoring:** Error tracking, performance monitoring, profiling
-- **Meal Discovery:** `/v1/meal-suggestions/discover` with image search (Unsplash/Pexels)
-- **Notification Dedup:** Cross-worker FCM deduplication (migration 047)
-- **Onboarding Redesign:** Challenge duration, training types (migration 045)
-- **Fiber-Aware Calories:** Fiber column + net-carb calorie derivation (migration 034)
+- **Configurable Referral Commission:** `REFERRAL_COMMISSIONS` env var (JSON dict, per-currency, default 2 USD)
+- **Custom Unit Normalization:** Food items with non-standard units now convert to grams before nutrition calculation
+- **BMR Floor Protection:** Daily target never drops below 85% of standard daily (raised from 80%); cutting deficit reduced to 300 kcal
+- **Email Deep Links:** Universal Links via `/.well-known/apple-app-site-association`; `/app-download` redirect with campaign tracking
+- **AsyncUnitOfWork Concurrency Guard:** `asyncio.Lock` prevents concurrent reuse; handlers receive fresh UoW per `event_bus.send()` call
+- **Variable-Length Referral Codes:** 3–15 character codes (previously fixed length)
 
 ---
 

--- a/docs/cqrs-guide.md
+++ b/docs/cqrs-guide.md
@@ -137,6 +137,18 @@ class UnitOfWork:
         else: ...     # Commit + invalidate caches
 ```
 
+### AsyncUnitOfWork Concurrency Guard
+
+`AsyncUnitOfWork` uses `asyncio.Lock` to prevent the same instance from being entered concurrently. If two coroutines attempt `async with uow:` simultaneously, the second will block until the first exits (commit/rollback + session close + lock release).
+
+To prevent shared-state bugs across handlers, the event bus clones each handler before dispatch — every `event_bus.send()` call receives a fresh `AsyncUnitOfWork` instance.
+
+```python
+# Correct — each call gets an isolated session
+async with AsyncUnitOfWork() as uow:
+    result = await uow.meals.find_by_id(meal_id)
+```
+
 ---
 
 ## Key Rules

--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -1,9 +1,9 @@
 # Backend Database Guide
 
-**Last Updated:** May 6, 2026
-**Engine:** MySQL 8.0 + SQLAlchemy 2.0
+**Last Updated:** May 15, 2026
+**Engine:** PostgreSQL (Neon) + SQLAlchemy 2.0 (psycopg2 sync / asyncpg async)
 **Migrations:** Alembic with auto-migration on startup
-**Tables:** 15 (13 core + notification_sent_log + food_reference)
+**Tables:** 15+ (core tables + notification_sent_log + food_reference + referral tables)
 
 ---
 
@@ -11,7 +11,7 @@
 
 ```python
 # src/infra/database/config.py
-DATABASE_URL = "mysql+pymysql://user:pass@host/db"
+DATABASE_URL = "postgresql+psycopg2://user:pass@host/db"
 
 pool_size = 20       # Base connections
 max_overflow = 10    # Additional under load

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,8 +1,8 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
-**Version:** 0.6.1
-**Last Updated:** May 6, 2026
-**Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: Sentry monitoring, meal discovery endpoint, notification deduplication, onboarding redesign (challenge_duration, training_types).
+**Version:** 0.6.2
+**Last Updated:** May 15, 2026
+**Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: configurable referral commissions, BMR floor protection, custom unit normalization, email Universal Links, AsyncUnitOfWork concurrency guard.
 
 ---
 
@@ -82,7 +82,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 - Weekly budget stored per user with remaining_days calculation (Mon=7, Sun=1).
 - Adjusted daily target redistributes weekly budget based on previous days' consumption.
 - Used by meal suggestions, meal plans, and nutrition tracking features.
-- BMR floor (80% of standard daily) protects against dangerously low targets.
+- BMR floor (85% of standard daily, raised from 80%) protects against dangerously low targets. Clinical minimums: 1200 kcal (female), 1500 kcal (male). Cutting deficit: 300 kcal (~0.3 kg/week).
 
 ---
 
@@ -117,6 +117,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 0.6.2 | May 15, 2026 | Configurable referral commissions (`REFERRAL_COMMISSIONS` env var, per-currency JSON). Custom unit-to-grams fix in nutrition calculation. BMR floor raised to 85% of standard daily; cutting deficit 500→300 kcal; clinical minimums 1200F/1500M. Email Universal Links (apple-app-site-association, /app-download). AsyncUnitOfWork concurrency guard (asyncio.Lock). Variable-length referral codes (3–15 chars). |
 | 0.6.0 | Mar 14, 2026 | Nutrition accuracy (5-phase implementation): fiber-aware calories, food density conversion, macro validation, food reference evolution, meal decomposition. Custom macro targets per profile. Date of birth tracking. Adjusted daily target from weekly budget in suggestions. 3 new services, 3 new migrations (034-037), 28+ modified/new files. |
 | 0.5.0 | Feb 3, 2026 | Updated metrics across all layers: API (76 files, 8,605 LOC), App (140 files, 6,229 LOC), Domain (133 files, 14,556 LOC), Infra (80 files, 8,895 LOC). Total: 430 files, ~38K LOC. Fixed metric inconsistencies from previous documentation. |
 | 0.4.9 | Jan 19, 2026 | Documentation refresh with updated dates. Verified CQRS patterns, domain services, and API endpoints against actual codebase. Weight-based macro calculation confirmed in TDEE service. |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,13 +1,21 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.1
-**Last Updated:** April 17, 2026
+**Version:** 0.6.2
+**Last Updated:** May 15, 2026
 **Status:** Production-ready. 430 source files, ~38K LOC across 4 layers (API: 76, App: 140, Domain: 133, Infra: 80). 681+ tests, 70%+ coverage.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
 
 ---
 
 ## Completed Phases
+
+### May 2026: Nutrition Fixes, Referral Improvements, Email Deep Links
+- [x] Configurable referral commission rates via `REFERRAL_COMMISSIONS` env var (per-currency JSON)
+- [x] Custom unit-to-grams normalization fix in nutrition calculation (`convert_quantity_to_grams`)
+- [x] BMR floor raised to 85% of standard daily; cutting deficit reduced 500→300 kcal (clinical floor: 1200F/1500M)
+- [x] Email Universal Links: `/.well-known/apple-app-site-association` + `/app-download` redirect
+- [x] AsyncUnitOfWork concurrency guard (`asyncio.Lock`); handlers cloned with fresh UoW per dispatch
+- [x] Variable-length referral codes: 3–15 characters (PR #252)
 
 ### April 2026: Sentry Monitoring, Meal Discovery, Onboarding Redesign
 - [x] Sentry SDK integration for error tracking and performance monitoring

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,6 +1,6 @@
 # Backend System Architecture Overview
 
-**Last Updated:** May 6, 2026
+**Last Updated:** May 15, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
 **Codebase:** 430 files, ~38.5K LOC across 4 layers
@@ -102,6 +102,7 @@ Smart sync (diff-based updates), eager loading via pre-defined `joinedload` opti
 - No API versioning strategy beyond v1
 - `CloudinaryImageStore` instantiated directly in routes (not via DI)
 - Hardcoded constants (MAX_FILE_SIZE, SLOW_REQUEST_THRESHOLD) not in config
+- `AsyncUnitOfWork` uses `asyncio.Lock`; concurrent reuse within one instance will block (by design — use separate instances per handler, enforced by event bus handler cloning)
 
 ---
 


### PR DESCRIPTION
## Summary
- Update backend documentation to reflect May 2026 features and fixes
- All docs remain under 200 lines per file

## Changes
- **cqrs-guide.md**: AsyncUnitOfWork concurrency guard documentation
- **api-endpoints.md**: App/universal links, referral code constraints (3-15 chars), configurable commission
- **project-roadmap.md**: May 2026 completed phase, version bump to 0.6.2
- **codebase-summary.md**: Updated recent features list
- **database-guide.md**: Fixed stale MySQL → PostgreSQL reference
- **project-overview-pdr.md**: BMR floor protection (85%), cutting deficit (300 kcal)
- **system-architecture.md**: AsyncUnitOfWork in Known Issues

## Validation
- All 11 doc files under 200 lines
- 19 code references validated
- 20 config keys confirmed

## Test plan
- [x] Run `wc -l docs/*.md` to verify line counts
- [x] Run validation script to check code references