### PR TITLE
fix(migrations): restore single Alembic head

### DIFF
--- a/migrations/versions/20260513070245_add_commission_currency_columns.py
+++ b/migrations/versions/20260513070245_add_commission_currency_columns.py
@@ -1,16 +1,16 @@
 """Add commission_currency and commission_amount_vnd columns.
 
 Revision ID: 20260513070245
-Revises: 20260503113601
+Revises: 20260512162000
 Create Date: 2026-05-13 07:02:45
 
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "20260513070245"
-down_revision = "20260503113601"
+down_revision = "20260512162000"
 branch_labels = None
 depends_on = None
 

--- a/tests/migrations/test_alembic_revision_graph.py
+++ b/tests/migrations/test_alembic_revision_graph.py
@@ -1,0 +1,8 @@
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def test_alembic_revision_graph_has_single_head() -> None:
+    script_dir = ScriptDirectory.from_config(Config("alembic.ini"))
+
+    assert script_dir.get_heads() == [script_dir.get_current_head()]


### PR DESCRIPTION
## Summary
- Repoint the commission currency migration to follow the existing Alembic merge revision.
- Add a regression test that fails if the Alembic revision graph has multiple heads.

## Root cause
The existing merge revision combined heads 059 and 20260509230545, but the later commission migration still revised 20260503113601 directly. That left the merge revision and commission migration as separate heads, triggering: `The script directory has multiple heads (due to branching). Please use get_heads(), or merge the branches using alembic merge.`

## Verification
- `env -u VIRTUAL_ENV uv run python -m alembic heads --verbose` reports only `20260513070245` as head.
- `env -u VIRTUAL_ENV uv run python -c "from alembic.config import Config; from alembic.script import ScriptDirectory; s=ScriptDirectory.from_config(Config('alembic.ini')); print('heads=', s.get_heads()); print('current_head=', s.get_current_head())"` prints `heads= ['20260513070245']` and `current_head= 20260513070245`.
- `env -u VIRTUAL_ENV uv run pytest tests/migrations/test_alembic_revision_graph.py` passes.
- `env -u VIRTUAL_ENV uv run ruff check migrations/versions/20260513070245_add_commission_currency_columns.py tests/migrations/test_alembic_revision_graph.py` passes.

## Note
`alembic current` was not used for verification because the copied worktree `.env` contains the placeholder database host `ep-xxx.region.aws.neon.tech`.