### PR TITLE
fix(referral): expose REFERRAL_COMMISSIONS env var to mobile

### DIFF
--- a/src/api/routes/v1/codes.py
+++ b/src/api/routes/v1/codes.py
@@ -1,6 +1,6 @@
 """Unified code validation — accepts promo codes and referral codes via a single endpoint."""
 import logging
-from typing import Literal, Optional, Union
+from typing import Dict, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
@@ -37,6 +37,7 @@ class ReferralValidatedResponse(BaseModel):
     referrer_name: str
     discount_monthly: int
     discount_annual: int
+    commission_rewards: Dict[str, float] = Field(default_factory=dict)
 
 
 @router.post(

--- a/src/api/routes/v1/referrals.py
+++ b/src/api/routes/v1/referrals.py
@@ -48,6 +48,7 @@ class ValidateCodeResponse(BaseModel):
     referrer_name: Optional[str] = None
     discount_monthly: int = 199000
     discount_annual: int = 499000
+    commission_rewards: Dict[str, float] = Field(default_factory=dict)
 
 
 SUPPORTED_CURRENCIES = {"VND", "USD", "EUR"}
@@ -93,6 +94,7 @@ class StatsResponse(BaseModel):
     total_converted: int
     conversions: List[ConversionDTO]
     has_pending_payout: bool
+    commission_rewards: Dict[str, float] = Field(default_factory=dict)
 
 
 class PayoutRequest(BaseModel):
@@ -159,6 +161,7 @@ async def get_stats(user_id: str = Depends(get_current_user_id)):
         total_converted=result.total_converted,
         conversions=[ConversionDTO(**c.__dict__) for c in result.conversions],
         has_pending_payout=result.has_pending_payout,
+        commission_rewards=result.commission_rewards,
     )
 
 

--- a/src/app/handlers/query_handlers/codes/validate_code_handler.py
+++ b/src/app/handlers/query_handlers/codes/validate_code_handler.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 from src.app.queries.codes.validate_code_query import CodeValidationError, ValidateCodeQuery
 from src.domain.utils.timezone_utils import utc_now
+from src.infra.config.settings import settings
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.promo_code_repository import PromoCodeRepository
@@ -68,6 +69,7 @@ class ValidateCodeQueryHandler:
                     "referrer_name": referrer_name,
                     "discount_monthly": 199000,
                     "discount_annual": 499000,
+                    "commission_rewards": settings.REFERRAL_COMMISSIONS,
                 }
 
             raise CodeValidationError(404, "Code not found")

--- a/src/app/handlers/query_handlers/referral/get_referral_stats_handler.py
+++ b/src/app/handlers/query_handlers/referral/get_referral_stats_handler.py
@@ -9,6 +9,7 @@ from src.app.queries.referral.get_referral_stats_query import (
     ReferralConversionDTO,
     ReferralStatsResult,
 )
+from src.infra.config.settings import settings
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
@@ -55,6 +56,7 @@ class GetReferralStatsQueryHandler:
                 total_converted=total_converted,
                 conversions=conversion_dtos,
                 has_pending_payout=pending_payout is not None,
+                commission_rewards=settings.REFERRAL_COMMISSIONS,
             )
 
     async def _get_first_name(self, uow, user_id: str) -> str:

--- a/src/app/handlers/query_handlers/referral/validate_referral_code_handler.py
+++ b/src/app/handlers/query_handlers/referral/validate_referral_code_handler.py
@@ -7,6 +7,7 @@ from src.app.queries.referral.validate_referral_code_query import (
     ValidateCodeResult,
     ValidateReferralCodeQuery,
 )
+from src.infra.config.settings import settings
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
@@ -21,14 +22,26 @@ class ValidateReferralCodeQueryHandler:
 
             code = await repo.get_code_by_code(query.code)
             if not code:
-                return ValidateCodeResult(valid=False, error="invalid_code")
+                return ValidateCodeResult(
+                    valid=False,
+                    error="invalid_code",
+                    commission_rewards=settings.REFERRAL_COMMISSIONS,
+                )
 
             if code.user_id == query.user_id:
-                return ValidateCodeResult(valid=False, error="self_referral")
+                return ValidateCodeResult(
+                    valid=False,
+                    error="self_referral",
+                    commission_rewards=settings.REFERRAL_COMMISSIONS,
+                )
 
             existing = await repo.get_conversion_by_referred_user(query.user_id)
             if existing:
-                return ValidateCodeResult(valid=False, error="already_referred")
+                return ValidateCodeResult(
+                    valid=False,
+                    error="already_referred",
+                    commission_rewards=settings.REFERRAL_COMMISSIONS,
+                )
 
             # Fetch referrer's first name for personalised UI copy
             result = await uow.session.execute(
@@ -45,4 +58,5 @@ class ValidateReferralCodeQueryHandler:
                 referrer_name=referrer_name,
                 discount_monthly=199000,
                 discount_annual=499000,
+                commission_rewards=settings.REFERRAL_COMMISSIONS,
             )

--- a/src/app/queries/referral/get_referral_stats_query.py
+++ b/src/app/queries/referral/get_referral_stats_query.py
@@ -1,6 +1,6 @@
 """Query and result dataclasses for retrieving a user's full referral stats and wallet."""
 from dataclasses import dataclass, field
-from typing import List
+from typing import Dict, List
 
 
 @dataclass
@@ -26,3 +26,4 @@ class ReferralStatsResult:
     total_converted: int
     conversions: List[ReferralConversionDTO] = field(default_factory=list)
     has_pending_payout: bool = False
+    commission_rewards: Dict[str, float] = field(default_factory=dict)

--- a/src/app/queries/referral/validate_referral_code_query.py
+++ b/src/app/queries/referral/validate_referral_code_query.py
@@ -1,6 +1,6 @@
 """Query and result dataclass for validating a referral code before it is applied."""
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 
 @dataclass
@@ -16,3 +16,4 @@ class ValidateCodeResult:
     referrer_name: Optional[str] = None
     discount_monthly: int = 199000
     discount_annual: int = 499000
+    commission_rewards: Dict[str, float] = field(default_factory=dict)

--- a/tests/unit/handlers/test_validate_code_handler.py
+++ b/tests/unit/handlers/test_validate_code_handler.py
@@ -119,6 +119,9 @@ async def test_valid_referral_code_returns_referral_type():
     assert result["referrer_name"] == "Alex"
     assert result["discount_monthly"] == 199000
     assert result["discount_annual"] == 499000
+    # Mobile reads commission_rewards to render localized reward strings;
+    # an empty dict here silently falls back to mobile's hardcoded defaults.
+    assert result["commission_rewards"], "commission_rewards must be exposed for mobile"
 
 
 @pytest.mark.asyncio
@@ -266,3 +269,27 @@ async def test_referral_falls_back_to_friend_when_no_name():
         )
 
     assert result["referrer_name"] == "Friend"
+
+
+@pytest.mark.asyncio
+async def test_commission_rewards_match_runtime_settings():
+    """Commission rewards in the response must match the live settings instance.
+
+    Render redeploy -> settings re-load -> response reflects the new value.
+    """
+    referral = _make_referral_code(user_id="referrer-id")
+    row = MagicMock()
+    row.first_name = "Alex"
+    row.display_name = None
+    mock_uow, mock_promo_repo, mock_referral_repo = _mock_uow(referral=referral, referrer_row=row)
+
+    overridden = {"USD": 5, "VND": 100000, "EUR": 4.5, "default": 5}
+    with _patch(mock_uow, mock_promo_repo, mock_referral_repo), \
+         patch(f"{HANDLER_PATH}.settings") as mock_settings:
+        mock_settings.REFERRAL_COMMISSIONS = overridden
+        from src.app.handlers.query_handlers.codes.validate_code_handler import ValidateCodeQueryHandler
+        result = await ValidateCodeQueryHandler().handle(
+            ValidateCodeQuery(code="ALEX123", user_id="user-456")
+        )
+
+    assert result["commission_rewards"] == overridden


### PR DESCRIPTION
## Summary

- Mobile reads `commission_rewards` from `/v1/referrals/stats`, `/v1/referrals/validate`, and `/v1/codes/validate` to render localized reward strings, but backend never serialized `settings.REFERRAL_COMMISSIONS` — mobile silently fell back to hardcoded defaults in `referral_constants.dart`.
- Result: updating `REFERRAL_COMMISSIONS` on Render had no effect on the rendered UI.
- This PR wires the parsed dict through three endpoints: result dataclasses → handlers → Pydantic schemas → routes.

## Root cause

`settings.REFERRAL_COMMISSIONS` is correctly parsed via `@field_validator` in `src/infra/config/settings.py`, but no query handler ever reads it. Mobile's `@Default({}) Map<String, double> commissionRewards` in `referral_models.dart` makes the missing field invisible — it deserializes to `{}` and the UI falls back to `defaultCommissionRewards` in `referral_constants.dart`.

## Changes (additive JSON, backward-compatible)

- `ReferralStatsResult` and `ValidateCodeResult` dataclasses gain `commission_rewards: Dict[str, float]`
- `GetReferralStatsQueryHandler`, `ValidateReferralCodeQueryHandler`, `ValidateCodeQueryHandler` all populate from `settings.REFERRAL_COMMISSIONS` (all 4 return paths in the referral validator covered: invalid_code, self_referral, already_referred, valid)
- `StatsResponse`, `ValidateCodeResponse`, `ReferralValidatedResponse` Pydantic schemas expose the new field
- `/stats` route wires `commission_rewards=result.commission_rewards` explicitly
- 1 new test asserts runtime settings override is reflected in the response; existing valid-referral test gains a truthiness assertion on the field

## Test plan

- [x] `pytest tests/unit/handlers/test_validate_code_handler.py` — 12/12 pass (1 new test)
- [x] Full unit suite `pytest tests/unit/handlers/ tests/unit/api/` — 351 passed, 1 pre-existing failure unrelated (`GOOGLE_API_KEY` env var, exists on `main`)
- [x] Diff stat: 8 files, +58/-7 — no unintended scope expansion
- [ ] Verify in staging: change `REFERRAL_COMMISSIONS` env var, redeploy, confirm mobile UI updates without an app release

## Out of scope (noted by code review)

- `src/api/routes/v1/referrals.py:118` uses `**result.__dict__` spread — pre-existing pattern, not modified here. Worth a follow-up to align with the explicit constructor pattern used on `/stats`.
- No new tests for `validate_referral_code_handler.py` / `get_referral_stats_handler.py` (both handlers follow the same `settings.REFERRAL_COMMISSIONS` pattern proven by the new unified-validator test).