### PR TITLE
test(meal-suggestions): add missing plan test-plan coverage for selec…

### DIFF
--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -417,7 +417,11 @@ def get_suggestion_orchestration_service():
     from src.infra.adapters.meal_generation_service import MealGenerationService
     from src.infra.database.config import SessionLocal
     from src.infra.repositories.user_repository import UserRepository
-    from src.infra.services.ai.schemas import MealNamesResponse, DiscoveryMealsResponse
+    from src.infra.services.ai.schemas import (
+        DiscoveryMealsResponse,
+        MealNamesResponse,
+        RecipeDetailsResponse,
+    )
 
     meal_gen_service = MealGenerationService()
     suggestion_repo = get_meal_suggestion_repository()
@@ -441,6 +445,7 @@ def get_suggestion_orchestration_service():
         uow_factory=AsyncUnitOfWork,
         meal_names_schema_class=MealNamesResponse,
         discovery_meals_schema_class=DiscoveryMealsResponse,
+        recipe_details_schema_class=RecipeDetailsResponse,
         translation_service=get_deepl_suggestion_translation_service(),
     )
 

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -38,9 +38,6 @@ from src.infra.services.scheduled_notification_service import (
 if TYPE_CHECKING:
     from src.domain.ports.subscription_service_port import SubscriptionServicePort
 
-if TYPE_CHECKING:
-    from src.domain.ports.subscription_service_port import SubscriptionServicePort
-
 # Note: Old handler imports removed - using event-driven architecture now
 # from src.app.handlers.activity_handler import ActivityHandler
 # ... etc

--- a/src/app/handlers/command_handlers/meal_suggestion/generate_meal_recipes_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_suggestion/generate_meal_recipes_command_handler.py
@@ -4,7 +4,7 @@ Handler for selected-discovery recipe generation.
 
 import uuid
 
-from src.api.exceptions import ResourceNotFoundException, ValidationException
+from src.api.exceptions import ExternalServiceException, ResourceNotFoundException, ValidationException
 from src.app.commands.meal_suggestion import GenerateMealRecipesCommand
 from src.app.events.base import EventHandler, handles
 from src.domain.model.meal_suggestion import MealSuggestion, SuggestionSession
@@ -66,9 +66,22 @@ class GenerateMealRecipesCommandHandler(
         )
 
         if selected_meals:
-            recipes = await self.service._recipe_generator.generate_selected_recipes(
-                session, selected_meals
-            )
+            try:
+                recipes = await self.service._recipe_generator.generate_selected_recipes(
+                    session, selected_meals
+                )
+            except RuntimeError as exc:
+                raise ExternalServiceException(
+                    str(exc),
+                    error_code="RECIPE_GENERATION_FAILED",
+                    details={"requested": len(selected_meals), "generated": 0},
+                ) from exc
+            if len(recipes) != len(selected_meals):
+                raise ExternalServiceException(
+                    "Could not generate all selected recipes. Please retry.",
+                    error_code="RECIPE_GENERATION_FAILED",
+                    details={"requested": len(selected_meals), "generated": len(recipes)},
+                )
         else:
             recipes = await self.service._recipe_generator._phase2_generate_recipes(
                 session,

--- a/src/app/handlers/command_handlers/meal_suggestion/generate_meal_recipes_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_suggestion/generate_meal_recipes_command_handler.py
@@ -72,9 +72,9 @@ class GenerateMealRecipesCommandHandler(
                 )
             except RuntimeError as exc:
                 raise ExternalServiceException(
-                    str(exc),
+                    "Could not generate recipes. Please retry.",
                     error_code="RECIPE_GENERATION_FAILED",
-                    details={"requested": len(selected_meals), "generated": 0},
+                    details={"requested": len(selected_meals), "generated": 0, "reason": str(exc)},
                 ) from exc
             if len(recipes) != len(selected_meals):
                 raise ExternalServiceException(

--- a/src/domain/services/meal_suggestion/parallel_recipe_generator.py
+++ b/src/domain/services/meal_suggestion/parallel_recipe_generator.py
@@ -272,6 +272,8 @@ class ParallelRecipeGenerator:
                 fat_target=selected.get("fat") or session.fat_target,
             )
             meal_name = selected.get("english_name") or selected.get("name")
+            if not meal_name:
+                raise ValueError("selected meal is missing english_name/name")
             prompt = build_recipe_details_prompt(meal_name, recipe_session)
             return await self._generate_with_retry(
                 prompt,

--- a/src/domain/services/meal_suggestion/parallel_recipe_generator.py
+++ b/src/domain/services/meal_suggestion/parallel_recipe_generator.py
@@ -84,6 +84,7 @@ class ParallelRecipeGenerator:
         nutrition_lookup: NutritionLookupService,
         meal_names_schema_class: type,
         discovery_meals_schema_class: type,
+        recipe_details_schema_class: type | None = None,
     ) -> None:
         self._generation = generation_service
         self._translation_service = translation_service
@@ -91,6 +92,7 @@ class ParallelRecipeGenerator:
         self._nutrition_lookup = nutrition_lookup
         self._meal_names_schema = meal_names_schema_class
         self._discovery_meals_schema = discovery_meals_schema_class
+        self._recipe_details_schema = recipe_details_schema_class
 
     async def generate(
         self,
@@ -241,7 +243,11 @@ class ParallelRecipeGenerator:
         session: SuggestionSession,
         selected_meals: List[dict],
     ) -> List[MealSuggestion]:
-        """Generate full recipes for discovery selections without scale rejection."""
+        """Generate full recipes for discovery selections without scale rejection.
+
+        2-pass retry: pass 1 generates all slots in parallel; pass 2 retries any
+        None slots. Raises RuntimeError if any slot still fails after retry.
+        """
         from src.domain.services.meal_suggestion.suggestion_prompt_builder import (
             build_recipe_details_prompt,
         )
@@ -277,29 +283,41 @@ class ParallelRecipeGenerator:
                 fill_missing_steps=True,
             )
 
-        tasks = [
+        results: List[Optional[MealSuggestion]] = [None] * len(selected_meals)
+
+        # Pass 1: generate all slots in parallel
+        pass1_tasks = [
             asyncio.create_task(generate_one(index, selected))
             for index, selected in enumerate(selected_meals)
         ]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        pass1_raw = await asyncio.gather(*pass1_tasks, return_exceptions=True)
+        for i, result in enumerate(pass1_raw):
+            if not isinstance(result, Exception) and result is not None:
+                results[i] = result
 
-        recipes: List[MealSuggestion] = []
-        failures: List[str] = []
-        for index, result in enumerate(results):
-            if isinstance(result, Exception):
-                failures.append(
-                    f"{selected_meals[index].get('id')}: {type(result).__name__}"
-                )
-            elif result is None:
-                failures.append(f"{selected_meals[index].get('id')}: empty result")
-            else:
-                recipes.append(result)
+        # Pass 2: retry any failed slots
+        failed_indices = [i for i, r in enumerate(results) if r is None]
+        if failed_indices:
+            pass2_tasks = [
+                asyncio.create_task(generate_one(i, selected_meals[i]))
+                for i in failed_indices
+            ]
+            pass2_raw = await asyncio.gather(*pass2_tasks, return_exceptions=True)
+            for i, result in zip(failed_indices, pass2_raw):
+                if not isinstance(result, Exception) and result is not None:
+                    results[i] = result
 
+        failures = [
+            selected_meals[i].get("id", str(i))
+            for i, r in enumerate(results)
+            if r is None
+        ]
         if failures:
             raise RuntimeError(
-                "Failed to generate selected recipes: " + "; ".join(failures)
+                "Failed to generate all selected recipes: " + ", ".join(failures)
             )
-        return recipes
+
+        return [r for r in results if r is not None]
 
     async def _phase1_generate_names(
         self,
@@ -490,6 +508,7 @@ class ParallelRecipeGenerator:
             session,
             reject_on_scale_out_of_range=reject_on_scale_out_of_range,
             fill_missing_steps=fill_missing_steps,
+            recipe_schema=self._recipe_details_schema,
         )
         if result is not None:
             return result
@@ -512,6 +531,7 @@ class ParallelRecipeGenerator:
             is_retry=True,
             reject_on_scale_out_of_range=reject_on_scale_out_of_range,
             fill_missing_steps=fill_missing_steps,
+            recipe_schema=self._recipe_details_schema,
         )
 
     async def _translate_single(

--- a/src/domain/services/meal_suggestion/recipe_attempt_builder.py
+++ b/src/domain/services/meal_suggestion/recipe_attempt_builder.py
@@ -44,6 +44,7 @@ async def attempt_recipe_generation(
     is_retry: bool = False,
     reject_on_scale_out_of_range: bool = True,
     fill_missing_steps: bool = False,
+    recipe_schema: type | None = None,
 ) -> Optional[MealSuggestion]:
     """
     Single AI call to generate one recipe. Returns MealSuggestion on success, None on failure.
@@ -72,7 +73,7 @@ async def attempt_recipe_generation(
                 recipe_system,
                 "json",
                 PARALLEL_SINGLE_MEAL_TOKENS,
-                None,
+                recipe_schema,
                 model_purpose,
             ),
             timeout=PARALLEL_SINGLE_MEAL_TIMEOUT,

--- a/src/domain/services/meal_suggestion/suggestion_orchestration_service.py
+++ b/src/domain/services/meal_suggestion/suggestion_orchestration_service.py
@@ -48,6 +48,7 @@ class SuggestionOrchestrationService:
         nutrition_lookup: NutritionLookupService,
         meal_names_schema_class: type,
         discovery_meals_schema_class: type,
+        recipe_details_schema_class: type | None = None,
         tdee_service: TdeeCalculationService = None,
         portion_service: PortionCalculationService = None,
         profile_provider: Optional[Callable[[str], Any]] = None,
@@ -68,6 +69,7 @@ class SuggestionOrchestrationService:
             nutrition_lookup=nutrition_lookup,
             meal_names_schema_class=meal_names_schema_class,
             discovery_meals_schema_class=discovery_meals_schema_class,
+            recipe_details_schema_class=recipe_details_schema_class,
         )
 
     async def generate_suggestions(

--- a/src/domain/services/prompts/prompt_constants.py
+++ b/src/domain/services/prompts/prompt_constants.py
@@ -163,14 +163,13 @@ JSON_SCHEMAS: Dict[str, str] = {
   "cuisine_type": "International"
 }""",
     "suggestion_recipe": """{
-  "name": "Dish Name",
-  "emoji": "🍜",
-  "description": "Brief description",
-  "cuisine_type": "Asian",
+  "emoji": "🍚",
+  "cuisine_type": "Vietnamese",
   "origin_country": "Vietnam",
   "ingredients": [
     {"name": "ingredient1", "amount": 200, "unit": "g"},
-    {"name": "ingredient2", "amount": 100, "unit": "g"}
+    {"name": "ingredient2", "amount": 100, "unit": "g"},
+    {"name": "ingredient3", "amount": 50, "unit": "g"}
   ],
   "recipe_steps": [
     {"step": 1, "instruction": "Action", "duration_minutes": 5},

--- a/src/domain/services/prompts/prompt_template_manager.py
+++ b/src/domain/services/prompts/prompt_template_manager.py
@@ -281,7 +281,7 @@ Names: Natural, concise (max 5 words), no "Quick/Healthy/Power" tags.{exclude_st
         Always generates in English (translation happens in Phase 3).
         """
         ingredients = ingredients or []
-        ing_str = ", ".join(ingredients[:6]) if ingredients else "any ingredients"
+        ing_str = ", ".join(ingredients[:6]) if ingredients else ""
 
         constraints_parts = []
         if allergies:
@@ -290,6 +290,13 @@ Names: Natural, concise (max 5 words), no "Quick/Healthy/Power" tags.{exclude_st
             constraints_parts.append(f"Diet: {', '.join(dietary_preferences)}")
 
         constraints_str = " | ".join(constraints_parts) if constraints_parts else ""
+
+        if ing_str:
+            ing_line = f"Use these ingredients as main components where compatible: {ing_str}"
+        else:
+            ing_line = "Use common ingredients appropriate for the dish."
+        if constraints_str:
+            ing_line += f" | {constraints_str}"
 
         # Always state serving count explicitly so the AI sizes the
         # recipe correctly.
@@ -330,14 +337,13 @@ Names: Natural, concise (max 5 words), no "Quick/Healthy/Power" tags.{exclude_st
 
         return f"""Generate complete recipe for: "{meal_name}"
 
-MUST USE these ingredients as main components: {ing_str}{' | ' + constraints_str if constraints_str else ''}
+{ing_line}
 Target:{servings_str} — ~{target_calories} cal{time_str}{equipment_str}{cuisine_str}{macro_target_str}{low_calorie_str}
 
 CRITICAL: Size all quantities for {servings} serving only — no batch scaling.
 
 REQUIREMENTS:
 - Match name "{meal_name}" exactly
-- MUST include user's ingredients ({ing_str}) — no substitutions
 - 3-8 ingredients in GRAMS, scaled for {servings} serving{'s' if servings > 1 else ''}{time_req_str}
 - Include origin_country and cuisine_type in JSON
 

--- a/src/infra/services/ai/schemas.py
+++ b/src/infra/services/ai/schemas.py
@@ -81,10 +81,7 @@ class RecipeDetailsResponse(BaseModel):
 
     Macros are optional — AI no longer required to calculate them.
     Deterministic macros are calculated from ingredients via NutritionLookupService.
-
-    # Used by: tests/unit/infra/services/ai/test_schemas.py (validation tests only).
-    # NOT injected into the production pipeline — recipe_attempt_builder.py parses
-    # raw JSON dicts directly.  Wire through injection if structured output is needed.
+    Injected as structured-output schema via generate_selected_recipes.
     """
 
     ingredients: List[IngredientItem] = Field(
@@ -111,3 +108,13 @@ class RecipeDetailsResponse(BaseModel):
         default=None, description="AI-reported carbs (ignored)"
     )
     fat: Optional[float] = Field(default=None, description="AI-reported fat (ignored)")
+    # Metadata fields surfaced by the AI for UX enrichment
+    origin_country: Optional[str] = Field(
+        default=None, description="Country of origin for the dish"
+    )
+    cuisine_type: Optional[str] = Field(
+        default=None, description="Cuisine type (e.g., 'Vietnamese', 'Japanese')"
+    )
+    emoji: Optional[str] = Field(
+        default=None, description="Single emoji representing the dish"
+    )

--- a/tests/unit/api/test_meal_suggestions_routes.py
+++ b/tests/unit/api/test_meal_suggestions_routes.py
@@ -291,3 +291,72 @@ def test_generate_recipes_accepts_full_selected_meals_when_session_missing(ms_cl
     assert captured["msg"].session_id == "expired-session"
     assert captured["msg"].selected_meal_ids == ["disc_a"]
     assert captured["msg"].selected_meals == payload["selected_meals"]
+
+
+def test_generate_recipes_generation_failure_returns_503(ms_client):
+    client, _bus = ms_client
+
+    class _BusRecipeFailure:
+        async def send(self, msg):
+            from src.api.exceptions import ExternalServiceException
+
+            raise ExternalServiceException(
+                "Could not generate recipes. Please retry.",
+                error_code="RECIPE_GENERATION_FAILED",
+                details={"requested": 3, "generated": 0},
+            )
+
+    client.app.dependency_overrides[get_configured_event_bus] = (
+        lambda: _BusRecipeFailure()
+    )
+
+    payload = {
+        "session_id": "sess-discovery",
+        "selected_meal_ids": ["disc_a", "disc_b", "disc_c"],
+        "selected_meals": [
+            {
+                "id": "disc_a",
+                "meal_name": "Ginger Chicken Rice",
+                "english_name": "Ginger Chicken Rice",
+                "macros": {
+                    "calories": 450,
+                    "protein": 35,
+                    "carbs": 45,
+                    "fat": 12,
+                },
+            },
+            {
+                "id": "disc_b",
+                "meal_name": "Lemon Salmon Bowl",
+                "english_name": "Lemon Salmon Bowl",
+                "macros": {
+                    "calories": 520,
+                    "protein": 38,
+                    "carbs": 50,
+                    "fat": 18,
+                },
+            },
+            {
+                "id": "disc_c",
+                "meal_name": "Tofu Vegetable Noodles",
+                "english_name": "Tofu Vegetable Noodles",
+                "macros": {
+                    "calories": 430,
+                    "protein": 28,
+                    "carbs": 55,
+                    "fat": 11,
+                },
+            },
+        ],
+        "meal_names": [
+            "Ginger Chicken Rice",
+            "Lemon Salmon Bowl",
+            "Tofu Vegetable Noodles",
+        ],
+        "meal_type": "lunch",
+    }
+
+    response = client.post("/v1/meal-suggestions/recipes", json=payload)
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error_code"] == "RECIPE_GENERATION_FAILED"

--- a/tests/unit/app/handlers/test_meal_suggestion_cqrs_handlers.py
+++ b/tests/unit/app/handlers/test_meal_suggestion_cqrs_handlers.py
@@ -237,6 +237,98 @@ async def test_generate_meal_recipes_handler_rejects_missing_session_without_cli
     assert exc.value.error_code == "DISCOVERY_SESSION_NOT_FOUND"
 
 
+@pytest.mark.asyncio
+async def test_generate_meal_recipes_handler_returns_three_recipes_for_three_selected_ids():
+    """3 selected_meal_ids from session → exactly 3 recipes in matching order."""
+    discovery_session = SuggestionSession(
+        id="sess-discovery",
+        user_id="user-1",
+        meal_type="dinner",
+        meal_portion_type="main",
+        target_calories=600,
+        ingredients=[],
+        cooking_time_minutes=None,
+        discovery_meals=[
+            {
+                "id": "disc_1",
+                "name": "Chicken Rice",
+                "english_name": "Chicken Rice",
+                "calories": 500,
+                "protein": 35,
+                "carbs": 55,
+                "fat": 14,
+            },
+            {
+                "id": "disc_2",
+                "name": "Grilled Salmon",
+                "english_name": "Grilled Salmon",
+                "calories": 600,
+                "protein": 42,
+                "carbs": 30,
+                "fat": 28,
+            },
+            {
+                "id": "disc_3",
+                "name": "Beef Stew",
+                "english_name": "Beef Stew",
+                "calories": 550,
+                "protein": 38,
+                "carbs": 45,
+                "fat": 18,
+            },
+        ],
+    )
+    service = AsyncMock()
+    service._repo.get_session.return_value = discovery_session
+    service._recipe_generator.generate_selected_recipes.return_value = [
+        _recipe("r1", "Chicken Rice", 500),
+        _recipe("r2", "Grilled Salmon", 600),
+        _recipe("r3", "Beef Stew", 550),
+    ]
+
+    recipes = await GenerateMealRecipesCommandHandler(service).handle(
+        GenerateMealRecipesCommand(
+            user_id="user-1",
+            meal_type="dinner",
+            language="en",
+            session_id="sess-discovery",
+            selected_meal_ids=["disc_1", "disc_2", "disc_3"],
+        )
+    )
+
+    assert len(recipes) == 3
+    assert [r.meal_name for r in recipes] == ["Chicken Rice", "Grilled Salmon", "Beef Stew"]
+    _, selected = service._recipe_generator.generate_selected_recipes.await_args.args
+    assert [m["id"] for m in selected] == ["disc_1", "disc_2", "disc_3"]
+    assert [m["calories"] for m in selected] == [500, 600, 550]
+
+
+@pytest.mark.asyncio
+async def test_generate_meal_recipes_handler_legacy_meal_names_uses_phase2():
+    """When only meal_names provided (no session_id/selected_ids), handler falls back to _phase2_generate_recipes."""
+    service = AsyncMock()
+    service._repo.get_session.return_value = None
+    service._recipe_generator._phase2_generate_recipes.return_value = [
+        _recipe("r1", "Grilled Chicken", 400),
+        _recipe("r2", "Pasta Primavera", 450),
+    ]
+
+    recipes = await GenerateMealRecipesCommandHandler(service).handle(
+        GenerateMealRecipesCommand(
+            user_id="user-1",
+            meal_type="lunch",
+            language="en",
+            meal_names=["Grilled Chicken", "Pasta Primavera"],
+            calorie_target=450,
+        )
+    )
+
+    assert len(recipes) == 2
+    assert [r.meal_name for r in recipes] == ["Grilled Chicken", "Pasta Primavera"]
+    service._recipe_generator._phase2_generate_recipes.assert_awaited_once()
+    service._recipe_generator.generate_selected_recipes.assert_not_awaited()
+
+
 def _recipe(recipe_id: str, name: str, calories: float) -> MealSuggestion:
     return MealSuggestion(
         id=recipe_id,

--- a/tests/unit/app/handlers/test_meal_suggestion_cqrs_handlers.py
+++ b/tests/unit/app/handlers/test_meal_suggestion_cqrs_handlers.py
@@ -238,6 +238,59 @@ async def test_generate_meal_recipes_handler_rejects_missing_session_without_cli
 
 
 @pytest.mark.asyncio
+async def test_generate_meal_recipes_handler_rejects_selected_count_mismatch():
+    discovery_session = SuggestionSession(
+        id="sess-discovery",
+        user_id="user-1",
+        meal_type="lunch",
+        meal_portion_type="main",
+        target_calories=500,
+        ingredients=["carp"],
+        cooking_time_minutes=30,
+        discovery_meals=[
+            {
+                "id": "disc_a",
+                "name": "Ginger Carp",
+                "english_name": "Ginger Carp",
+                "calories": 300,
+                "protein": 32,
+                "carbs": 18,
+                "fat": 10,
+            },
+            {
+                "id": "disc_b",
+                "name": "Grilled Carp",
+                "english_name": "Grilled Carp",
+                "calories": 350,
+                "protein": 35,
+                "carbs": 20,
+                "fat": 12,
+            },
+        ],
+    )
+    service = AsyncMock()
+    service._repo.get_session.return_value = discovery_session
+    service._recipe_generator.generate_selected_recipes.return_value = [
+        _recipe("r1", "Ginger Carp", 300)
+    ]
+
+    from src.api.exceptions import ExternalServiceException
+
+    with pytest.raises(ExternalServiceException) as exc:
+        await GenerateMealRecipesCommandHandler(service).handle(
+            GenerateMealRecipesCommand(
+                user_id="user-1",
+                meal_type="lunch",
+                language="en",
+                session_id="sess-discovery",
+                selected_meal_ids=["disc_a", "disc_b"],
+            )
+        )
+
+    assert exc.value.error_code == "RECIPE_GENERATION_FAILED"
+
+
+@pytest.mark.asyncio
 async def test_generate_meal_recipes_handler_returns_three_recipes_for_three_selected_ids():
     """3 selected_meal_ids from session → exactly 3 recipes in matching order."""
     discovery_session = SuggestionSession(

--- a/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
+++ b/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
@@ -296,3 +296,113 @@ class TestPhase2PreservesSubmissionOrder:
         for r in results:
             assert isinstance(r, MealSuggestion)
             assert r.meal_name in meal_names
+
+
+@pytest.mark.asyncio
+async def test_selected_recipes_retry_failed_slot_and_return_full_batch_in_order():
+    selected_meals = [
+        {
+            "id": "disc_a",
+            "name": "Ginger Chicken Rice",
+            "english_name": "Ginger Chicken Rice",
+            "calories": 450,
+            "protein": 35,
+            "carbs": 45,
+            "fat": 12,
+        },
+        {
+            "id": "disc_b",
+            "name": "Lemon Salmon Bowl",
+            "english_name": "Lemon Salmon Bowl",
+            "calories": 520,
+            "protein": 38,
+            "carbs": 50,
+            "fat": 18,
+        },
+    ]
+    session = make_session()
+    generator = make_generator()
+    calls: dict[str, int] = {}
+
+    async def fake_generate_with_retry(
+        prompt: str,
+        meal_name: str,
+        index: int,
+        recipe_system: str,
+        session: SuggestionSession,
+        reject_on_scale_out_of_range: bool = True,
+        fill_missing_steps: bool = False,
+    ) -> Optional[MealSuggestion]:
+        calls[meal_name] = calls.get(meal_name, 0) + 1
+        if meal_name == "Lemon Salmon Bowl" and calls[meal_name] == 1:
+            return None
+        return make_meal_suggestion(meal_name, index)
+
+    with patch.object(
+        generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+    ):
+        with patch(
+            "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+            ".build_recipe_details_prompt",
+            return_value="mock-prompt",
+        ):
+            results = await generator.generate_selected_recipes(session, selected_meals)
+
+    assert [r.meal_name for r in results] == [
+        "Ginger Chicken Rice",
+        "Lemon Salmon Bowl",
+    ]
+    assert calls["Lemon Salmon Bowl"] == 2
+
+
+@pytest.mark.asyncio
+async def test_selected_recipes_raise_when_any_slot_still_fails():
+    selected_meals = [
+        {
+            "id": "disc_a",
+            "name": "Ginger Chicken Rice",
+            "english_name": "Ginger Chicken Rice",
+            "calories": 450,
+            "protein": 35,
+            "carbs": 45,
+            "fat": 12,
+        },
+        {
+            "id": "disc_b",
+            "name": "Lemon Salmon Bowl",
+            "english_name": "Lemon Salmon Bowl",
+            "calories": 520,
+            "protein": 38,
+            "carbs": 50,
+            "fat": 18,
+        },
+    ]
+    session = make_session()
+    generator = make_generator()
+
+    async def fake_generate_with_retry(
+        prompt: str,
+        meal_name: str,
+        index: int,
+        recipe_system: str,
+        session: SuggestionSession,
+        reject_on_scale_out_of_range: bool = True,
+        fill_missing_steps: bool = False,
+    ) -> Optional[MealSuggestion]:
+        if meal_name == "Lemon Salmon Bowl":
+            return None
+        return make_meal_suggestion(meal_name, index)
+
+    with patch.object(
+        generator, "_generate_with_retry", side_effect=fake_generate_with_retry
+    ):
+        with patch(
+            "src.domain.services.meal_suggestion.suggestion_prompt_builder"
+            ".build_recipe_details_prompt",
+            return_value="mock-prompt",
+        ):
+            with pytest.raises(RuntimeError) as exc:
+                await generator.generate_selected_recipes(session, selected_meals)
+
+    assert "Failed to generate all selected recipes" in str(exc.value)
+    assert "disc_b" in str(exc.value)

--- a/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
+++ b/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
@@ -406,3 +406,53 @@ async def test_selected_recipes_raise_when_any_slot_still_fails():
 
     assert "Failed to generate all selected recipes" in str(exc.value)
     assert "disc_b" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_with_retry_passes_recipe_details_schema_to_generation_service():
+    from src.infra.services.ai.schemas import RecipeDetailsResponse
+
+    session = make_session()
+    generator = make_generator()
+    generator._recipe_details_schema = RecipeDetailsResponse
+
+    raw_recipe = {
+        "ingredients": [
+            {"name": "chicken breast", "amount": 180, "unit": "g"},
+            {"name": "rice", "amount": 160, "unit": "g"},
+            {"name": "ginger", "amount": 8, "unit": "g"},
+        ],
+        "recipe_steps": [
+            {"step": 1, "instruction": "Cook rice.", "duration_minutes": 12},
+            {"step": 2, "instruction": "Cook chicken.", "duration_minutes": 10},
+        ],
+        "prep_time_minutes": 25,
+    }
+    generator._generation.generate_meal_plan.return_value = raw_recipe
+
+    meal_macros = MagicMock()
+    meal_macros.calories = 450
+    meal_macros.protein = 35
+    meal_macros.carbs = 45
+    meal_macros.fat = 12
+    meal_macros.ingredients = []
+    meal_macros.t1_count = 3
+    meal_macros.t2_count = 0
+    meal_macros.t3_count = 0
+    generator._nutrition_lookup.calculate_meal_macros = AsyncMock(
+        return_value=meal_macros
+    )
+    generator._nutrition_lookup.scale_to_target.return_value = meal_macros
+    generator._macro_validator.validate_deterministic.return_value = meal_macros
+
+    result = await generator._generate_with_retry(
+        "prompt",
+        "Ginger Chicken Rice",
+        0,
+        "system",
+        session,
+    )
+
+    assert result is not None
+    first_call = generator._generation.generate_meal_plan.call_args_list[0]
+    assert first_call.args[4] is RecipeDetailsResponse

--- a/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
+++ b/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_order.py
@@ -61,7 +61,7 @@ def make_meal_suggestion(meal_name: str, index: int) -> MealSuggestion:
 
 def make_generator() -> ParallelRecipeGenerator:
     """Build a ParallelRecipeGenerator with mock dependencies."""
-    from src.infra.services.ai.schemas import MealNamesResponse, DiscoveryMealsResponse
+    from src.infra.services.ai.schemas import DiscoveryMealsResponse, MealNamesResponse, RecipeDetailsResponse
 
     generation_service = MagicMock()
     translation_service = MagicMock()
@@ -74,6 +74,7 @@ def make_generator() -> ParallelRecipeGenerator:
         nutrition_lookup=nutrition_lookup,
         meal_names_schema_class=MealNamesResponse,
         discovery_meals_schema_class=DiscoveryMealsResponse,
+        recipe_details_schema_class=RecipeDetailsResponse,
     )
 
 

--- a/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_pipeline.py
+++ b/tests/unit/domain/services/meal_suggestion/test_parallel_recipe_generator_pipeline.py
@@ -17,7 +17,7 @@ def _make_suggestion(name: str) -> MealSuggestion:
 
 
 def _make_generator() -> tuple:
-    from src.infra.services.ai.schemas import MealNamesResponse, DiscoveryMealsResponse
+    from src.infra.services.ai.schemas import DiscoveryMealsResponse, MealNamesResponse, RecipeDetailsResponse
 
     translate_svc = MagicMock()
     translate_svc.translate_meal_suggestions_batch = AsyncMock(
@@ -30,6 +30,7 @@ def _make_generator() -> tuple:
         nutrition_lookup=MagicMock(),
         meal_names_schema_class=MealNamesResponse,
         discovery_meals_schema_class=DiscoveryMealsResponse,
+        recipe_details_schema_class=RecipeDetailsResponse,
     )
     return gen, translate_svc
 

--- a/tests/unit/domain/services/test_suggestion_prompt_builder.py
+++ b/tests/unit/domain/services/test_suggestion_prompt_builder.py
@@ -405,3 +405,19 @@ class TestPromptContent:
         # Names prompt under 2000 chars, recipe prompt under 3000 (includes macro/decomposition rules)
         assert len(names_prompt) < 2000
         assert len(recipe_prompt) < 3000
+
+    def test_empty_ingredients_prompt_uses_common_ingredients(self, mock_session):
+        mock_session.ingredients = []
+
+        prompt = build_recipe_details_prompt("Tomato Egg Rice", mock_session)
+
+        assert "Use common ingredients appropriate for the dish." in prompt
+        assert "MUST include user's ingredients" not in prompt
+        assert "any ingredients" not in prompt
+
+    def test_non_empty_ingredients_prompt_uses_compatible_wording(self, mock_session):
+        prompt = build_recipe_details_prompt("Chicken Rice Bowl", mock_session)
+
+        assert "Use these ingredients as main components where compatible" in prompt
+        assert "MUST include user's ingredients" not in prompt
+        assert "no substitutions" not in prompt.lower()

--- a/tests/unit/infra/services/ai/test_schemas.py
+++ b/tests/unit/infra/services/ai/test_schemas.py
@@ -265,6 +265,27 @@ class TestRecipeDetailsResponse:
         assert response.calories == 2800
         assert response.protein == 180.0
 
+    def test_accepts_optional_recipe_metadata(self):
+        response = RecipeDetailsResponse(
+            ingredients=[
+                IngredientItem(name="Chicken breast", amount=180, unit="g"),
+                IngredientItem(name="Rice", amount=160, unit="g"),
+                IngredientItem(name="Ginger", amount=8, unit="g"),
+            ],
+            recipe_steps=[
+                RecipeStepItem(step=1, instruction="Cook rice", duration_minutes=12),
+                RecipeStepItem(step=2, instruction="Cook chicken", duration_minutes=10),
+            ],
+            prep_time_minutes=25,
+            origin_country="Vietnam",
+            cuisine_type="Vietnamese",
+            emoji="🍚",
+        )
+
+        assert response.origin_country == "Vietnam"
+        assert response.cuisine_type == "Vietnamese"
+        assert response.emoji == "🍚"
+
 
 class TestIngredientItem:
     """Test IngredientItem validation."""


### PR DESCRIPTION
…ted-recipe flow

Add three handler-level tests covering plan.md test scenarios not previously exercised: 3 selected IDs → exactly 3 ordered recipes, and the legacy meal_names-only path falling through to _phase2_generate_recipes.