### PR TITLE
fix(notifications): align reminder timing and language

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -479,9 +479,10 @@ def get_configured_event_bus() -> EventBus:
         UpdateTimezoneCommand,
         UpdateTimezoneCommandHandler(),
     )
+    precompute_service = get_daily_context_precompute_service()
     event_bus.register_handler(
         UpdateLanguageCommand,
-        UpdateLanguageCommandHandler(),
+        UpdateLanguageCommandHandler(precompute_service=precompute_service),
     )
     event_bus.register_handler(
         UpdateCustomMacrosCommand,
@@ -510,7 +511,6 @@ def get_configured_event_bus() -> EventBus:
         RegisterFcmTokenCommand, RegisterFcmTokenCommandHandler()
     )
     event_bus.register_handler(DeleteFcmTokenCommand, DeleteFcmTokenCommandHandler())
-    precompute_service = get_daily_context_precompute_service()
     event_bus.register_handler(
         UpdateNotificationPreferencesCommand,
         UpdateNotificationPreferencesCommandHandler(

--- a/src/app/handlers/command_handlers/update_language_command_handler.py
+++ b/src/app/handlers/command_handlers/update_language_command_handler.py
@@ -8,6 +8,9 @@ from src.app.commands.user.update_language_command import (
     SUPPORTED_LANGUAGES,
 )
 from src.app.events.base import EventHandler, handles
+from src.infra.services.daily_context_precompute_service import (
+    DailyContextPrecomputeService,
+)
 from src.infra.database.uow_async import AsyncUnitOfWork
 
 logger = logging.getLogger(__name__)
@@ -16,6 +19,16 @@ logger = logging.getLogger(__name__)
 @handles(UpdateLanguageCommand)
 class UpdateLanguageCommandHandler(EventHandler[UpdateLanguageCommand, Dict[str, Any]]):
     """Handler for updating user language preference."""
+
+    def __init__(
+        self, precompute_service: DailyContextPrecomputeService | None = None
+    ):
+        self.precompute_service = precompute_service
+
+    def set_dependencies(self, **kwargs):
+        """Set dependencies for dependency injection."""
+        if "precompute_service" in kwargs:
+            self.precompute_service = kwargs["precompute_service"]
 
     async def handle(self, command: UpdateLanguageCommand) -> Dict[str, Any]:
         """Handle language update command."""
@@ -29,7 +42,21 @@ class UpdateLanguageCommandHandler(EventHandler[UpdateLanguageCommand, Dict[str,
 
         async with AsyncUnitOfWork() as uow:
             await uow.users.update_user_language(command.user_id, language)
+            await uow.notifications.update_notification_language(
+                str(command.user_id), language
+            )
             await uow.commit()
+
+        if self.precompute_service:
+            try:
+                await self.precompute_service.reschedule_user_notifications(
+                    str(command.user_id)
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to reschedule notifications after language update: %s",
+                    exc,
+                )
 
         logger.info(f"Updated language for user {command.user_id}: {language}")
         return {"success": True, "language_code": language}

--- a/src/domain/ports/notification_repository_port.py
+++ b/src/domain/ports/notification_repository_port.py
@@ -122,6 +122,20 @@ class NotificationRepositoryPort(ABC):
         pass
 
     @abstractmethod
+    def update_notification_language(self, user_id: str, language: str) -> int:
+        """
+        Updates the notification language for an existing preferences row.
+
+        Args:
+            user_id: The user ID to update preferences for
+            language: ISO 639-1 notification language
+
+        Returns:
+            Number of updated rows
+        """
+        pass
+
+    @abstractmethod
     def delete_notification_preferences(self, user_id: str) -> bool:
         """
         Deletes notification preferences for a user.

--- a/src/infra/repositories/notification/reminder_query_builder.py
+++ b/src/infra/repositories/notification/reminder_query_builder.py
@@ -1,6 +1,6 @@
 """Reminder query builder for finding users due for notifications."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -126,16 +126,17 @@ class ReminderQueryBuilder:
 
     @staticmethod
     def find_due_notifications(db: Session, now: datetime) -> list:
-        """Return all pending notifications due on or before the end of the current 60-second window.
+        """Return all pending notifications due at or before the current moment.
 
         No lower bound: if the scheduler is delayed, past-due pending rows are
-        still picked up rather than silently dropped.
+        still picked up rather than silently dropped. Future rows are excluded
+        so reminders are never intentionally sent before the user's configured
+        minute.
         """
-        window_end = now + timedelta(seconds=60)
         return (
             db.query(NotificationORM)
             .filter(
-                NotificationORM.scheduled_for_utc <= window_end,
+                NotificationORM.scheduled_for_utc <= now,
                 NotificationORM.status == "pending",
             )
             .all()

--- a/src/infra/repositories/notification_repository.py
+++ b/src/infra/repositories/notification_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from src.domain.model.notification import UserFcmToken, NotificationPreferences
 from src.domain.ports.notification_repository_port import NotificationRepositoryPort
 from src.infra.database.config import ScopedSession
+from src.infra.database.models.notification import NotificationPreferencesORM
 from src.infra.repositories.notification.fcm_token_operations import FcmTokenOperations
 from src.infra.repositories.notification.notification_preferences_operations import (
     NotificationPreferencesOperations,
@@ -106,6 +107,23 @@ class NotificationRepository(NotificationRepositoryPort):
     ) -> NotificationPreferences:
         """Update notification preferences for a user."""
         return self.save_notification_preferences(preferences)
+
+    def update_notification_language(self, user_id: str, language: str) -> int:
+        """Update notification language for a user."""
+        db = self._get_db()
+        try:
+            rows = (
+                db.query(NotificationPreferencesORM)
+                .filter(
+                    NotificationPreferencesORM.user_id == user_id,
+                    NotificationPreferencesORM.is_deleted.is_(False),
+                )
+                .update({"language": language})
+            )
+            db.commit()
+            return rows
+        finally:
+            self._close_db_if_created(db)
 
     def delete_notification_preferences(self, user_id: str) -> bool:
         """Delete notification preferences for a user."""

--- a/src/infra/repositories/notification_repository_async.py
+++ b/src/infra/repositories/notification_repository_async.py
@@ -10,7 +10,7 @@ import logging
 from datetime import date
 from typing import List, Optional
 
-from sqlalchemy import select, and_, delete
+from sqlalchemy import select, and_, delete, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -175,6 +175,21 @@ class AsyncNotificationRepository:
     ) -> NotificationPreferences:
         """Update notification preferences for a user (delegates to save)."""
         return await self.save_notification_preferences(preferences)
+
+    async def update_notification_language(self, user_id: str, language: str) -> int:
+        """Update the notification language for an existing preferences row."""
+        result = await self.session.execute(
+            update(NotificationPreferencesORM)
+            .where(
+                and_(
+                    NotificationPreferencesORM.user_id == user_id,
+                    NotificationPreferencesORM.is_deleted.is_(False),
+                )
+            )
+            .values(language=language)
+        )
+        await self.session.flush()
+        return result.rowcount or 0
 
     async def delete_notification_preferences(self, user_id: str) -> bool:
         """Delete notification preferences for a user."""

--- a/src/infra/services/daily_context_precompute_service.py
+++ b/src/infra/services/daily_context_precompute_service.py
@@ -199,10 +199,9 @@ class DailyContextPrecomputeService:
             ).fetchone()
 
             gender = (profile_row.gender if profile_row else None) or "male"
-            language_code = (
-                pref_row.language
-                or (profile_row.language_code if profile_row else "en")
-                or "en"
+            language_code = _resolve_notification_language(
+                pref_row.language,
+                profile_row.language_code if profile_row else None,
             )
 
             # Calculate calorie goal (simplified - use TDEE service for accuracy)
@@ -543,7 +542,10 @@ class DailyContextPrecomputeService:
                 user_id = pref_row.user_id
                 profile = profiles_by_user.get(user_id)
                 gender = (profile.gender if profile else None) or "male"
-                language_code = pref_row.language or "en"
+                language_code = _resolve_notification_language(
+                    pref_row.language,
+                    profile.language_code if profile else None,
+                )
 
                 mapping = {
                     "calorie_goal": str(calorie_goals.get(user_id, 2000)),
@@ -587,7 +589,10 @@ class DailyContextPrecomputeService:
             calorie_goal = calorie_goals.get(user_id, 2000)
             profile = profiles_by_user.get(user_id)
             gender = (profile.gender if profile else None) or "male"
-            language_code = pref.language or "en"
+            language_code = _resolve_notification_language(
+                pref.language,
+                profile.language_code if profile else None,
+            )
 
             context = {
                 "fcm_tokens": tokens,
@@ -671,3 +676,15 @@ def _local_minutes_to_utc(local_date: date, local_minutes: int, tz_name: str):
             "Cannot compute UTC for tz=%s minutes=%d: %s", tz_name, local_minutes, exc
         )
         return None
+
+
+def _resolve_notification_language(
+    pref_language: str | None,
+    user_language: str | None,
+) -> str:
+    """Resolve notification language from supported in-app locales."""
+    if user_language in ("en", "vi"):
+        return user_language
+    if pref_language in ("en", "vi"):
+        return pref_language
+    return "en"

--- a/src/infra/services/scheduled_notification_service.py
+++ b/src/infra/services/scheduled_notification_service.py
@@ -134,7 +134,7 @@ class ScheduledNotificationService:
                 if self._cleanup_counter >= _CLEANUP_TICKS:
                     self._cleanup_counter = 0
                     await asyncio.to_thread(self._cleanup_expired_notifications)
-                await asyncio.sleep(self.LOOP_INTERVAL_SECONDS)
+                await asyncio.sleep(_seconds_until_next_minute(now))
             except asyncio.CancelledError:
                 break
             except Exception as exc:
@@ -403,3 +403,12 @@ def _render_message(
 def _chunked(lst: list, size: int):
     for i in range(0, len(lst), size):
         yield lst[i : i + size]
+
+
+def _seconds_until_next_minute(now: datetime) -> float:
+    """Sleep until the next minute boundary without looking ahead."""
+    seconds = now.second + (now.microsecond / 1_000_000)
+    remaining = 60 - seconds
+    if remaining <= 0 or remaining > 60:
+        return float(ScheduledNotificationService.LOOP_INTERVAL_SECONDS)
+    return remaining

--- a/tests/fixtures/fakes/fake_notification_repository.py
+++ b/tests/fixtures/fakes/fake_notification_repository.py
@@ -53,6 +53,13 @@ class FakeNotificationRepository(NotificationRepositoryPort):
         self.preferences[user_id] = preferences
         return preferences
 
+    async def update_notification_language(self, user_id: str, language: str) -> int:
+        prefs = self.preferences.get(user_id)
+        if prefs is None:
+            return 0
+        self.preferences[user_id] = prefs.update_preferences(language=language)
+        return 1
+
     async def delete_notification_preferences(self, user_id: str) -> bool:
         if user_id in self.preferences:
             del self.preferences[user_id]

--- a/tests/unit/handlers/command_handlers/test_update_language_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_update_language_command_handler.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.app.commands.user.update_language_command import UpdateLanguageCommand
+from src.app.handlers.command_handlers.update_language_command_handler import (
+    UpdateLanguageCommandHandler,
+)
+from src.domain.model.notification import NotificationPreferences
+from tests.fixtures.fakes.fake_uow import FakeUnitOfWork
+
+
+@pytest.mark.asyncio
+async def test_update_language_syncs_notification_preferences_and_reschedules():
+    user_id = str(uuid4())
+    fake_uow = FakeUnitOfWork()
+    fake_uow.notifications.preferences[user_id] = (
+        NotificationPreferences.create_default(user_id)
+    )
+    precompute = AsyncMock()
+    handler = UpdateLanguageCommandHandler(precompute_service=precompute)
+
+    with patch(
+        "src.app.handlers.command_handlers.update_language_command_handler.AsyncUnitOfWork",
+        return_value=fake_uow,
+    ):
+        result = await handler.handle(
+            UpdateLanguageCommand(user_id=user_id, language_code="vi")
+        )
+
+    assert result == {"success": True, "language_code": "vi"}
+    assert fake_uow.notifications.preferences[user_id].language == "vi"
+    precompute.reschedule_user_notifications.assert_awaited_once_with(user_id)
+
+
+@pytest.mark.asyncio
+async def test_update_language_rejects_unsupported_language_without_reschedule():
+    precompute = AsyncMock()
+    handler = UpdateLanguageCommandHandler(precompute_service=precompute)
+
+    result = await handler.handle(
+        UpdateLanguageCommand(user_id=uuid4(), language_code="unsupported")
+    )
+
+    assert result["success"] is False
+    precompute.reschedule_user_notifications.assert_not_called()

--- a/tests/unit/infra/test_daily_context_precompute_service.py
+++ b/tests/unit/infra/test_daily_context_precompute_service.py
@@ -58,6 +58,22 @@ def test_context_key_format():
     assert svc.context_key("user-123") == "user_daily_context:user-123"
 
 
+def test_notification_language_prefers_in_app_user_language():
+    from src.infra.services.daily_context_precompute_service import (
+        _resolve_notification_language,
+    )
+
+    assert _resolve_notification_language("en", "vi") == "vi"
+
+
+def test_notification_language_uses_pref_when_user_language_missing():
+    from src.infra.services.daily_context_precompute_service import (
+        _resolve_notification_language,
+    )
+
+    assert _resolve_notification_language("vi", None) == "vi"
+
+
 def test_user_calorie_goal_uses_adjusted_weekly_budget_target():
     from src.infra.services.daily_context_precompute_service import (
         DailyContextPrecomputeService,

--- a/tests/unit/infra/test_notification_queries.py
+++ b/tests/unit/infra/test_notification_queries.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 
-def test_find_due_notifications_queries_pending_in_window():
+def test_find_due_notifications_queries_pending_due_rows():
     from src.infra.repositories.notification.reminder_query_builder import (
         ReminderQueryBuilder,
     )
@@ -60,3 +60,32 @@ def test_find_due_notifications_includes_past_due_rows(test_session, sample_user
     assert any(
         r.id == past_due.id for r in results
     ), "Past-due pending row must be returned"
+
+
+def test_find_due_notifications_excludes_future_rows(test_session, sample_user):
+    """Future rows must not be returned, even if they are within the next minute."""
+    from datetime import timedelta
+    from src.infra.database.models.notification.notification import NotificationORM
+    from src.infra.repositories.notification.reminder_query_builder import (
+        ReminderQueryBuilder,
+    )
+    import uuid
+
+    now = datetime(2026, 4, 22, 8, 0, 0, tzinfo=timezone.utc)
+    future = NotificationORM(
+        id=str(uuid.uuid4()),
+        user_id=sample_user.id,
+        notification_type="meal_reminder_lunch",
+        scheduled_date=now.date(),
+        scheduled_for_utc=now + timedelta(seconds=30),
+        status="pending",
+        context={"fcm_tokens": []},
+        created_at=now,
+        expires_at=now + timedelta(days=7),
+    )
+    test_session.add(future)
+    test_session.flush()
+
+    results = ReminderQueryBuilder.find_due_notifications(test_session, now)
+
+    assert all(r.id != future.id for r in results)

--- a/tests/unit/infra/test_scheduled_notification_service.py
+++ b/tests/unit/infra/test_scheduled_notification_service.py
@@ -177,6 +177,16 @@ def test_render_unknown_type_falls_through_to_generic_stub():
     assert body == "You have a notification 📬"
 
 
+def test_seconds_until_next_minute_aligns_scheduler_tick():
+    from src.infra.services.scheduled_notification_service import (
+        _seconds_until_next_minute,
+    )
+
+    now = datetime(2026, 4, 22, 5, 0, 58, 500_000, tzinfo=timezone.utc)
+
+    assert _seconds_until_next_minute(now) == 1.5
+
+
 def _make_trial_notif(notif_type: str = "trial_expiry_2d"):
     n = MagicMock()
     n.id = "n1"


### PR DESCRIPTION
## Summary
- send queued reminders only when scheduled_for_utc is due, not within a future lookahead window
- align scheduler loop to minute boundaries without early dispatch
- sync in-app language changes into notification preferences and reschedule pending rows
- prefer current user language when building notification context

## Verification
- pytest tests/unit/handlers/command_handlers/test_update_language_command_handler.py tests/unit/infra/test_notification_queries.py tests/unit/infra/test_scheduled_notification_service.py tests/unit/infra/test_daily_context_precompute_service.py -q

Related issues: none found via gh issue search.