### PR TITLE
fix(webhooks): handle RevenueCat lifecycle events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,12 @@ REVENUECAT_SECRET_API_KEY=
 REVENUECAT_WEBHOOK_SECRET=
 
 # ---------------------------------------------------------------------------
+# PostHog (backend lifecycle analytics)
+# ---------------------------------------------------------------------------
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://app.posthog.com
+
+# ---------------------------------------------------------------------------
 # Email / SMTP configuration
 # ---------------------------------------------------------------------------
 SMTP_HOST=smtp.gmail.com

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -7,15 +7,14 @@ import hmac
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
-from fastapi import APIRouter, Request, HTTPException, Header
-
-from sqlalchemy import text
+from fastapi import APIRouter, Header, HTTPException, Request
+from sqlalchemy import select, text
 
 from src.domain.services.email_service import EmailService
 from src.domain.utils.timezone_utils import utc_now
+from src.infra.adapters.posthog_adapter import PostHogAdapter
 from src.infra.adapters.resend_email_adapter import ResendEmailAdapter
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
@@ -24,6 +23,24 @@ from src.infra.services.email_template_renderer import EmailTemplateRenderer
 
 router = APIRouter(prefix="/v1/webhooks", tags=["Webhooks"])
 logger = logging.getLogger(__name__)
+
+NON_RETRYABLE_USERLESS_EVENTS = {
+    "TRANSFER",
+    "CANCELLATION",
+    "EXPIRATION",
+    "BILLING_ISSUE",
+    "PRODUCT_CHANGE",
+    "REFUND",
+}
+
+POSTHOG_LIFECYCLE_EVENTS = {
+    "CANCELLATION": "subscription_cancelled",
+    "EXPIRATION": "subscription_expired",
+    "BILLING_ISSUE": "subscription_billing_issue",
+    "REFUND": "subscription_refunded",
+    "RENEWAL": "subscription_renewed",
+    "PRODUCT_CHANGE": "subscription_product_changed",
+}
 
 
 def _get_email_service() -> EmailService:
@@ -36,7 +53,7 @@ def _get_email_service() -> EmailService:
 @router.post("/revenuecat")
 async def revenuecat_webhook(
     request: Request,
-    authorization: Optional[str] = Header(None)
+    authorization: str | None = Header(None)
 ):
     """
     Handle RevenueCat webhook events.
@@ -54,73 +71,41 @@ async def revenuecat_webhook(
     if not hmac.compare_digest(authorization or "", webhook_secret):
         logger.warning("Invalid RevenueCat webhook authorization")
         raise HTTPException(status_code=401, detail="Unauthorized")
-    
+
     # Parse webhook payload
     try:
         payload = await request.json()
     except Exception as e:
         logger.error(f"Failed to parse webhook: {e}")
-        raise HTTPException(status_code=400, detail="Invalid JSON")
-    
+        raise HTTPException(status_code=400, detail="Invalid JSON") from e
+
     # Extract event data
     event = payload.get("event", {})
     event_type = event.get("type")
     app_user_id = event.get("app_user_id")
-    
+
     logger.error(f"RevenueCat webhook received: {event_type} for app_user_id={app_user_id}")
 
     # Get user
-    from sqlalchemy import select
-
     async with AsyncUnitOfWork() as uow:
-        # Try firebase_uid first (primary lookup path)
-        result = await uow.session.execute(
-            select(User).where(User.firebase_uid == app_user_id)
-        )
-        user = result.scalars().first()
+        if event_type == "TRANSFER":
+            await handle_transfer(uow, event)
+            return {"status": "success"}
 
-        # Fallback: try matching by internal user ID (UUID)
-        if not user:
-            result = await uow.session.execute(select(User).where(User.id == app_user_id))
-            user = result.scalars().first()
-
-        # Fallback: try aliases from event payload (RevenueCat may send anonymous ID)
-        if not user:
-            aliases = event.get("aliases", [])
-            for alias in aliases:
-                if alias != app_user_id:
-                    result = await uow.session.execute(
-                        select(User).where(User.firebase_uid == alias)
-                    )
-                    user = result.scalars().first()
-                    if not user:
-                        result = await uow.session.execute(select(User).where(User.id == alias))
-                        user = result.scalars().first()
-                    if user:
-                        break
-
-        # Fallback: lookup via existing Subscription record (handles anonymous ID renewals)
-        if not user:
-            subscription = await uow.subscriptions.find_by_revenuecat_id(app_user_id)
-            if subscription:
-                result = await uow.session.execute(
-                    select(User).where(User.id == subscription.user_id)
-                )
-                user = result.scalars().first()
-                if user:
-                    logger.info(
-                        f"RevenueCat webhook: found user via subscription record — "
-                        f"app_user_id={app_user_id}, user_id={user.id}"
-                    )
+        user = await find_user_for_revenuecat_event(uow, event)
 
         if not user:
             logger.error(
                 f"RevenueCat webhook: user not found — "
                 f"event_type={event_type}, app_user_id={app_user_id}, "
-                f"aliases={event.get('aliases', [])}, product_id={event.get('product_id')}"
+                f"aliases={event.get('aliases', [])}, "
+                f"original_app_user_id={event.get('original_app_user_id')}, "
+                f"product_id={event.get('product_id')}"
             )
+            if event_type in NON_RETRYABLE_USERLESS_EVENTS:
+                return {"status": "ignored", "reason": "user_not_found"}
             raise HTTPException(status_code=404, detail="User not found")
-        
+
         # Handle events — commit/rollback is owned by the AsyncUnitOfWork context manager
         if event_type == "INITIAL_PURCHASE":
             await handle_purchase(uow, user, event)
@@ -144,6 +129,98 @@ async def revenuecat_webhook(
             await handle_refund(uow, user, event)
 
     return {"status": "success"}
+
+
+def _candidate_revenuecat_ids(event: dict) -> list[str]:
+    """Return RevenueCat IDs worth trying for user/subscription lookup."""
+    candidates = [
+        event.get("app_user_id"),
+        event.get("original_app_user_id"),
+        *(event.get("aliases") or []),
+        *(event.get("transferred_to") or []),
+        *(event.get("transferred_from") or []),
+    ]
+    seen: set[str] = set()
+    return [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, str) and candidate and not (candidate in seen or seen.add(candidate))
+    ]
+
+
+async def find_user_for_revenuecat_event(uow, event: dict) -> User | None:
+    """Find a user from any RevenueCat identifier present in a webhook payload."""
+    for candidate in _candidate_revenuecat_ids(event):
+        result = await uow.session.execute(
+            select(User).where(User.firebase_uid == candidate)
+        )
+        user = result.scalars().first()
+        if user:
+            return user
+
+        result = await uow.session.execute(select(User).where(User.id == candidate))
+        user = result.scalars().first()
+        if user:
+            return user
+
+        subscription = await uow.subscriptions.find_by_revenuecat_id(candidate)
+        if subscription:
+            result = await uow.session.execute(
+                select(User).where(User.id == subscription.user_id)
+            )
+            user = result.scalars().first()
+            if user:
+                logger.info(
+                    "RevenueCat webhook: found user via subscription record — "
+                    "revenuecat_id=%s, user_id=%s",
+                    candidate,
+                    user.id,
+                )
+                return user
+    return None
+
+
+async def handle_transfer(uow, event):
+    """Handle RevenueCat subscriber transfers without failing on anonymous IDs."""
+    transferred_from = event.get("transferred_from") or []
+    transferred_to = event.get("transferred_to") or []
+    if not transferred_from or not transferred_to:
+        logger.info("RevenueCat transfer ignored: missing transfer IDs")
+        return
+
+    subscription = None
+    for source_id in transferred_from:
+        subscription = await uow.subscriptions.find_by_revenuecat_id(source_id)
+        if subscription:
+            break
+
+    if not subscription:
+        logger.info(
+            "RevenueCat transfer ignored: no local subscription matched transferred_from=%s",
+            transferred_from,
+        )
+        return
+
+    target_id = _preferred_transfer_target(transferred_to)
+    if not target_id:
+        logger.info("RevenueCat transfer ignored: no valid transferred_to ID")
+        return
+
+    subscription.revenuecat_subscriber_id = target_id
+    subscription.updated_at = utc_now()
+    logger.info(
+        "RevenueCat transfer updated subscription %s to subscriber_id=%s",
+        subscription.id,
+        target_id,
+    )
+
+
+def _preferred_transfer_target(transferred_to: list[str]) -> str | None:
+    """Prefer a custom app user ID over RevenueCat anonymous IDs."""
+    for candidate in transferred_to:
+        if isinstance(candidate, str) and candidate and not candidate.startswith("$RCAnonymousID:"):
+            return candidate
+    return next((item for item in transferred_to if isinstance(item, str) and item), None)
 
 
 async def handle_purchase(uow, user, event):
@@ -195,8 +272,10 @@ async def handle_renewal(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} renewed subscription until {subscription.expires_at}")
     else:
-        logger.warning(f"Subscription not found for renewal, creating new one")
+        logger.warning("Subscription not found for renewal, creating new one")
         await handle_purchase(uow, user, event)
+
+    await capture_subscription_lifecycle_event(user, event, "RENEWAL", subscription)
 
     # Purge any pending trial-expiry pushes so renewed users don't get a
     # "your trial ends tomorrow" push for a sub that just auto-renewed.
@@ -230,6 +309,8 @@ async def handle_cancellation(uow, user, event):
         # Note: User still has access until expires_at
         logger.info(f"User {user.id} cancelled subscription (expires {subscription.expires_at})")
 
+    await capture_subscription_lifecycle_event(user, event, "CANCELLATION", subscription)
+
     # Send cancellation email
     if not user.email_opt_out:
         try:
@@ -249,6 +330,8 @@ async def handle_expiration(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} subscription expired")
 
+    await capture_subscription_lifecycle_event(user, event, "EXPIRATION", subscription)
+
 
 async def handle_billing_issue(uow, user, event):
     """Handle billing issues."""
@@ -258,6 +341,8 @@ async def handle_billing_issue(uow, user, event):
         subscription.status = "billing_issue"
         subscription.updated_at = utc_now()
         logger.warning(f"Billing issue for user {user.id}")
+
+    await capture_subscription_lifecycle_event(user, event, "BILLING_ISSUE", subscription)
 
 
 async def handle_product_change(uow, user, event):
@@ -271,6 +356,8 @@ async def handle_product_change(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} changed to {subscription.product_id}")
 
+    await capture_subscription_lifecycle_event(user, event, "PRODUCT_CHANGE", subscription)
+
 
 async def handle_refund(uow, user, event):
     """Handle refund — update subscription status and revoke referral credit."""
@@ -280,7 +367,35 @@ async def handle_refund(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} subscription refunded")
 
+    await capture_subscription_lifecycle_event(user, event, "REFUND", subscription)
+
     await _revoke_referral_on_refund(uow, str(user.id))
+
+
+async def capture_subscription_lifecycle_event(user, event, event_type, subscription) -> None:
+    """Mirror RevenueCat lifecycle webhooks into PostHog when configured."""
+    posthog_event = POSTHOG_LIFECYCLE_EVENTS.get(event_type)
+    if not posthog_event:
+        return
+
+    properties = {
+        "revenuecat_event_type": event_type,
+        "product_id": event.get("product_id") or getattr(subscription, "product_id", None),
+        "platform": parse_platform(event.get("store")),
+        "store": event.get("store"),
+        "environment": event.get("environment"),
+        "subscription_status": getattr(subscription, "status", None),
+        "expiration_at_ms": event.get("expiration_at_ms"),
+        "purchased_at_ms": event.get("purchased_at_ms"),
+        "cancel_reason": event.get("cancel_reason"),
+        "period_type": event.get("period_type"),
+        "is_sandbox": event.get("environment") == "SANDBOX",
+    }
+    await PostHogAdapter().capture(
+        distinct_id=getattr(user, "firebase_uid", None) or str(user.id),
+        event=posthog_event,
+        properties={key: value for key, value in properties.items() if value is not None},
+    )
 
 
 async def _credit_referral_on_purchase(uow, user_id: str) -> None:
@@ -354,23 +469,23 @@ def parse_platform(store: str) -> str:
     """Parse store name to platform."""
     if not store:
         return "ios"
-    
+
     store_upper = store.upper()
     store_map = {
         "APP_STORE": "ios",
-        "PLAY_STORE": "android", 
+        "PLAY_STORE": "android",
         "STRIPE": "web",
         "MAC_APP_STORE": "ios",
     }
     return store_map.get(store_upper, "ios")
 
 
-def parse_timestamp(ms: Optional[int]) -> Optional[datetime]:
+def parse_timestamp(ms: int | None) -> datetime | None:
     """Parse millisecond timestamp to datetime."""
     if ms is None:
         return None
     try:
-        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(ms / 1000, tz=UTC)
     except Exception as e:
         logger.error(f"Error parsing timestamp {ms}: {e}")
         return None

--- a/src/infra/adapters/posthog_adapter.py
+++ b/src/infra/adapters/posthog_adapter.py
@@ -1,0 +1,45 @@
+"""Small PostHog capture adapter for backend lifecycle events."""
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class PostHogAdapter:
+    """Fire-and-forget PostHog event capture using environment configuration."""
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("POSTHOG_API_KEY", "")
+        self.host = os.getenv("POSTHOG_HOST", "https://app.posthog.com").rstrip("/")
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.api_key)
+
+    async def capture(
+        self,
+        *,
+        distinct_id: str,
+        event: str,
+        properties: dict[str, Any],
+    ) -> None:
+        """Capture an event without blocking the caller on analytics failures."""
+        if not self.enabled:
+            return
+
+        payload = {
+            "api_key": self.api_key,
+            "event": event,
+            "distinct_id": distinct_id,
+            "properties": properties,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                response = await client.post(f"{self.host}/capture/", json=payload)
+                response.raise_for_status()
+        except Exception:
+            logger.warning("PostHog capture failed for %s", event, exc_info=True)

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -8,20 +8,21 @@ import pytest
 from fastapi import HTTPException
 
 from src.api.routes.v1.webhooks import (
-    revenuecat_webhook,
-    parse_platform,
-    parse_timestamp,
-    handle_purchase,
-    handle_renewal,
+    handle_billing_issue,
     handle_cancellation,
     handle_expiration,
-    handle_billing_issue
+    handle_purchase,
+    handle_renewal,
+    handle_transfer,
+    parse_platform,
+    parse_timestamp,
+    revenuecat_webhook,
 )
 
 
 class TestWebhookHelpers:
     """Test webhook helper functions."""
-    
+
     def test_parse_platform(self):
         """Test platform parsing from store name."""
         assert parse_platform("APP_STORE") == "ios"
@@ -31,7 +32,7 @@ class TestWebhookHelpers:
         assert parse_platform(None) == "ios"
         assert parse_platform("") == "ios"
         assert parse_platform("UNKNOWN") == "ios"
-    
+
     def test_parse_timestamp(self):
         """Test timestamp parsing from milliseconds."""
         # Valid timestamp
@@ -39,15 +40,15 @@ class TestWebhookHelpers:
         result = parse_timestamp(ms)
         assert isinstance(result, datetime)
         assert result.year == 2023
-        
+
         # None timestamp
         assert parse_timestamp(None) is None
-        
+
         # Zero timestamp
         assert parse_timestamp(0) is not None
-        
+
         # Invalid timestamp
-        with patch('src.api.routes.v1.webhooks.logger') as mock_logger:
+        with patch("src.api.routes.v1.webhooks.logger"):
             result = parse_timestamp("invalid")
             assert result is None
 
@@ -55,14 +56,14 @@ class TestWebhookHelpers:
 @pytest.mark.asyncio
 class TestWebhookHandler:
     """Test webhook handler functions."""
-    
+
     @pytest.fixture
     def mock_request(self):
         """Create mock request object."""
         request = MagicMock()
         request.json = AsyncMock()
         return request
-    
+
     @pytest.fixture
     def mock_uow(self):
         """Create mock Unit of Work."""
@@ -72,7 +73,7 @@ class TestWebhookHandler:
         uow.commit = AsyncMock()
         uow.rollback = AsyncMock()
         return uow
-    
+
     @pytest.fixture
     def webhook_event(self):
         """Create sample webhook event."""
@@ -88,7 +89,7 @@ class TestWebhookHandler:
                 "transaction_id": "1000000123456789"
             }
         }
-    
+
     async def test_webhook_success(self, mock_request, webhook_event):
         """Test successful webhook processing."""
         mock_request.json.return_value = webhook_event
@@ -102,22 +103,22 @@ class TestWebhookHandler:
                 mock_uow.commit = AsyncMock()
                 mock_uow.rollback = AsyncMock()
                 mock_uow_class.return_value = mock_uow
-                
+
                 # Mock user exists
                 mock_user = MagicMock(id="user_123")
                 mock_uow.session.execute = AsyncMock()
                 mock_result = MagicMock()
                 mock_result.scalars.return_value.first.return_value = mock_user
                 mock_uow.session.execute.return_value = mock_result
-                
+
                 # Mock no existing subscription (async)
                 with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=None):
                     result = await revenuecat_webhook(mock_request, authorization="test_secret")
-                
+
                 assert result == {"status": "success"}
                 # commit/rollback are owned by the AsyncUnitOfWork context manager, not called explicitly
                 mock_uow.commit.assert_not_awaited()
-    
+
     async def test_webhook_user_not_found(self, mock_request, webhook_event):
         """Test webhook returns 404 when user not found (so RevenueCat retries)."""
         mock_request.json.return_value = webhook_event
@@ -150,7 +151,57 @@ class TestWebhookHandler:
                     await revenuecat_webhook(mock_request, authorization="test_secret")
 
                 assert exc_info.value.status_code == 404
-    
+
+    async def test_webhook_lifecycle_user_not_found_is_ignored(self, mock_request):
+        """Test userless lifecycle events ACK to stop RevenueCat retry storms."""
+        mock_request.json.return_value = {
+            "event": {
+                "type": "BILLING_ISSUE",
+                "app_user_id": "$RCAnonymousID:missing",
+                "product_id": "nutree_2999_1y_0",
+            }
+        }
+
+        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
+            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+                mock_uow = MagicMock()
+                mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+                mock_uow.__aexit__ = AsyncMock(return_value=False)
+                mock_uow.subscriptions = MagicMock()
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow.session.execute = AsyncMock()
+                mock_result = MagicMock()
+                mock_result.scalars.return_value.first.return_value = None
+                mock_uow.session.execute.return_value = mock_result
+                mock_uow_class.return_value = mock_uow
+
+                result = await revenuecat_webhook(mock_request, authorization="test_secret")
+
+                assert result == {"status": "ignored", "reason": "user_not_found"}
+
+    async def test_webhook_transfer_without_user_acknowledged(self, mock_request):
+        """Test RevenueCat TRANSFER webhooks do not require app_user_id lookup."""
+        mock_request.json.return_value = {
+            "event": {
+                "type": "TRANSFER",
+                "transferred_from": ["$RCAnonymousID:old"],
+                "transferred_to": ["$RCAnonymousID:new"],
+            }
+        }
+
+        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
+            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+                mock_uow = MagicMock()
+                mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+                mock_uow.__aexit__ = AsyncMock(return_value=False)
+                mock_uow.subscriptions = MagicMock()
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow_class.return_value = mock_uow
+
+                result = await revenuecat_webhook(mock_request, authorization="test_secret")
+
+                assert result == {"status": "success"}
+
     async def test_webhook_invalid_json(self, mock_request):
         """Test webhook with invalid JSON."""
         mock_request.json.side_effect = Exception("Invalid JSON")
@@ -162,21 +213,21 @@ class TestWebhookHandler:
 
             assert exc_info.value.status_code == 400
             assert exc_info.value.detail == "Invalid JSON"
-    
+
     async def test_webhook_authorization_check(self, mock_request, webhook_event):
         """Test webhook authorization check."""
         mock_request.json.return_value = webhook_event
-        
+
         with patch('src.api.routes.v1.webhooks.os.getenv') as mock_getenv:
             mock_getenv.return_value = "secret_token"
-            
+
             # Test with wrong authorization
             with pytest.raises(HTTPException) as exc_info:
                 await revenuecat_webhook(mock_request, authorization="wrong_token")
-            
+
             assert exc_info.value.status_code == 401
             assert exc_info.value.detail == "Unauthorized"
-    
+
     async def test_handle_purchase(self, mock_uow):
         """Test handling initial purchase event."""
         user = MagicMock(id="user_123")
@@ -201,7 +252,7 @@ class TestWebhookHandler:
         assert added_subscription.user_id == "user_123"
         assert added_subscription.product_id == "premium_monthly"
         assert added_subscription.status == "active"
-    
+
     async def test_handle_renewal(self, mock_uow):
         """Test handling renewal event."""
         user = MagicMock(id="user_123")
@@ -217,7 +268,7 @@ class TestWebhookHandler:
 
         assert subscription.status == "active"
         assert subscription.expires_at is not None
-    
+
     async def test_handle_cancellation(self, mock_uow):
         """Test handling cancellation event."""
         user = MagicMock(id="user_123")
@@ -230,7 +281,7 @@ class TestWebhookHandler:
 
         assert subscription.status == "cancelled"
         assert subscription.cancelled_at is not None
-    
+
     async def test_handle_expiration(self, mock_uow):
         """Test handling expiration event."""
         user = MagicMock(id="user_123")
@@ -242,7 +293,7 @@ class TestWebhookHandler:
             await handle_expiration(mock_uow, user, event)
 
         assert subscription.status == "expired"
-    
+
     async def test_handle_billing_issue(self, mock_uow):
         """Test handling billing issue event."""
         user = MagicMock(id="user_123")
@@ -254,3 +305,18 @@ class TestWebhookHandler:
             await handle_billing_issue(mock_uow, user, event)
 
         assert subscription.status == "billing_issue"
+
+    async def test_handle_transfer_updates_known_subscription(self, mock_uow):
+        """Test transfer remaps existing subscription to the canonical subscriber ID."""
+        subscription = MagicMock()
+        event = {
+            "transferred_from": ["$RCAnonymousID:old"],
+            "transferred_to": ["firebase_uid_123", "$RCAnonymousID:new"],
+        }
+        mock_uow.subscriptions = MagicMock()
+        mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=subscription)
+
+        await handle_transfer(mock_uow, event)
+
+        assert subscription.revenuecat_subscriber_id == "firebase_uid_123"
+        assert subscription.updated_at is not None


### PR DESCRIPTION
## Summary
- acknowledge userless RevenueCat lifecycle events to stop retry storms
- handle TRANSFER events before user lookup and remap known subscriptions
- resolve users from app user ID, original app user ID, aliases, transfer IDs, and existing subscription records
- mirror cancellation, expiration, billing issue, refund, renewal, and product change lifecycle events to PostHog when configured

## Verification
- ruff check src/api/routes/v1/webhooks.py src/infra/adapters/posthog_adapter.py tests/unit/api/test_webhook_handler.py
- pytest tests/unit/api/test_webhook_handler.py
- python -m compileall src/api/routes/v1/webhooks.py src/infra/adapters/posthog_adapter.py