### PR TITLE
docs: refresh backend docs + document 200-line principle

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,6 +1,6 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** May 6, 2026
+**Last Updated:** May 27, 2026
 **Base URL:** `http://localhost:8000` (dev) or deployed host
 **API Docs:** `/docs` (Swagger UI)
 **Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
@@ -143,11 +143,11 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 
 ## Referrals
 
-Referral codes are 3–15 characters. Commission rates are configurable via `REFERRAL_COMMISSIONS` env var (per-currency JSON; default: `{"USD": 2, "VND": 50000, "EUR": 1.8, "default": 2}`).
+Codes are 3–15 characters. Commission rates set via `REFERRAL_COMMISSIONS` env var. See `external-services.md`.
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/v1/referrals/validate` | Validate referral code (3–15 chars) |
+| POST | `/v1/referrals/validate` | Validate referral code |
 | POST | `/v1/referrals/apply` | Apply referral code |
 | GET | `/v1/referrals/my-code` | Get user's referral code |
 | GET | `/v1/referrals/stats` | Get referral stats |
@@ -176,7 +176,17 @@ Referral codes are 3–15 characters. Commission rates are configurable via `REF
 
 ---
 
+## Codes
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/codes/validate` | Validate promo or referral code before purchase (does not redeem) |
+
+---
+
 ## Webhooks
+
+Handles RevenueCat lifecycle events (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER). Signature verified via constant-time HMAC; events mirrored to PostHog when `POSTHOG_API_KEY` is set.
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,6 +1,6 @@
 # Backend Code Standards — Python Style & Conventions
 
-**Last Updated:** May 6, 2026
+**Last Updated:** May 27, 2026
 **Scope:** All code in `src/` (430 files, ~38.5K LOC)  
 **Applies To:** Typing, naming, imports, code organization, error handling
 
@@ -25,11 +25,20 @@
 
 ---
 
-## File Size Limits
+## File Size Limits (200-Line Principle)
 
+Keep files small enough to read, review, and — for AI-context files — load with full model attention. Origin: context-engineering research on LLM instruction-following (degradation past ~200–300 instructions). Source: [Quy tắc 200 dòng](https://thieunv.substack.com/p/ce-02-quy-tac-200-dong).
+
+### Code files
 - **Target**: <200 LOC per file for readability
 - **Maximum**: 400 LOC absolute limit
 - **Action**: Split into smaller, focused modules if exceeding target
+
+### Documentation & AI-context files
+Entry points stay lean; detail moves to on-demand references (progressive disclosure):
+- **`CLAUDE.md`**: <100 lines (loads every session)
+- **Tier-3 reference docs** (`docs/*.md`): target <200 lines, hard cap ~300; split by topic and link from the entry point
+- Treat each doc as a table of contents that points to detail, not a dumping ground
 
 ---
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,6 +1,6 @@
 # Backend Codebase Summary
 
-**Generated:** May 15, 2026
+**Generated:** May 27, 2026
 **Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)
 **Language:** Python 3.11+ | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
 
@@ -31,7 +31,7 @@
 | Database Tables | 13+ (core + notification_sent_log for dedup) |
 | Repositories | 10+ with smart sync and eager loading |
 | Port Interfaces | 17 port interfaces for dependency inversion |
-| External Integrations | 8 (Gemini, Pinecone, Firebase, Cloudinary, RevenueCat, Redis, MySQL, Sentry) |
+| External Integrations | 9 (Gemini, Pinecone, Firebase, Cloudinary, RevenueCat, PostHog, Redis, MySQL, Sentry) |
 
 ---
 
@@ -55,12 +55,13 @@
 
 ## Recent Features (May 2026)
 
+- **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry pushes at T-2d and T-1d; notifications rescheduled on timezone changes; `SchedulerLeaderLock` (flock + PostgreSQL advisory lock) for multi-replica deployments; `DailyContextPrecomputeService` pre-computes calorie context at timezone midnight
+- **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; PostHog lifecycle mirroring
+- **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` — fire-and-forget async capture; enabled by `POSTHOG_API_KEY`
+- **Parallel Recipe Generator:** `src/domain/services/meal_suggestion/parallel_recipe_generator.py` with per-recipe attempt logic in `recipe_attempt_builder.py`; 3-phase pipeline: name generation → parallel recipe generation → translation
+- **Scheduled Email Service:** `ScheduledEmailService` runs re-engagement and trial-expiry emails at startup via `src/infra/services/scheduled_email_service.py`
 - **Configurable Referral Commission:** `REFERRAL_COMMISSIONS` env var (JSON dict, per-currency, default 2 USD)
-- **Custom Unit Normalization:** Food items with non-standard units now convert to grams before nutrition calculation
-- **BMR Floor Protection:** Daily target never drops below 85% of standard daily (raised from 80%); cutting deficit reduced to 300 kcal
-- **Email Deep Links:** Universal Links via `/.well-known/apple-app-site-association`; `/app-download` redirect with campaign tracking
-- **AsyncUnitOfWork Concurrency Guard:** `asyncio.Lock` prevents concurrent reuse; handlers receive fresh UoW per `event_bus.send()` call
-- **Variable-Length Referral Codes:** 3–15 character codes (previously fixed length)
+- **Variable-Length Referral Codes:** 3–15 character codes
 
 ---
 
@@ -83,7 +84,7 @@
 | SuggestionOrchestrationService | Session-based meal suggestions (4h Redis TTL) |
 | MealGenerationService | Multi-model Gemini for meal generation |
 | TranslationService | 7-language support (en, vi, es, fr, de, ja, zh) |
-| NotificationService | FCM push notifications with dedup |
+| NotificationService | FCM push notifications with dedup; platform-specific builders; scheduler leader election |
 | MealDiscoveryService | Image-based meal discovery |
 
 ---

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,7 +1,7 @@
 # Backend External Services Integration
 
-**Last Updated:** May 6, 2026
-**Services:** Firebase, Cloudinary, Google Gemini, RevenueCat, Redis, Sentry
+**Last Updated:** May 27, 2026
+**Services:** Firebase, Cloudinary, Google Gemini, RevenueCat, PostHog, Redis, Sentry
 **All services gracefully degrade on failure** (except Firebase Auth and DB which fail fast)
 
 ---
@@ -18,9 +18,16 @@
 **Config:** `FIREBASE_CREDENTIALS=path/to/credentials.json`
 
 ### Firebase Cloud Messaging (FCM)
-- Platform-specific configs (Android high priority, APNS alert/badge/sound)
+- Platform-specific payload builders in `src/infra/services/push/`
+  - `android_payload_builder.py`: high-priority Android config with channel ID (`meal_reminders` or `daily_summary`)
+  - `apns_payload_builder.py`: APNs Time Sensitive payload with `interruption-level` in payload body (not headers), priority 10
 - Multi-device support via `user_fcm_tokens` table
 - Deduplication across workers via `notification_sent_log` table (migration 047)
+- Trial-expiry pushes at T-2d and T-1d via `ScheduledSubscriptionPushService` (`src/infra/services/scheduled_subscription_push_service.py`)
+- Notifications rescheduled automatically on timezone changes — triggered from `UpdateTimezoneCommandHandler` and `RegisterFcmTokenCommandHandler`
+- Scheduler leader election: `SchedulerLeaderLock` (`src/infra/services/scheduler_leader_lock.py`) uses `fcntl.flock` (per-process) + PostgreSQL advisory lock (cross-container) to ensure a single scheduler leader
+- Batch loop in `ScheduledNotificationService` (`src/infra/services/scheduled_notification_service.py`): 60-second tick, detects timezone midnights for `DailyContextPrecomputeService`, fetches due notifications, batch-sends, marks sent
+- APNs diagnostics surfaced at `/health/notifications` via `apns_diagnostics()` to verify `interruption-level` placement
 
 ---
 
@@ -75,12 +82,37 @@
 
 - Webhook sync to local `subscriptions` table
 - Premium status check with Redis cache fallback
-- Signature verification for webhooks
-- Webhook events: purchase, renewal, cancellation, expiration
+- Signature verification via constant-time HMAC comparison
+- Webhook events handled in `src/api/routes/v1/webhooks.py`:
+
+| Event | Action |
+|-------|--------|
+| `INITIAL_PURCHASE` | Create subscription record, credit referral wallet |
+| `RENEWAL` | Update expiry, reset billing-issue flag |
+| `CANCELLATION` | Set status to `cancelled` |
+| `EXPIRATION` | Set status to `expired` |
+| `BILLING_ISSUE` | Set status to `billing_issue` |
+| `PRODUCT_CHANGE` | Update product ID and expiry |
+| `REFUND` | Set status to `refunded`, revoke referral credit |
+| `TRANSFER` | Re-point subscription to new subscriber ID |
+
+- PostHog lifecycle mirroring for CANCELLATION, EXPIRATION, BILLING_ISSUE, REFUND, RENEWAL, PRODUCT_CHANGE events (configurable via `POSTHOG_API_KEY`)
 
 **Config:** `REVENUECAT_SECRET_API_KEY`, `REVENUECAT_WEBHOOK_SECRET`
 
 **Status:** Premium feature gates planned, not currently enforced on routes
+
+---
+
+## PostHog
+
+**Purpose:** Product analytics — subscription lifecycle event capture
+
+- `src/infra/adapters/posthog_adapter.py`: fire-and-forget async capture via `httpx` (3s timeout)
+- Only sends events when `POSTHOG_API_KEY` is set; silently skips otherwise
+- Currently captures subscription lifecycle events mirrored from RevenueCat webhooks
+
+**Config:** `POSTHOG_API_KEY`, `POSTHOG_HOST` (default: `https://app.posthog.com`)
 
 ---
 
@@ -144,6 +176,7 @@ GET /health/notifications      # FCM health
 | Gemini | Fail fast (503) | Return error to client |
 | Cloudinary | Degrade (fallback URL) | Continue with best-effort image |
 | RevenueCat | Degrade (assume premium from cache) | Continue with last-known status |
+| PostHog | Degrade (log warning) | Continue without analytics |
 | Redis | Degrade (bypass cache) | Continue without caching |
 | Sentry | Degrade (log locally) | Continue with local logging |
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,7 +1,7 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.2
-**Last Updated:** May 15, 2026
+**Version:** 0.6.3
+**Last Updated:** May 27, 2026
 **Status:** Production-ready. 430 source files, ~38K LOC across 4 layers (API: 76, App: 140, Domain: 133, Infra: 80). 681+ tests, 70%+ coverage.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
 
@@ -9,13 +9,26 @@
 
 ## Completed Phases
 
-### May 2026: Nutrition Fixes, Referral Improvements, Email Deep Links
+### May 2026 (late): Notification Overhaul, RevenueCat Webhook Expansion, Meal-Suggestion Parallel Generator
+- [x] Platform-specific FCM payload builders: `android_payload_builder.py` (high-priority, channel IDs), `apns_payload_builder.py` (APNs Time Sensitive, `interruption-level` in payload body)
+- [x] Trial-expiry push notifications at T-2d and T-1d via `ScheduledSubscriptionPushService`
+- [x] Timezone-change notification reschedule in `UpdateTimezoneCommandHandler` and `RegisterFcmTokenCommandHandler`
+- [x] Scheduler leader election: `SchedulerLeaderLock` (flock + PostgreSQL advisory lock) prevents duplicate scheduled sends across replicas
+- [x] `DailyContextPrecomputeService`: batch pre-computes user calorie context at timezone midnight
+- [x] `ScheduledNotificationService`: 60-second tick loop with timezone-midnight detection and batch FCM send
+- [x] RevenueCat webhook full lifecycle: INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER
+- [x] PostHog lifecycle mirroring for subscription events via `PostHogAdapter`
+- [x] Referral credit/revoke wired to INITIAL_PURCHASE / REFUND webhooks
+- [x] Parallel recipe generator: 3-phase pipeline (name generation → parallel generation → translation)
+- [x] Scheduled email service: re-engagement and trial-expiry emails at startup
+
+### May 2026 (early): Nutrition Fixes, Referral Improvements, Email Deep Links
 - [x] Configurable referral commission rates via `REFERRAL_COMMISSIONS` env var (per-currency JSON)
 - [x] Custom unit-to-grams normalization fix in nutrition calculation (`convert_quantity_to_grams`)
 - [x] BMR floor raised to 85% of standard daily; cutting deficit reduced 500→300 kcal (clinical floor: 1200F/1500M)
 - [x] Email Universal Links: `/.well-known/apple-app-site-association` + `/app-download` redirect
 - [x] AsyncUnitOfWork concurrency guard (`asyncio.Lock`); handlers cloned with fresh UoW per dispatch
-- [x] Variable-length referral codes: 3–15 characters (PR #252)
+- [x] Variable-length referral codes: 3–15 characters
 
 ### April 2026: Sentry Monitoring, Meal Discovery, Onboarding Redesign
 - [x] Sentry SDK integration for error tracking and performance monitoring

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,6 +1,6 @@
 # Backend System Architecture Overview
 
-**Last Updated:** May 15, 2026
+**Last Updated:** May 27, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
 **Codebase:** 430 files, ~38.5K LOC across 4 layers
@@ -40,7 +40,7 @@
 | API | 76 | ~8,605 | 17 route modules, 34 Pydantic schemas, 8 mappers, 3 middleware |
 | App | 140 | ~6,229 | 30 commands, 31 queries, 19 events, 51+ handlers, 3 app services |
 | Domain | 133 | ~14,556 | 8 bounded contexts, 30+ entities, 50+ services, 17 port interfaces |
-| Infra | 80 | ~8,895 | 13+ DB tables, 10+ repos, Redis, PyMediator, external adapters |
+| Infra | 80 | ~8,895 | 13+ DB tables, 10+ repos, Redis, PyMediator, external adapters, push payload builders |
 | **Total** | **430** | **~38,300** | |
 
 **Layer rule:** Domain has ZERO external dependencies. See `cqrs-guide.md` for handler patterns.
@@ -77,7 +77,7 @@ Smart sync (diff-based updates), eager loading via pre-defined `joinedload` opti
 | User | User, UserProfile, Activity, TdeeRequest |
 | Meal Planning | MealPlan, PlannedMeal, DayPlan, UserPreferences |
 | Conversation | Conversation, Message, ConversationState |
-| Notification | UserFcmToken, NotificationPreferences, PushNotification |
+| Notification | UserFcmToken, NotificationPreferences, PushNotification, NotificationSentLog |
 | AI | GPTAnalysisResponse, GPTFoodItem, GPTResponseError |
 | Chat | Thread, Message, ThreadStatus, MessageRole |
 


### PR DESCRIPTION
## Summary
- Refresh backend docs to reflect recent backend work: notification/push overhaul (platform-specific FCM payload builders, trial-expiry pushes, scheduler leader lock + `NotificationSentLog`), RevenueCat webhook lifecycle events, PostHog analytics adapter, and the parallel recipe generator.
- Document the **200-line principle** in `code-standards.md` (applies to both code files and AI-context/doc files) with source citation, and formalize progressive disclosure for docs (lean entry point → on-demand references).
- Bump roadmap to 0.6.3; refresh `codebase-summary.md` and `system-architecture.md` accordingly.

## Files
- `docs/code-standards.md` — 200-line principle + citation
- `docs/external-services.md` — FCM push builders, RevenueCat lifecycle table, PostHog
- `docs/codebase-summary.md` — integrations 8→9, recent features
- `docs/project-roadmap.md` — 0.6.2 → 0.6.3
- `docs/api-endpoints.md` — `/v1/codes/validate`, expanded webhooks
- `docs/system-architecture.md` — push builders, `NotificationSentLog`

## Notes
- Docs-only change; no source code touched.
- `docs/api-endpoints.md` is at ~210 lines, slightly over the 200-line target — flagged as a follow-up split, not addressed here to keep this PR scoped to the refresh.

## Test plan
- [ ] Skim each doc for accuracy against current backend behavior
- [ ] Confirm 200-line citation/link renders correctly