### PR TITLE
fix(migrations): correct duplicate revision ID in 20260503113601 migr…

### DIFF
--- a/migrations/versions/20260503113601_fix_datetime_timezone_columns_batch.py
+++ b/migrations/versions/20260503113601_fix_datetime_timezone_columns_batch.py
@@ -11,7 +11,7 @@ Tables affected:
 - food_reference.created_at, updated_at
 - user_profiles.goal_started_at
 
-Revision ID: 059
+Revision ID: 20260503113601
 Revises: 058
 Create Date: 2026-05-03 11:36:01
 """
@@ -20,7 +20,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = '059'
+revision: str = '20260503113601'
 down_revision: Union[str, None] = '058'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/tests/unit/api/test_event_bus_dependency_singletons.py
+++ b/tests/unit/api/test_event_bus_dependency_singletons.py
@@ -26,7 +26,9 @@ def test_get_food_search_event_bus_is_singleton(monkeypatch):
     monkeypatch.setattr(deps, "get_fat_secret_service_instance", lambda: object())
     monkeypatch.setattr(deps, "get_food_reference_repository", lambda: object())
 
-    # Patch MealGenerationService + translation service referenced in function
+    # Patch MealGenerationService + translation service referenced in function.
+    # These are locally imported inside get_food_search_event_bus(), so we must
+    # patch the source module, not the event_bus module attribute.
     class _MealGen:
         pass
 
@@ -34,7 +36,8 @@ def test_get_food_search_event_bus_is_singleton(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr(mod, "MealGenerationService", _MealGen, raising=False)
+    import src.infra.adapters.meal_generation_service as _meal_gen_mod
+    monkeypatch.setattr(_meal_gen_mod, "MealGenerationService", _MealGen)
     monkeypatch.setattr(mod, "FoodSearchTranslationService", _Translator, raising=False)
 
     # Patch handlers to avoid constructing real ones


### PR DESCRIPTION
…ation

The file was accidentally stamped with revision='059' (matching 059_extend_referral_code_length.py), causing Alembic to error with "Revision 059 is present more than once" and "20260503113601 not present", breaking prod pre-deploy migrations.

Also fix test_get_food_search_event_bus_is_singleton to patch MealGenerationService at its source module (locally imported inside the function) rather than the event_bus module attribute, preventing the GOOGLE_API_KEY ValueError in unit tests.