### PR TITLE
feat(nutrition): expose gross food_calories on daily nutrition response

### DIFF
--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -453,6 +453,9 @@ class MealMapper:
             target_calories=target_calories,
             target_macros=target_macros,
             consumed_calories=consumed_calories,
+            # Gross intake + burn, so burn-owning clients avoid double-subtraction.
+            food_calories=daily_macros_data.get("food_calories"),
+            movement_kcal_burned=daily_macros_data.get("movement_kcal_burned", 0.0),
             consumed_macros=consumed_macros,
             remaining_calories=remaining_calories,
             remaining_macros=remaining_macros,

--- a/src/api/schemas/response/daily_nutrition_response.py
+++ b/src/api/schemas/response/daily_nutrition_response.py
@@ -50,7 +50,20 @@ class DailyNutritionResponse(BaseModel):
     date: str = Field(..., description="Date in YYYY-MM-DD format")
     target_calories: float = Field(..., description="Target calories for the day")
     target_macros: MacrosResponse = Field(..., description="Target macros for the day")
-    consumed_calories: float = Field(..., description="Calories consumed so far")
+    consumed_calories: float = Field(
+        ...,
+        description="NET calories consumed (food intake minus movement burn). "
+        "Clients must NOT subtract burn again from this value.",
+    )
+    food_calories: Optional[float] = Field(
+        None,
+        description="GROSS food calories consumed, before subtracting movement "
+        "burn. Clients that apply burn themselves should use this to avoid "
+        "double-subtraction.",
+    )
+    movement_kcal_burned: float = Field(
+        0.0, ge=0, description="Active calories burned from movement in the balance"
+    )
     consumed_macros: MacrosResponse = Field(..., description="Macros consumed so far")
     remaining_calories: float = Field(..., description="Remaining calories for the day")
     remaining_macros: MacrosResponse = Field(

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -416,6 +416,34 @@ class TestMealMapper:
         assert result.remaining_macros.protein == 50.0
         assert result.completion_percentage["calories"] == 75.0
         assert result.completion_percentage["protein"] == pytest.approx(66.67, rel=0.01)
+        # Gross/burn fields default safely when the payload omits them.
+        assert result.food_calories is None
+        assert result.movement_kcal_burned == 0.0
+
+    def test_to_daily_nutrition_response_surfaces_gross_food_and_burn(self):
+        """consumed_calories stays NET; gross food_calories + burn are surfaced.
+
+        Pins the contract that lets burn-owning clients avoid double-subtraction:
+        consumed_calories is net (food - burn), food_calories is the gross intake.
+        """
+        daily_macros_data = {
+            "date": "2025-01-17",
+            "user_id": "user-789",
+            "target_calories": 2000.0,
+            "target_macros": {"protein": 150.0, "carbs": 250.0, "fat": 67.0},
+            "total_calories": 1500.0,  # NET (gross 1800 - 300 burn)
+            "food_calories": 1800.0,
+            "movement_kcal_burned": 300.0,
+            "total_protein": 100.0,
+            "total_carbs": 180.0,
+            "total_fat": 50.0,
+        }
+
+        result = MealMapper.to_daily_nutrition_response(daily_macros_data)
+
+        assert result.consumed_calories == 1500.0  # NET, unchanged
+        assert result.food_calories == 1800.0  # GROSS surfaced separately
+        assert result.movement_kcal_burned == 300.0
 
     def test_to_daily_nutrition_response_missing_target_calories(self):
         """Test error when target_calories is missing."""


### PR DESCRIPTION
consumed_calories is NET (food minus movement burn); burn-owning clients need the gross intake to avoid double-subtracting it. Surface the gross components the handler already computes and document the net semantics.

- add food_calories (optional) + movement_kcal_burned to DailyNutritionResponse
- populate them in meal_mapper.to_daily_nutrition_response
- clarify consumed_calories as NET in the schema
- add net-vs-gross contract test