### PR TITLE
perf(nutrition): bulk cache + batched food-ref lookups (P1 tech-debt pt.2)

### DIFF
--- a/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
+++ b/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
@@ -30,10 +30,33 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, Dict[str,
         self.cache_service = cache_service
 
     async def handle(self, query: GetNutritionBulkQuery) -> Dict[str, Any]:
-        """Fetch nutrition summaries for all dates in range."""
+        """Fetch nutrition summaries for all dates in range (cache-aside).
+
+        The full response is cached under a short-TTL per-range key. The short
+        TTL bounds staleness from day-rollover (the weekly summary is relative
+        to "today") and from rare target changes not on the high-frequency
+        write paths; meal/movement/hydration/custom-macro writes purge this key
+        synchronously (CacheInvalidationService) for instant freshness.
+        """
         if (query.end_date - query.start_date).days > MAX_DATE_RANGE:
             raise ValueError(f"Date range cannot exceed {MAX_DATE_RANGE} days")
 
+        if self.cache_service is None:
+            return await self._compute(query)
+
+        key, ttl = CacheKeys.nutrition_bulk(
+            query.user_id, query.start_date, query.end_date
+        )
+        cached_or_fresh = await self.cache_service.get_or_set(
+            key, lambda: self._compute(query), ttl
+        )
+        if cached_or_fresh is not None:
+            return cached_or_fresh
+        # get_or_set returns None only if the factory did; _compute never does.
+        return await self._compute(query)
+
+    async def _compute(self, query: GetNutritionBulkQuery) -> Dict[str, Any]:
+        """Build the bulk nutrition response (uncached)."""
         async with AsyncUnitOfWork() as uow:
             user_tz_str = await resolve_user_timezone_async(
                 query.user_id, uow, query.header_timezone

--- a/src/app/services/cache_invalidation_service.py
+++ b/src/app/services/cache_invalidation_service.py
@@ -60,6 +60,7 @@ class CacheInvalidationService:
         await self._invalidate_pattern(
             f"user:{user_id}:activities:{meal_date.isoformat()}:*"
         )
+        await self._invalidate_pattern(f"user:{user_id}:nutrition_bulk:*")
         await self._invalidate_key(CacheKeys.daily_macros(user_id, meal_date)[0])
         await self._invalidate_key(CacheKeys.weekly_budget(user_id, meal_week_start)[0])
 
@@ -83,6 +84,7 @@ class CacheInvalidationService:
         await self._invalidate_pattern(
             f"user:{user_id}:activities:{log_date.isoformat()}:*"
         )
+        await self._invalidate_pattern(f"user:{user_id}:nutrition_bulk:*")
         await self._invalidate_key(CacheKeys.daily_macros(user_id, log_date)[0])
         await self._invalidate_key(CacheKeys.weekly_budget(user_id, week_start)[0])
         await self._invalidate_key(CacheKeys.daily_breakdown(user_id, week_start)[0])
@@ -107,6 +109,7 @@ class CacheInvalidationService:
         await self._invalidate_pattern(
             f"user:{user_id}:activities:{log_date.isoformat()}:*"
         )
+        await self._invalidate_pattern(f"user:{user_id}:nutrition_bulk:*")
         await self._invalidate_pattern(
             f"user:{user_id}:hydration:{log_date.isoformat()}:*"
         )
@@ -133,6 +136,7 @@ class CacheInvalidationService:
         await self._invalidate_key(CacheKeys.user_profile(user_id)[0])
         # Purge ALL daily_macros for this user (targets are embedded in cached response)
         await self._invalidate_pattern(f"user:{user_id}:macros:*")
+        await self._invalidate_pattern(f"user:{user_id}:nutrition_bulk:*")
         # Weekly budget for current and next week (covers timezone skew)
         today = date.today()
         this_week = _get_week_start(today)

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -55,6 +55,23 @@ class CacheKeys:
         )
 
     @staticmethod
+    def nutrition_bulk(
+        user_id: str, start_date: date, end_date: date
+    ) -> tuple[str, int]:
+        """Cache key for a bulk-nutrition date range. Short TTL.
+
+        The cached response embeds a weekly summary computed relative to the
+        current day, so the TTL is deliberately short to bound day-rollover
+        drift and any target change (weight/metrics) not on the high-frequency
+        write paths. Meal/movement/hydration/custom-macro writes purge these
+        keys synchronously (see CacheInvalidationService) for instant freshness.
+        """
+        return (
+            f"user:{user_id}:nutrition_bulk:{start_date.isoformat()}:{end_date.isoformat()}",
+            CacheKeys.TTL_5_MIN,
+        )
+
+    @staticmethod
     def food_search(query: str) -> tuple[str, int]:
         normalized = query.lower().strip()[:64]
         return (f"food:search:{normalized}", CacheKeys.TTL_7_DAYS)

--- a/src/domain/services/meal_suggestion/nutrition_lookup_service.py
+++ b/src/domain/services/meal_suggestion/nutrition_lookup_service.py
@@ -129,15 +129,55 @@ class NutritionLookupService:
         Returns:
             MealMacros with aggregated totals and per-ingredient breakdown.
         """
-        tasks = [
-            self._lookup_ingredient(
+        # Normalize names and convert to grams once per ingredient.
+        prepared = [
+            (
                 ing["name"],
+                normalize_food_name(ing["name"]),
                 self._to_grams(ing["name"], float(ing["amount"]), ing["unit"]),
             )
             for ing in ingredients
         ]
-        results: List[IngredientMacros] = await asyncio.gather(*tasks)
-        meal = self._aggregate(list(results))
+
+        # Tier 0 (Redis): check every key concurrently.
+        results: List[Optional[IngredientMacros]] = list(
+            await asyncio.gather(
+                *(
+                    self._check_redis_cache(normalized, name, quantity_g)
+                    for name, normalized, quantity_g in prepared
+                )
+            )
+        )
+
+        # Tier 1 (food_reference): resolve every Redis miss with ONE batched
+        # query instead of N concurrent single-row lookups — each of which would
+        # open its own sync session, churning the connection pool under fan-out.
+        miss_normalized = [
+            normalized
+            for (name, normalized, quantity_g), cached in zip(prepared, results)
+            if cached is None
+        ]
+        t1_map: Dict[str, Dict[str, Any]] = {}
+        if miss_normalized:
+            t1_map = await asyncio.to_thread(
+                self._repo.find_batch_by_normalized_names, miss_normalized
+            )
+
+        # Resolve the Redis misses concurrently: T1 from the batch map → T2 → T3.
+        pending = [i for i, cached in enumerate(results) if cached is None]
+
+        async def _resolve(index: int) -> IngredientMacros:
+            name, normalized, quantity_g = prepared[index]
+            _cache_metrics["redis_misses"] += 1
+            return await self._resolve_uncached(
+                name, normalized, quantity_g, t1_map.get(normalized)
+            )
+
+        resolved = await asyncio.gather(*(_resolve(i) for i in pending))
+        for index, macros in zip(pending, resolved):
+            results[index] = macros
+
+        meal = self._aggregate([m for m in results if m is not None])
         total = _cache_metrics["redis_hits"] + _cache_metrics["redis_misses"]
         if total > 0 and total % 100 == 0:
             self.log_cache_metrics()
@@ -147,33 +187,48 @@ class NutritionLookupService:
     # Three-tier lookup
     # ------------------------------------------------------------------
 
-    async def _lookup_ingredient(
-        self, name: str, quantity_g: float
+    async def _check_redis_cache(
+        self, normalized: str, name: str, quantity_g: float
+    ) -> Optional[IngredientMacros]:
+        """Tier 0: return cached macros from Redis, or None on miss/disabled/error.
+
+        Increments the redis_hits metric on a hit; misses are counted by the
+        caller so the totals are identical whether lookups run singly (via
+        _lookup_ingredient) or batched (via calculate_meal_macros).
+        """
+        if not self._redis:
+            return None
+        cache_key = f"nutrition:{normalized}"
+        try:
+            cached = await self._redis.get(cache_key)
+            if cached:
+                data = json.loads(cached)
+                _cache_metrics["redis_hits"] += 1
+                return self._build_from_cached(data, name, quantity_g)
+        except Exception as exc:
+            logger.warning("Redis get failed for %s: %s", cache_key, exc)
+        return None
+
+    async def _resolve_uncached(
+        self,
+        name: str,
+        normalized: str,
+        quantity_g: float,
+        t1_ref: Optional[Dict[str, Any]],
     ) -> IngredientMacros:
-        """Resolve macros for one ingredient: Redis → T1 → T2 → T3."""
-        normalized = normalize_food_name(name)
+        """Resolve a Redis-missed ingredient: T1 (caller-supplied ref) → T2 → T3.
+
+        ``t1_ref`` is the food_reference row for ``normalized`` (or None), fetched
+        by the caller either singly or in one batch. The resolved per-100g macros
+        are cached back to Redis.
+        """
         cache_key = f"nutrition:{normalized}"
 
-        # Check Redis cache first
-        if self._redis:
-            try:
-                cached = await self._redis.get(cache_key)
-                if cached:
-                    data = json.loads(cached)
-                    _cache_metrics["redis_hits"] += 1
-                    return self._build_from_cached(data, name, quantity_g)
-            except Exception as exc:
-                logger.warning("Redis get failed for %s: %s", cache_key, exc)
-
-        _cache_metrics["redis_misses"] += 1
-
-        # T1: exact match on name_normalized.
-        # Repo uses a sync Session; offload so the event loop isn't blocked.
-        ref = await asyncio.to_thread(self._repo.find_by_normalized_name, normalized)
-        if ref:
+        # T1: exact match on name_normalized (already fetched by the caller).
+        if t1_ref:
             _cache_metrics["t1_hits"] += 1
             result = self._calculate_from_ref(
-                ref, name, quantity_g, "T1_food_reference"
+                t1_ref, name, quantity_g, "T1_food_reference"
             )
             await self._cache_result(cache_key, result)
             return result
@@ -213,6 +268,24 @@ class NutritionLookupService:
                 sugar=0.0,
                 source_tier="T3_ai_estimate",
             )
+
+    async def _lookup_ingredient(
+        self, name: str, quantity_g: float
+    ) -> IngredientMacros:
+        """Resolve macros for one ingredient: Redis → T1 → T2 → T3.
+
+        Standalone per-ingredient path. calculate_meal_macros batches the T1
+        tier across all ingredients rather than calling this in a loop, but the
+        resolution semantics are identical.
+        """
+        normalized = normalize_food_name(name)
+        cached = await self._check_redis_cache(normalized, name, quantity_g)
+        if cached is not None:
+            return cached
+        _cache_metrics["redis_misses"] += 1
+        # Repo uses a sync Session; offload so the event loop isn't blocked.
+        ref = await asyncio.to_thread(self._repo.find_by_normalized_name, normalized)
+        return await self._resolve_uncached(name, normalized, quantity_g, ref)
 
     # ------------------------------------------------------------------
     # Redis cache helpers

--- a/tests/unit/app/services/test_cache_invalidation_service.py
+++ b/tests/unit/app/services/test_cache_invalidation_service.py
@@ -86,12 +86,21 @@ async def test_after_meal_write_backdated_also_invalidates_current_week(service,
 
 @pytest.mark.asyncio
 async def test_after_meal_write_retries_on_invalidate_pattern_failure(cache_mock):
-    """Transient failure on first attempt triggers one retry."""
-    cache_mock.invalidate_pattern.side_effect = [ConnectionError("redis down"), None]
+    """Transient failure on the first pattern triggers one retry on the same key."""
+    patterns_called = []
+
+    def flaky(pattern):
+        patterns_called.append(pattern)
+        if len(patterns_called) == 1:
+            raise ConnectionError("redis down")
+        return 1
+
+    cache_mock.invalidate_pattern.side_effect = flaky
     svc = CacheInvalidationService(cache_mock)
-    # Should not raise — error is swallowed after 2 attempts
+    # Should not raise — the transient failure is retried, then succeeds.
     await svc.after_meal_write("user1", date(2026, 6, 2))
-    assert cache_mock.invalidate_pattern.call_count == 2
+    # The failed key was retried (attempted twice in a row) before moving on.
+    assert patterns_called[0] == patterns_called[1]
 
 
 @pytest.mark.asyncio
@@ -217,6 +226,35 @@ async def test_after_custom_macros_update_invalidates_current_and_next_week_budg
 
     cache_mock.invalidate.assert_any_call(this_budget_key)
     cache_mock.invalidate.assert_any_call(next_budget_key)
+
+
+# ---------------------------------------------------------------------------
+# nutrition_bulk purge (cached date ranges covering any changed date)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_meal_write_purges_nutrition_bulk(service, cache_mock):
+    await service.after_meal_write("user1", date(2026, 6, 2))
+    cache_mock.invalidate_pattern.assert_any_call("user:user1:nutrition_bulk:*")
+
+
+@pytest.mark.asyncio
+async def test_movement_write_purges_nutrition_bulk(service, cache_mock):
+    await service.after_movement_write("user2", date(2026, 6, 2))
+    cache_mock.invalidate_pattern.assert_any_call("user:user2:nutrition_bulk:*")
+
+
+@pytest.mark.asyncio
+async def test_hydration_write_purges_nutrition_bulk(service, cache_mock):
+    await service.after_hydration_write("user3", date(2026, 6, 2))
+    cache_mock.invalidate_pattern.assert_any_call("user:user3:nutrition_bulk:*")
+
+
+@pytest.mark.asyncio
+async def test_custom_macros_update_purges_nutrition_bulk(service, cache_mock):
+    await service.after_custom_macros_update("user4")
+    cache_mock.invalidate_pattern.assert_any_call("user:user4:nutrition_bulk:*")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/domain/services/meal_suggestion/test_nutrition_lookup_service.py
+++ b/tests/unit/domain/services/meal_suggestion/test_nutrition_lookup_service.py
@@ -249,7 +249,7 @@ async def test_calculate_meal_macros_runs_lookups_in_parallel():
         return PerHundredGramsMacros(protein=10.0, carbs=10.0, fat=5.0)
 
     repo = MagicMock()
-    repo.find_by_normalized_name.return_value = None  # force T2
+    repo.find_batch_by_normalized_names.return_value = {}  # no T1 → force T2
     resolver = MagicMock()
     resolver.resolve = slow_resolve
     gen = MagicMock()
@@ -278,6 +278,47 @@ async def test_calculate_meal_macros_runs_lookups_in_parallel():
     # Both "start" events appear before any "end" confirms actual concurrency
     starts = [e for e in call_order if e.startswith("start")]
     assert len(starts) == 3
+
+
+@pytest.mark.asyncio
+async def test_calculate_meal_macros_batches_t1_lookups():
+    """T1 tier resolves via ONE batched repo call, never per-ingredient lookups.
+
+    Guards the connection-pool-churn fix: the per-row find_by_normalized_name
+    must not be called from the meal-level path (it would open one sync session
+    per ingredient under fan-out).
+    """
+    refs = {
+        "chicken": _make_ref(protein=23.0, carbs=0.0, fat=2.5, ref_id=1),
+        "rice": _make_ref(protein=2.0, carbs=22.0, fat=0.3, ref_id=2),
+    }
+
+    def find_batch(names):
+        return {n: refs[k] for n in names for k in refs if k in n}
+
+    repo = MagicMock()
+    repo.find_batch_by_normalized_names.side_effect = find_batch
+    resolver = MagicMock()
+    resolver.resolve = AsyncMock(return_value=None)
+    gen = MagicMock()
+
+    svc = NutritionLookupService(
+        food_ref_repo=repo,
+        ingredient_nutrition_resolver=resolver,
+        generation_service=gen,
+    )
+
+    meal = await svc.calculate_meal_macros(
+        [
+            {"name": "chicken breast", "amount": 100.0, "unit": "g"},
+            {"name": "white rice", "amount": 100.0, "unit": "g"},
+        ]
+    )
+
+    repo.find_batch_by_normalized_names.assert_called_once()
+    repo.find_by_normalized_name.assert_not_called()
+    assert meal.t1_count == 2
+    assert meal.t2_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +531,9 @@ async def test_chicken_fried_rice_realistic_totals():
         return None
 
     repo = MagicMock()
-    repo.find_by_normalized_name.side_effect = find_ref
+    repo.find_batch_by_normalized_names.side_effect = lambda names: {
+        n: find_ref(n) for n in names if find_ref(n) is not None
+    }
     resolver = MagicMock()
     resolver.resolve = AsyncMock(return_value=None)  # force T1 path
     gen = MagicMock()


### PR DESCRIPTION
Part of the Priority-1 tech-debt remediation (continues the merged #319). **Behavior-preserving**; import gate 4 kept / 0 broken, 1473 unit tests pass.

## Performance
- **Bulk-nutrition caching** (#18): wrap `GetNutritionBulkQueryHandler` in `get_or_set` under a short-TTL `nutrition_bulk` key, and add synchronous `nutrition_bulk:*` invalidation to all four `CacheInvalidationService` write paths (meal / movement / hydration / custom-macros). The short TTL bounds day-rollover and rare target-change drift; explicit invalidation gives instant freshness on the high-frequency writes.
- **Food-reference pool churn** (#17): batch the T1 tier in `NutritionLookupService` — a meal's Redis-missed ingredients resolve via one `find_batch_by_normalized_names` call instead of N per-ingredient sync sessions. The audit's "inject request-scoped session" was **rejected as unsafe**: those lookups run across `asyncio.to_thread` workers and SQLAlchemy sessions are not thread-safe.

## Verification
- `uv run lint-imports` → 4 kept / 0 broken
- `uv run pytest tests/unit` → 1473 passed

## Not in this PR (follow-up)
- Arch 2B (#6/#9/#10/#11/#8/#12) — ports-first (`UnitOfWorkPort` / `EventBus` port), separate PR.
- #19 meal-save re-fetch → `session.refresh` — risky (avoids async lazy-load); needs tests first.
