### PR TITLE
Sync selected main commits to delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,12 @@ REVENUECAT_SECRET_API_KEY=
 REVENUECAT_WEBHOOK_SECRET=
 
 # ---------------------------------------------------------------------------
+# PostHog (backend lifecycle analytics)
+# ---------------------------------------------------------------------------
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://app.posthog.com
+
+# ---------------------------------------------------------------------------
 # Email / SMTP configuration
 # ---------------------------------------------------------------------------
 SMTP_HOST=smtp.gmail.com

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,7 +1,7 @@
 # Backend Codebase Summary
 
-**Generated:** May 15, 2026  
-**Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)  
+**Generated:** May 15, 2026
+**Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)
 **Language:** Python 3.11+ | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
 
 ---

--- a/docs/specs/2026-05-09-email-triggers-design.md
+++ b/docs/specs/2026-05-09-email-triggers-design.md
@@ -1,7 +1,7 @@
 # Email Triggers System Design
 
-**Date:** 2026-05-09  
-**Status:** Approved  
+**Date:** 2026-05-09
+**Status:** Approved
 **App:** Nutree
 
 ## Problem Statement
@@ -64,7 +64,7 @@ email_opt_out = Column(Boolean, default=False, nullable=False)
 ```python
 class EmailLog(Base):
     __tablename__ = "email_logs"
-    
+
     id = Column(String(36), primary_key=True)
     user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
     email_type = Column(String(50), nullable=False)  # welcome, reengagement_day3, trial_expiring, cancelled
@@ -76,8 +76,8 @@ class EmailLog(Base):
 ### Index for Scheduled Job
 
 ```sql
-CREATE INDEX idx_users_last_accessed_active 
-ON users(last_accessed) 
+CREATE INDEX idx_users_last_accessed_active
+ON users(last_accessed)
 WHERE is_active = true AND email_opt_out = false;
 ```
 
@@ -91,9 +91,9 @@ WHERE is_active = true AND email_opt_out = false;
 class EmailServicePort(ABC):
     @abstractmethod
     async def send_email(
-        self, 
-        to: str, 
-        subject: str, 
+        self,
+        to: str,
+        subject: str,
         html_body: str,
         tags: list[str] | None = None
     ) -> EmailResult:

--- a/docs/specs/2026-05-09-email-triggers-plan.md
+++ b/docs/specs/2026-05-09-email-triggers-plan.md
@@ -602,7 +602,7 @@ Create `src/infra/templates/emails/trial_cancelled.html`:
 </div>
 
 <p style="color: #666;">
-  <strong>Need a break instead?</strong> You can pause your subscription for 30 days instead of cancelling. 
+  <strong>Need a break instead?</strong> You can pause your subscription for 30 days instead of cancelling.
   <a href="{{ pause_url }}" style="color: #22c55e;">Pause instead</a>
 </p>
 
@@ -1608,7 +1608,7 @@ In the lifespan function, after `scheduled_notification_service.start()`, add:
     email_renderer = EmailTemplateRenderer()
     email_service = EmailService(email_adapter=email_adapter, template_renderer=email_renderer)
     scheduled_email_service = ScheduledEmailService(email_service=email_service)
-    
+
     # Run email check daily (integrate with existing scheduler or run on startup)
     # For now, run on startup and rely on cron/external scheduler for daily runs
     try:

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -475,11 +475,11 @@ def get_configured_event_bus() -> EventBus:
             uow=AsyncUnitOfWork(), cache_service=cache_service
         ),
     )
+    precompute_service = get_daily_context_precompute_service()
     event_bus.register_handler(
         UpdateTimezoneCommand,
-        UpdateTimezoneCommandHandler(),
+        UpdateTimezoneCommandHandler(precompute_service=precompute_service),
     )
-    precompute_service = get_daily_context_precompute_service()
     event_bus.register_handler(
         UpdateLanguageCommand,
         UpdateLanguageCommandHandler(precompute_service=precompute_service),
@@ -508,7 +508,8 @@ def get_configured_event_bus() -> EventBus:
 
     # Register notification handlers
     event_bus.register_handler(
-        RegisterFcmTokenCommand, RegisterFcmTokenCommandHandler()
+        RegisterFcmTokenCommand,
+        RegisterFcmTokenCommandHandler(precompute_service=precompute_service),
     )
     event_bus.register_handler(DeleteFcmTokenCommand, DeleteFcmTokenCommandHandler())
     event_bus.register_handler(

--- a/src/api/routes/v1/codes.py
+++ b/src/api/routes/v1/codes.py
@@ -1,6 +1,6 @@
 """Unified code validation — accepts promo codes and referral codes via a single endpoint."""
 import logging
-from typing import Literal, Optional, Union
+from typing import Dict, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
@@ -37,6 +37,7 @@ class ReferralValidatedResponse(BaseModel):
     referrer_name: str
     discount_monthly: int
     discount_annual: int
+    commission_rewards: Dict[str, float] = Field(default_factory=dict)
 
 
 @router.post(

--- a/src/api/routes/v1/referrals.py
+++ b/src/api/routes/v1/referrals.py
@@ -48,6 +48,7 @@ class ValidateCodeResponse(BaseModel):
     referrer_name: Optional[str] = None
     discount_monthly: int = 199000
     discount_annual: int = 499000
+    commission_rewards: Dict[str, float] = Field(default_factory=dict)
 
 
 SUPPORTED_CURRENCIES = {"VND", "USD", "EUR"}
@@ -93,6 +94,7 @@ class StatsResponse(BaseModel):
     total_converted: int
     conversions: List[ConversionDTO]
     has_pending_payout: bool
+    commission_rewards: Dict[str, float] = Field(default_factory=dict)
 
 
 class PayoutRequest(BaseModel):
@@ -159,6 +161,7 @@ async def get_stats(user_id: str = Depends(get_current_user_id)):
         total_converted=result.total_converted,
         conversions=[ConversionDTO(**c.__dict__) for c in result.conversions],
         has_pending_payout=result.has_pending_payout,
+        commission_rewards=result.commission_rewards,
     )
 
 

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -7,15 +7,14 @@ import hmac
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
-from fastapi import APIRouter, Request, HTTPException, Header
-
-from sqlalchemy import text
+from fastapi import APIRouter, Header, HTTPException, Request
+from sqlalchemy import select, text
 
 from src.domain.services.email_service import EmailService
 from src.domain.utils.timezone_utils import utc_now
+from src.infra.adapters.posthog_adapter import PostHogAdapter
 from src.infra.adapters.resend_email_adapter import ResendEmailAdapter
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
@@ -24,6 +23,24 @@ from src.infra.services.email_template_renderer import EmailTemplateRenderer
 
 router = APIRouter(prefix="/v1/webhooks", tags=["Webhooks"])
 logger = logging.getLogger(__name__)
+
+NON_RETRYABLE_USERLESS_EVENTS = {
+    "TRANSFER",
+    "CANCELLATION",
+    "EXPIRATION",
+    "BILLING_ISSUE",
+    "PRODUCT_CHANGE",
+    "REFUND",
+}
+
+POSTHOG_LIFECYCLE_EVENTS = {
+    "CANCELLATION": "subscription_cancelled",
+    "EXPIRATION": "subscription_expired",
+    "BILLING_ISSUE": "subscription_billing_issue",
+    "REFUND": "subscription_refunded",
+    "RENEWAL": "subscription_renewed",
+    "PRODUCT_CHANGE": "subscription_product_changed",
+}
 
 
 def _get_email_service() -> EmailService:
@@ -36,7 +53,7 @@ def _get_email_service() -> EmailService:
 @router.post("/revenuecat")
 async def revenuecat_webhook(
     request: Request,
-    authorization: Optional[str] = Header(None)
+    authorization: str | None = Header(None)
 ):
     """
     Handle RevenueCat webhook events.
@@ -54,73 +71,41 @@ async def revenuecat_webhook(
     if not hmac.compare_digest(authorization or "", webhook_secret):
         logger.warning("Invalid RevenueCat webhook authorization")
         raise HTTPException(status_code=401, detail="Unauthorized")
-    
+
     # Parse webhook payload
     try:
         payload = await request.json()
     except Exception as e:
         logger.error(f"Failed to parse webhook: {e}")
-        raise HTTPException(status_code=400, detail="Invalid JSON")
-    
+        raise HTTPException(status_code=400, detail="Invalid JSON") from e
+
     # Extract event data
     event = payload.get("event", {})
     event_type = event.get("type")
     app_user_id = event.get("app_user_id")
-    
+
     logger.error(f"RevenueCat webhook received: {event_type} for app_user_id={app_user_id}")
 
     # Get user
-    from sqlalchemy import select
-
     async with AsyncUnitOfWork() as uow:
-        # Try firebase_uid first (primary lookup path)
-        result = await uow.session.execute(
-            select(User).where(User.firebase_uid == app_user_id)
-        )
-        user = result.scalars().first()
+        if event_type == "TRANSFER":
+            await handle_transfer(uow, event)
+            return {"status": "success"}
 
-        # Fallback: try matching by internal user ID (UUID)
-        if not user:
-            result = await uow.session.execute(select(User).where(User.id == app_user_id))
-            user = result.scalars().first()
-
-        # Fallback: try aliases from event payload (RevenueCat may send anonymous ID)
-        if not user:
-            aliases = event.get("aliases", [])
-            for alias in aliases:
-                if alias != app_user_id:
-                    result = await uow.session.execute(
-                        select(User).where(User.firebase_uid == alias)
-                    )
-                    user = result.scalars().first()
-                    if not user:
-                        result = await uow.session.execute(select(User).where(User.id == alias))
-                        user = result.scalars().first()
-                    if user:
-                        break
-
-        # Fallback: lookup via existing Subscription record (handles anonymous ID renewals)
-        if not user:
-            subscription = await uow.subscriptions.find_by_revenuecat_id(app_user_id)
-            if subscription:
-                result = await uow.session.execute(
-                    select(User).where(User.id == subscription.user_id)
-                )
-                user = result.scalars().first()
-                if user:
-                    logger.info(
-                        f"RevenueCat webhook: found user via subscription record — "
-                        f"app_user_id={app_user_id}, user_id={user.id}"
-                    )
+        user = await find_user_for_revenuecat_event(uow, event)
 
         if not user:
             logger.error(
                 f"RevenueCat webhook: user not found — "
                 f"event_type={event_type}, app_user_id={app_user_id}, "
-                f"aliases={event.get('aliases', [])}, product_id={event.get('product_id')}"
+                f"aliases={event.get('aliases', [])}, "
+                f"original_app_user_id={event.get('original_app_user_id')}, "
+                f"product_id={event.get('product_id')}"
             )
+            if event_type in NON_RETRYABLE_USERLESS_EVENTS:
+                return {"status": "ignored", "reason": "user_not_found"}
             raise HTTPException(status_code=404, detail="User not found")
-        
+
         # Handle events — commit/rollback is owned by the AsyncUnitOfWork context manager
         if event_type == "INITIAL_PURCHASE":
             await handle_purchase(uow, user, event)
@@ -144,6 +129,98 @@ async def revenuecat_webhook(
             await handle_refund(uow, user, event)
 
     return {"status": "success"}
+
+
+def _candidate_revenuecat_ids(event: dict) -> list[str]:
+    """Return RevenueCat IDs worth trying for user/subscription lookup."""
+    candidates = [
+        event.get("app_user_id"),
+        event.get("original_app_user_id"),
+        *(event.get("aliases") or []),
+        *(event.get("transferred_to") or []),
+        *(event.get("transferred_from") or []),
+    ]
+    seen: set[str] = set()
+    return [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, str) and candidate and not (candidate in seen or seen.add(candidate))
+    ]
+
+
+async def find_user_for_revenuecat_event(uow, event: dict) -> User | None:
+    """Find a user from any RevenueCat identifier present in a webhook payload."""
+    for candidate in _candidate_revenuecat_ids(event):
+        result = await uow.session.execute(
+            select(User).where(User.firebase_uid == candidate)
+        )
+        user = result.scalars().first()
+        if user:
+            return user
+
+        result = await uow.session.execute(select(User).where(User.id == candidate))
+        user = result.scalars().first()
+        if user:
+            return user
+
+        subscription = await uow.subscriptions.find_by_revenuecat_id(candidate)
+        if subscription:
+            result = await uow.session.execute(
+                select(User).where(User.id == subscription.user_id)
+            )
+            user = result.scalars().first()
+            if user:
+                logger.info(
+                    "RevenueCat webhook: found user via subscription record — "
+                    "revenuecat_id=%s, user_id=%s",
+                    candidate,
+                    user.id,
+                )
+                return user
+    return None
+
+
+async def handle_transfer(uow, event):
+    """Handle RevenueCat subscriber transfers without failing on anonymous IDs."""
+    transferred_from = event.get("transferred_from") or []
+    transferred_to = event.get("transferred_to") or []
+    if not transferred_from or not transferred_to:
+        logger.info("RevenueCat transfer ignored: missing transfer IDs")
+        return
+
+    subscription = None
+    for source_id in transferred_from:
+        subscription = await uow.subscriptions.find_by_revenuecat_id(source_id)
+        if subscription:
+            break
+
+    if not subscription:
+        logger.info(
+            "RevenueCat transfer ignored: no local subscription matched transferred_from=%s",
+            transferred_from,
+        )
+        return
+
+    target_id = _preferred_transfer_target(transferred_to)
+    if not target_id:
+        logger.info("RevenueCat transfer ignored: no valid transferred_to ID")
+        return
+
+    subscription.revenuecat_subscriber_id = target_id
+    subscription.updated_at = utc_now()
+    logger.info(
+        "RevenueCat transfer updated subscription %s to subscriber_id=%s",
+        subscription.id,
+        target_id,
+    )
+
+
+def _preferred_transfer_target(transferred_to: list[str]) -> str | None:
+    """Prefer a custom app user ID over RevenueCat anonymous IDs."""
+    for candidate in transferred_to:
+        if isinstance(candidate, str) and candidate and not candidate.startswith("$RCAnonymousID:"):
+            return candidate
+    return next((item for item in transferred_to if isinstance(item, str) and item), None)
 
 
 async def handle_purchase(uow, user, event):
@@ -195,8 +272,10 @@ async def handle_renewal(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} renewed subscription until {subscription.expires_at}")
     else:
-        logger.warning(f"Subscription not found for renewal, creating new one")
+        logger.warning("Subscription not found for renewal, creating new one")
         await handle_purchase(uow, user, event)
+
+    await capture_subscription_lifecycle_event(user, event, "RENEWAL", subscription)
 
     # Purge any pending trial-expiry pushes so renewed users don't get a
     # "your trial ends tomorrow" push for a sub that just auto-renewed.
@@ -230,6 +309,8 @@ async def handle_cancellation(uow, user, event):
         # Note: User still has access until expires_at
         logger.info(f"User {user.id} cancelled subscription (expires {subscription.expires_at})")
 
+    await capture_subscription_lifecycle_event(user, event, "CANCELLATION", subscription)
+
     # Send cancellation email
     if not user.email_opt_out:
         try:
@@ -249,6 +330,8 @@ async def handle_expiration(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} subscription expired")
 
+    await capture_subscription_lifecycle_event(user, event, "EXPIRATION", subscription)
+
 
 async def handle_billing_issue(uow, user, event):
     """Handle billing issues."""
@@ -258,6 +341,8 @@ async def handle_billing_issue(uow, user, event):
         subscription.status = "billing_issue"
         subscription.updated_at = utc_now()
         logger.warning(f"Billing issue for user {user.id}")
+
+    await capture_subscription_lifecycle_event(user, event, "BILLING_ISSUE", subscription)
 
 
 async def handle_product_change(uow, user, event):
@@ -271,6 +356,8 @@ async def handle_product_change(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} changed to {subscription.product_id}")
 
+    await capture_subscription_lifecycle_event(user, event, "PRODUCT_CHANGE", subscription)
+
 
 async def handle_refund(uow, user, event):
     """Handle refund — update subscription status and revoke referral credit."""
@@ -280,7 +367,35 @@ async def handle_refund(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} subscription refunded")
 
+    await capture_subscription_lifecycle_event(user, event, "REFUND", subscription)
+
     await _revoke_referral_on_refund(uow, str(user.id))
+
+
+async def capture_subscription_lifecycle_event(user, event, event_type, subscription) -> None:
+    """Mirror RevenueCat lifecycle webhooks into PostHog when configured."""
+    posthog_event = POSTHOG_LIFECYCLE_EVENTS.get(event_type)
+    if not posthog_event:
+        return
+
+    properties = {
+        "revenuecat_event_type": event_type,
+        "product_id": event.get("product_id") or getattr(subscription, "product_id", None),
+        "platform": parse_platform(event.get("store")),
+        "store": event.get("store"),
+        "environment": event.get("environment"),
+        "subscription_status": getattr(subscription, "status", None),
+        "expiration_at_ms": event.get("expiration_at_ms"),
+        "purchased_at_ms": event.get("purchased_at_ms"),
+        "cancel_reason": event.get("cancel_reason"),
+        "period_type": event.get("period_type"),
+        "is_sandbox": event.get("environment") == "SANDBOX",
+    }
+    await PostHogAdapter().capture(
+        distinct_id=getattr(user, "firebase_uid", None) or str(user.id),
+        event=posthog_event,
+        properties={key: value for key, value in properties.items() if value is not None},
+    )
 
 
 async def _credit_referral_on_purchase(uow, user_id: str) -> None:
@@ -354,23 +469,23 @@ def parse_platform(store: str) -> str:
     """Parse store name to platform."""
     if not store:
         return "ios"
-    
+
     store_upper = store.upper()
     store_map = {
         "APP_STORE": "ios",
-        "PLAY_STORE": "android", 
+        "PLAY_STORE": "android",
         "STRIPE": "web",
         "MAC_APP_STORE": "ios",
     }
     return store_map.get(store_upper, "ios")
 
 
-def parse_timestamp(ms: Optional[int]) -> Optional[datetime]:
+def parse_timestamp(ms: int | None) -> datetime | None:
     """Parse millisecond timestamp to datetime."""
     if ms is None:
         return None
     try:
-        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(ms / 1000, tz=UTC)
     except Exception as e:
         logger.error(f"Error parsing timestamp {ms}: {e}")
         return None

--- a/src/app/handlers/command_handlers/register_fcm_token_command_handler.py
+++ b/src/app/handlers/command_handlers/register_fcm_token_command_handler.py
@@ -3,29 +3,43 @@ Handler for registering FCM tokens.
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from src.app.commands.notification import RegisterFcmTokenCommand
 from src.app.events.base import EventHandler, handles
-from src.domain.model.notification import UserFcmToken, DeviceType
+from src.domain.model.notification import DeviceType, UserFcmToken
 from src.domain.ports.notification_repository_port import NotificationRepositoryPort
 from src.domain.utils.timezone_utils import is_valid_timezone, normalize_timezone
 from src.infra.database.uow_async import AsyncUnitOfWork
+from src.infra.services.daily_context_precompute_service import (
+    DailyContextPrecomputeService,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @handles(RegisterFcmTokenCommand)
 class RegisterFcmTokenCommandHandler(
-    EventHandler[RegisterFcmTokenCommand, Dict[str, Any]]
+    EventHandler[RegisterFcmTokenCommand, dict[str, Any]]
 ):
     """Handler for registering FCM tokens."""
 
-    def __init__(self, notification_repository: NotificationRepositoryPort = None):
+    def __init__(
+        self,
+        notification_repository: NotificationRepositoryPort = None,
+        precompute_service: DailyContextPrecomputeService | None = None,
+    ):
         self.notification_repository = notification_repository
+        self.precompute_service = precompute_service
 
-    async def handle(self, command: RegisterFcmTokenCommand) -> Dict[str, Any]:
+    def set_dependencies(self, **kwargs):
+        """Set dependencies for dependency injection."""
+        if "precompute_service" in kwargs:
+            self.precompute_service = kwargs["precompute_service"]
+
+    async def handle(self, command: RegisterFcmTokenCommand) -> dict[str, Any]:
         """Handle FCM token registration with old token cleanup."""
+        timezone_changed = False
         async with AsyncUnitOfWork() as uow:
             # Use notification repository from UoW if not injected
             notification_repo = self.notification_repository or uow.notifications
@@ -61,12 +75,40 @@ class RegisterFcmTokenCommandHandler(
             # 3. Update user timezone if provided
             if command.timezone and is_valid_timezone(command.timezone):
                 canonical_tz = normalize_timezone(command.timezone)
-                await uow.users.update_user_timezone(command.user_id, canonical_tz)
-                logger.info(
-                    f"Updated timezone for user {command.user_id}: {canonical_tz}"
+                current_tz = await uow.users.get_user_timezone(command.user_id)
+                if current_tz != canonical_tz:
+                    await uow.users.update_user_timezone(command.user_id, canonical_tz)
+                    timezone_changed = True
+                    logger.info(
+                        f"Updated timezone for user {command.user_id}: {canonical_tz}"
+                    )
+            elif command.timezone:
+                logger.warning(
+                    "Invalid timezone ignored during FCM registration: %r for user %s",
+                    command.timezone,
+                    command.user_id,
                 )
 
             # UoW auto-commits on exit
+
+        if timezone_changed and self.precompute_service:
+            try:
+                scheduled_count = (
+                    await self.precompute_service.reschedule_user_notifications(
+                        command.user_id
+                    )
+                )
+                logger.info(
+                    "Rescheduled %s notifications after FCM timezone update "
+                    "for user %s",
+                    scheduled_count,
+                    command.user_id,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to reschedule notifications after FCM timezone update: %s",
+                    exc,
+                )
 
         logger.info(
             f"FCM token registered for user {command.user_id}, "

--- a/src/app/handlers/command_handlers/update_timezone_command_handler.py
+++ b/src/app/handlers/command_handlers/update_timezone_command_handler.py
@@ -1,21 +1,32 @@
 """Handler for updating user timezone."""
 
 import logging
-from typing import Dict, Any
+from typing import Any
 
 from src.app.commands.user.update_timezone_command import UpdateTimezoneCommand
 from src.app.events.base import EventHandler, handles
 from src.domain.utils.timezone_utils import is_valid_timezone, normalize_timezone
 from src.infra.database.uow_async import AsyncUnitOfWork
+from src.infra.services.daily_context_precompute_service import (
+    DailyContextPrecomputeService,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @handles(UpdateTimezoneCommand)
-class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, Dict[str, Any]]):
+class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, dict[str, Any]]):
     """Handler for updating user timezone."""
 
-    async def handle(self, command: UpdateTimezoneCommand) -> Dict[str, Any]:
+    def __init__(self, precompute_service: DailyContextPrecomputeService | None = None):
+        self.precompute_service = precompute_service
+
+    def set_dependencies(self, **kwargs):
+        """Set dependencies for dependency injection."""
+        if "precompute_service" in kwargs:
+            self.precompute_service = kwargs["precompute_service"]
+
+    async def handle(self, command: UpdateTimezoneCommand) -> dict[str, Any]:
         """Handle timezone update command. Skips DB write if timezone is unchanged."""
         logger.info(
             f"Timezone update request: user={command.user_id}, "
@@ -36,7 +47,9 @@ class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, Dict[str,
 
         if current_tz == canonical_tz:
             logger.debug(
-                f"Timezone unchanged for user {command.user_id}: {canonical_tz!r} — skipping write"
+                "Timezone unchanged for user %s: %r - skipping write",
+                command.user_id,
+                canonical_tz,
             )
             return {"success": True, "timezone": canonical_tz}
 
@@ -46,4 +59,23 @@ class UpdateTimezoneCommandHandler(EventHandler[UpdateTimezoneCommand, Dict[str,
             await uow.commit()
 
         logger.info(f"Updated timezone for user {command.user_id}: {canonical_tz}")
+
+        if self.precompute_service:
+            try:
+                scheduled_count = (
+                    await self.precompute_service.reschedule_user_notifications(
+                        str(command.user_id)
+                    )
+                )
+                logger.info(
+                    "Rescheduled %s notifications after timezone update for user %s",
+                    scheduled_count,
+                    command.user_id,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to reschedule notifications after timezone update: %s",
+                    exc,
+                )
+
         return {"success": True, "timezone": canonical_tz}

--- a/src/app/handlers/query_handlers/codes/validate_code_handler.py
+++ b/src/app/handlers/query_handlers/codes/validate_code_handler.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 from src.app.queries.codes.validate_code_query import CodeValidationError, ValidateCodeQuery
 from src.domain.utils.timezone_utils import utc_now
+from src.infra.config.settings import settings
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.promo_code_repository import PromoCodeRepository
@@ -68,6 +69,7 @@ class ValidateCodeQueryHandler:
                     "referrer_name": referrer_name,
                     "discount_monthly": 199000,
                     "discount_annual": 499000,
+                    "commission_rewards": settings.REFERRAL_COMMISSIONS,
                 }
 
             raise CodeValidationError(404, "Code not found")

--- a/src/app/handlers/query_handlers/referral/get_referral_stats_handler.py
+++ b/src/app/handlers/query_handlers/referral/get_referral_stats_handler.py
@@ -9,6 +9,7 @@ from src.app.queries.referral.get_referral_stats_query import (
     ReferralConversionDTO,
     ReferralStatsResult,
 )
+from src.infra.config.settings import settings
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
@@ -55,6 +56,7 @@ class GetReferralStatsQueryHandler:
                 total_converted=total_converted,
                 conversions=conversion_dtos,
                 has_pending_payout=pending_payout is not None,
+                commission_rewards=settings.REFERRAL_COMMISSIONS,
             )
 
     async def _get_first_name(self, uow, user_id: str) -> str:

--- a/src/app/handlers/query_handlers/referral/validate_referral_code_handler.py
+++ b/src/app/handlers/query_handlers/referral/validate_referral_code_handler.py
@@ -7,6 +7,7 @@ from src.app.queries.referral.validate_referral_code_query import (
     ValidateCodeResult,
     ValidateReferralCodeQuery,
 )
+from src.infra.config.settings import settings
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.referral_repository import ReferralRepository
@@ -21,14 +22,26 @@ class ValidateReferralCodeQueryHandler:
 
             code = await repo.get_code_by_code(query.code)
             if not code:
-                return ValidateCodeResult(valid=False, error="invalid_code")
+                return ValidateCodeResult(
+                    valid=False,
+                    error="invalid_code",
+                    commission_rewards=settings.REFERRAL_COMMISSIONS,
+                )
 
             if code.user_id == query.user_id:
-                return ValidateCodeResult(valid=False, error="self_referral")
+                return ValidateCodeResult(
+                    valid=False,
+                    error="self_referral",
+                    commission_rewards=settings.REFERRAL_COMMISSIONS,
+                )
 
             existing = await repo.get_conversion_by_referred_user(query.user_id)
             if existing:
-                return ValidateCodeResult(valid=False, error="already_referred")
+                return ValidateCodeResult(
+                    valid=False,
+                    error="already_referred",
+                    commission_rewards=settings.REFERRAL_COMMISSIONS,
+                )
 
             # Fetch referrer's first name for personalised UI copy
             result = await uow.session.execute(
@@ -45,4 +58,5 @@ class ValidateReferralCodeQueryHandler:
                 referrer_name=referrer_name,
                 discount_monthly=199000,
                 discount_annual=499000,
+                commission_rewards=settings.REFERRAL_COMMISSIONS,
             )

--- a/src/app/queries/referral/get_referral_stats_query.py
+++ b/src/app/queries/referral/get_referral_stats_query.py
@@ -1,6 +1,6 @@
 """Query and result dataclasses for retrieving a user's full referral stats and wallet."""
 from dataclasses import dataclass, field
-from typing import List
+from typing import Dict, List
 
 
 @dataclass
@@ -26,3 +26,4 @@ class ReferralStatsResult:
     total_converted: int
     conversions: List[ReferralConversionDTO] = field(default_factory=list)
     has_pending_payout: bool = False
+    commission_rewards: Dict[str, float] = field(default_factory=dict)

--- a/src/app/queries/referral/validate_referral_code_query.py
+++ b/src/app/queries/referral/validate_referral_code_query.py
@@ -1,6 +1,6 @@
 """Query and result dataclass for validating a referral code before it is applied."""
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 
 @dataclass
@@ -16,3 +16,4 @@ class ValidateCodeResult:
     referrer_name: Optional[str] = None
     discount_monthly: int = 199000
     discount_annual: int = 499000
+    commission_rewards: Dict[str, float] = field(default_factory=dict)

--- a/src/infra/adapters/posthog_adapter.py
+++ b/src/infra/adapters/posthog_adapter.py
@@ -1,0 +1,45 @@
+"""Small PostHog capture adapter for backend lifecycle events."""
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class PostHogAdapter:
+    """Fire-and-forget PostHog event capture using environment configuration."""
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("POSTHOG_API_KEY", "")
+        self.host = os.getenv("POSTHOG_HOST", "https://app.posthog.com").rstrip("/")
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.api_key)
+
+    async def capture(
+        self,
+        *,
+        distinct_id: str,
+        event: str,
+        properties: dict[str, Any],
+    ) -> None:
+        """Capture an event without blocking the caller on analytics failures."""
+        if not self.enabled:
+            return
+
+        payload = {
+            "api_key": self.api_key,
+            "event": event,
+            "distinct_id": distinct_id,
+            "properties": properties,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                response = await client.post(f"{self.host}/capture/", json=payload)
+                response.raise_for_status()
+        except Exception:
+            logger.warning("PostHog capture failed for %s", event, exc_info=True)

--- a/tests/unit/api/test_event_bus_dependency_singletons.py
+++ b/tests/unit/api/test_event_bus_dependency_singletons.py
@@ -26,7 +26,9 @@ def test_get_food_search_event_bus_is_singleton(monkeypatch):
     monkeypatch.setattr(deps, "get_fat_secret_service_instance", lambda: object())
     monkeypatch.setattr(deps, "get_food_reference_repository", lambda: object())
 
-    # Patch MealGenerationService + translation service referenced in function
+    # Patch MealGenerationService + translation service referenced in function.
+    # These are locally imported inside get_food_search_event_bus(), so we must
+    # patch the source module, not the event_bus module attribute.
     class _MealGen:
         pass
 
@@ -34,7 +36,8 @@ def test_get_food_search_event_bus_is_singleton(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr(mod, "MealGenerationService", _MealGen, raising=False)
+    import src.infra.adapters.meal_generation_service as _meal_gen_mod
+    monkeypatch.setattr(_meal_gen_mod, "MealGenerationService", _MealGen)
     monkeypatch.setattr(mod, "FoodSearchTranslationService", _Translator, raising=False)
 
     # Patch handlers to avoid constructing real ones

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -8,20 +8,21 @@ import pytest
 from fastapi import HTTPException
 
 from src.api.routes.v1.webhooks import (
-    revenuecat_webhook,
-    parse_platform,
-    parse_timestamp,
-    handle_purchase,
-    handle_renewal,
+    handle_billing_issue,
     handle_cancellation,
     handle_expiration,
-    handle_billing_issue
+    handle_purchase,
+    handle_renewal,
+    handle_transfer,
+    parse_platform,
+    parse_timestamp,
+    revenuecat_webhook,
 )
 
 
 class TestWebhookHelpers:
     """Test webhook helper functions."""
-    
+
     def test_parse_platform(self):
         """Test platform parsing from store name."""
         assert parse_platform("APP_STORE") == "ios"
@@ -31,7 +32,7 @@ class TestWebhookHelpers:
         assert parse_platform(None) == "ios"
         assert parse_platform("") == "ios"
         assert parse_platform("UNKNOWN") == "ios"
-    
+
     def test_parse_timestamp(self):
         """Test timestamp parsing from milliseconds."""
         # Valid timestamp
@@ -39,15 +40,15 @@ class TestWebhookHelpers:
         result = parse_timestamp(ms)
         assert isinstance(result, datetime)
         assert result.year == 2023
-        
+
         # None timestamp
         assert parse_timestamp(None) is None
-        
+
         # Zero timestamp
         assert parse_timestamp(0) is not None
-        
+
         # Invalid timestamp
-        with patch('src.api.routes.v1.webhooks.logger') as mock_logger:
+        with patch("src.api.routes.v1.webhooks.logger"):
             result = parse_timestamp("invalid")
             assert result is None
 
@@ -55,14 +56,14 @@ class TestWebhookHelpers:
 @pytest.mark.asyncio
 class TestWebhookHandler:
     """Test webhook handler functions."""
-    
+
     @pytest.fixture
     def mock_request(self):
         """Create mock request object."""
         request = MagicMock()
         request.json = AsyncMock()
         return request
-    
+
     @pytest.fixture
     def mock_uow(self):
         """Create mock Unit of Work."""
@@ -72,7 +73,7 @@ class TestWebhookHandler:
         uow.commit = AsyncMock()
         uow.rollback = AsyncMock()
         return uow
-    
+
     @pytest.fixture
     def webhook_event(self):
         """Create sample webhook event."""
@@ -88,7 +89,7 @@ class TestWebhookHandler:
                 "transaction_id": "1000000123456789"
             }
         }
-    
+
     async def test_webhook_success(self, mock_request, webhook_event):
         """Test successful webhook processing."""
         mock_request.json.return_value = webhook_event
@@ -102,22 +103,22 @@ class TestWebhookHandler:
                 mock_uow.commit = AsyncMock()
                 mock_uow.rollback = AsyncMock()
                 mock_uow_class.return_value = mock_uow
-                
+
                 # Mock user exists
                 mock_user = MagicMock(id="user_123")
                 mock_uow.session.execute = AsyncMock()
                 mock_result = MagicMock()
                 mock_result.scalars.return_value.first.return_value = mock_user
                 mock_uow.session.execute.return_value = mock_result
-                
+
                 # Mock no existing subscription (async)
                 with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=None):
                     result = await revenuecat_webhook(mock_request, authorization="test_secret")
-                
+
                 assert result == {"status": "success"}
                 # commit/rollback are owned by the AsyncUnitOfWork context manager, not called explicitly
                 mock_uow.commit.assert_not_awaited()
-    
+
     async def test_webhook_user_not_found(self, mock_request, webhook_event):
         """Test webhook returns 404 when user not found (so RevenueCat retries)."""
         mock_request.json.return_value = webhook_event
@@ -150,7 +151,57 @@ class TestWebhookHandler:
                     await revenuecat_webhook(mock_request, authorization="test_secret")
 
                 assert exc_info.value.status_code == 404
-    
+
+    async def test_webhook_lifecycle_user_not_found_is_ignored(self, mock_request):
+        """Test userless lifecycle events ACK to stop RevenueCat retry storms."""
+        mock_request.json.return_value = {
+            "event": {
+                "type": "BILLING_ISSUE",
+                "app_user_id": "$RCAnonymousID:missing",
+                "product_id": "nutree_2999_1y_0",
+            }
+        }
+
+        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
+            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+                mock_uow = MagicMock()
+                mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+                mock_uow.__aexit__ = AsyncMock(return_value=False)
+                mock_uow.subscriptions = MagicMock()
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow.session.execute = AsyncMock()
+                mock_result = MagicMock()
+                mock_result.scalars.return_value.first.return_value = None
+                mock_uow.session.execute.return_value = mock_result
+                mock_uow_class.return_value = mock_uow
+
+                result = await revenuecat_webhook(mock_request, authorization="test_secret")
+
+                assert result == {"status": "ignored", "reason": "user_not_found"}
+
+    async def test_webhook_transfer_without_user_acknowledged(self, mock_request):
+        """Test RevenueCat TRANSFER webhooks do not require app_user_id lookup."""
+        mock_request.json.return_value = {
+            "event": {
+                "type": "TRANSFER",
+                "transferred_from": ["$RCAnonymousID:old"],
+                "transferred_to": ["$RCAnonymousID:new"],
+            }
+        }
+
+        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
+            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+                mock_uow = MagicMock()
+                mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+                mock_uow.__aexit__ = AsyncMock(return_value=False)
+                mock_uow.subscriptions = MagicMock()
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow_class.return_value = mock_uow
+
+                result = await revenuecat_webhook(mock_request, authorization="test_secret")
+
+                assert result == {"status": "success"}
+
     async def test_webhook_invalid_json(self, mock_request):
         """Test webhook with invalid JSON."""
         mock_request.json.side_effect = Exception("Invalid JSON")
@@ -162,21 +213,21 @@ class TestWebhookHandler:
 
             assert exc_info.value.status_code == 400
             assert exc_info.value.detail == "Invalid JSON"
-    
+
     async def test_webhook_authorization_check(self, mock_request, webhook_event):
         """Test webhook authorization check."""
         mock_request.json.return_value = webhook_event
-        
+
         with patch('src.api.routes.v1.webhooks.os.getenv') as mock_getenv:
             mock_getenv.return_value = "secret_token"
-            
+
             # Test with wrong authorization
             with pytest.raises(HTTPException) as exc_info:
                 await revenuecat_webhook(mock_request, authorization="wrong_token")
-            
+
             assert exc_info.value.status_code == 401
             assert exc_info.value.detail == "Unauthorized"
-    
+
     async def test_handle_purchase(self, mock_uow):
         """Test handling initial purchase event."""
         user = MagicMock(id="user_123")
@@ -201,7 +252,7 @@ class TestWebhookHandler:
         assert added_subscription.user_id == "user_123"
         assert added_subscription.product_id == "premium_monthly"
         assert added_subscription.status == "active"
-    
+
     async def test_handle_renewal(self, mock_uow):
         """Test handling renewal event."""
         user = MagicMock(id="user_123")
@@ -217,7 +268,7 @@ class TestWebhookHandler:
 
         assert subscription.status == "active"
         assert subscription.expires_at is not None
-    
+
     async def test_handle_cancellation(self, mock_uow):
         """Test handling cancellation event."""
         user = MagicMock(id="user_123")
@@ -230,7 +281,7 @@ class TestWebhookHandler:
 
         assert subscription.status == "cancelled"
         assert subscription.cancelled_at is not None
-    
+
     async def test_handle_expiration(self, mock_uow):
         """Test handling expiration event."""
         user = MagicMock(id="user_123")
@@ -242,7 +293,7 @@ class TestWebhookHandler:
             await handle_expiration(mock_uow, user, event)
 
         assert subscription.status == "expired"
-    
+
     async def test_handle_billing_issue(self, mock_uow):
         """Test handling billing issue event."""
         user = MagicMock(id="user_123")
@@ -254,3 +305,18 @@ class TestWebhookHandler:
             await handle_billing_issue(mock_uow, user, event)
 
         assert subscription.status == "billing_issue"
+
+    async def test_handle_transfer_updates_known_subscription(self, mock_uow):
+        """Test transfer remaps existing subscription to the canonical subscriber ID."""
+        subscription = MagicMock()
+        event = {
+            "transferred_from": ["$RCAnonymousID:old"],
+            "transferred_to": ["firebase_uid_123", "$RCAnonymousID:new"],
+        }
+        mock_uow.subscriptions = MagicMock()
+        mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=subscription)
+
+        await handle_transfer(mock_uow, event)
+
+        assert subscription.revenuecat_subscriber_id == "firebase_uid_123"
+        assert subscription.updated_at is not None

--- a/tests/unit/handlers/command_handlers/test_register_fcm_token_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_register_fcm_token_command_handler.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.app.commands.notification import RegisterFcmTokenCommand
+from src.app.handlers.command_handlers.register_fcm_token_command_handler import (
+    RegisterFcmTokenCommandHandler,
+)
+
+
+def _mock_uow(current_timezone="UTC"):
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    uow.users.get_user_timezone = AsyncMock(return_value=current_timezone)
+    uow.users.update_user_timezone = AsyncMock()
+    return uow
+
+
+def _mock_notification_repo():
+    repo = MagicMock()
+    repo.find_active_fcm_tokens_by_user = AsyncMock(return_value=[])
+    repo.save_fcm_token = AsyncMock(return_value=MagicMock(token_id="token-id"))
+    repo.deactivate_fcm_token = AsyncMock()
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_register_fcm_token_reschedules_when_timezone_changes():
+    user_id = str(uuid4())
+    precompute = AsyncMock()
+    repo = _mock_notification_repo()
+    uow = _mock_uow(current_timezone="UTC")
+    handler = RegisterFcmTokenCommandHandler(
+        notification_repository=repo,
+        precompute_service=precompute,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.register_fcm_token_command_handler.AsyncUnitOfWork",
+        return_value=uow,
+    ):
+        result = await handler.handle(
+            RegisterFcmTokenCommand(
+                user_id=user_id,
+                fcm_token="fcm-token-valid-123",
+                device_type="ios",
+                timezone="Asia/Ho_Chi_Minh",
+            )
+        )
+
+    assert result["success"] is True
+    uow.users.update_user_timezone.assert_awaited_once_with(user_id, "Asia/Ho_Chi_Minh")
+    precompute.reschedule_user_notifications.assert_awaited_once_with(user_id)
+
+
+@pytest.mark.asyncio
+async def test_register_fcm_token_skips_reschedule_when_timezone_unchanged():
+    user_id = str(uuid4())
+    precompute = AsyncMock()
+    repo = _mock_notification_repo()
+    uow = _mock_uow(current_timezone="Asia/Ho_Chi_Minh")
+    handler = RegisterFcmTokenCommandHandler(
+        notification_repository=repo,
+        precompute_service=precompute,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.register_fcm_token_command_handler.AsyncUnitOfWork",
+        return_value=uow,
+    ):
+        result = await handler.handle(
+            RegisterFcmTokenCommand(
+                user_id=user_id,
+                fcm_token="fcm-token-valid-123",
+                device_type="android",
+                timezone="Asia/Ho_Chi_Minh",
+            )
+        )
+
+    assert result["success"] is True
+    uow.users.update_user_timezone.assert_not_called()
+    precompute.reschedule_user_notifications.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_register_fcm_token_ignores_invalid_timezone_without_reschedule():
+    user_id = str(uuid4())
+    precompute = AsyncMock()
+    repo = _mock_notification_repo()
+    uow = _mock_uow(current_timezone="UTC")
+    handler = RegisterFcmTokenCommandHandler(
+        notification_repository=repo,
+        precompute_service=precompute,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.register_fcm_token_command_handler.AsyncUnitOfWork",
+        return_value=uow,
+    ):
+        result = await handler.handle(
+            RegisterFcmTokenCommand(
+                user_id=user_id,
+                fcm_token="fcm-token-valid-123",
+                device_type="ios",
+                timezone="Not/AZone",
+            )
+        )
+
+    assert result["success"] is True
+    uow.users.update_user_timezone.assert_not_called()
+    precompute.reschedule_user_notifications.assert_not_called()

--- a/tests/unit/handlers/command_handlers/test_update_timezone_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_update_timezone_command_handler.py
@@ -1,7 +1,8 @@
 """Unit tests: timezone update handler skips DB write when tz is unchanged."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from src.app.commands.user.update_timezone_command import UpdateTimezoneCommand
 from src.app.handlers.command_handlers.update_timezone_command_handler import (
@@ -12,7 +13,8 @@ from src.app.handlers.command_handlers.update_timezone_command_handler import (
 @pytest.mark.asyncio
 async def test_skips_db_write_when_timezone_unchanged():
     """If the stored timezone equals the incoming one, no DB write occurs."""
-    handler = UpdateTimezoneCommandHandler()
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
     command = UpdateTimezoneCommand(user_id="user-1", timezone="Asia/Ho_Chi_Minh")
 
     mock_uow = MagicMock()
@@ -31,13 +33,15 @@ async def test_skips_db_write_when_timezone_unchanged():
 
     assert result == {"success": True, "timezone": "Asia/Ho_Chi_Minh"}
     mock_uow.users.update_user_timezone.assert_not_called()
-    # commit() may be called by the read-path UoW's __exit__ — we only assert the write didn't happen
+    precompute.reschedule_user_notifications.assert_not_called()
+    # commit() may be called by the read UoW exit; only assert no write happened.
 
 
 @pytest.mark.asyncio
 async def test_writes_db_when_timezone_changed():
     """If the stored timezone differs, the update proceeds."""
-    handler = UpdateTimezoneCommandHandler()
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
     command = UpdateTimezoneCommand(user_id="user-1", timezone="America/New_York")
 
     mock_uow = MagicMock()
@@ -57,12 +61,14 @@ async def test_writes_db_when_timezone_changed():
     mock_uow.users.update_user_timezone.assert_called_once_with(
         "user-1", "America/New_York"
     )
+    precompute.reschedule_user_notifications.assert_awaited_once_with("user-1")
 
 
 @pytest.mark.asyncio
 async def test_writes_db_when_no_stored_timezone():
     """If no timezone is stored yet (None), the update proceeds."""
-    handler = UpdateTimezoneCommandHandler()
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
     command = UpdateTimezoneCommand(user_id="user-1", timezone="Asia/Ho_Chi_Minh")
 
     mock_uow = MagicMock()
@@ -82,3 +88,18 @@ async def test_writes_db_when_no_stored_timezone():
     mock_uow.users.update_user_timezone.assert_called_once_with(
         "user-1", "Asia/Ho_Chi_Minh"
     )
+    precompute.reschedule_user_notifications.assert_awaited_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_timezone_without_reschedule():
+    """Invalid timezone input should not write or reschedule."""
+    precompute = AsyncMock()
+    handler = UpdateTimezoneCommandHandler(precompute_service=precompute)
+
+    result = await handler.handle(
+        UpdateTimezoneCommand(user_id="user-1", timezone="Not/AZone")
+    )
+
+    assert result == {"success": False, "error": "Invalid timezone"}
+    precompute.reschedule_user_notifications.assert_not_called()

--- a/tests/unit/handlers/test_validate_code_handler.py
+++ b/tests/unit/handlers/test_validate_code_handler.py
@@ -119,6 +119,9 @@ async def test_valid_referral_code_returns_referral_type():
     assert result["referrer_name"] == "Alex"
     assert result["discount_monthly"] == 199000
     assert result["discount_annual"] == 499000
+    # Mobile reads commission_rewards to render localized reward strings;
+    # an empty dict here silently falls back to mobile's hardcoded defaults.
+    assert result["commission_rewards"], "commission_rewards must be exposed for mobile"
 
 
 @pytest.mark.asyncio
@@ -266,3 +269,27 @@ async def test_referral_falls_back_to_friend_when_no_name():
         )
 
     assert result["referrer_name"] == "Friend"
+
+
+@pytest.mark.asyncio
+async def test_commission_rewards_match_runtime_settings():
+    """Commission rewards in the response must match the live settings instance.
+
+    Render redeploy -> settings re-load -> response reflects the new value.
+    """
+    referral = _make_referral_code(user_id="referrer-id")
+    row = MagicMock()
+    row.first_name = "Alex"
+    row.display_name = None
+    mock_uow, mock_promo_repo, mock_referral_repo = _mock_uow(referral=referral, referrer_row=row)
+
+    overridden = {"USD": 5, "VND": 100000, "EUR": 4.5, "default": 5}
+    with _patch(mock_uow, mock_promo_repo, mock_referral_repo), \
+         patch(f"{HANDLER_PATH}.settings") as mock_settings:
+        mock_settings.REFERRAL_COMMISSIONS = overridden
+        from src.app.handlers.query_handlers.codes.validate_code_handler import ValidateCodeQueryHandler
+        result = await ValidateCodeQueryHandler().handle(
+            ValidateCodeQuery(code="ALEX123", user_id="user-456")
+        )
+
+    assert result["commission_rewards"] == overridden


### PR DESCRIPTION
## Summary
- Cherry-pick selected commits from `main` onto `delivery`
- Exclude historical sync and duplicate-subject commits already represented on `delivery`
- Includes migration duplicate revision fix, notification timezone reschedule, referral env exposure, RevenueCat webhook lifecycle handling, and delivery docs whitespace cleanup

## Validation
- `git diff --check origin/delivery..HEAD`
- `python -m compileall -q src tests`

## Cherry-picked commits
- 50be9604 docs: remove trailing whitespace in delivery docs
- 0ca92d93 fix(migrations): correct duplicate revision ID in 20260503113601 migration (#280)
- 208c7cb0 fix(notifications): reschedule after timezone changes (#279)
- c5e12f0d fix(referral): expose REFERRAL_COMMISSIONS env var to mobile (#281)
- aab7a2c8 fix(webhooks): handle revenuecat lifecycle events (#283)