### PR TITLE
fix: deactivate FCM tokens that return PERMISSION_DENIED

### DIFF
--- a/src/domain/services/notification_service.py
+++ b/src/domain/services/notification_service.py
@@ -21,6 +21,7 @@ DEACTIVATABLE_FCM_ERRORS = {
     "UNREGISTERED",  # Token unregistered from FCM
     "INVALID_ARGUMENT",  # Malformed token
     "UNAUTHENTICATED",  # Token from different Firebase project (e.g. debug build)
+    "PERMISSION_DENIED",  # Token registered to a different sender ID / Firebase project
 }
 
 


### PR DESCRIPTION
Tokens from a different Firebase project (e.g. dev builds) return PERMISSION_DENIED rather than UNREGISTERED, causing the cron job to retry them on every run without ever cleaning them up.