### PR TITLE
fix(notifications): send iOS time sensitive payload

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -76,7 +76,8 @@ load_dotenv()
 initialize_sentry()
 
 # Configure logging
-logging.basicConfig(level=logging.WARNING)
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
 logger = logging.getLogger(__name__)
 
 

--- a/src/api/routes/v1/health.py
+++ b/src/api/routes/v1/health.py
@@ -3,6 +3,7 @@ Health check endpoints for monitoring and status.
 """
 
 import asyncio
+import os
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter
@@ -19,6 +20,23 @@ from src.infra.database.config import (
 router = APIRouter(tags=["Health"])
 
 
+def _deployment_info() -> Dict[str, Optional[str]]:
+    """Expose non-sensitive deploy identity for staging/runtime verification."""
+    return {
+        "environment": os.getenv("ENVIRONMENT"),
+        "railway_environment": os.getenv("RAILWAY_ENVIRONMENT_NAME"),
+        "git_branch": os.getenv("GIT_BRANCH") or os.getenv("RAILWAY_GIT_BRANCH"),
+        "git_commit": (
+            os.getenv("GIT_SHA")
+            or os.getenv("COMMIT_SHA")
+            or os.getenv("RAILWAY_GIT_COMMIT_SHA")
+            or os.getenv("RENDER_GIT_COMMIT")
+            or os.getenv("SOURCE_VERSION")
+        ),
+        "app_version": os.getenv("APP_VERSION"),
+    }
+
+
 @router.api_route("/health", methods=["GET", "HEAD"])
 async def health_check():
     """
@@ -30,6 +48,7 @@ async def health_check():
         content={
             "status": "healthy",
             "message": "API is running",
+            "deployment": _deployment_info(),
         },
     )
 
@@ -163,6 +182,7 @@ async def notification_health_check():
         health_status = {
             "status": "healthy",
             "firebase_initialized": firebase_service.is_initialized(),
+            "deployment": _deployment_info(),
             "components": {},
         }
         health_status["components"]["apns"] = {

--- a/src/api/routes/v1/health.py
+++ b/src/api/routes/v1/health.py
@@ -165,6 +165,10 @@ async def notification_health_check():
             "firebase_initialized": firebase_service.is_initialized(),
             "components": {},
         }
+        health_status["components"]["apns"] = {
+            "status": "healthy",
+            **FirebaseService.apns_diagnostics(),
+        }
 
         # Check Firebase Admin SDK
         if not firebase_service.is_initialized():

--- a/src/infra/services/daily_context_precompute_service.py
+++ b/src/infra/services/daily_context_precompute_service.py
@@ -194,7 +194,7 @@ class DailyContextPrecomputeService:
             language_code = pref_row.language or (profile_row.language_code if profile_row else "en") or "en"
 
             # Calculate calorie goal (simplified - use TDEE service for accuracy)
-            calorie_goal = self._get_user_calorie_goal(session, user_id)
+            calorie_goal = self._get_user_calorie_goal(session, user_id, today)
 
             # Get today's consumed calories
             day_start_utc = datetime(today.year, today.month, today.day, 0, 0, 0, tzinfo=tz).astimezone(timezone.utc)
@@ -281,20 +281,23 @@ class DailyContextPrecomputeService:
             logger.info("Rescheduled %d notifications for user %s", len(rows), user_id)
             return len(rows)
 
-    def _get_user_calorie_goal(self, session, user_id: str) -> int:
+    def _get_user_calorie_goal(self, session, user_id: str, target_date: date) -> int:
         """Get user's daily calorie goal from weekly budget or TDEE."""
         # Try weekly budget first
         budget_row = session.execute(
             text("""
-                SELECT adjusted_daily_calories FROM weekly_budgets
-                WHERE user_id = :user_id AND is_active = true
-                ORDER BY week_start_date DESC LIMIT 1
+                SELECT target_calories
+                FROM weekly_macro_budgets
+                WHERE user_id = :user_id
+                  AND week_start_date <= :target_date
+                ORDER BY week_start_date DESC
+                LIMIT 1
             """),
-            {"user_id": user_id},
+            {"user_id": user_id, "target_date": target_date},
         ).fetchone()
 
-        if budget_row and budget_row.adjusted_daily_calories:
-            return int(budget_row.adjusted_daily_calories)
+        if budget_row and budget_row.target_calories:
+            return int(round(float(budget_row.target_calories) / 7))
 
         # Fallback to TDEE calculation
         profile_row = session.execute(

--- a/src/infra/services/firebase_service.py
+++ b/src/infra/services/firebase_service.py
@@ -161,13 +161,13 @@ class FirebaseService:
                     headers={
                         "apns-priority": "10",
                         "apns-push-type": "alert",
-                        "apns-interruption-level": "time-sensitive",
                     },
                     payload=messaging.APNSPayload(
                         aps=messaging.Aps(
                             sound="default",
                             badge=1,
                             alert=messaging.ApsAlert(title=title, body=body),
+                            custom_data={"interruption-level": "time-sensitive"},
                         )
                     ),
                 ),
@@ -247,13 +247,13 @@ class FirebaseService:
                     headers={
                         "apns-priority": "10",
                         "apns-push-type": "alert",
-                        "apns-interruption-level": "time-sensitive",
                     },
                     payload=messaging.APNSPayload(
                         aps=messaging.Aps(
                             sound="default",
                             badge=1,
                             alert=messaging.ApsAlert(title=title, body=body),
+                            custom_data={"interruption-level": "time-sensitive"},
                         )
                     ),
                 ),

--- a/src/infra/services/firebase_service.py
+++ b/src/infra/services/firebase_service.py
@@ -21,6 +21,9 @@ class NotificationChannelConfig:
     LOW_PRIORITY_CHANNEL_ID = "low_priority_channel"
 
 
+APNS_INTERRUPTION_LEVEL = "time-sensitive"
+
+
 class FirebaseService:
     """Service for Firebase Admin SDK operations."""
 
@@ -157,20 +160,7 @@ class FirebaseService:
                         sound="default",
                     ),
                 ),
-                apns=messaging.APNSConfig(
-                    headers={
-                        "apns-priority": "10",
-                        "apns-push-type": "alert",
-                    },
-                    payload=messaging.APNSPayload(
-                        aps=messaging.Aps(
-                            sound="default",
-                            badge=1,
-                            alert=messaging.ApsAlert(title=title, body=body),
-                            custom_data={"interruption-level": "time-sensitive"},
-                        )
-                    ),
-                ),
+                apns=self._build_apns_config(title, body),
             )
 
             # Send the message
@@ -243,20 +233,7 @@ class FirebaseService:
                         sound="default",
                     ),
                 ),
-                apns=messaging.APNSConfig(
-                    headers={
-                        "apns-priority": "10",
-                        "apns-push-type": "alert",
-                    },
-                    payload=messaging.APNSPayload(
-                        aps=messaging.Aps(
-                            sound="default",
-                            badge=1,
-                            alert=messaging.ApsAlert(title=title, body=body),
-                            custom_data={"interruption-level": "time-sensitive"},
-                        )
-                    ),
-                ),
+                apns=self._build_apns_config(title, body),
             )
 
             # Send the message
@@ -273,3 +250,30 @@ class FirebaseService:
     def is_initialized(self) -> bool:
         """Check if Firebase Admin SDK is initialized."""
         return len(firebase_admin._apps) > 0
+
+    @staticmethod
+    def apns_diagnostics() -> Dict[str, Any]:
+        """Return non-sensitive APNs settings used for all iOS push sends."""
+        return {
+            "push_type": "alert",
+            "priority": "10",
+            "interruption_level": APNS_INTERRUPTION_LEVEL,
+            "interruption_level_location": "payload.aps.interruption-level",
+        }
+
+    @staticmethod
+    def _build_apns_config(title: str, body: str):
+        return messaging.APNSConfig(
+            headers={
+                "apns-priority": "10",
+                "apns-push-type": "alert",
+            },
+            payload=messaging.APNSPayload(
+                aps=messaging.Aps(
+                    sound="default",
+                    badge=1,
+                    alert=messaging.ApsAlert(title=title, body=body),
+                    custom_data={"interruption-level": APNS_INTERRUPTION_LEVEL},
+                )
+            ),
+        )

--- a/src/infra/services/firebase_service.py
+++ b/src/infra/services/firebase_service.py
@@ -148,14 +148,16 @@ class FirebaseService:
             # Ensure all data values are strings
             string_data = {k: str(v) for k, v in data.items()} if data else {}
 
-            # Create multicast message
+            # Use platform-specific notification blocks only. This keeps iOS on the
+            # explicit APNs payload that carries aps.interruption-level.
             message = messaging.MulticastMessage(
-                notification=messaging.Notification(title=title, body=body),
                 data=string_data,
                 tokens=tokens,
                 android=messaging.AndroidConfig(
                     priority="high",
                     notification=messaging.AndroidNotification(
+                        title=title,
+                        body=body,
                         channel_id=NotificationChannelConfig.HIGH_PRIORITY_CHANNEL_ID,
                         sound="default",
                     ),
@@ -221,14 +223,16 @@ class FirebaseService:
             message_data = data or {}
             message_data["topic"] = topic
 
-            # Create message
+            # Use platform-specific notification blocks only. This keeps iOS on the
+            # explicit APNs payload that carries aps.interruption-level.
             message = messaging.Message(
-                notification=messaging.Notification(title=title, body=body),
                 data=message_data,
                 topic=topic,
                 android=messaging.AndroidConfig(
                     priority="high",
                     notification=messaging.AndroidNotification(
+                        title=title,
+                        body=body,
                         channel_id=NotificationChannelConfig.HIGH_PRIORITY_CHANNEL_ID,
                         sound="default",
                     ),

--- a/src/infra/services/scheduled_notification_service.py
+++ b/src/infra/services/scheduled_notification_service.py
@@ -314,37 +314,37 @@ def _render_message(
     calories_consumed: int = 0,
     calorie_goal: int = 2000,
 ) -> tuple[str, str]:
-    """Render title + body for a notification type. Title is empty for Time Sensitive."""
+    """Render title + body for a notification type."""
     messages = get_messages(lang, gender)
     if notification_type == "meal_reminder_breakfast":
         cfg = messages["meal_reminder"]["breakfast"]
-        return "", cfg.get("body", "Time to log your meal 🍽️")
+        return "Nutree", cfg.get("body", "Time to log your meal 🍽️")
     elif notification_type == "meal_reminder_lunch":
         cfg = messages["meal_reminder"]["lunch"]
-        return "", cfg["body_template"].format(remaining=remaining)
+        return "Nutree", cfg["body_template"].format(remaining=remaining)
     elif notification_type == "meal_reminder_dinner":
         cfg = messages["meal_reminder"]["dinner"]
-        return "", cfg["body_template"].format(remaining=remaining)
+        return "Nutree", cfg["body_template"].format(remaining=remaining)
     elif notification_type == "daily_summary":
         summary = messages["daily_summary"]
         if calories_consumed == 0:
-            return "", summary["zero_logs"]["body"]
+            return "Nutree", summary["zero_logs"]["body"]
         pct = (calories_consumed / calorie_goal * 100) if calorie_goal > 0 else 0
         if 95 <= pct <= 105:
-            return "", summary["on_target"]["body_template"].format(percentage=int(pct))
+            return "Nutree", summary["on_target"]["body_template"].format(percentage=int(pct))
         elif pct < 95:
-            return "", summary["under_goal"]["body_template"].format(
+            return "Nutree", summary["under_goal"]["body_template"].format(
                 deficit=int(calorie_goal - calories_consumed)
             )
         elif pct <= 120:
-            return "", summary["slightly_over"]["body_template"].format(
+            return "Nutree", summary["slightly_over"]["body_template"].format(
                 excess=int(calories_consumed - calorie_goal)
             )
         else:
-            return "", summary["way_over"]["body_template"].format(
+            return "Nutree", summary["way_over"]["body_template"].format(
                 excess=int(calories_consumed - calorie_goal)
             )
-    return "", "You have a notification 📬"
+    return "Nutree", "You have a notification 📬"
 
 
 def _chunked(lst: list, size: int):

--- a/tests/unit/api/test_health_router.py
+++ b/tests/unit/api/test_health_router.py
@@ -11,3 +11,17 @@ def test_health_accepts_head_requests():
     response = TestClient(app).head("/health")
 
     assert response.status_code == 200
+
+
+def test_health_exposes_deployment_identity(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "1e1170b7")
+    monkeypatch.setenv("RAILWAY_GIT_BRANCH", "fix/ios-time-sensitive-notifications")
+    app = FastAPI()
+    app.include_router(router)
+
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    deployment = response.json()["deployment"]
+    assert deployment["git_commit"] == "1e1170b7"
+    assert deployment["git_branch"] == "fix/ios-time-sensitive-notifications"

--- a/tests/unit/infra/test_daily_context_precompute_service.py
+++ b/tests/unit/infra/test_daily_context_precompute_service.py
@@ -55,3 +55,22 @@ def test_context_key_format():
 
     svc = DailyContextPrecomputeService(redis_client=MagicMock())
     assert svc.context_key("user-123") == "user_daily_context:user-123"
+
+
+def test_user_calorie_goal_reads_weekly_macro_budget_table():
+    from src.infra.services.daily_context_precompute_service import (
+        DailyContextPrecomputeService,
+    )
+
+    session = MagicMock()
+    weekly_budget_row = MagicMock()
+    weekly_budget_row.target_calories = 14000
+    session.execute.return_value.fetchone.return_value = weekly_budget_row
+
+    svc = DailyContextPrecomputeService(redis_client=MagicMock())
+    result = svc._get_user_calorie_goal(session, "user-123", date(2026, 5, 17))
+
+    executed_sql = str(session.execute.call_args.args[0])
+    assert result == 2000
+    assert "weekly_macro_budgets" in executed_sql
+    assert "weekly_budgets" not in executed_sql

--- a/tests/unit/infra/test_firebase_multicast.py
+++ b/tests/unit/infra/test_firebase_multicast.py
@@ -9,7 +9,6 @@ def test_apns_config_encodes_time_sensitive_payload():
 
     message = messaging.Message(
         token="tok",
-        notification=messaging.Notification(title="Lunch", body="Log your meal"),
         apns=FirebaseService._build_apns_config("Lunch", "Log your meal"),
     )
 
@@ -23,6 +22,7 @@ def test_apns_config_encodes_time_sensitive_payload():
     }
     assert "apns-interruption-level" not in apns["headers"]
     assert aps["interruption-level"] == "time-sensitive"
+    assert "notification" not in encoded
 
 
 def test_send_multicast_delegates_to_send_to_tokens():
@@ -96,5 +96,6 @@ def test_send_notification_sets_ios_time_sensitive_payload(monkeypatch):
 
     apns = captured["message"]["apns"]
     assert result["success"] is True
+    assert "notification" not in captured["message"]
     assert apns.headers == {"apns-priority": "10", "apns-push-type": "alert"}
     assert apns.payload.aps.custom_data == {"interruption-level": "time-sensitive"}

--- a/tests/unit/infra/test_firebase_multicast.py
+++ b/tests/unit/infra/test_firebase_multicast.py
@@ -1,6 +1,30 @@
 from unittest.mock import patch, MagicMock
 
 
+def test_apns_config_encodes_time_sensitive_payload():
+    from firebase_admin import messaging
+    from firebase_admin._messaging_encoder import MessageEncoder
+
+    from src.infra.services.firebase_service import FirebaseService
+
+    message = messaging.Message(
+        token="tok",
+        notification=messaging.Notification(title="Lunch", body="Log your meal"),
+        apns=FirebaseService._build_apns_config("Lunch", "Log your meal"),
+    )
+
+    encoded = MessageEncoder().default(message)
+    apns = encoded["apns"]
+    aps = apns["payload"]["aps"]
+
+    assert apns["headers"] == {
+        "apns-priority": "10",
+        "apns-push-type": "alert",
+    }
+    assert "apns-interruption-level" not in apns["headers"]
+    assert aps["interruption-level"] == "time-sensitive"
+
+
 def test_send_multicast_delegates_to_send_to_tokens():
     from src.infra.services.firebase_service import FirebaseService
 
@@ -61,10 +85,6 @@ def test_send_notification_sets_ios_time_sensitive_payload(monkeypatch):
     monkeypatch.setattr(firebase_module.messaging, "Notification", FakeValue)
     monkeypatch.setattr(firebase_module.messaging, "AndroidConfig", FakeValue)
     monkeypatch.setattr(firebase_module.messaging, "AndroidNotification", FakeValue)
-    monkeypatch.setattr(firebase_module.messaging, "APNSConfig", FakeValue)
-    monkeypatch.setattr(firebase_module.messaging, "APNSPayload", FakeValue)
-    monkeypatch.setattr(firebase_module.messaging, "Aps", FakeValue)
-    monkeypatch.setattr(firebase_module.messaging, "ApsAlert", FakeValue)
     monkeypatch.setattr(
         firebase_module.messaging,
         "send_each_for_multicast",
@@ -74,7 +94,7 @@ def test_send_notification_sets_ios_time_sensitive_payload(monkeypatch):
     svc = FirebaseService.__new__(FirebaseService)
     result = svc._send_to_tokens(["tok"], "Lunch", "Log your meal", {"type": "meal"})
 
-    aps = captured["message"]["apns"].kwargs["payload"].kwargs["aps"]
+    apns = captured["message"]["apns"]
     assert result["success"] is True
-    assert "apns-interruption-level" not in captured["message"]["apns"].kwargs["headers"]
-    assert aps.kwargs["custom_data"] == {"interruption-level": "time-sensitive"}
+    assert apns.headers == {"apns-priority": "10", "apns-push-type": "alert"}
+    assert apns.payload.aps.custom_data == {"interruption-level": "time-sensitive"}

--- a/tests/unit/infra/test_firebase_multicast.py
+++ b/tests/unit/infra/test_firebase_multicast.py
@@ -32,3 +32,49 @@ def test_send_multicast_returns_not_initialized_when_firebase_not_ready():
         result = svc.send_multicast(tokens=["tok"], title="t", body="b")
 
     assert result == {"success": False, "reason": "firebase_not_initialized"}
+
+
+def test_send_notification_sets_ios_time_sensitive_payload(monkeypatch):
+    from src.infra.services import firebase_service as firebase_module
+    from src.infra.services.firebase_service import FirebaseService
+
+    captured = {}
+
+    class FakeMulticastMessage:
+        def __init__(self, **kwargs):
+            captured["message"] = kwargs
+
+    class FakeResponse:
+        success_count = 1
+        failure_count = 0
+        responses = []
+
+    class FakeValue:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(
+        firebase_module.messaging,
+        "MulticastMessage",
+        FakeMulticastMessage,
+    )
+    monkeypatch.setattr(firebase_module.messaging, "Notification", FakeValue)
+    monkeypatch.setattr(firebase_module.messaging, "AndroidConfig", FakeValue)
+    monkeypatch.setattr(firebase_module.messaging, "AndroidNotification", FakeValue)
+    monkeypatch.setattr(firebase_module.messaging, "APNSConfig", FakeValue)
+    monkeypatch.setattr(firebase_module.messaging, "APNSPayload", FakeValue)
+    monkeypatch.setattr(firebase_module.messaging, "Aps", FakeValue)
+    monkeypatch.setattr(firebase_module.messaging, "ApsAlert", FakeValue)
+    monkeypatch.setattr(
+        firebase_module.messaging,
+        "send_each_for_multicast",
+        MagicMock(return_value=FakeResponse()),
+    )
+
+    svc = FirebaseService.__new__(FirebaseService)
+    result = svc._send_to_tokens(["tok"], "Lunch", "Log your meal", {"type": "meal"})
+
+    aps = captured["message"]["apns"].kwargs["payload"].kwargs["aps"]
+    assert result["success"] is True
+    assert "apns-interruption-level" not in captured["message"]["apns"].kwargs["headers"]
+    assert aps.kwargs["custom_data"] == {"interruption-level": "time-sensitive"}

--- a/tests/unit/infra/test_scheduled_notification_service.py
+++ b/tests/unit/infra/test_scheduled_notification_service.py
@@ -67,7 +67,7 @@ def test_render_message_daily_summary_zero_logs():
     title, body = _render_message(
         "daily_summary", 2000, "male", "en", calories_consumed=0, calorie_goal=2000
     )
-    assert title == ""  # daily_summary has no title
+    assert title == "Nutree"
     assert "Busy" in body
     assert "log" in body.lower()
 


### PR DESCRIPTION
## Summary
- Move iOS Time Sensitive interruption level into the APNs `aps` payload instead of an APNs header.
- Send explicit platform-specific notification blocks only: Android notification + APNs alert, with no generic top-level FCM `notification` object.
- Use a simple non-empty iOS title (`Nutree`) while preserving the personalized body text.
- Centralize APNs config so multicast and topic sends use the same Time Sensitive payload shape.
- Fix notification preference rescheduling to read the real `weekly_macro_budgets` table instead of stale `weekly_budgets` SQL.
- Expose non-sensitive APNs diagnostics in `/health/notifications` so staging can prove the deployed config.
- Default backend logging to `INFO` via `LOG_LEVEL` so successful scheduled notification sends appear in Railway logs.

## Root cause
- Staging backend `delivery` still had `apns-interruption-level` in APNs headers, which APNs does not use for Time Sensitive classification.
- The fix was previously only on this PR branch, not on `delivery`, so staging backend could still send regular notifications.
- `PUT /v1/notifications/preferences` updated preferences but failed rescheduling because `DailyContextPrecomputeService` queried removed table `weekly_budgets.adjusted_daily_calories`; current schema uses `weekly_macro_budgets.target_calories`.
- Backend logging was configured at `WARNING`, while successful notification sends are logged at `INFO`, hiding delivery evidence.

## Test plan
- [x] `.venv/bin/python -m pytest tests/unit/infra/test_firebase_multicast.py tests/unit/infra/test_scheduled_notification_service.py tests/unit/infra/test_daily_context_precompute_service.py -q`
- [x] `.venv/bin/python -m py_compile src/infra/services/firebase_service.py src/infra/services/scheduled_notification_service.py tests/unit/infra/test_firebase_multicast.py tests/unit/infra/test_scheduled_notification_service.py`
- [x] Verified Firebase Admin encoder emits APNs-only alert payload with `payload.aps.interruption-level = time-sensitive` and no top-level FCM `notification` object.

Related issues: none found from `gh issue list --search "time sensitive notification staging"`.