### PR TITLE
fix(notifications): reschedule after timezone changes

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -475,11 +475,11 @@ def get_configured_event_bus() -> EventBus:
             uow=AsyncUnitOfWork(), cache_service=cache_service
         ),
     )
+    precompute_service = get_daily_context_precompute_service()
     event_bus.register_handler(
         UpdateTimezoneCommand,
-        UpdateTimezoneCommandHandler(),
+        UpdateTimezoneCommandHandler(precompute_service=precompute_service),
     )
-    precompute_service = get_daily_context_precompute_service()
     event_bus.register_handler(
         UpdateLanguageCommand,
         UpdateLanguageCommandHandler(precompute_service=precompute_service),
@@ -508,7 +508,8 @@ def get_configured_event_bus() -> EventBus:
 
     # Register notification handlers
     event_bus.register_handler(
-        RegisterFcmTokenCommand, RegisterFcmTokenCommandHandler()
+        RegisterFcmTokenCommand,
+        RegisterFcmTokenCommandHandler(precompute_service=precompute_service),
     )
     event_bus.register_handler(DeleteFcmTokenCommand, DeleteFcmTokenCommandHandler())
     event_bus.register_handler(

--- a/src/app/handlers/command_handlers/register_fcm_token_command_handler.py
+++ b/src/app/handlers/command_handlers/register_fcm_token_command_handler.py
@@ -3,29 +3,43 @@ Handler for registering FCM tokens.
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from src.app.commands.notification import RegisterFcmTokenCommand
 from src.app.events.base import EventHandler, handles
-from src.domain.model.notification import UserFcmToken, DeviceType
+from src.domain.model.notification import DeviceType, UserFcmToken
 from src.domain.ports.notification_repository_port import NotificationRepositoryPort
 from src.domain.utils.timezone_utils import is_valid_timezone, normalize_timezone
 from src.infra.database.uow_async import AsyncUnitOfWork
+from src.infra.services.daily_context_precompute_service import (
+    DailyContextPrecomputeService,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @handles(RegisterFcmTokenCommand)
 class RegisterFcmTokenCommandHandler(
-    EventHandler[RegisterFcmTokenCommand, Dict[str, Any]]
+    EventHandler[RegisterFcmTokenCommand, dict[str, Any]]
 ):
     """Handler for registering FCM tokens."""
 
-    def __init__(self, notification_repository: NotificationRepositoryPort = None):
+    def __init__(
+        self,
+        notification_repository: NotificationRepositoryPort = None,
+        precompute_service: DailyContextPrecomputeService | None = None,
+    ):
         self.notification_repository = notification_repository
+        self.precompute_service = precompute_service
 
-    async def handle(self, command: RegisterFcmTokenCommand) -> Dict[str, Any]:
+    def set_dependencies(self, **kwargs):
+        """Set dependencies for dependency injection."""
+        if "precompute_service" in kwargs:
+            self.precompute_service = kwargs["precompute_service"]
+
+    async def handle(self, command: RegisterFcmTokenCommand) -> dict[str, Any]:
         """Handle FCM token registration with old token cleanup."""
+        timezone_changed = False
         async with AsyncUnitOfWork() as uow:
             # Use notification repository from UoW if not injected
             notification_repo = self.notification_repository or uow.notifications
@@ -61,12 +75,40 @@ class RegisterFcmTokenCommandHandler(
             # 3. Update user timezone if provided
             if command.timezone and is_valid_timezone(command.timezone):
                 canonical_tz = normalize_timezone(command.timezone)
-                await uow.users.update_user_timezone(command.user_id, canonical_tz)
-                logger.info(
-                    f"Updated timezone for user {command.user_id}: {canonical_tz}"
+                current_tz = await uow.users.get_user_timezone(command.user_id)
+                if current_tz != canonical_tz:
+                    await uow.users.update_user_timezone(command.user_id, canonical_tz)
+                    timezone_changed = True
+                    logger.info(
+                        f"Updated timezone for user {command.user_id}: {canonical_tz}"
+                    )
+            elif command.timezone:
+                logger.warning(
+                    "Invalid timezone ignored during FCM registration: %r for user %s",
+                    command.timezone,
+                    command.user_id,
                 )
 
             # UoW auto-commits on exit
+
+        if timezone_changed and self.precompute_service:
+            try:
+                scheduled_count = (
+                    await self.precompute_service.reschedule_user_notifications(
+                        command.user_id
+                    )
+                )
+                logger.info(
+                    "Rescheduled %s notifications after FCM timezone update "
+                    "for user %s",
+                    scheduled_count,
+                    command.user_id,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to reschedule notifications after FCM timezone update: %s",
+                    exc,
+                )
 
         logger.info(
             f"FCM token registered for user {command.user_id}, "

--- a/src/app/handlers/command_handlers/update_timezone_command_handler.py
+++ b/src/app/handlers/command_handlers/update_timezone_command_handler.py
@@ -1,21 +1,32 @@
 """Handler for updating user timezone."""
 
 import logging
-from typing import Dict, Any
+from typing import Any
 
 from src.app.commands.user.update_timezone_command import UpdateTimezoneCommand
 from src.app.events.base import EventHandler, handles
 from src.domain.utils.timezone_utils import is_valid_timezone, normalize_timezone
 from src.infra.database.uow_async import AsyncUnitOfWork
+from src.infra.services.daily_context_precompute_service import (
+    DailyContextPrecomputeService,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @handles(UpdateTimezoneCommand)
-class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, Dict[str, Any]]):
+class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, dict[str, Any]]):
     """Handler for updating user timezone."""
 
-    async def handle(self, command: UpdateTimezoneCommand) -> Dict[str, Any]:
+    def __init__(self, precompute_service: DailyContextPrecomputeService | None = None):
+        self.precompute_service = precompute_service
+
+    def set_dependencies(self, **kwargs):
+        """Set dependencies for dependency injection."""
+        if "precompute_service" in kwargs:
+            self.precompute_service = kwargs["precompute_service"]
+
+    async def handle(self, command: UpdateTimezoneCommand) -> dict[str, Any]:
         """Handle timezone update command. Skips DB write if timezone is unchanged."""
         logger.info(
             f"Timezone update request: user={command.user_id}, "
@@ -36,7 +47,9 @@ class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, Dict[str,
 
         if current_tz == canonical_tz:
             logger.debug(
-                f"Timezone unchanged for user {command.user_id}: {canonical_tz!r} — skipping write"
+                "Timezone unchanged for user %s: %r - skipping write",
+                command.user_id,
+                canonical_tz,
             )
             return {"success": True, "timezone": canonical_tz}
 
@@ -46,4 +59,23 @@ class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, Dict[str,
             await uow.commit()
 
         logger.info(f"Updated timezone for user {command.user_id}: {canonical_tz}")
+
+        if self.precompute_service:
+            try:
+                scheduled_count = (
+                    await self.precompute_service.reschedule_user_notifications(
+                        str(command.user_id)
+                    )
+                )
+                logger.info(
+                    "Rescheduled %s notifications after timezone update for user %s",
+                    scheduled_count,
+                    command.user_id,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to reschedule notifications after timezone update: %s",
+                    exc,
+                )
+
         return {"success": True, "timezone": canonical_tz}

--- a/tests/unit/handlers/command_handlers/test_register_fcm_token_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_register_fcm_token_command_handler.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.app.commands.notification import RegisterFcmTokenCommand
+from src.app.handlers.command_handlers.register_fcm_token_command_handler import (
+    RegisterFcmTokenCommandHandler,
+)
+
+
+def _mock_uow(current_timezone="UTC"):
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    uow.users.get_user_timezone = AsyncMock(return_value=current_timezone)
+    uow.users.update_user_timezone = AsyncMock()
+    return uow
+
+
+def _mock_notification_repo():
+    repo = MagicMock()
+    repo.find_active_fcm_tokens_by_user = AsyncMock(return_value=[])
+    repo.save_fcm_token = AsyncMock(return_value=MagicMock(token_id="token-id"))
+    repo.deactivate_fcm_token = AsyncMock()
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_register_fcm_token_reschedules_when_timezone_changes():
+    user_id = str(uuid4())
+    precompute = AsyncMock()
+    repo = _mock_notification_repo()
+    uow = _mock_uow(current_timezone="UTC")
+    handler = RegisterFcmTokenCommandHandler(
+        notification_repository=repo,
+        precompute_service=precompute,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.register_fcm_token_command_handler.AsyncUnitOfWork",
+        return_value=uow,
+    ):
+        result = await handler.handle(
+            RegisterFcmTokenCommand(
+                user_id=user_id,
+                fcm_token="fcm-token-valid-123",
+                device_type="ios",
+                timezone="Asia/Ho_Chi_Minh",
+            )
+        )
+
+    assert result["success"] is True
+    uow.users.update_user_timezone.assert_awaited_once_with(user_id, "Asia/Ho_Chi_Minh")
+    precompute.reschedule_user_notifications.assert_awaited_once_with(user_id)
+
+
+@pytest.mark.asyncio
+async def test_register_fcm_token_skips_reschedule_when_timezone_unchanged():
+    user_id = str(uuid4())
+    precompute = AsyncMock()
+    repo = _mock_notification_repo()
+    uow = _mock_uow(current_timezone="Asia/Ho_Chi_Minh")
+    handler = RegisterFcmTokenCommandHandler(
+        notification_repository=repo,
+        precompute_service=precompute,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.register_fcm_token_command_handler.AsyncUnitOfWork",
+        return_value=uow,
+    ):
+        result = await handler.handle(
+            RegisterFcmTokenCommand(
+                user_id=user_id,
+                fcm_token="fcm-token-valid-123",
+                device_type="android",
+                timezone="Asia/Ho_Chi_Minh",
+            )
+        )
+
+    assert result["success"] is True
+    uow.users.update_user_timezone.assert_not_called()
+    precompute.reschedule_user_notifications.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_register_fcm_token_ignores_invalid_timezone_without_reschedule():
+    user_id = str(uuid4())
+    precompute = AsyncMock()
+    repo = _mock_notification_repo()
+    uow = _mock_uow(current_timezone="UTC")
+    handler = RegisterFcmTokenCommandHandler(
+        notification_repository=repo,
+        precompute_service=precompute,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.register_fcm_token_command_handler.AsyncUnitOfWork",
+        return_value=uow,
+    ):
+        result = await handler.handle(
+            RegisterFcmTokenCommand(
+                user_id=user_id,
+                fcm_token="fcm-token-valid-123",
+                device_type="ios",
+                timezone="Not/AZone",
+            )
+        )
+
+    assert result["success"] is True
+    uow.users.update_user_timezone.assert_not_called()
+    precompute.reschedule_user_notifications.assert_not_called()

--- a/tests/unit/handlers/command_handlers/test_update_timezone_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_update_timezone_command_handler.py
@@ -1,7 +1,8 @@
 """Unit tests: timezone update handler skips DB write when tz is unchanged."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from src.app.commands.user.update_timezone_command import UpdateTimezoneCommand
 from src.app.handlers.command_handlers.update_timezone_command_handler import (
@@ -12,7 +13,8 @@ from src.app.handlers.command_handlers.update_timezone_command_handler import (
 @pytest.mark.asyncio
 async def test_skips_db_write_when_timezone_unchanged():
     """If the stored timezone equals the incoming one, no DB write occurs."""
-    handler = UpdateTimezoneCommandHandler()
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
     command = UpdateTimezoneCommand(user_id="user-1", timezone="Asia/Ho_Chi_Minh")
 
     mock_uow = MagicMock()
@@ -31,13 +33,15 @@ async def test_skips_db_write_when_timezone_unchanged():
 
     assert result == {"success": True, "timezone": "Asia/Ho_Chi_Minh"}
     mock_uow.users.update_user_timezone.assert_not_called()
-    # commit() may be called by the read-path UoW's __exit__ — we only assert the write didn't happen
+    precompute.reschedule_user_notifications.assert_not_called()
+    # commit() may be called by the read UoW exit; only assert no write happened.
 
 
 @pytest.mark.asyncio
 async def test_writes_db_when_timezone_changed():
     """If the stored timezone differs, the update proceeds."""
-    handler = UpdateTimezoneCommandHandler()
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
     command = UpdateTimezoneCommand(user_id="user-1", timezone="America/New_York")
 
     mock_uow = MagicMock()
@@ -57,12 +61,14 @@ async def test_writes_db_when_timezone_changed():
     mock_uow.users.update_user_timezone.assert_called_once_with(
         "user-1", "America/New_York"
     )
+    precompute.reschedule_user_notifications.assert_awaited_once_with("user-1")
 
 
 @pytest.mark.asyncio
 async def test_writes_db_when_no_stored_timezone():
     """If no timezone is stored yet (None), the update proceeds."""
-    handler = UpdateTimezoneCommandHandler()
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
     command = UpdateTimezoneCommand(user_id="user-1", timezone="Asia/Ho_Chi_Minh")
 
     mock_uow = MagicMock()
@@ -82,3 +88,18 @@ async def test_writes_db_when_no_stored_timezone():
     mock_uow.users.update_user_timezone.assert_called_once_with(
         "user-1", "Asia/Ho_Chi_Minh"
     )
+    precompute.reschedule_user_notifications.assert_awaited_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_timezone_without_reschedule():
+    """Invalid timezone input should not write or reschedule."""
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
+
+    result = await handler.handle(
+        UpdateTimezoneCommand(user_id="user-1", timezone="Not/AZone")
+    )
+
+    assert result == {"success": False, "error": "Invalid timezone"}
+    precompute.reschedule_user_notifications.assert_not_called()


### PR DESCRIPTION
## Summary
- Reschedule pending daily notifications after a successful user timezone update.
- Apply the same reschedule path when FCM token registration updates timezone.
- Keep invalid or unchanged timezone paths from rescheduling unnecessarily.

## Verification
- pytest tests/unit/handlers/command_handlers/test_update_timezone_command_handler.py tests/unit/handlers/command_handlers/test_register_fcm_token_command_handler.py tests/unit/handlers/command_handlers/test_update_language_command_handler.py tests/unit/infra/test_scheduled_notification_service.py tests/unit/infra/test_notification_queries.py -q
- ruff check --select E,F changed backend files