### PR TITLE
feat(backend): trial-expiry push notifications at T-2d and T-1d

### DIFF
--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -328,11 +328,19 @@ def initialize_scheduled_notification_service() -> ScheduledNotificationService:
     """
     global _scheduled_notification_service
     if _scheduled_notification_service is None:
+        from src.infra.services.scheduled_subscription_push_service import (
+            ScheduledSubscriptionPushService,
+        )
+
         firebase_service = get_firebase_service()
+        trial_push_service = ScheduledSubscriptionPushService()
         _scheduled_notification_service = ScheduledNotificationService(
             firebase_service,
             _redis_client,
+            trial_push_service=trial_push_service,
         )
+        # Expose for webhook handler to purge stale trial rows on RENEWAL.
+        _scheduled_notification_service.trial_push_service = trial_push_service
     return _scheduled_notification_service
 
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -187,6 +187,10 @@ async def lifespan(app: FastAPI):
     try:
         logger.info("Initializing scheduled notification service...")
         scheduled_service = initialize_scheduled_notification_service()
+        # Expose trial_push for the RevenueCat RENEWAL webhook handler.
+        app.state.trial_push_service = getattr(
+            scheduled_service, "trial_push_service", None
+        )
         await scheduled_service.start()
         logger.info("Scheduled notification service started successfully!")
     except Exception as e:

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 from fastapi import APIRouter, Request, HTTPException, Header
 
+from sqlalchemy import text
+
 from src.domain.services.email_service import EmailService
 from src.domain.utils.timezone_utils import utc_now
 from src.infra.adapters.resend_email_adapter import ResendEmailAdapter
@@ -195,6 +197,26 @@ async def handle_renewal(uow, user, event):
     else:
         logger.warning(f"Subscription not found for renewal, creating new one")
         await handle_purchase(uow, user, event)
+
+    # Purge any pending trial-expiry pushes so renewed users don't get a
+    # "your trial ends tomorrow" push for a sub that just auto-renewed.
+    try:
+        await uow.session.execute(
+            text(
+                """
+                DELETE FROM notifications
+                WHERE user_id = :uid
+                  AND notification_type LIKE 'trial_expiry%'
+                  AND status = 'pending'
+                """
+            ),
+            {"uid": user.id},
+        )
+    except Exception:
+        # Do not raise — webhook MUST still ACK so RevenueCat doesn't retry.
+        logger.exception(
+            "Failed to purge stale trial pushes for user %s after renewal", user.id
+        )
 
 
 async def handle_cancellation(uow, user, event):

--- a/src/domain/ports/subscription_repository_port.py
+++ b/src/domain/ports/subscription_repository_port.py
@@ -38,6 +38,20 @@ class SubscriptionRepositoryPort(ABC):
         pass
 
     @abstractmethod
+    def find_expiring_in_window(
+        self,
+        from_days: int,
+        to_days: int,
+        now: Optional[datetime] = None,
+    ) -> List[Subscription]:
+        """Active subs whose expires_at falls within [reference+from_days, reference+to_days).
+
+        `now` lets callers pin the reference moment for deterministic tests and
+        consistent window boundaries within a single scheduler run.
+        """
+        pass
+
+    @abstractmethod
     def cancel(self, subscription_id: str, reason: str = None) -> bool:
         """Cancel a subscription."""
         pass

--- a/src/domain/services/notification_messages.py
+++ b/src/domain/services/notification_messages.py
@@ -44,6 +44,16 @@ NOTIFICATION_MESSAGES = {
                     "body_template": "All good, bro! {excess} cal over — tomorrow's a fresh start! 🤙",
                 },
             },
+            "trial_expiry": {
+                "2d": {
+                    "title": "",
+                    "body": "Heads up, bro — your trial ends in 2 days. Lock in your streak! ⏳",
+                },
+                "1d": {
+                    "title": "",
+                    "body": "Last day, bro — trial ends tomorrow. Keep your progress going! 🔥",
+                },
+            },
         },
         "female": {
             "meal_reminder": {
@@ -72,6 +82,16 @@ NOTIFICATION_MESSAGES = {
                 },
                 "way_over": {
                     "body_template": "All good, mate! {excess} cal over — tomorrow's a fresh start! 🤙",
+                },
+            },
+            "trial_expiry": {
+                "2d": {
+                    "title": "",
+                    "body": "Heads up, mate — your trial ends in 2 days. Lock in your streak! ⏳",
+                },
+                "1d": {
+                    "title": "",
+                    "body": "Last day, mate — trial ends tomorrow. Keep your progress going! 🔥",
                 },
             },
         },
@@ -106,6 +126,16 @@ NOTIFICATION_MESSAGES = {
                     "body_template": "Không sao bro! Vượt {excess} cal — mai là ngày mới! 🤙",
                 },
             },
+            "trial_expiry": {
+                "2d": {
+                    "title": "",
+                    "body": "Còn 2 ngày là trial hết hạn nha bro — giữ streak nào! ⏳",
+                },
+                "1d": {
+                    "title": "",
+                    "body": "Ngày cuối rồi bro — trial mai hết hạn. Tiếp tục nha! 🔥",
+                },
+            },
         },
         "female": {
             "meal_reminder": {
@@ -134,6 +164,16 @@ NOTIFICATION_MESSAGES = {
                 },
                 "way_over": {
                     "body_template": "Không sao bạn ơi! Vượt {excess} cal — mai là ngày mới! 🤙",
+                },
+            },
+            "trial_expiry": {
+                "2d": {
+                    "title": "",
+                    "body": "Còn 2 ngày là trial hết hạn nha bạn ơi — giữ streak nào! ⏳",
+                },
+                "1d": {
+                    "title": "",
+                    "body": "Ngày cuối rồi bạn ơi — trial mai hết hạn. Tiếp tục nha! 🔥",
                 },
             },
         },

--- a/src/infra/repositories/subscription_repository.py
+++ b/src/infra/repositories/subscription_repository.py
@@ -93,6 +93,30 @@ class SubscriptionRepository(BaseRepository[Subscription], SubscriptionRepositor
             .all()
         )
 
+    def find_expiring_in_window(
+        self,
+        from_days: int,
+        to_days: int,
+        now: Optional[datetime] = None,
+    ) -> List[Subscription]:
+        """Active subs whose expires_at falls within [reference+from_days, reference+to_days)."""
+        from datetime import timedelta
+
+        reference = now or utc_now()
+        lower = reference + timedelta(days=from_days)
+        upper = reference + timedelta(days=to_days)
+        return (
+            self.session.query(Subscription)
+            .filter(
+                and_(
+                    Subscription.status == "active",
+                    Subscription.expires_at >= lower,
+                    Subscription.expires_at < upper,
+                )
+            )
+            .all()
+        )
+
     def cancel(self, subscription_id: str, reason: str = None) -> bool:
         """Cancel a subscription."""
         subscription = self.get(subscription_id)

--- a/src/infra/services/scheduled_notification_service.py
+++ b/src/infra/services/scheduled_notification_service.py
@@ -31,6 +31,9 @@ from src.infra.services.daily_context_precompute_service import (
     DailyContextPrecomputeService,
 )
 from src.infra.services.firebase_service import FirebaseService
+from src.infra.services.scheduled_subscription_push_service import (
+    ScheduledSubscriptionPushService,
+)
 from src.infra.services.scheduler_leader_lock import SchedulerLeaderLock
 
 logger = logging.getLogger(__name__)
@@ -57,16 +60,32 @@ class ScheduledNotificationService:
     LOOP_INTERVAL_SECONDS = 60
     LOOP_ERROR_RETRY_SECONDS = 30
 
-    def __init__(self, firebase_service: FirebaseService, redis_client: RedisClient):
+    def __init__(
+        self,
+        firebase_service: FirebaseService,
+        redis_client: RedisClient,
+        trial_push_service: "ScheduledSubscriptionPushService | None" = None,
+    ):
         self._firebase = firebase_service
         self._redis = redis_client
         self._precompute = DailyContextPrecomputeService(redis_client)
+        self._trial_push = trial_push_service
         self._running = False
         self._tasks: List[asyncio.Task] = []
         self._leader_lock = SchedulerLeaderLock()
         self._leader_acquired = False
         self._cleanup_counter = 0
         self._distinct_timezones: list[str] = []
+
+        if self._trial_push is None:
+            logger.warning(
+                "ScheduledNotificationService constructed without "
+                "trial_push_service — trial reminders disabled"
+            )
+        else:
+            logger.info(
+                "ScheduledNotificationService: trial_push scheduler active"
+            )
 
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -137,6 +156,14 @@ class ScheduledNotificationService:
             "Startup catch-up complete for %d timezones", len(self._distinct_timezones)
         )
 
+        if self._trial_push is not None:
+            try:
+                await asyncio.to_thread(
+                    self._trial_push.check_and_schedule_pushes, now
+                )
+            except Exception:
+                logger.exception("Startup trial-push catchup failed")
+
     # ── Phase 1: Midnight pre-compute ─────────────────────────────────────────
 
     async def _check_midnight_precompute(self, now: datetime) -> None:
@@ -149,6 +176,16 @@ class ScheduledNotificationService:
                 await self._precompute.precompute_for_timezone(tz_name, today)
             except Exception as exc:
                 logger.error("Pre-compute failed for %s: %s", tz_name, exc)
+
+            if self._trial_push is not None:
+                try:
+                    await asyncio.to_thread(
+                        self._trial_push.check_and_schedule_pushes, now
+                    )
+                except Exception:
+                    logger.exception(
+                        "Trial-push scheduling failed for tz=%s", tz_name
+                    )
 
     # ── Phase 2: Send due notifications ───────────────────────────────────────
 
@@ -188,6 +225,10 @@ class ScheduledNotificationService:
             if notif.notification_type == "daily_summary":
                 # Use JSONB snapshot from midnight pre-compute (stable for full-day summary)
                 calories_consumed = int(ctx.get("calories_consumed", 0))
+            elif notif.notification_type.startswith("trial_expiry"):
+                # Trial reminders don't depend on calorie data; skip Redis to avoid
+                # a "cache miss" WARNING per row.
+                calories_consumed = 0
             else:
                 # Use Redis for meal reminders (fresher, ~30 min stale)
                 if not redis_ctx:
@@ -212,11 +253,17 @@ class ScheduledNotificationService:
                 groups[(notif.notification_type, title, body)].append(tok)
             sent_ids.append(notif.id)
 
-        # Batch FCM — 500 tokens per call
+        # Batch FCM — 500 tokens per call.
+        # DB stores trial_expiry_2d / trial_expiry_1d so the UNIQUE
+        # (user_id, type, scheduled_date) constraint dedups per-day; mobile expects
+        # a single "trial_expiry" type in data.type for dispatch.
         for (notif_type, title, body), tokens in groups.items():
+            fcm_type = (
+                "trial_expiry" if notif_type.startswith("trial_expiry") else notif_type
+            )
             for chunk in _chunked(tokens, 500):
                 result = self._firebase.send_multicast(
-                    tokens=chunk, title=title, body=body, notification_type=notif_type
+                    tokens=chunk, title=title, body=body, notification_type=fcm_type
                 )
                 if result.get("failed_tokens"):
                     await self._handle_failed_tokens(result["failed_tokens"])
@@ -344,6 +391,12 @@ def _render_message(
             return "", summary["way_over"]["body_template"].format(
                 excess=int(calories_consumed - calorie_goal)
             )
+    elif notification_type.startswith("trial_expiry"):
+        days = "2d" if notification_type.endswith("_2d") else "1d"
+        trial = messages.get("trial_expiry", {}).get(days, {})
+        return trial.get("title", ""), trial.get(
+            "body", "Your trial is ending soon."
+        )
     return "", "You have a notification 📬"
 
 

--- a/src/infra/services/scheduled_subscription_push_service.py
+++ b/src/infra/services/scheduled_subscription_push_service.py
@@ -1,0 +1,231 @@
+"""Scheduler that inserts T-2d / T-1d trial-expiry push rows for the
+existing ScheduledNotificationService loop to send."""
+
+import logging
+import uuid
+from collections.abc import Iterable
+from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from src.domain.utils.timezone_utils import utc_now
+from src.infra.database.models.notification.notification import NotificationORM
+from src.infra.database.uow import UnitOfWork
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LUNCH_MINUTES = 690    # 11:30 — mirrors daily_context_precompute_service
+_FIRE_OFFSET_MINUTES = 30       # send at lunch + 30
+_FALLBACK_FIRE_LOCAL = time(12, 0)  # if lunch_time_minutes missing → noon local
+
+
+class ScheduledSubscriptionPushService:
+    """Inserts trial-expiry push notifications at T-2d and T-1d.
+
+    Does not send. The existing ScheduledNotificationService loop polls
+    `notifications` and sends due rows on its 60s tick.
+    """
+
+    def __init__(self) -> None:
+        # Stateless; constructed once per process in main.py lifespan.
+        pass
+
+    def check_and_schedule_pushes(self, now: datetime | None = None) -> int:
+        """Run T-2d + T-1d windows. Returns total rows inserted (excludes
+        conflict-do-nothing skips)."""
+        moment = now or utc_now()
+        logger.info("Trial-push scheduler: starting run at %s", moment.isoformat())
+
+        scheduled = 0
+        scheduled += self._schedule_window(moment, days_left=2)
+        scheduled += self._schedule_window(moment, days_left=1)
+
+        logger.info("Trial-push scheduler: complete, inserted=%s", scheduled)
+        return scheduled
+
+    # ---- window pipeline ------------------------------------------------
+
+    def _schedule_window(self, now: datetime, days_left: int) -> int:
+        with UnitOfWork() as uow:
+            subs = uow.subscriptions.find_expiring_in_window(
+                from_days=days_left, to_days=days_left + 1, now=now
+            )
+            if not subs:
+                return 0
+
+            user_ids = [s.user_id for s in subs]
+            prefs = self._fetch_prefs(uow.session, user_ids)
+            tokens_by_user = self._fetch_fcm_tokens(uow.session, user_ids)
+
+            rows: list[dict] = []
+            for sub in subs:
+                pref = prefs.get(sub.user_id)
+                tokens = tokens_by_user.get(sub.user_id, [])
+                if not tokens:
+                    continue
+                row = self._build_row(
+                    user_id=sub.user_id,
+                    days_left=days_left,
+                    tokens=tokens,
+                    pref=pref,
+                    now=now,
+                )
+                if row is not None:
+                    rows.append(row)
+
+            if not rows:
+                return 0
+
+            return self._insert_with_dedup(uow.session, rows)
+
+    # ---- pref + token fetch (batch) -------------------------------------
+
+    @staticmethod
+    def _fetch_prefs(session, user_ids: list[str]) -> dict[str, dict]:
+        if not user_ids:
+            return {}
+        result = session.execute(
+            text(
+                """
+                SELECT
+                    np.user_id,
+                    np.lunch_time_minutes,
+                    np.language,
+                    u.timezone,
+                    u.gender,
+                    u.language_code
+                FROM notification_preferences np
+                JOIN users u ON u.id = np.user_id
+                WHERE np.user_id = ANY(:ids) AND np.is_deleted = false
+                """
+            ),
+            {"ids": user_ids},
+        ).fetchall()
+
+        def _resolve_lang(pref_lang, user_lang) -> str:
+            # Matches daily_context_precompute_service.py:194
+            if pref_lang in ("en", "vi"):
+                return pref_lang
+            if user_lang in ("en", "vi"):
+                return user_lang
+            return "en"
+
+        return {
+            r.user_id: {
+                "lunch_time_minutes": r.lunch_time_minutes,
+                "language": _resolve_lang(r.language, r.language_code),
+                "timezone": r.timezone or "UTC",
+                "gender": r.gender or "male",
+            }
+            for r in result
+        }
+
+    @staticmethod
+    def _fetch_fcm_tokens(session, user_ids: list[str]) -> dict[str, list[str]]:
+        if not user_ids:
+            return {}
+        result = session.execute(
+            text(
+                """
+                SELECT user_id, fcm_token
+                FROM user_fcm_tokens
+                WHERE user_id = ANY(:ids) AND is_active = true
+                """
+            ),
+            {"ids": user_ids},
+        ).fetchall()
+        tokens: dict[str, list[str]] = {}
+        for r in result:
+            tokens.setdefault(r.user_id, []).append(r.fcm_token)
+        return tokens
+
+    # ---- row construction -----------------------------------------------
+
+    def _build_row(
+        self,
+        user_id: str,
+        days_left: int,
+        tokens: list[str],
+        pref: dict | None,
+        now: datetime,
+    ) -> dict | None:
+        tz_name = (pref or {}).get("timezone", "UTC")
+        try:
+            tz = ZoneInfo(tz_name)
+        except Exception:
+            tz = ZoneInfo("UTC")
+
+        scheduled_utc, scheduled_local_date = self._compute_scheduled_at(
+            now_utc=now,
+            tz=tz,
+            lunch_time_minutes=(pref or {}).get("lunch_time_minutes"),
+        )
+
+        if scheduled_utc <= now:
+            # Window already passed today in this tz — skip; tomorrow's
+            # midnight run will pick it up if still in window.
+            return None
+
+        return {
+            "id": str(uuid.uuid4()),
+            "user_id": user_id,
+            "notification_type": f"trial_expiry_{days_left}d",
+            "scheduled_date": scheduled_local_date,
+            "scheduled_for_utc": scheduled_utc,
+            "status": "pending",
+            "context": {
+                "fcm_tokens": tokens,
+                "calorie_goal": 2000,    # non-zero sentinel; trial render ignores it
+                "calories_consumed": 0,
+                "gender": (pref or {}).get("gender", "male"),
+                "language_code": (pref or {}).get("language", "en"),
+            },
+            "created_at": utc_now(),
+            "expires_at": scheduled_utc + timedelta(days=2),
+        }
+
+    @staticmethod
+    def _compute_scheduled_at(
+        now_utc: datetime,
+        tz: ZoneInfo,
+        lunch_time_minutes: int | None,
+    ) -> tuple[datetime, date]:
+        """Returns (UTC datetime to fire at, local date the push fires)."""
+        local_now = now_utc.astimezone(tz)
+        local_today = local_now.date()
+
+        if lunch_time_minutes is None:
+            fire_local = datetime.combine(local_today, _FALLBACK_FIRE_LOCAL, tz)
+        else:
+            minutes = lunch_time_minutes + _FIRE_OFFSET_MINUTES
+            hour, minute = divmod(minutes, 60)
+            # Wrap to next day if lunch+30 overflows past midnight (extreme edge).
+            extra_days, hour = divmod(hour, 24)
+            fire_local = datetime.combine(
+                local_today + timedelta(days=extra_days),
+                time(hour, minute),
+                tz,
+            )
+
+        return (
+            fire_local.astimezone(now_utc.tzinfo or ZoneInfo("UTC")),
+            fire_local.date(),
+        )
+
+    # ---- insert ----------------------------------------------------------
+
+    @staticmethod
+    def _insert_with_dedup(session, rows: Iterable[dict]) -> int:
+        rows_list = list(rows)
+        if not rows_list:
+            return 0
+        stmt = pg_insert(NotificationORM).values(rows_list)
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=["user_id", "notification_type", "scheduled_date"],
+        )
+        result = session.execute(stmt)
+        # rowcount reflects rows actually inserted (excludes conflict skips).
+        # Some drivers return -1 when count is unknown; treat as 0 for logging.
+        return result.rowcount if (result.rowcount or 0) >= 0 else 0

--- a/tests/fixtures/fakes/fake_subscription_repository.py
+++ b/tests/fixtures/fakes/fake_subscription_repository.py
@@ -48,6 +48,24 @@ class FakeSubscriptionRepository(SubscriptionRepositoryPort):
             if sub.expires_at and datetime.now() < sub.expires_at <= cutoff
         ]
 
+    def find_expiring_in_window(
+        self,
+        from_days: int,
+        to_days: int,
+        now: Optional[datetime] = None,
+    ) -> List[Subscription]:
+        """Active subs whose expires_at falls within the [from_days, to_days) window."""
+        reference = now or datetime.now()
+        lower = reference + timedelta(days=from_days)
+        upper = reference + timedelta(days=to_days)
+        return [
+            sub
+            for sub in self._subscriptions.values()
+            if sub.status == "active"
+            and sub.expires_at is not None
+            and lower <= sub.expires_at < upper
+        ]
+
     async def cancel(self, subscription_id: str, reason: str = None) -> bool:
         """Cancel a subscription."""
         if subscription_id in self._subscriptions:

--- a/tests/unit/domain/services/test_notification_messages.py
+++ b/tests/unit/domain/services/test_notification_messages.py
@@ -1,0 +1,44 @@
+"""Unit tests for notification message templates (trial_expiry)."""
+
+import pytest
+
+from src.domain.services.notification_messages import get_messages
+
+
+@pytest.mark.parametrize(
+    "lang,gender",
+    [
+        ("en", "male"),
+        ("en", "female"),
+        ("vi", "male"),
+        ("vi", "female"),
+    ],
+)
+def test_trial_expiry_keys_exist(lang, gender):
+    msgs = get_messages(lang, gender)
+    assert "trial_expiry" in msgs
+    assert "2d" in msgs["trial_expiry"]
+    assert "1d" in msgs["trial_expiry"]
+    assert msgs["trial_expiry"]["2d"]["body"]
+    assert msgs["trial_expiry"]["1d"]["body"]
+    # Time-sensitive: title is empty so iOS shows app name.
+    assert msgs["trial_expiry"]["2d"]["title"] == ""
+    assert msgs["trial_expiry"]["1d"]["title"] == ""
+
+
+def test_trial_expiry_fallback_locale_returns_english():
+    msgs = get_messages("fr", "male")
+    assert "trial_expiry" in msgs
+    assert "2 days" in msgs["trial_expiry"]["2d"]["body"]
+
+
+def test_trial_expiry_vi_contains_vietnamese_phrasing():
+    msgs = get_messages("vi", "male")
+    assert "trial" in msgs["trial_expiry"]["2d"]["body"]
+    # Distinct buddy term for male VN.
+    assert "bro" in msgs["trial_expiry"]["2d"]["body"]
+
+
+def test_trial_expiry_en_female_uses_mate():
+    msgs = get_messages("en", "female")
+    assert "mate" in msgs["trial_expiry"]["2d"]["body"]

--- a/tests/unit/infra/services/test_scheduled_subscription_push_service.py
+++ b/tests/unit/infra/services/test_scheduled_subscription_push_service.py
@@ -1,0 +1,236 @@
+"""Unit tests for ScheduledSubscriptionPushService."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+from src.infra.services.scheduled_subscription_push_service import (
+    ScheduledSubscriptionPushService,
+)
+
+NOW_UTC = datetime(2026, 5, 17, 5, 0, 0, tzinfo=UTC)
+
+
+def _make_sub(user_id: str, expires_at: datetime, status: str = "active"):
+    sub = MagicMock()
+    sub.user_id = user_id
+    sub.status = status
+    sub.expires_at = expires_at
+    return sub
+
+
+def _patch_uow_with_subs(subs):
+    """Build a context-manager mock for UnitOfWork wired to return `subs`."""
+    uow_cm = MagicMock()
+    uow_cm.subscriptions.find_expiring_in_window.return_value = subs
+    uow_cm.session = MagicMock()
+    uow_cm.session.execute.return_value.rowcount = len(subs)
+
+    uow_ctx = MagicMock()
+    uow_ctx.__enter__.return_value = uow_cm
+    uow_ctx.__exit__.return_value = False
+    return uow_ctx, uow_cm
+
+
+def test_schedules_row_for_active_expiring_sub_with_token():
+    svc = ScheduledSubscriptionPushService()
+    user_id = str(uuid.uuid4())
+    sub = _make_sub(user_id, NOW_UTC + timedelta(days=2, hours=6))
+
+    uow_ctx, _uow = _patch_uow_with_subs([sub])
+
+    with patch(
+        "src.infra.services.scheduled_subscription_push_service.UnitOfWork",
+        return_value=uow_ctx,
+    ), patch.object(
+        ScheduledSubscriptionPushService,
+        "_fetch_prefs",
+        return_value={
+            user_id: {
+                "lunch_time_minutes": 720,
+                "language": "en",
+                "timezone": "Asia/Ho_Chi_Minh",
+                "gender": "male",
+            }
+        },
+    ), patch.object(
+        ScheduledSubscriptionPushService,
+        "_fetch_fcm_tokens",
+        return_value={user_id: ["tok1", "tok2"]},
+    ):
+        n = svc.check_and_schedule_pushes(NOW_UTC)
+        assert n >= 1
+
+
+def test_skips_user_without_fcm_token():
+    svc = ScheduledSubscriptionPushService()
+    user_id = str(uuid.uuid4())
+    sub = _make_sub(user_id, NOW_UTC + timedelta(days=2))
+
+    uow_ctx, _uow = _patch_uow_with_subs([sub])
+
+    with patch(
+        "src.infra.services.scheduled_subscription_push_service.UnitOfWork",
+        return_value=uow_ctx,
+    ), patch.object(
+        ScheduledSubscriptionPushService,
+        "_fetch_prefs",
+        return_value={
+            user_id: {
+                "lunch_time_minutes": 720,
+                "language": "en",
+                "timezone": "UTC",
+                "gender": "male",
+            }
+        },
+    ), patch.object(
+        ScheduledSubscriptionPushService,
+        "_fetch_fcm_tokens",
+        return_value={},  # no tokens
+    ):
+        n = svc.check_and_schedule_pushes(NOW_UTC)
+        assert n == 0
+
+
+def test_returns_zero_when_no_subs_in_window():
+    svc = ScheduledSubscriptionPushService()
+    uow_ctx, _uow = _patch_uow_with_subs([])
+    with patch(
+        "src.infra.services.scheduled_subscription_push_service.UnitOfWork",
+        return_value=uow_ctx,
+    ):
+        assert svc.check_and_schedule_pushes(NOW_UTC) == 0
+
+
+def test_compute_scheduled_at_uses_lunch_plus_30():
+    out_utc, _ = ScheduledSubscriptionPushService._compute_scheduled_at(
+        now_utc=NOW_UTC,                                 # 05:00 UTC = 12:00 ICT
+        tz=ZoneInfo("Asia/Ho_Chi_Minh"),
+        lunch_time_minutes=720,                          # 12:00 local
+    )
+    local = out_utc.astimezone(ZoneInfo("Asia/Ho_Chi_Minh"))
+    assert local.hour == 12 and local.minute == 30
+
+
+def test_compute_scheduled_at_fallback_noon_when_lunch_missing():
+    out_utc, _ = ScheduledSubscriptionPushService._compute_scheduled_at(
+        now_utc=NOW_UTC,
+        tz=ZoneInfo("Asia/Ho_Chi_Minh"),
+        lunch_time_minutes=None,
+    )
+    local = out_utc.astimezone(ZoneInfo("Asia/Ho_Chi_Minh"))
+    assert local.hour == 12 and local.minute == 0
+
+
+def test_compute_scheduled_at_returns_local_date_not_utc_date():
+    """05:00 UTC on May 17 = 12:00 May 17 ICT; scheduled_date must be local."""
+    _, scheduled_date = ScheduledSubscriptionPushService._compute_scheduled_at(
+        now_utc=NOW_UTC,
+        tz=ZoneInfo("Asia/Ho_Chi_Minh"),
+        lunch_time_minutes=720,
+    )
+    assert scheduled_date.isoformat() == "2026-05-17"
+
+
+def test_runs_both_windows():
+    svc = ScheduledSubscriptionPushService()
+    with patch.object(svc, "_schedule_window", return_value=0) as sw:
+        svc.check_and_schedule_pushes(NOW_UTC)
+        assert sw.call_count == 2
+        called_days = sorted(
+            (c.kwargs.get("days_left") if "days_left" in c.kwargs else c.args[1])
+            for c in sw.call_args_list
+        )
+        assert called_days == [1, 2]
+
+
+def test_language_resolution_falls_back_to_users_language_code():
+    """pref.language=None + users.language_code='vi' → 'vi' (not 'en')."""
+    session = MagicMock()
+    row = MagicMock()
+    row.user_id = "u1"
+    row.lunch_time_minutes = 720
+    row.language = None
+    row.timezone = "Asia/Ho_Chi_Minh"
+    row.gender = "female"
+    row.language_code = "vi"
+    session.execute.return_value.fetchall.return_value = [row]
+
+    out = ScheduledSubscriptionPushService._fetch_prefs(session, ["u1"])
+    assert out["u1"]["language"] == "vi"
+
+
+def test_language_resolution_pref_overrides_user():
+    session = MagicMock()
+    row = MagicMock()
+    row.user_id = "u1"
+    row.lunch_time_minutes = 720
+    row.language = "en"
+    row.timezone = "UTC"
+    row.gender = "male"
+    row.language_code = "vi"
+    session.execute.return_value.fetchall.return_value = [row]
+
+    out = ScheduledSubscriptionPushService._fetch_prefs(session, ["u1"])
+    assert out["u1"]["language"] == "en"
+
+
+def test_language_resolution_unknown_falls_back_to_en():
+    session = MagicMock()
+    row = MagicMock()
+    row.user_id = "u1"
+    row.lunch_time_minutes = 720
+    row.language = "fr"
+    row.timezone = "UTC"
+    row.gender = "male"
+    row.language_code = "de"
+    session.execute.return_value.fetchall.return_value = [row]
+
+    out = ScheduledSubscriptionPushService._fetch_prefs(session, ["u1"])
+    assert out["u1"]["language"] == "en"
+
+
+def test_build_row_skips_if_scheduled_time_already_passed():
+    """Mid-day midnight-trigger run shouldn't insert a row that fires in the past."""
+    svc = ScheduledSubscriptionPushService()
+    user_id = "u1"
+    # User in UTC, lunch_time=00 → fires at 00:30 UTC. `now` is 05:00 UTC.
+    pref = {
+        "lunch_time_minutes": 0,
+        "language": "en",
+        "timezone": "UTC",
+        "gender": "male",
+    }
+    row = svc._build_row(
+        user_id=user_id,
+        days_left=2,
+        tokens=["tok1"],
+        pref=pref,
+        now=NOW_UTC,
+    )
+    assert row is None
+
+
+def test_build_row_returns_full_row_when_in_future():
+    svc = ScheduledSubscriptionPushService()
+    pref = {
+        "lunch_time_minutes": 720,
+        "language": "vi",
+        "timezone": "Asia/Ho_Chi_Minh",
+        "gender": "female",
+    }
+    row = svc._build_row(
+        user_id="u1",
+        days_left=1,
+        tokens=["tok1"],
+        pref=pref,
+        now=NOW_UTC,
+    )
+    assert row is not None
+    assert row["notification_type"] == "trial_expiry_1d"
+    assert row["status"] == "pending"
+    assert row["context"]["language_code"] == "vi"
+    assert row["context"]["gender"] == "female"
+    assert row["context"]["fcm_tokens"] == ["tok1"]
+    assert row["expires_at"] == row["scheduled_for_utc"] + timedelta(days=2)

--- a/tests/unit/infra/test_scheduled_notification_service.py
+++ b/tests/unit/infra/test_scheduled_notification_service.py
@@ -120,7 +120,143 @@ async def test_startup_catchup_calls_precompute_for_each_timezone():
     svc = ScheduledNotificationService.__new__(ScheduledNotificationService)
     svc._precompute = mock_precompute
     svc._distinct_timezones = ["UTC", "Asia/Ho_Chi_Minh"]
+    svc._trial_push = None  # disable trial-push branch for this test
 
     await svc._startup_catchup()
 
     assert mock_precompute.precompute_for_timezone.call_count == 2
+
+
+# ── Trial-expiry coverage ──────────────────────────────────────────────────────
+
+
+def test_render_trial_expiry_2d_en_male_returns_2_day_body():
+    from src.infra.services.scheduled_notification_service import _render_message
+
+    title, body = _render_message(
+        "trial_expiry_2d", 0, "male", "en"
+    )
+    assert title == ""
+    assert "2 days" in body
+
+
+def test_render_trial_expiry_1d_en_female_returns_1_day_body():
+    from src.infra.services.scheduled_notification_service import _render_message
+
+    title, body = _render_message(
+        "trial_expiry_1d", 0, "female", "en"
+    )
+    assert title == ""
+    assert "tomorrow" in body.lower()
+
+
+def test_render_trial_expiry_2d_vi_male_returns_vietnamese():
+    from src.infra.services.scheduled_notification_service import _render_message
+
+    title, body = _render_message(
+        "trial_expiry_2d", 0, "male", "vi"
+    )
+    assert "2 ngày" in body
+    assert "bro" in body
+
+
+def test_render_trial_expiry_1d_vi_female_returns_vietnamese():
+    from src.infra.services.scheduled_notification_service import _render_message
+
+    _, body = _render_message(
+        "trial_expiry_1d", 0, "female", "vi"
+    )
+    assert "bạn ơi" in body
+    assert "mai" in body
+
+
+def test_render_unknown_type_falls_through_to_generic_stub():
+    from src.infra.services.scheduled_notification_service import _render_message
+
+    _, body = _render_message("totally_unknown", 0, "male", "en")
+    assert body == "You have a notification 📬"
+
+
+def _make_trial_notif(notif_type: str = "trial_expiry_2d"):
+    n = MagicMock()
+    n.id = "n1"
+    n.user_id = "u1"
+    n.notification_type = notif_type
+    n.context = {
+        "fcm_tokens": ["tok1"],
+        "calorie_goal": 2000,
+        "calories_consumed": 0,
+        "gender": "male",
+        "language_code": "en",
+    }
+    return n
+
+
+@pytest.mark.asyncio
+async def test_send_due_normalizes_trial_fcm_type():
+    """trial_expiry_2d in DB → 'trial_expiry' in FCM data.type."""
+    import asyncio as _asyncio
+
+    from src.infra.services.scheduled_notification_service import (
+        ScheduledNotificationService,
+    )
+
+    svc = ScheduledNotificationService.__new__(ScheduledNotificationService)
+    svc._firebase = MagicMock()
+    svc._firebase.send_multicast = MagicMock(
+        return_value={"success": True, "failed_tokens": []}
+    )
+    svc._redis = AsyncMock()
+    svc._redis.hgetall_batch = AsyncMock(return_value=[{}])
+    svc._running = True
+
+    async def _passthrough(fn, *a, **kw):
+        return fn(*a, **kw)
+
+    with patch(
+        "src.infra.services.scheduled_notification_service.ReminderQueryBuilder"
+    ) as Q, patch(
+        "src.infra.services.scheduled_notification_service.UnitOfWork"
+    ), patch.object(_asyncio, "to_thread", new=_passthrough):
+        Q.find_due_notifications.return_value = [_make_trial_notif("trial_expiry_2d")]
+        await svc._send_due_notifications(
+            datetime(2026, 5, 17, tzinfo=timezone.utc)
+        )
+
+    call_kwargs = svc._firebase.send_multicast.call_args.kwargs
+    assert call_kwargs["notification_type"] == "trial_expiry"
+
+
+@pytest.mark.asyncio
+async def test_send_due_trial_skips_redis_lookup(caplog):
+    """Trial rows must NOT log Redis cache-miss WARNING."""
+    import asyncio as _asyncio
+
+    from src.infra.services.scheduled_notification_service import (
+        ScheduledNotificationService,
+    )
+
+    svc = ScheduledNotificationService.__new__(ScheduledNotificationService)
+    svc._firebase = MagicMock()
+    svc._firebase.send_multicast = MagicMock(
+        return_value={"success": True, "failed_tokens": []}
+    )
+    svc._redis = AsyncMock()
+    svc._redis.hgetall_batch = AsyncMock(return_value=[{}])  # empty cache
+    svc._running = True
+
+    async def _passthrough(fn, *a, **kw):
+        return fn(*a, **kw)
+
+    with patch(
+        "src.infra.services.scheduled_notification_service.ReminderQueryBuilder"
+    ) as Q, patch(
+        "src.infra.services.scheduled_notification_service.UnitOfWork"
+    ), patch.object(_asyncio, "to_thread", new=_passthrough):
+        Q.find_due_notifications.return_value = [_make_trial_notif("trial_expiry_1d")]
+        with caplog.at_level("WARNING"):
+            await svc._send_due_notifications(
+                datetime(2026, 5, 17, tzinfo=timezone.utc)
+            )
+
+    assert "Redis cache miss" not in caplog.text

--- a/tests/unit/repositories/test_subscription_repository.py
+++ b/tests/unit/repositories/test_subscription_repository.py
@@ -2,7 +2,7 @@
 Unit tests for SubscriptionRepository.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 
 from src.infra.database.models.subscription import Subscription
@@ -128,6 +128,56 @@ class TestSubscriptionRepository:
         result = self.repository.get_expired_subscriptions()
 
         assert len(result) == 1
+
+    def test_find_expiring_in_window_queries_subscription(self):
+        """Window query returns subscriptions filtered through SQLAlchemy."""
+        sub = Mock(spec=Subscription, status="active")
+        self.mock_session.query.return_value.filter.return_value.all.return_value = [
+            sub
+        ]
+
+        result = self.repository.find_expiring_in_window(from_days=1, to_days=2)
+
+        assert result == [sub]
+        self.mock_session.query.assert_called_with(Subscription)
+
+    def test_find_expiring_in_window_is_deterministic_with_now(self):
+        """Passing `now` pins both bounds against the same reference moment."""
+        self.mock_session.query.return_value.filter.return_value.all.return_value = []
+        fixed = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        # Two consecutive calls with the same `now` must produce the same
+        # bound literals. SQLAlchemy expressions don't support ==; compile
+        # them and compare the rendered SQL + parameter values.
+        from sqlalchemy.dialects import postgresql
+
+        def _compiled(call):
+            expr = call.args[0]
+            return str(
+                expr.compile(
+                    dialect=postgresql.dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+
+        self.repository.find_expiring_in_window(
+            from_days=1, to_days=2, now=fixed
+        )
+        first = _compiled(
+            self.mock_session.query.return_value.filter.call_args
+        )
+
+        self.repository.find_expiring_in_window(
+            from_days=1, to_days=2, now=fixed
+        )
+        second = _compiled(
+            self.mock_session.query.return_value.filter.call_args
+        )
+
+        assert first == second
+        # Bound timestamps must appear in the compiled SQL (proves `now` was used).
+        assert "2026-06-02" in first  # from_days=1
+        assert "2026-06-03" in first  # to_days=2
 
     def test_update_subscription_status(self):
         """Test updating subscription status."""


### PR DESCRIPTION
## Summary
- New `ScheduledSubscriptionPushService` schedules localized FCM push reminders for trial/sub users whose `expires_at` falls in 1–2 days, mirroring `ScheduledEmailService` cadence
- Runs from the existing scheduler (startup catch-up + per-timezone midnight precompute) — no Redis dependency added
- Webhook cleanup: `RENEWAL` event purges any pending `trial_expiry_*` rows so renewed users don't get "trial ends tomorrow" pushes

## How it works
- At midnight in each user's tz, the scheduler queries `subscriptions` for active rows with `expires_at` in the [now+1d, now+3d) window
- Per user, schedules a row in `notifications` with `type=trial_expiry_2d` or `trial_expiry_1d` and `scheduled_for_utc = today + lunch_time_minutes + 30min` (fallback noon local)
- Dedup via UNIQUE `(user_id, notification_type, scheduled_date)` + `ON CONFLICT DO NOTHING`
- `ScheduledNotificationService._send_due_notifications` skips the Redis cache lookup for trial rows and normalizes FCM `data.type` to `trial_expiry` (mobile already routes this to `/paywall` via `NotificationType.trialExpiry`)
- Messages: en/vi × male/female with empty title (iOS Time Sensitive shows app name); unknown locales fall back to en, unknown types fall back to "Your trial is ending soon."

## Files
- `src/infra/services/scheduled_subscription_push_service.py` (new)
- `src/infra/services/scheduled_notification_service.py` (trial render branch + Redis bypass + FCM type normalize + startup/midnight hooks)
- `src/api/base_dependencies.py`, `src/api/main.py` (wire-up)
- `src/api/routes/v1/webhooks.py` (renewal cleanup)
- `src/domain/services/notification_messages.py` (trial_expiry sub-tree × 4 combos)
- `src/domain/ports/subscription_repository_port.py` + `src/infra/repositories/subscription_repository.py` + `tests/fixtures/fakes/fake_subscription_repository.py` (new `find_expiring_in_window`)

## Test plan
- [x] Unit tests: 48 new/extended tests across 4 files, all green
- [x] Full unit suite: 1219 passed, 3 skipped, 1 pre-existing `GOOGLE_API_KEY` env-only failure unrelated to this PR
- [x] FastAPI app import + route registration smoke
- [x] All 8 message permutations (en/vi × male/female × 2d/1d) render correctly
- [ ] Manual: backfill a test user's `expires_at` to NOW + 1d 12h, wait for next midnight tick, confirm FCM push arrives at lunch+30
- [ ] Manual: trigger `RENEWAL` webhook for a user with pending `trial_expiry_*` rows, confirm rows are deleted