### PR TITLE
fix: harden concurrency, security, and webhook robustness

### DIFF
--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -123,6 +123,6 @@ def handle_exception(exc: Exception) -> HTTPException:
         detail={
             "error_code": "INTERNAL_ERROR",
             "message": "An unexpected error occurred",
-            "details": {"error": str(exc)},
+            "details": {},
         },
     )

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -207,7 +207,6 @@ async def lifespan(app: FastAPI):
         if os.getenv("FAIL_ON_CACHE_ERROR", "false").lower() == "true":
             raise
 
-
     # Initialize Gemini explicit context caches
     gemini_cache_manager = None
     try:
@@ -221,6 +220,7 @@ async def lifespan(app: FastAPI):
             gemini_cache_manager.start_refresh_loop()
             logger.info("Gemini context caches warmed")
             from src.infra.services.ai.ai_model_manager import AIModelManager
+
             AIModelManager.get_instance().set_cache_manager(gemini_cache_manager)
             logger.info("GeminiCacheManager wired into AIModelManager")
         else:
@@ -228,6 +228,20 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Gemini cache warmup failed (non-fatal): {e}")
 
+    # Eagerly build singleton event buses during single-threaded startup so
+    # concurrent first requests never race the lazy initializer (which would
+    # otherwise build several throwaway buses on a cold start).
+    try:
+        from src.api.dependencies.event_bus import (
+            get_configured_event_bus,
+            get_food_search_event_bus,
+        )
+
+        get_configured_event_bus()
+        get_food_search_event_bus()
+        logger.info("Event buses initialized")
+    except Exception as e:
+        logger.warning("Event bus eager init failed (non-fatal): %s", e)
 
     logger.info("MealTrack API started successfully!")
     yield
@@ -241,7 +255,6 @@ async def lifespan(app: FastAPI):
             await gemini_cache_manager.stop()
         except Exception as e:
             logger.warning(f"Gemini cache manager stop failed: {e}")
-
 
     # Disconnect cache
     await shutdown_cache_layer()

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -248,10 +248,16 @@ async def parse_meal_text(
     User types "2 eggs and toast" → Gemini parses → returns structured items with nutrition.
     """
     try:
+        sanitized_text = sanitize_user_description(payload.text)
+        if not sanitized_text:
+            raise ValidationException(
+                message="Invalid or empty meal description.",
+                error_code="INVALID_MEAL_TEXT",
+            )
         # Use Accept-Language header as single source of truth for locale
         language = get_request_language(request)
         command = ParseMealTextCommand(
-            text=payload.text,
+            text=sanitized_text,
             language=language,
             user_id=user_id,
             current_items=payload.current_items,
@@ -450,7 +456,6 @@ async def update_meal_ingredients(
     Requires authentication - users can only modify their own meals.
     """
     try:
-
         logger.info("Updating meal ingredients for meal %s", meal_id)
         # Convert request to command
         food_item_changes = []

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -8,7 +8,7 @@ import hmac
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Header, HTTPException, Request
 from sqlalchemy import select, text
@@ -162,15 +162,15 @@ async def find_user_for_revenuecat_event(uow, event: dict) -> User | None:
         if user:
             return user
 
-        # User.id is a UUID column; non-UUID candidates (e.g. $RCAnonymousID:...)
-        # would raise asyncpg DataError → 500 → RevenueCat retry storm.
+        # User.id stores UUID values as strings; skip anonymous/non-UUID
+        # RevenueCat IDs here so only valid internal IDs hit this fallback.
         try:
             candidate_uuid = uuid.UUID(candidate)
         except (ValueError, AttributeError, TypeError):
             candidate_uuid = None
         if candidate_uuid is not None:
             result = await uow.session.execute(
-                select(User).where(User.id == candidate_uuid)
+                select(User).where(User.id == str(candidate_uuid))
             )
             user = result.scalars().first()
             if user:
@@ -519,7 +519,7 @@ def parse_timestamp(ms: int | None) -> datetime | None:
     if ms is None:
         return None
     try:
-        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(ms / 1000, tz=UTC)
     except Exception as e:
         logger.error(f"Error parsing timestamp {ms}: {e}")
         return None

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -3,6 +3,7 @@ Webhook handlers for RevenueCat events.
 
 Syncs subscription data to local database.
 """
+
 import hmac
 import logging
 import os
@@ -52,8 +53,7 @@ def _get_email_service() -> EmailService:
 
 @router.post("/revenuecat")
 async def revenuecat_webhook(
-    request: Request,
-    authorization: str | None = Header(None)
+    request: Request, authorization: str | None = Header(None)
 ):
     """
     Handle RevenueCat webhook events.
@@ -84,7 +84,9 @@ async def revenuecat_webhook(
     event_type = event.get("type")
     app_user_id = event.get("app_user_id")
 
-    logger.info(f"RevenueCat webhook received: {event_type} for app_user_id={app_user_id}")
+    logger.info(
+        f"RevenueCat webhook received: {event_type} for app_user_id={app_user_id}"
+    )
 
     # Get user
     async with AsyncUnitOfWork() as uow:
@@ -144,7 +146,9 @@ def _candidate_revenuecat_ids(event: dict) -> list[str]:
     return [
         candidate
         for candidate in candidates
-        if isinstance(candidate, str) and candidate and not (candidate in seen or seen.add(candidate))
+        if isinstance(candidate, str)
+        and candidate
+        and not (candidate in seen or seen.add(candidate))
     ]
 
 
@@ -158,10 +162,19 @@ async def find_user_for_revenuecat_event(uow, event: dict) -> User | None:
         if user:
             return user
 
-        result = await uow.session.execute(select(User).where(User.id == candidate))
-        user = result.scalars().first()
-        if user:
-            return user
+        # User.id is a UUID column; non-UUID candidates (e.g. $RCAnonymousID:...)
+        # would raise asyncpg DataError → 500 → RevenueCat retry storm.
+        try:
+            candidate_uuid = uuid.UUID(candidate)
+        except (ValueError, AttributeError, TypeError):
+            candidate_uuid = None
+        if candidate_uuid is not None:
+            result = await uow.session.execute(
+                select(User).where(User.id == candidate_uuid)
+            )
+            user = result.scalars().first()
+            if user:
+                return user
 
         subscription = await uow.subscriptions.find_by_revenuecat_id(candidate)
         if subscription:
@@ -218,9 +231,15 @@ async def handle_transfer(uow, event):
 def _preferred_transfer_target(transferred_to: list[str]) -> str | None:
     """Prefer a custom app user ID over RevenueCat anonymous IDs."""
     for candidate in transferred_to:
-        if isinstance(candidate, str) and candidate and not candidate.startswith("$RCAnonymousID:"):
+        if (
+            isinstance(candidate, str)
+            and candidate
+            and not candidate.startswith("$RCAnonymousID:")
+        ):
             return candidate
-    return next((item for item in transferred_to if isinstance(item, str) and item), None)
+    return next(
+        (item for item in transferred_to if isinstance(item, str) and item), None
+    )
 
 
 async def handle_purchase(uow, user, event):
@@ -228,10 +247,7 @@ async def handle_purchase(uow, user, event):
     logger.info(f"Creating subscription for user {user.id}")
 
     # Check if subscription already exists
-    existing = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
-    )
+    existing = await get_subscription_by_revenuecat_id(uow, event.get("app_user_id"))
 
     if existing:
         logger.warning(f"Subscription already exists for {user.id}, updating instead")
@@ -262,15 +278,16 @@ async def handle_purchase(uow, user, event):
 async def handle_renewal(uow, user, event):
     """Handle subscription renewal."""
     subscription = await get_subscription_by_revenuecat_id(
-        uow,
-        event.get("app_user_id")
+        uow, event.get("app_user_id")
     )
 
     if subscription:
         subscription.expires_at = parse_timestamp(event.get("expiration_at_ms"))
         subscription.status = "active"
         subscription.updated_at = utc_now()
-        logger.info(f"User {user.id} renewed subscription until {subscription.expires_at}")
+        logger.info(
+            f"User {user.id} renewed subscription until {subscription.expires_at}"
+        )
     else:
         logger.warning("Subscription not found for renewal, creating new one")
         await handle_purchase(uow, user, event)
@@ -281,14 +298,12 @@ async def handle_renewal(uow, user, event):
     # "your trial ends tomorrow" push for a sub that just auto-renewed.
     try:
         await uow.session.execute(
-            text(
-                """
+            text("""
                 DELETE FROM notifications
                 WHERE user_id = :uid
                   AND notification_type LIKE 'trial_expiry%'
                   AND status = 'pending'
-                """
-            ),
+                """),
             {"uid": user.id},
         )
     except Exception:
@@ -307,9 +322,13 @@ async def handle_cancellation(uow, user, event):
         subscription.cancelled_at = utc_now()
         subscription.updated_at = utc_now()
         # Note: User still has access until expires_at
-        logger.info(f"User {user.id} cancelled subscription (expires {subscription.expires_at})")
+        logger.info(
+            f"User {user.id} cancelled subscription (expires {subscription.expires_at})"
+        )
 
-    await capture_subscription_lifecycle_event(user, event, "CANCELLATION", subscription)
+    await capture_subscription_lifecycle_event(
+        user, event, "CANCELLATION", subscription
+    )
 
     # Send cancellation email
     if not user.email_opt_out:
@@ -342,7 +361,9 @@ async def handle_billing_issue(uow, user, event):
         subscription.updated_at = utc_now()
         logger.warning(f"Billing issue for user {user.id}")
 
-    await capture_subscription_lifecycle_event(user, event, "BILLING_ISSUE", subscription)
+    await capture_subscription_lifecycle_event(
+        user, event, "BILLING_ISSUE", subscription
+    )
 
 
 async def handle_product_change(uow, user, event):
@@ -356,7 +377,9 @@ async def handle_product_change(uow, user, event):
         subscription.updated_at = utc_now()
         logger.info(f"User {user.id} changed to {subscription.product_id}")
 
-    await capture_subscription_lifecycle_event(user, event, "PRODUCT_CHANGE", subscription)
+    await capture_subscription_lifecycle_event(
+        user, event, "PRODUCT_CHANGE", subscription
+    )
 
 
 async def handle_refund(uow, user, event):
@@ -372,7 +395,9 @@ async def handle_refund(uow, user, event):
     await _revoke_referral_on_refund(uow, str(user.id))
 
 
-async def capture_subscription_lifecycle_event(user, event, event_type, subscription) -> None:
+async def capture_subscription_lifecycle_event(
+    user, event, event_type, subscription
+) -> None:
     """Mirror RevenueCat lifecycle webhooks into PostHog when configured."""
     posthog_event = POSTHOG_LIFECYCLE_EVENTS.get(event_type)
     if not posthog_event:
@@ -380,7 +405,8 @@ async def capture_subscription_lifecycle_event(user, event, event_type, subscrip
 
     properties = {
         "revenuecat_event_type": event_type,
-        "product_id": event.get("product_id") or getattr(subscription, "product_id", None),
+        "product_id": event.get("product_id")
+        or getattr(subscription, "product_id", None),
         "platform": parse_platform(event.get("store")),
         "store": event.get("store"),
         "environment": event.get("environment"),
@@ -394,15 +420,18 @@ async def capture_subscription_lifecycle_event(user, event, event_type, subscrip
     await PostHogAdapter().capture(
         distinct_id=getattr(user, "firebase_uid", None) or str(user.id),
         event=posthog_event,
-        properties={key: value for key, value in properties.items() if value is not None},
+        properties={
+            key: value for key, value in properties.items() if value is not None
+        },
     )
 
 
 async def _credit_referral_on_purchase(uow, user_id: str) -> None:
     """Credit the referrer's wallet when a referred user completes their first purchase."""
     from src.infra.repositories.referral_repository import ReferralRepository
+
     repo = ReferralRepository(uow.session)
-    conversion = await repo.get_conversion_by_referred_user(user_id)
+    conversion = await repo.get_conversion_by_referred_user(user_id, for_update=True)
     if conversion and conversion.status == "pending":
         conversion.status = "converted"
         conversion.converted_at = utc_now()
@@ -421,8 +450,9 @@ async def _credit_referral_on_purchase(uow, user_id: str) -> None:
 async def _revoke_referral_on_refund(uow, user_id: str) -> None:
     """Revoke the referrer's wallet credit when a referred user is refunded."""
     from src.infra.repositories.referral_repository import ReferralRepository
+
     repo = ReferralRepository(uow.session)
-    conversion = await repo.get_conversion_by_referred_user(user_id)
+    conversion = await repo.get_conversion_by_referred_user(user_id, for_update=True)
     if conversion and conversion.status == "converted":
         conversion.status = "revoked"
         conversion.revoked_at = utc_now()
@@ -438,10 +468,14 @@ async def _revoke_referral_on_refund(uow, user_id: str) -> None:
 
 async def get_or_create_subscription(uow, user, event):
     """Get existing subscription or create one if missing (handles missed INITIAL_PURCHASE)."""
-    subscription = await uow.subscriptions.find_by_revenuecat_id(event.get("app_user_id"))
+    subscription = await uow.subscriptions.find_by_revenuecat_id(
+        event.get("app_user_id")
+    )
 
     if not subscription:
-        logger.warning(f"No subscription found for user {user.id}, creating record (missed INITIAL_PURCHASE)")
+        logger.warning(
+            f"No subscription found for user {user.id}, creating record (missed INITIAL_PURCHASE)"
+        )
         subscription = Subscription(
             id=str(uuid.uuid4()),
             user_id=user.id,

--- a/src/domain/services/meal_suggestion/ingredient_nutrition_resolver.py
+++ b/src/domain/services/meal_suggestion/ingredient_nutrition_resolver.py
@@ -6,6 +6,7 @@ ingredients. Every cache hit is persisted to food_reference so T1
 warms automatically over time.
 """
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -134,7 +135,9 @@ class IngredientNutritionResolver:
         external_id: Optional[str] = food.get("food_id")
 
         try:
-            self._repo.upsert_by_normalized_name(
+            # Repo uses a sync Session; offload so the event loop isn't blocked.
+            await asyncio.to_thread(
+                self._repo.upsert_by_normalized_name,
                 name=name,
                 name_normalized=name_normalized,
                 protein_100g=macros.protein,

--- a/src/domain/services/meal_suggestion/nutrition_lookup_service.py
+++ b/src/domain/services/meal_suggestion/nutrition_lookup_service.py
@@ -167,8 +167,9 @@ class NutritionLookupService:
 
         _cache_metrics["redis_misses"] += 1
 
-        # T1: exact match on name_normalized
-        ref = self._repo.find_by_normalized_name(normalized)
+        # T1: exact match on name_normalized.
+        # Repo uses a sync Session; offload so the event loop isn't blocked.
+        ref = await asyncio.to_thread(self._repo.find_by_normalized_name, normalized)
         if ref:
             _cache_metrics["t1_hits"] += 1
             result = self._calculate_from_ref(

--- a/src/domain/services/meal_suggestion/suggestion_orchestration_service.py
+++ b/src/domain/services/meal_suggestion/suggestion_orchestration_service.py
@@ -5,6 +5,7 @@ Generation logic: parallel_recipe_generator.py
 TDEE helpers: suggestion_tdee_helpers.py
 """
 
+import asyncio
 import logging
 import uuid
 from typing import List, Optional, Tuple, Callable, Any, AsyncGenerator, Dict
@@ -281,7 +282,8 @@ class SuggestionOrchestrationService:
             raise RuntimeError(
                 "Profile provider not configured for SuggestionOrchestrationService"
             )
-        profile = self._profile_provider(user_id)
+        # profile_provider uses a sync Session; offload so the event loop isn't blocked.
+        profile = await asyncio.to_thread(self._profile_provider, user_id)
         if not profile:
             raise ValueError(f"User {user_id} profile not found")
 

--- a/src/domain/services/weekly_budget_service.py
+++ b/src/domain/services/weekly_budget_service.py
@@ -120,7 +120,10 @@ class WeeklyBudgetService:
         tz = get_zone_info(user_timezone) if user_timezone else None
 
         meals = await uow.meals.find_by_date_range(
-            user_id, week_start, week_end, user_timezone=user_timezone,
+            user_id,
+            week_start,
+            week_end,
+            user_timezone=user_timezone,
         )
 
         total_calories = 0.0
@@ -134,55 +137,7 @@ class WeeklyBudgetService:
                 if (exclude_date or exclude_dates_set) and meal.created_at:
                     aware_dt = ensure_utc(meal.created_at)
                     meal_local_date = (
-                        aware_dt.astimezone(tz).date() if tz
-                        else aware_dt.date()
-                    )
-                    if exclude_date and meal_local_date == exclude_date:
-                        continue
-                    if meal_local_date in exclude_dates_set:
-                        continue
-                total_calories += meal.nutrition.calories or 0
-                total_protein += meal.nutrition.macros.protein or 0
-                total_carbs += meal.nutrition.macros.carbs or 0
-                total_fat += meal.nutrition.macros.fat or 0
-
-        return {
-            "calories": total_calories,
-            "protein": total_protein,
-            "carbs": total_carbs,
-            "fat": total_fat,
-        }
-
-    @staticmethod
-    async def calculate_weekly_consumed_async(
-        uow: Any,
-        user_id: str,
-        week_start: date,
-        exclude_date: Optional[date] = None,
-        exclude_dates: Optional[List[date]] = None,
-        user_timezone: Optional[str] = None,
-    ) -> Dict[str, float]:
-        """Async version of calculate_weekly_consumed for AsyncUnitOfWork."""
-        week_end = week_start + timedelta(days=6)
-        tz = get_zone_info(user_timezone) if user_timezone else None
-
-        meals = await uow.meals.find_by_date_range(
-            user_id, week_start, week_end, user_timezone=user_timezone,
-        )
-
-        total_calories = 0.0
-        total_protein = 0.0
-        total_carbs = 0.0
-        total_fat = 0.0
-
-        exclude_dates_set = set(exclude_dates) if exclude_dates else set()
-        for meal in meals:
-            if meal.status == MealStatus.READY and meal.nutrition:
-                if (exclude_date or exclude_dates_set) and meal.created_at:
-                    aware_dt = ensure_utc(meal.created_at)
-                    meal_local_date = (
-                        aware_dt.astimezone(tz).date() if tz
-                        else aware_dt.date()
+                        aware_dt.astimezone(tz).date() if tz else aware_dt.date()
                     )
                     if exclude_date and meal_local_date == exclude_date:
                         continue
@@ -427,31 +382,43 @@ class WeeklyBudgetService:
         past_days_count = (target_date - week_start).days
         if past_days_count > 0:
             daily_counts = await uow.meals.get_daily_meal_counts(
-                user_id, week_start, past_end,
+                user_id,
+                week_start,
+                past_end,
                 user_timezone=user_timezone,
             )
             logged_past_days = len(daily_counts)
             skipped_days = past_days_count - logged_past_days
 
             total_logged = logged_past_days + 1
-            if (total_logged < WeeklyBudgetConstants.MIN_LOGGED_DAYS_FOR_REDISTRIBUTION
-                    and past_days_count >= 3):
+            if (
+                total_logged < WeeklyBudgetConstants.MIN_LOGGED_DAYS_FOR_REDISTRIBUTION
+                and past_days_count >= 3
+            ):
                 show_logging_prompt = True
 
         redistribution_logged_days = max(0, logged_past_days - past_cheat_count)
 
         # --- Calculate consumed totals from actual meals ---
         consumed_total = await calc.calculate_weekly_consumed_async(
-            uow, user_id, week_start, user_timezone=user_timezone,
+            uow,
+            user_id,
+            week_start,
+            user_timezone=user_timezone,
         )
         consumed_before_today = await calc.calculate_weekly_consumed_async(
-            uow, user_id, week_start,
-            exclude_date=target_date, user_timezone=user_timezone,
+            uow,
+            user_id,
+            week_start,
+            exclude_date=target_date,
+            user_timezone=user_timezone,
         )
 
         if past_cheat_dates:
             consumed_for_redistribution = await calc.calculate_weekly_consumed_async(
-                uow, user_id, week_start,
+                uow,
+                user_id,
+                week_start,
                 exclude_date=target_date,
                 exclude_dates=past_cheat_dates,
                 user_timezone=user_timezone,
@@ -462,13 +429,19 @@ class WeeklyBudgetService:
         # --- Calculate adjusted daily ---
         if show_logging_prompt:
             adjusted = calc.calculate_adjusted_daily(
-                replace(weekly_budget, consumed_calories=0, consumed_protein=0,
-                        consumed_carbs=0, consumed_fat=0),
+                replace(
+                    weekly_budget,
+                    consumed_calories=0,
+                    consumed_protein=0,
+                    consumed_carbs=0,
+                    consumed_fat=0,
+                ),
                 standard_daily_calories=base_daily_cal,
                 standard_daily_carbs=base_daily_carbs,
                 standard_daily_fat=base_daily_fat,
                 standard_daily_protein=base_daily_protein,
-                bmr=bmr, remaining_days=7,
+                bmr=bmr,
+                remaining_days=7,
             )
         else:
             effective_week_days = redistribution_logged_days + remaining_days
@@ -499,7 +472,9 @@ class WeeklyBudgetService:
             )
 
         # --- Budget cap ---
-        remaining_before_today = weekly_budget.target_calories - consumed_before_today["calories"]
+        remaining_before_today = (
+            weekly_budget.target_calories - consumed_before_today["calories"]
+        )
         if remaining_days > 0 and remaining_before_today > 0:
             max_daily = remaining_before_today / remaining_days
             if adjusted.calories > max_daily:

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -4,6 +4,7 @@ Provides product lookup by barcode and food search using OAuth 2.0.
 """
 
 from typing import Dict, Any, Optional, List
+import asyncio
 import logging
 import time
 import base64
@@ -216,9 +217,9 @@ class FatSecretService:
             if isinstance(foods, dict):
                 foods = [foods]
 
-            # Process each food with nutrition data
-            processed = []
-            for food in foods:
+            # Process each food, fetching detailed nutrition concurrently to
+            # avoid N+1 sequential round trips (one food.get per search result).
+            async def _process(food: Dict) -> Dict:
                 food_id = food.get("food_id")
                 mapped = self._map_search_result(food)
 
@@ -241,9 +242,11 @@ class FatSecretService:
                     except Exception:
                         pass  # Use basic mapped data if details fail
 
-                processed.append(mapped)
+                return mapped
 
-            return processed
+            # gather preserves input order
+            processed = await asyncio.gather(*[_process(food) for food in foods])
+            return list(processed)
         except Exception as e:
             logger.warning(f"FatSecret search error for query '{query}': {e}")
             return []

--- a/src/infra/adapters/unsplash_image_adapter.py
+++ b/src/infra/adapters/unsplash_image_adapter.py
@@ -10,6 +10,7 @@ Compliance: https://help.unsplash.com/en/articles/2511245-unsplash-api-guideline
 
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -20,6 +21,7 @@ from src.infra.config.settings import settings
 logger = logging.getLogger(__name__)
 
 UNSPLASH_API_URL = "https://api.unsplash.com/search/photos"
+UNSPLASH_API_HOST = "api.unsplash.com"
 UTM_PARAMS = "utm_source=nutree&utm_medium=referral"
 
 
@@ -84,6 +86,17 @@ class UnsplashImageAdapter(FoodImageSearchPort):
         """Fire Unsplash download event (required by API guidelines)."""
         access_key = settings.UNSPLASH_ACCESS_KEY
         if not access_key or not download_location:
+            return
+        # SSRF guard: download_location is client-supplied and the request
+        # carries our API key, so only call genuine https://api.unsplash.com URLs.
+        # hostname (not netloc) defeats userinfo/suffix bypasses like
+        # api.unsplash.com@evil.com or api.unsplash.com.evil.com.
+        parsed = urlparse(download_location)
+        if parsed.scheme != "https" or parsed.hostname != UNSPLASH_API_HOST:
+            logger.warning(
+                "Unsplash download trigger rejected non-Unsplash URL: %s",
+                download_location,
+            )
             return
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:

--- a/src/infra/repositories/food_reference_repository.py
+++ b/src/infra/repositories/food_reference_repository.py
@@ -298,10 +298,16 @@ class FoodReferenceRepository:
             }
             update_fields = {k: v for k, v in values.items() if k != "name_normalized"}
             stmt = pg_insert(FoodReferenceModel).values(**values)
-            stmt = stmt.on_conflict_do_update(
-                index_elements=["name_normalized"],
-                set_=update_fields,
-            )
+            on_conflict_kwargs: Dict[str, Any] = {
+                "index_elements": ["name_normalized"],
+                "set_": update_fields,
+            }
+            if not is_verified:
+                # Atomically refuse to overwrite a curated (verified) row with
+                # unverified data — closes the race the SELECT above leaves open
+                # if a concurrent writer verifies the row between the two steps.
+                on_conflict_kwargs["where"] = FoodReferenceModel.is_verified.is_(False)
+            stmt = stmt.on_conflict_do_update(**on_conflict_kwargs)
             session.execute(stmt)
             session.commit()
 

--- a/src/infra/repositories/referral_repository.py
+++ b/src/infra/repositories/referral_repository.py
@@ -56,13 +56,22 @@ class ReferralRepository:
 
     # === Conversion Operations ===
 
-    async def get_conversion_by_referred_user(self, user_id: str) -> Optional[ReferralConversion]:
-        result = await self.session.execute(
-            select(ReferralConversion).where(ReferralConversion.referred_user_id == user_id)
+    async def get_conversion_by_referred_user(
+        self, user_id: str, for_update: bool = False
+    ) -> Optional[ReferralConversion]:
+        stmt = select(ReferralConversion).where(
+            ReferralConversion.referred_user_id == user_id
         )
+        if for_update:
+            # Serialize concurrent/duplicate webhook deliveries: the second txn
+            # blocks until the first commits, then re-reads the updated status.
+            stmt = stmt.with_for_update()
+        result = await self.session.execute(stmt)
         return result.scalars().first()
 
-    async def get_conversions_by_referrer(self, user_id: str) -> List[ReferralConversion]:
+    async def get_conversions_by_referrer(
+        self, user_id: str
+    ) -> List[ReferralConversion]:
         result = await self.session.execute(
             select(ReferralConversion)
             .where(ReferralConversion.referrer_user_id == user_id)
@@ -95,10 +104,15 @@ class ReferralRepository:
 
     # === Wallet Operations ===
 
-    async def get_or_create_wallet(self, user_id: str) -> ReferralWallet:
-        result = await self.session.execute(
-            select(ReferralWallet).where(ReferralWallet.user_id == user_id)
-        )
+    async def get_or_create_wallet(
+        self, user_id: str, for_update: bool = False
+    ) -> ReferralWallet:
+        stmt = select(ReferralWallet).where(ReferralWallet.user_id == user_id)
+        if for_update:
+            # Lock the wallet row so concurrent credits/revokes serialize their
+            # read-modify-write of balance instead of losing updates.
+            stmt = stmt.with_for_update()
+        result = await self.session.execute(stmt)
         wallet = result.scalars().first()
         if not wallet:
             wallet = ReferralWallet(
@@ -113,14 +127,14 @@ class ReferralRepository:
         return wallet
 
     async def credit_wallet(self, user_id: str, amount: int) -> ReferralWallet:
-        wallet = await self.get_or_create_wallet(user_id)
+        wallet = await self.get_or_create_wallet(user_id, for_update=True)
         wallet.balance += amount
         wallet.total_earned += amount
         wallet.updated_at = utc_now()
         return wallet
 
     async def revoke_from_wallet(self, user_id: str, amount: int) -> ReferralWallet:
-        wallet = await self.get_or_create_wallet(user_id)
+        wallet = await self.get_or_create_wallet(user_id, for_update=True)
         wallet.balance = max(0, wallet.balance - amount)
         wallet.total_revoked += amount
         wallet.updated_at = utc_now()

--- a/src/infra/services/scheduled_notification_service.py
+++ b/src/infra/services/scheduled_notification_service.py
@@ -58,6 +58,9 @@ class ScheduledNotificationService:
 
     LOOP_INTERVAL_SECONDS = 60
     LOOP_ERROR_RETRY_SECONDS = 30
+    # Rows claimed for sending sit in 'processing' only for one tick (seconds);
+    # anything still 'processing' this long past its send time was abandoned.
+    STALE_PROCESSING_MINUTES = 10
 
     def __init__(
         self,
@@ -183,6 +186,10 @@ class ScheduledNotificationService:
     async def _send_due_notifications(self, now: datetime) -> None:
         """Fetch due rows, fetch calories_consumed from DB, render, batch FCM, mark sent."""
 
+        # Recover rows stranded in 'processing' by a worker that died mid-send,
+        # otherwise they would never be delivered.
+        await asyncio.to_thread(self._recover_stale_processing)
+
         def _claim_due():
             with UnitOfWork() as uow:
                 due_rows = ReminderQueryBuilder.find_due_notifications(
@@ -201,8 +208,7 @@ class ScheduledNotificationService:
         # Batch-fetch real-time calories_consumed from DB for meal reminders.
         # daily_summary uses the JSONB snapshot; trial_expiry ignores calories.
         meal_reminder_ids = [
-            n.user_id for n in due
-            if n.notification_type.startswith("meal_reminder")
+            n.user_id for n in due if n.notification_type.startswith("meal_reminder")
         ]
         consumed_map: dict[str, int] = {}
         if meal_reminder_ids:
@@ -211,7 +217,8 @@ class ScheduledNotificationService:
             )
 
         hydration_user_ids = [
-            n.user_id for n in due
+            n.user_id
+            for n in due
             if n.notification_type.startswith("hydration_reminder")
         ]
         hydration_map: dict[str, tuple[int, int]] = {}
@@ -350,6 +357,30 @@ class ScheduledNotificationService:
                 text("DELETE FROM notifications WHERE expires_at < NOW()")
             )
             logger.info("Cleaned up %d expired notification rows", result.rowcount)
+
+    def _recover_stale_processing(self) -> None:
+        """Reset notifications stranded in 'processing' back to 'pending'.
+
+        A row is set to 'processing' when claimed for sending; if the worker
+        dies before marking it sent/failed it would otherwise stay 'processing'
+        forever and never be delivered. Anything still 'processing' well past
+        its scheduled time was abandoned by a dead worker.
+        """
+        cutoff = utc_now() - timedelta(minutes=self.STALE_PROCESSING_MINUTES)
+        with UnitOfWork() as uow:
+            result = uow.session.execute(
+                text("""
+                    UPDATE notifications
+                    SET status = 'pending'
+                    WHERE status = 'processing' AND scheduled_for_utc < :cutoff
+                    """),
+                {"cutoff": cutoff},
+            )
+            if result.rowcount:
+                logger.warning(
+                    "Recovered %d stale 'processing' notifications → pending",
+                    result.rowcount,
+                )
 
     async def _handle_failed_tokens(self, failed_tokens: list[dict]) -> None:
         to_deactivate = [

--- a/tests/unit/api/test_exceptions_unexpected.py
+++ b/tests/unit/api/test_exceptions_unexpected.py
@@ -1,4 +1,5 @@
 """Cover handle_exception generic Exception branch (unexpected errors)."""
+
 from fastapi import HTTPException, status
 
 from src.api.exceptions import handle_exception
@@ -9,4 +10,7 @@ def test_handle_exception_unexpected_returns_500():
     assert isinstance(exc, HTTPException)
     assert exc.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert exc.detail["error_code"] == "INTERNAL_ERROR"
-    assert "boom" in exc.detail["details"]["error"]
+    assert exc.detail["message"] == "An unexpected error occurred"
+    # Internal exception text must never reach the client; it is logged server-side only.
+    assert exc.detail["details"] == {}
+    assert "boom" not in str(exc.detail)

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 from src.api.routes.v1.webhooks import (
+    find_user_for_revenuecat_event,
     handle_billing_issue,
     handle_cancellation,
     handle_expiration,
@@ -178,6 +179,25 @@ class TestWebhookHandler:
                 result = await revenuecat_webhook(mock_request, authorization="test_secret")
 
                 assert result == {"status": "ignored", "reason": "user_not_found"}
+
+    async def test_find_user_for_revenuecat_event_matches_uuid_string_user_id(self):
+        """UUID-shaped RevenueCat IDs must be compared against string User.id values."""
+        user_id = "1d599ac9-1f3f-4697-b11f-92e30584bb2b"
+        mock_user = MagicMock(id=user_id)
+        mock_uow = MagicMock()
+        mock_uow.session.execute = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.side_effect = [None, mock_user]
+        mock_uow.session.execute.return_value = mock_result
+
+        result = await find_user_for_revenuecat_event(
+            mock_uow,
+            {"app_user_id": user_id},
+        )
+
+        assert result is mock_user
+        id_lookup = mock_uow.session.execute.await_args_list[1].args[0]
+        assert id_lookup.compile().params["id_1"] == user_id
 
     async def test_webhook_transfer_without_user_acknowledged(self, mock_request):
         """Test RevenueCat TRANSFER webhooks do not require app_user_id lookup."""


### PR DESCRIPTION
## Summary
Hardening fixes from the backend codebase review — concurrency/race conditions, security, and webhook robustness.

- **Security**: stop returning internal exception text to clients (log server-side only); SSRF host-allowlist guard on the Unsplash download trigger; sanitize/validate meal text input before parsing.
- **Webhook robustness**: guard RevenueCat user lookup against non-UUID `app_user_id` values (prevents asyncpg errors → 500 → retry storms); row-lock referral conversion/wallet rows so concurrent credit/revoke deliveries serialize instead of losing updates.
- **Concurrency**: offload synchronous DB session calls off the event loop; fetch FatSecret nutrition concurrently (removes sequential N+1 round trips); atomic `food_reference` upsert that refuses to overwrite verified rows; recover notifications stranded in `processing` by dead workers; eager singleton event-bus init to avoid a cold-start race.

## Test plan
- [x] `pytest tests/unit` → 1396 passed, 3 skipped (CI scope: `tests/unit` + coverage ≥ 65%)
- [x] `black` clean on changed files

## Notes
- A `tests/architecture/test_layer_boundaries.py` failure (domain→infra import in `meal_analysis_strategy.py` / `parallel_recipe_generator.py`) is **pre-existing on `delivery`** and unrelated to this PR — CI runs `tests/unit` only. Suggested as a separate follow-up.
- Premium-gating (B12) and auth-cache (B13) review items were intentionally left out of scope for this PR.