### PR TITLE
fix(notifications): prevent duplicate scheduled sends

### DIFF
--- a/src/domain/services/notification_messages.py
+++ b/src/domain/services/notification_messages.py
@@ -1,8 +1,9 @@
 """
 Notification message templates keyed by language and gender.
 
-Time Sensitive notifications: title is empty (iOS shows app name).
-All content in body field with emoji at end.
+Time Sensitive notifications use a title plus body field.
+Bodies intentionally include one line break so iOS renders richer copy across
+two lines without leaving the emoji alone on a third line.
 
 Gender-aware buddy terms:
 - EN: male="bro", female="mate"
@@ -18,80 +19,80 @@ NOTIFICATION_MESSAGES = {
         "male": {
             "meal_reminder": {
                 "breakfast": {
-                    "body": "Morning, bro! Grab a bite or coffee — log it! ☕",
+                    "body": "Morning, bro! Grab a bite or coffee\nWhen you can — log it 🌅",
                 },
                 "lunch": {
-                    "body_template": "Lunch o'clock, bro! {remaining} cal left — what's on the plate? 🥗",
+                    "body_template": "Lunch o'clock, bro! {remaining} cal left\nWhat's going on the plate? 🥗",
                 },
                 "dinner": {
-                    "body_template": "Dinner time, bro! {remaining} cal left — make it count! 🍽️",
+                    "body_template": "Dinner time, bro! {remaining} cal left\nMake it count tonight 🌙",
                 },
             },
             "daily_summary": {
                 "zero_logs": {
-                    "body": "Busy day, bro? Drop a quick meal log when you can! 📝",
+                    "body": "Busy day, bro? No stress\nLog one quick meal when you can 📝",
                 },
                 "on_target": {
-                    "body_template": "Crushed it, bro! {percentage}% of your goal! 🎉",
+                    "body_template": "Crushed it, bro! {percentage}% of your goal\nKeep that momentum going 🎉",
                 },
                 "under_goal": {
-                    "body_template": "Almost there, bro! {deficit} cal left — grab a snack! 💪",
+                    "body_template": "Almost there, bro! {deficit} cal left\nA smart snack can close it 💪",
                 },
                 "slightly_over": {
-                    "body_template": "No stress, bro! {excess} cal over — keep going! 😎",
+                    "body_template": "No stress, bro! {excess} cal over\nKeep going and stay consistent 😎",
                 },
                 "way_over": {
-                    "body_template": "All good, bro! {excess} cal over — tomorrow's a fresh start! 🤙",
+                    "body_template": "All good, bro! {excess} cal over\nTomorrow's a fresh start 🤙",
                 },
             },
             "trial_expiry": {
                 "2d": {
                     "title": "Nutree",
-                    "body": "Heads up, bro — your trial ends in 2 days. Lock in your streak! ⏳",
+                    "body": "Heads up, bro — trial ends in 2 days\nLock in your streak ⏳",
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Last day, bro — trial ends tomorrow. Keep your progress going! 🔥",
+                    "body": "Last day, bro — trial ends tomorrow\nKeep your progress going 🔥",
                 },
             },
         },
         "female": {
             "meal_reminder": {
                 "breakfast": {
-                    "body": "Morning, mate! Grab a bite or coffee — log it! ☕",
+                    "body": "Morning, mate! Grab a bite or coffee\nWhen you can — log it 🌅",
                 },
                 "lunch": {
-                    "body_template": "Lunch o'clock, mate! {remaining} cal left — what's on the plate? 🥗",
+                    "body_template": "Lunch o'clock, mate! {remaining} cal left\nWhat's going on the plate? 🥗",
                 },
                 "dinner": {
-                    "body_template": "Dinner time, mate! {remaining} cal left — make it count! 🍽️",
+                    "body_template": "Dinner time, mate! {remaining} cal left\nMake it count tonight 🌙",
                 },
             },
             "daily_summary": {
                 "zero_logs": {
-                    "body": "Busy day, mate? Drop a quick meal log when you can! 📝",
+                    "body": "Busy day, mate? No stress\nLog one quick meal when you can 📝",
                 },
                 "on_target": {
-                    "body_template": "Crushed it, mate! {percentage}% of your goal! 🎉",
+                    "body_template": "Crushed it, mate! {percentage}% of your goal\nKeep that momentum going 🎉",
                 },
                 "under_goal": {
-                    "body_template": "Almost there, mate! {deficit} cal left — grab a snack! 💪",
+                    "body_template": "Almost there, mate! {deficit} cal left\nA smart snack can close it 💪",
                 },
                 "slightly_over": {
-                    "body_template": "No stress, mate! {excess} cal over — keep going! 😎",
+                    "body_template": "No stress, mate! {excess} cal over\nKeep going and stay consistent 😎",
                 },
                 "way_over": {
-                    "body_template": "All good, mate! {excess} cal over — tomorrow's a fresh start! 🤙",
+                    "body_template": "All good, mate! {excess} cal over\nTomorrow's a fresh start 🤙",
                 },
             },
             "trial_expiry": {
                 "2d": {
                     "title": "Nutree",
-                    "body": "Heads up, mate — your trial ends in 2 days. Lock in your streak! ⏳",
+                    "body": "Heads up, mate — trial ends in 2 days\nLock in your streak ⏳",
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Last day, mate — trial ends tomorrow. Keep your progress going! 🔥",
+                    "body": "Last day, mate — trial ends tomorrow\nKeep your progress going 🔥",
                 },
             },
         },
@@ -100,80 +101,80 @@ NOTIFICATION_MESSAGES = {
         "male": {
             "meal_reminder": {
                 "breakfast": {
-                    "body": "Sáng rồi bro! Ăn nhẹ hay cà phê đi — ghi lại nha! ☕",
+                    "body": "Sáng rồi bro! Ăn nhẹ hay cà phê đi\nNhớ ghi lại nha 🌅",
                 },
                 "lunch": {
-                    "body_template": "Trưa rồi bro! Còn {remaining} cal — ăn gì chưa? 🥗",
+                    "body_template": "Trưa rồi bro! Còn {remaining} cal\nĂn gì cho ngon đây? 🥗",
                 },
                 "dinner": {
-                    "body_template": "Tối rồi bro! Còn {remaining} cal — ăn gì đi hả? 🍽️",
+                    "body_template": "Tối rồi bro! Còn {remaining} cal\nĂn gì cho đúng mục tiêu? 🌙",
                 },
             },
             "daily_summary": {
                 "zero_logs": {
-                    "body": "Bận cả ngày hả bro? Tranh thủ ghi lại bữa nào đó nha! 📝",
+                    "body": "Bận cả ngày hả bro? Không sao\nTranh thủ ghi lại một bữa nha 📝",
                 },
                 "on_target": {
-                    "body_template": "Đỉnh nóc bro! {percentage}% mục tiêu! 🎉",
+                    "body_template": "Đỉnh nóc bro! {percentage}% mục tiêu\nCứ giữ nhịp này nha 🎉",
                 },
                 "under_goal": {
-                    "body_template": "Gần tới rồi bro! Còn {deficit} cal — ăn nhẹ gì đi! 💪",
+                    "body_template": "Gần tới rồi bro! Còn {deficit} cal\nĂn nhẹ gì đó đi 💪",
                 },
                 "slightly_over": {
-                    "body_template": "Thoải mái bro! Vượt một ít {excess} cal — tiếp tục nha! 😎",
+                    "body_template": "Thoải mái bro! Vượt {excess} cal\nVẫn ổn, tiếp tục nha 😎",
                 },
                 "way_over": {
-                    "body_template": "Không sao bro! Vượt {excess} cal — mai là ngày mới! 🤙",
+                    "body_template": "Không sao bro! Vượt {excess} cal\nMai là ngày mới nha 🤙",
                 },
             },
             "trial_expiry": {
                 "2d": {
                     "title": "Nutree",
-                    "body": "Còn 2 ngày là trial hết hạn nha bro — giữ streak nào! ⏳",
+                    "body": "Trial còn 2 ngày là hết hạn nha bro\nGiữ streak tiếp nào ⏳",
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Ngày cuối rồi bro — trial mai hết hạn. Tiếp tục nha! 🔥",
+                    "body": "Mai hết trial rồi bro\nĐừng để mất tiến độ nha 🔥",
                 },
             },
         },
         "female": {
             "meal_reminder": {
                 "breakfast": {
-                    "body": "Sáng rồi bạn ơi! Ăn nhẹ hay cà phê đi — ghi lại nha! ☕",
+                    "body": "Sáng rồi bạn ơi! Ăn nhẹ hay cà phê đi\nNhớ ghi lại nha 🌅",
                 },
                 "lunch": {
-                    "body_template": "Trưa rồi bạn ơi! Còn {remaining} cal — ăn gì chưa? 🥗",
+                    "body_template": "Trưa rồi bạn ơi! Còn {remaining} cal\nĂn gì cho ngon đây? 🥗",
                 },
                 "dinner": {
-                    "body_template": "Tối rồi bạn ơi! Còn {remaining} cal — ăn gì đi hả? 🍽️",
+                    "body_template": "Tối rồi bạn ơi! Còn {remaining} cal\nĂn gì cho đúng mục tiêu? 🌙",
                 },
             },
             "daily_summary": {
                 "zero_logs": {
-                    "body": "Bận cả ngày hả bạn ơi? Tranh thủ ghi lại bữa nào đó nha! 📝",
+                    "body": "Bận cả ngày hả bạn ơi? Không sao\nTranh thủ ghi lại một bữa nha 📝",
                 },
                 "on_target": {
-                    "body_template": "Đỉnh nóc bạn ơi! {percentage}% mục tiêu! 🎉",
+                    "body_template": "Đỉnh nóc bạn ơi! {percentage}% mục tiêu\nCứ giữ nhịp này nha 🎉",
                 },
                 "under_goal": {
-                    "body_template": "Gần tới rồi bạn ơi! Còn {deficit} cal — ăn nhẹ gì đi! 💪",
+                    "body_template": "Gần tới rồi bạn ơi! Còn {deficit} cal\nĂn nhẹ gì đó đi 💪",
                 },
                 "slightly_over": {
-                    "body_template": "Thoải mái bạn ơi! Vượt một ít {excess} cal — tiếp tục nha! 😎",
+                    "body_template": "Thoải mái bạn ơi! Vượt {excess} cal\nVẫn ổn, tiếp tục nha 😎",
                 },
                 "way_over": {
-                    "body_template": "Không sao bạn ơi! Vượt {excess} cal — mai là ngày mới! 🤙",
+                    "body_template": "Không sao bạn ơi! Vượt {excess} cal\nMai là ngày mới nha 🤙",
                 },
             },
             "trial_expiry": {
                 "2d": {
                     "title": "Nutree",
-                    "body": "Còn 2 ngày là trial hết hạn nha bạn ơi — giữ streak nào! ⏳",
+                    "body": "Trial còn 2 ngày là hết hạn nha bạn ơi\nGiữ streak tiếp nào ⏳",
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Ngày cuối rồi bạn ơi — trial mai hết hạn. Tiếp tục nha! 🔥",
+                    "body": "Mai hết trial rồi bạn ơi\nĐừng để mất tiến độ nha 🔥",
                 },
             },
         },

--- a/src/infra/repositories/notification/reminder_query_builder.py
+++ b/src/infra/repositories/notification/reminder_query_builder.py
@@ -1,8 +1,8 @@
 """Reminder query builder for finding users due for notifications."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
 from src.domain.utils.timezone_utils import DEFAULT_TIMEZONE, utc_to_local_minutes
@@ -18,6 +18,8 @@ from src.infra.database.models.user.user import User
 
 class ReminderQueryBuilder:
     """Builds queries for finding users due for reminders."""
+
+    PROCESSING_RECLAIM_AFTER = timedelta(minutes=10)
 
     @staticmethod
     def _active_token_users_subquery(db: Session):
@@ -125,7 +127,9 @@ class ReminderQueryBuilder:
         return matching_users
 
     @staticmethod
-    def find_due_notifications(db: Session, now: datetime) -> list:
+    def find_due_notifications(
+        db: Session, now: datetime, lock_rows: bool = False
+    ) -> list:
         """Return all pending notifications due at or before the current moment.
 
         No lower bound: if the scheduler is delayed, past-due pending rows are
@@ -133,11 +137,27 @@ class ReminderQueryBuilder:
         so reminders are never intentionally sent before the user's configured
         minute.
         """
-        return (
+        status_filter = NotificationORM.status == "pending"
+        if lock_rows:
+            stale_processing_before = (
+                now - ReminderQueryBuilder.PROCESSING_RECLAIM_AFTER
+            )
+            status_filter = or_(
+                status_filter,
+                and_(
+                    NotificationORM.status == "processing",
+                    NotificationORM.scheduled_for_utc <= stale_processing_before,
+                ),
+            )
+
+        query = (
             db.query(NotificationORM)
             .filter(
                 NotificationORM.scheduled_for_utc <= now,
-                NotificationORM.status == "pending",
+                status_filter,
             )
-            .all()
+            .order_by(NotificationORM.scheduled_for_utc, NotificationORM.created_at)
         )
+        if lock_rows:
+            query = query.with_for_update(skip_locked=True)
+        return query.all()

--- a/src/infra/services/daily_context_precompute_service.py
+++ b/src/infra/services/daily_context_precompute_service.py
@@ -141,15 +141,19 @@ class DailyContextPrecomputeService:
 
             today = datetime.now(tz).date()
 
-            # Delete existing pending notifications for today
+            now = utc_now()
+
+            # Delete only future pending notifications. Due rows may already be
+            # claimed by the scheduler and must not be recreated for the same day.
             session.execute(
                 text("""
                     DELETE FROM notifications
                     WHERE user_id = :user_id
                       AND scheduled_date = :today
                       AND status = 'pending'
+                      AND scheduled_for_utc > :now
                 """),
-                {"user_id": user_id, "today": today},
+                {"user_id": user_id, "today": today, "now": now},
             )
 
             # Get user's notification preferences
@@ -247,7 +251,6 @@ class DailyContextPrecomputeService:
                 "language_code": language_code,
             }
 
-            now = utc_now()
             expires_at = datetime(
                 today.year, today.month, today.day, tzinfo=timezone.utc
             ) + timedelta(days=_NOTIF_EXPIRY_DAYS)

--- a/src/infra/services/scheduled_notification_service.py
+++ b/src/infra/services/scheduled_notification_service.py
@@ -83,9 +83,7 @@ class ScheduledNotificationService:
                 "trial_push_service — trial reminders disabled"
             )
         else:
-            logger.info(
-                "ScheduledNotificationService: trial_push scheduler active"
-            )
+            logger.info("ScheduledNotificationService: trial_push scheduler active")
 
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -158,9 +156,7 @@ class ScheduledNotificationService:
 
         if self._trial_push is not None:
             try:
-                await asyncio.to_thread(
-                    self._trial_push.check_and_schedule_pushes, now
-                )
+                await asyncio.to_thread(self._trial_push.check_and_schedule_pushes, now)
             except Exception:
                 logger.exception("Startup trial-push catchup failed")
 
@@ -183,31 +179,36 @@ class ScheduledNotificationService:
                         self._trial_push.check_and_schedule_pushes, now
                     )
                 except Exception:
-                    logger.exception(
-                        "Trial-push scheduling failed for tz=%s", tz_name
-                    )
+                    logger.exception("Trial-push scheduling failed for tz=%s", tz_name)
 
     # ── Phase 2: Send due notifications ───────────────────────────────────────
 
     async def _send_due_notifications(self, now: datetime) -> None:
         """Fetch due rows, pull consumed from Redis, render, batch FCM, mark sent."""
 
-        def _fetch_due():
+        def _claim_due():
             with UnitOfWork() as uow:
-                return ReminderQueryBuilder.find_due_notifications(uow.session, now)
+                due_rows = ReminderQueryBuilder.find_due_notifications(
+                    uow.session, now, lock_rows=True
+                )
+                for row in due_rows:
+                    row.status = "processing"
+                return due_rows
 
-        due = await asyncio.to_thread(_fetch_due)
+        due = await asyncio.to_thread(_claim_due)
         if not due:
             return
 
-        logger.info("Sending %d due notifications", len(due))
+        logger.info("Sending %d claimed due notifications", len(due))
 
         # Batch-fetch calories_consumed from Redis
         context_keys = [f"user_daily_context:{n.user_id}" for n in due]
         redis_contexts = await self._redis.hgetall_batch(context_keys)
 
         # Render messages per notification and group by (type, title, body)
-        groups: dict[tuple[str, str, str], list[str]] = defaultdict(list)
+        groups: dict[tuple[str, str, str], dict[str, list[str]]] = defaultdict(
+            lambda: {"tokens": [], "ids": []}
+        )
         sent_ids = []
         failed_ids = []
 
@@ -249,21 +250,31 @@ class ScheduledNotificationService:
                 calories_consumed=calories_consumed,
                 calorie_goal=calorie_goal,
             )
-            for tok in tokens:
-                groups[(notif.notification_type, title, body)].append(tok)
+            group = groups[(notif.notification_type, title, body)]
+            group["tokens"].extend(tokens)
+            group["ids"].append(str(notif.id))
             sent_ids.append(notif.id)
 
         # Batch FCM — 500 tokens per call.
         # DB stores trial_expiry_2d / trial_expiry_1d so the UNIQUE
         # (user_id, type, scheduled_date) constraint dedups per-day; mobile expects
         # a single "trial_expiry" type in data.type for dispatch.
-        for (notif_type, title, body), tokens in groups.items():
+        for (notif_type, title, body), group in groups.items():
             fcm_type = (
                 "trial_expiry" if notif_type.startswith("trial_expiry") else notif_type
             )
+            data = {
+                "notification_ids": ",".join(group["ids"]),
+                "notification_count": str(len(group["ids"])),
+            }
+            tokens = group["tokens"]
             for chunk in _chunked(tokens, 500):
                 result = self._firebase.send_multicast(
-                    tokens=chunk, title=title, body=body, notification_type=fcm_type
+                    tokens=chunk,
+                    title=title,
+                    body=body,
+                    notification_type=fcm_type,
+                    data=data,
                 )
                 if result.get("failed_tokens"):
                     await self._handle_failed_tokens(result["failed_tokens"])
@@ -285,16 +296,20 @@ class ScheduledNotificationService:
         with UnitOfWork() as uow:
             if sent_ids:
                 uow.session.execute(
-                    text(
-                        "UPDATE notifications SET status = 'sent' WHERE id IN :ids"
-                    ).bindparams(bindparam("ids", expanding=True)),
+                    text("""
+                        UPDATE notifications
+                        SET status = 'sent'
+                        WHERE status = 'processing' AND id IN :ids
+                        """).bindparams(bindparam("ids", expanding=True)),
                     {"ids": sent_ids},
                 )
             if failed_ids:
                 uow.session.execute(
-                    text(
-                        "UPDATE notifications SET status = 'failed' WHERE id IN :ids"
-                    ).bindparams(bindparam("ids", expanding=True)),
+                    text("""
+                        UPDATE notifications
+                        SET status = 'failed'
+                        WHERE status = 'processing' AND id IN :ids
+                        """).bindparams(bindparam("ids", expanding=True)),
                     {"ids": failed_ids},
                 )
 
@@ -378,7 +393,9 @@ def _render_message(
             return "Nutree", summary["zero_logs"]["body"]
         pct = (calories_consumed / calorie_goal * 100) if calorie_goal > 0 else 0
         if 95 <= pct <= 105:
-            return "Nutree", summary["on_target"]["body_template"].format(percentage=int(pct))
+            return "Nutree", summary["on_target"]["body_template"].format(
+                percentage=int(pct)
+            )
         elif pct < 95:
             return "Nutree", summary["under_goal"]["body_template"].format(
                 deficit=int(calorie_goal - calories_consumed)

--- a/tests/unit/domain/services/test_notification_messages.py
+++ b/tests/unit/domain/services/test_notification_messages.py
@@ -34,7 +34,7 @@ def test_trial_expiry_fallback_locale_returns_english():
 
 def test_trial_expiry_vi_contains_vietnamese_phrasing():
     msgs = get_messages("vi", "male")
-    assert "trial" in msgs["trial_expiry"]["2d"]["body"]
+    assert "trial" in msgs["trial_expiry"]["2d"]["body"].lower()
     # Distinct buddy term for male VN.
     assert "bro" in msgs["trial_expiry"]["2d"]["body"]
 

--- a/tests/unit/infra/test_notification_queries.py
+++ b/tests/unit/infra/test_notification_queries.py
@@ -21,6 +21,7 @@ def test_find_due_notifications_queries_pending_due_rows():
 
     mock_query = MagicMock()
     mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
     mock_query.all.return_value = [mock_notif]
 
     db = MagicMock()
@@ -29,6 +30,30 @@ def test_find_due_notifications_queries_pending_due_rows():
     results = ReminderQueryBuilder.find_due_notifications(db, now)
 
     db.query.assert_called_once_with(NotificationORM)
+    assert results == [mock_notif]
+
+
+def test_find_due_notifications_can_lock_rows_for_scheduler_claims():
+    from src.infra.repositories.notification.reminder_query_builder import (
+        ReminderQueryBuilder,
+    )
+    from src.infra.database.models.notification.notification import NotificationORM
+
+    now = datetime(2026, 4, 22, 5, 0, 0, tzinfo=timezone.utc)
+    mock_notif = MagicMock(spec=NotificationORM)
+
+    mock_query = MagicMock()
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.with_for_update.return_value = mock_query
+    mock_query.all.return_value = [mock_notif]
+
+    db = MagicMock()
+    db.query.return_value = mock_query
+
+    results = ReminderQueryBuilder.find_due_notifications(db, now, lock_rows=True)
+
+    mock_query.with_for_update.assert_called_once_with(skip_locked=True)
     assert results == [mock_notif]
 
 
@@ -89,3 +114,48 @@ def test_find_due_notifications_excludes_future_rows(test_session, sample_user):
     results = ReminderQueryBuilder.find_due_notifications(test_session, now)
 
     assert all(r.id != future.id for r in results)
+
+
+def test_find_due_notifications_reclaims_stale_processing_rows(
+    test_session, sample_user
+):
+    from datetime import timedelta
+    import uuid
+
+    from src.infra.database.models.notification.notification import NotificationORM
+    from src.infra.repositories.notification.reminder_query_builder import (
+        ReminderQueryBuilder,
+    )
+
+    now = datetime(2026, 4, 22, 8, 30, 0, tzinfo=timezone.utc)
+    stale = NotificationORM(
+        id=str(uuid.uuid4()),
+        user_id=sample_user.id,
+        notification_type="meal_reminder_lunch",
+        scheduled_date=now.date(),
+        scheduled_for_utc=now - timedelta(minutes=15),
+        status="processing",
+        context={"fcm_tokens": []},
+        created_at=now - timedelta(minutes=20),
+        expires_at=now + timedelta(days=7),
+    )
+    fresh = NotificationORM(
+        id=str(uuid.uuid4()),
+        user_id=sample_user.id,
+        notification_type="meal_reminder_dinner",
+        scheduled_date=now.date(),
+        scheduled_for_utc=now - timedelta(minutes=2),
+        status="processing",
+        context={"fcm_tokens": []},
+        created_at=now - timedelta(minutes=20),
+        expires_at=now + timedelta(days=7),
+    )
+    test_session.add_all([stale, fresh])
+    test_session.flush()
+
+    results = ReminderQueryBuilder.find_due_notifications(
+        test_session, now, lock_rows=True
+    )
+
+    assert any(r.id == stale.id for r in results)
+    assert all(r.id != fresh.id for r in results)

--- a/tests/unit/infra/test_scheduled_notification_service.py
+++ b/tests/unit/infra/test_scheduled_notification_service.py
@@ -59,6 +59,11 @@ async def test_send_loop_marks_notifications_sent():
         await svc._send_due_notifications(now)
 
     mock_firebase.send_multicast.assert_called_once()
+    assert mock_notif.status == "processing"
+    assert mock_firebase.send_multicast.call_args.kwargs["data"] == {
+        "notification_ids": "notif-id-1",
+        "notification_count": "1",
+    }
 
 
 def test_render_message_daily_summary_zero_logs():
@@ -133,9 +138,7 @@ async def test_startup_catchup_calls_precompute_for_each_timezone():
 def test_render_trial_expiry_2d_en_male_returns_2_day_body():
     from src.infra.services.scheduled_notification_service import _render_message
 
-    title, body = _render_message(
-        "trial_expiry_2d", 0, "male", "en"
-    )
+    title, body = _render_message("trial_expiry_2d", 0, "male", "en")
     assert title == "Nutree"
     assert "2 days" in body
 
@@ -143,9 +146,7 @@ def test_render_trial_expiry_2d_en_male_returns_2_day_body():
 def test_render_trial_expiry_1d_en_female_returns_1_day_body():
     from src.infra.services.scheduled_notification_service import _render_message
 
-    title, body = _render_message(
-        "trial_expiry_1d", 0, "female", "en"
-    )
+    title, body = _render_message("trial_expiry_1d", 0, "female", "en")
     assert title == "Nutree"
     assert "tomorrow" in body.lower()
 
@@ -153,9 +154,7 @@ def test_render_trial_expiry_1d_en_female_returns_1_day_body():
 def test_render_trial_expiry_2d_vi_male_returns_vietnamese():
     from src.infra.services.scheduled_notification_service import _render_message
 
-    title, body = _render_message(
-        "trial_expiry_2d", 0, "male", "vi"
-    )
+    title, body = _render_message("trial_expiry_2d", 0, "male", "vi")
     assert "2 ngày" in body
     assert "bro" in body
 
@@ -163,11 +162,9 @@ def test_render_trial_expiry_2d_vi_male_returns_vietnamese():
 def test_render_trial_expiry_1d_vi_female_returns_vietnamese():
     from src.infra.services.scheduled_notification_service import _render_message
 
-    _, body = _render_message(
-        "trial_expiry_1d", 0, "female", "vi"
-    )
+    _, body = _render_message("trial_expiry_1d", 0, "female", "vi")
     assert "bạn ơi" in body
-    assert "mai" in body
+    assert "mai" in body.lower()
 
 
 def test_render_unknown_type_falls_through_to_generic_stub():
@@ -227,11 +224,11 @@ async def test_send_due_normalizes_trial_fcm_type():
         "src.infra.services.scheduled_notification_service.ReminderQueryBuilder"
     ) as Q, patch(
         "src.infra.services.scheduled_notification_service.UnitOfWork"
-    ), patch.object(_asyncio, "to_thread", new=_passthrough):
+    ), patch.object(
+        _asyncio, "to_thread", new=_passthrough
+    ):
         Q.find_due_notifications.return_value = [_make_trial_notif("trial_expiry_2d")]
-        await svc._send_due_notifications(
-            datetime(2026, 5, 17, tzinfo=timezone.utc)
-        )
+        await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=timezone.utc))
 
     call_kwargs = svc._firebase.send_multicast.call_args.kwargs
     assert call_kwargs["notification_type"] == "trial_expiry"
@@ -262,7 +259,9 @@ async def test_send_due_trial_skips_redis_lookup(caplog):
         "src.infra.services.scheduled_notification_service.ReminderQueryBuilder"
     ) as Q, patch(
         "src.infra.services.scheduled_notification_service.UnitOfWork"
-    ), patch.object(_asyncio, "to_thread", new=_passthrough):
+    ), patch.object(
+        _asyncio, "to_thread", new=_passthrough
+    ):
         Q.find_due_notifications.return_value = [_make_trial_notif("trial_expiry_1d")]
         with caplog.at_level("WARNING"):
             await svc._send_due_notifications(


### PR DESCRIPTION
## Summary
- Claim due notification rows with row locks and a processing state before Firebase sends.
- Avoid recreating due/in-flight reminders during language or preference reschedules.
- Add notification ID diagnostics to FCM data for future duplicate tracing.
- Update meal reminder and summary copy to explicit two-line content with capitalized line starts and meal-time emojis.

## Test plan
- [x] pytest tests/unit/infra/test_notification_queries.py tests/unit/infra/test_scheduled_notification_service.py tests/unit/infra/services/push/test_apns_payload_builder.py tests/unit/infra/services/test_firebase_service_payload.py tests/unit/handlers/command_handlers/test_update_language_command_handler.py tests/unit/domain/services/test_notification_messages.py -q
- [x] python -m py_compile src/domain/services/notification_messages.py src/infra/services/scheduled_notification_service.py src/infra/repositories/notification/reminder_query_builder.py src/infra/services/daily_context_precompute_service.py