### PR TITLE
feat(notifications): fire one trial-expiry push ~2h before charge

### DIFF
--- a/src/domain/services/notification_messages.py
+++ b/src/domain/services/notification_messages.py
@@ -52,7 +52,7 @@ NOTIFICATION_MESSAGES = {
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Last day, bro — trial ends tomorrow\nKeep your progress going 🔥",
+                    "body": "Heads up, bro — your free trial ends soon\nKeep your progress going 🔥",
                 },
             },
             "hydration_reminder": {
@@ -100,7 +100,7 @@ NOTIFICATION_MESSAGES = {
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Last day, mate — trial ends tomorrow\nKeep your progress going 🔥",
+                    "body": "Heads up, mate — your free trial ends soon\nKeep your progress going 🔥",
                 },
             },
             "hydration_reminder": {
@@ -150,7 +150,7 @@ NOTIFICATION_MESSAGES = {
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Mai hết trial rồi bro\nĐừng để mất tiến độ nha 🔥",
+                    "body": "Sắp hết free trial rồi bro\nĐừng để mất tiến độ nha 🔥",
                 },
             },
             "hydration_reminder": {
@@ -198,7 +198,7 @@ NOTIFICATION_MESSAGES = {
                 },
                 "1d": {
                     "title": "Nutree",
-                    "body": "Mai hết trial rồi bạn ơi\nĐừng để mất tiến độ nha 🔥",
+                    "body": "Sắp hết free trial rồi bạn ơi\nĐừng để mất tiến độ nha 🔥",
                 },
             },
             "hydration_reminder": {

--- a/src/infra/services/scheduled_subscription_push_service.py
+++ b/src/infra/services/scheduled_subscription_push_service.py
@@ -1,10 +1,10 @@
-"""Scheduler that inserts T-2d / T-1d trial-expiry push rows for the
-existing ScheduledNotificationService loop to send."""
+"""Scheduler that inserts a single trial-expiry push shortly before the trial
+converts to paid, for the existing ScheduledNotificationService loop to send."""
 
 import logging
 import uuid
 from collections.abc import Iterable
-from datetime import date, datetime, time, timedelta
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import text
@@ -16,13 +16,17 @@ from src.infra.database.uow import UnitOfWork
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_LUNCH_MINUTES = 690    # 11:30 — mirrors daily_context_precompute_service
-_FIRE_OFFSET_MINUTES = 30       # send at lunch + 30
-_FALLBACK_FIRE_LOCAL = time(12, 0)  # if lunch_time_minutes missing → noon local
+# Fire the reminder this long before the trial charges — a last-minute nudge
+# so the user knows the charge is imminent.
+_CHARGE_LEAD = timedelta(hours=2)
+# Consider subscriptions charging within the next day; the row sits pending
+# until its scheduled_for_utc, so a generous lookahead just means it is
+# created early, never sent early.
+_LOOKAHEAD_DAYS = 1
 
 
 class ScheduledSubscriptionPushService:
-    """Inserts trial-expiry push notifications at T-2d and T-1d.
+    """Inserts one trial-expiry push per subscription, ~2h before its charge.
 
     Does not send. The existing ScheduledNotificationService loop polls
     `notifications` and sends due rows on its 60s tick.
@@ -33,24 +37,23 @@ class ScheduledSubscriptionPushService:
         pass
 
     def check_and_schedule_pushes(self, now: datetime | None = None) -> int:
-        """Run T-2d + T-1d windows. Returns total rows inserted (excludes
-        conflict-do-nothing skips)."""
+        """Schedule the pre-charge push for subs charging soon. Returns rows
+        inserted (excludes conflict-do-nothing skips)."""
         moment = now or utc_now()
         logger.info("Trial-push scheduler: starting run at %s", moment.isoformat())
 
-        scheduled = 0
-        scheduled += self._schedule_window(moment, days_left=2)
-        scheduled += self._schedule_window(moment, days_left=1)
+        scheduled = self._schedule_due_pushes(moment)
 
         logger.info("Trial-push scheduler: complete, inserted=%s", scheduled)
         return scheduled
 
-    # ---- window pipeline ------------------------------------------------
+    # ---- scheduling pipeline --------------------------------------------
 
-    def _schedule_window(self, now: datetime, days_left: int) -> int:
+    def _schedule_due_pushes(self, now: datetime) -> int:
         with UnitOfWork() as uow:
+            # Active subs whose trial converts to paid within the next day.
             subs = uow.subscriptions.find_expiring_in_window(
-                from_days=days_left, to_days=days_left + 1, now=now
+                from_days=0, to_days=_LOOKAHEAD_DAYS, now=now
             )
             if not subs:
                 return 0
@@ -61,15 +64,14 @@ class ScheduledSubscriptionPushService:
 
             rows: list[dict] = []
             for sub in subs:
-                pref = prefs.get(sub.user_id)
                 tokens = tokens_by_user.get(sub.user_id, [])
                 if not tokens:
                     continue
                 row = self._build_row(
                     user_id=sub.user_id,
-                    days_left=days_left,
+                    charge_at=sub.expires_at,
                     tokens=tokens,
-                    pref=pref,
+                    pref=prefs.get(sub.user_id),
                     now=now,
                 )
                 if row is not None:
@@ -87,11 +89,9 @@ class ScheduledSubscriptionPushService:
         if not user_ids:
             return {}
         result = session.execute(
-            text(
-                """
+            text("""
                 SELECT
                     np.user_id,
-                    np.lunch_time_minutes,
                     np.language,
                     u.timezone,
                     up.gender,
@@ -100,8 +100,7 @@ class ScheduledSubscriptionPushService:
                 JOIN users u ON u.id = np.user_id
                 LEFT JOIN user_profiles up ON up.user_id = np.user_id AND up.is_current = true
                 WHERE np.user_id = ANY(:ids) AND np.is_deleted = false
-                """
-            ),
+                """),
             {"ids": user_ids},
         ).fetchall()
 
@@ -115,7 +114,6 @@ class ScheduledSubscriptionPushService:
 
         return {
             r.user_id: {
-                "lunch_time_minutes": r.lunch_time_minutes,
                 "language": _resolve_lang(r.language, r.language_code),
                 "timezone": r.timezone or "UTC",
                 "gender": r.gender or "male",
@@ -128,13 +126,11 @@ class ScheduledSubscriptionPushService:
         if not user_ids:
             return {}
         result = session.execute(
-            text(
-                """
+            text("""
                 SELECT user_id, fcm_token
                 FROM user_fcm_tokens
                 WHERE user_id = ANY(:ids) AND is_active = true
-                """
-            ),
+                """),
             {"ids": user_ids},
         ).fetchall()
         tokens: dict[str, list[str]] = {}
@@ -147,38 +143,45 @@ class ScheduledSubscriptionPushService:
     def _build_row(
         self,
         user_id: str,
-        days_left: int,
+        charge_at: datetime | None,
         tokens: list[str],
         pref: dict | None,
         now: datetime,
     ) -> dict | None:
+        if charge_at is None or charge_at <= now:
+            # No known charge moment, or the trial already converted — nothing
+            # to warn about.
+            return None
+
         tz_name = (pref or {}).get("timezone", "UTC")
         try:
             tz = ZoneInfo(tz_name)
         except Exception:
             tz = ZoneInfo("UTC")
 
-        scheduled_utc, scheduled_local_date = self._compute_scheduled_at(
-            now_utc=now,
-            tz=tz,
-            lunch_time_minutes=(pref or {}).get("lunch_time_minutes"),
-        )
+        # Fire shortly before the charge. If the sub only surfaced once we are
+        # already inside that lead window (e.g. loop downtime), send on the next
+        # tick — still before the charge.
+        scheduled_utc = charge_at - _CHARGE_LEAD
+        if scheduled_utc < now:
+            scheduled_utc = now
 
-        if scheduled_utc <= now:
-            # Window already passed today in this tz — skip; tomorrow's
-            # midnight run will pick it up if still in window.
-            return None
+        # Dedup date is pinned to the charge (stable per sub), so repeated ticks
+        # and the clamp above never produce a second row for the same user.
+        scheduled_local_date = charge_at.astimezone(tz).date()
 
         return {
             "id": str(uuid.uuid4()),
             "user_id": user_id,
-            "notification_type": f"trial_expiry_{days_left}d",
+            # "_1d" selects the single trial-expiry message variant; the suffix
+            # is retained for dispatch routing and analytics continuity.
+            "notification_type": "trial_expiry_1d",
             "scheduled_date": scheduled_local_date,
             "scheduled_for_utc": scheduled_utc,
             "status": "pending",
             "context": {
                 "fcm_tokens": tokens,
-                "calorie_goal": 2000,    # non-zero sentinel; trial render ignores it
+                "calorie_goal": 2000,  # non-zero sentinel; trial render ignores it
                 "calories_consumed": 0,
                 "gender": (pref or {}).get("gender", "male"),
                 "language_code": (pref or {}).get("language", "en"),
@@ -186,34 +189,6 @@ class ScheduledSubscriptionPushService:
             "created_at": utc_now(),
             "expires_at": scheduled_utc + timedelta(days=2),
         }
-
-    @staticmethod
-    def _compute_scheduled_at(
-        now_utc: datetime,
-        tz: ZoneInfo,
-        lunch_time_minutes: int | None,
-    ) -> tuple[datetime, date]:
-        """Returns (UTC datetime to fire at, local date the push fires)."""
-        local_now = now_utc.astimezone(tz)
-        local_today = local_now.date()
-
-        if lunch_time_minutes is None:
-            fire_local = datetime.combine(local_today, _FALLBACK_FIRE_LOCAL, tz)
-        else:
-            minutes = lunch_time_minutes + _FIRE_OFFSET_MINUTES
-            hour, minute = divmod(minutes, 60)
-            # Wrap to next day if lunch+30 overflows past midnight (extreme edge).
-            extra_days, hour = divmod(hour, 24)
-            fire_local = datetime.combine(
-                local_today + timedelta(days=extra_days),
-                time(hour, minute),
-                tz,
-            )
-
-        return (
-            fire_local.astimezone(now_utc.tzinfo or ZoneInfo("UTC")),
-            fire_local.date(),
-        )
 
     # ---- insert ----------------------------------------------------------
 

--- a/tests/unit/infra/services/test_scheduled_subscription_push_service.py
+++ b/tests/unit/infra/services/test_scheduled_subscription_push_service.py
@@ -3,7 +3,6 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
-from zoneinfo import ZoneInfo
 
 from src.infra.services.scheduled_subscription_push_service import (
     ScheduledSubscriptionPushService,
@@ -36,7 +35,7 @@ def _patch_uow_with_subs(subs):
 def test_schedules_row_for_active_expiring_sub_with_token():
     svc = ScheduledSubscriptionPushService()
     user_id = str(uuid.uuid4())
-    sub = _make_sub(user_id, NOW_UTC + timedelta(days=2, hours=6))
+    sub = _make_sub(user_id, NOW_UTC + timedelta(hours=6))
 
     uow_ctx, _uow = _patch_uow_with_subs([sub])
 
@@ -48,7 +47,6 @@ def test_schedules_row_for_active_expiring_sub_with_token():
         "_fetch_prefs",
         return_value={
             user_id: {
-                "lunch_time_minutes": 720,
                 "language": "en",
                 "timezone": "Asia/Ho_Chi_Minh",
                 "gender": "male",
@@ -66,7 +64,7 @@ def test_schedules_row_for_active_expiring_sub_with_token():
 def test_skips_user_without_fcm_token():
     svc = ScheduledSubscriptionPushService()
     user_id = str(uuid.uuid4())
-    sub = _make_sub(user_id, NOW_UTC + timedelta(days=2))
+    sub = _make_sub(user_id, NOW_UTC + timedelta(hours=6))
 
     uow_ctx, _uow = _patch_uow_with_subs([sub])
 
@@ -78,7 +76,6 @@ def test_skips_user_without_fcm_token():
         "_fetch_prefs",
         return_value={
             user_id: {
-                "lunch_time_minutes": 720,
                 "language": "en",
                 "timezone": "UTC",
                 "gender": "male",
@@ -103,46 +100,26 @@ def test_returns_zero_when_no_subs_in_window():
         assert svc.check_and_schedule_pushes(NOW_UTC) == 0
 
 
-def test_compute_scheduled_at_uses_lunch_plus_30():
-    out_utc, _ = ScheduledSubscriptionPushService._compute_scheduled_at(
-        now_utc=NOW_UTC,                                 # 05:00 UTC = 12:00 ICT
-        tz=ZoneInfo("Asia/Ho_Chi_Minh"),
-        lunch_time_minutes=720,                          # 12:00 local
-    )
-    local = out_utc.astimezone(ZoneInfo("Asia/Ho_Chi_Minh"))
-    assert local.hour == 12 and local.minute == 30
-
-
-def test_compute_scheduled_at_fallback_noon_when_lunch_missing():
-    out_utc, _ = ScheduledSubscriptionPushService._compute_scheduled_at(
-        now_utc=NOW_UTC,
-        tz=ZoneInfo("Asia/Ho_Chi_Minh"),
-        lunch_time_minutes=None,
-    )
-    local = out_utc.astimezone(ZoneInfo("Asia/Ho_Chi_Minh"))
-    assert local.hour == 12 and local.minute == 0
-
-
-def test_compute_scheduled_at_returns_local_date_not_utc_date():
-    """05:00 UTC on May 17 = 12:00 May 17 ICT; scheduled_date must be local."""
-    _, scheduled_date = ScheduledSubscriptionPushService._compute_scheduled_at(
-        now_utc=NOW_UTC,
-        tz=ZoneInfo("Asia/Ho_Chi_Minh"),
-        lunch_time_minutes=720,
-    )
-    assert scheduled_date.isoformat() == "2026-05-17"
-
-
-def test_runs_both_windows():
+def test_runs_single_schedule_pass():
+    """One scheduling pass per run (no separate T-2d / T-1d windows)."""
     svc = ScheduledSubscriptionPushService()
-    with patch.object(svc, "_schedule_window", return_value=0) as sw:
+    with patch.object(svc, "_schedule_due_pushes", return_value=0) as sd:
         svc.check_and_schedule_pushes(NOW_UTC)
-        assert sw.call_count == 2
-        called_days = sorted(
-            (c.kwargs.get("days_left") if "days_left" in c.kwargs else c.args[1])
-            for c in sw.call_args_list
-        )
-        assert called_days == [1, 2]
+        sd.assert_called_once_with(NOW_UTC)
+
+
+def test_queries_next_day_charge_window():
+    """Subs charging within the next day are considered (from_days=0, to_days=1)."""
+    svc = ScheduledSubscriptionPushService()
+    uow_ctx, uow = _patch_uow_with_subs([])
+    with patch(
+        "src.infra.services.scheduled_subscription_push_service.UnitOfWork",
+        return_value=uow_ctx,
+    ):
+        svc.check_and_schedule_pushes(NOW_UTC)
+    uow.subscriptions.find_expiring_in_window.assert_called_once_with(
+        from_days=0, to_days=1, now=NOW_UTC
+    )
 
 
 def test_language_resolution_falls_back_to_users_language_code():
@@ -150,7 +127,6 @@ def test_language_resolution_falls_back_to_users_language_code():
     session = MagicMock()
     row = MagicMock()
     row.user_id = "u1"
-    row.lunch_time_minutes = 720
     row.language = None
     row.timezone = "Asia/Ho_Chi_Minh"
     row.gender = "female"
@@ -165,7 +141,6 @@ def test_language_resolution_pref_overrides_user():
     session = MagicMock()
     row = MagicMock()
     row.user_id = "u1"
-    row.lunch_time_minutes = 720
     row.language = "en"
     row.timezone = "UTC"
     row.gender = "male"
@@ -180,7 +155,6 @@ def test_language_resolution_unknown_falls_back_to_en():
     session = MagicMock()
     row = MagicMock()
     row.user_id = "u1"
-    row.lunch_time_minutes = 720
     row.language = "fr"
     row.timezone = "UTC"
     row.gender = "male"
@@ -191,20 +165,53 @@ def test_language_resolution_unknown_falls_back_to_en():
     assert out["u1"]["language"] == "en"
 
 
-def test_build_row_skips_if_scheduled_time_already_passed():
-    """Mid-day midnight-trigger run shouldn't insert a row that fires in the past."""
+def test_build_row_schedules_two_hours_before_charge():
     svc = ScheduledSubscriptionPushService()
-    user_id = "u1"
-    # User in UTC, lunch_time=00 → fires at 00:30 UTC. `now` is 05:00 UTC.
     pref = {
-        "lunch_time_minutes": 0,
-        "language": "en",
-        "timezone": "UTC",
-        "gender": "male",
+        "language": "vi",
+        "timezone": "Asia/Ho_Chi_Minh",
+        "gender": "female",
     }
+    charge_at = NOW_UTC + timedelta(hours=10)
     row = svc._build_row(
-        user_id=user_id,
-        days_left=2,
+        user_id="u1",
+        charge_at=charge_at,
+        tokens=["tok1"],
+        pref=pref,
+        now=NOW_UTC,
+    )
+    assert row is not None
+    assert row["notification_type"] == "trial_expiry_1d"
+    assert row["scheduled_for_utc"] == charge_at - timedelta(hours=2)
+    assert row["status"] == "pending"
+    assert row["context"]["language_code"] == "vi"
+    assert row["context"]["gender"] == "female"
+    assert row["context"]["fcm_tokens"] == ["tok1"]
+    assert row["expires_at"] == row["scheduled_for_utc"] + timedelta(days=2)
+
+
+def test_build_row_clamps_to_now_when_inside_lead_window():
+    """Sub surfaced within the 2h lead → send now (still before charge), not skipped."""
+    svc = ScheduledSubscriptionPushService()
+    pref = {"language": "en", "timezone": "UTC", "gender": "male"}
+    charge_at = NOW_UTC + timedelta(minutes=30)  # < 2h lead
+    row = svc._build_row(
+        user_id="u1",
+        charge_at=charge_at,
+        tokens=["tok1"],
+        pref=pref,
+        now=NOW_UTC,
+    )
+    assert row is not None
+    assert row["scheduled_for_utc"] == NOW_UTC  # clamped, fires next tick
+
+
+def test_build_row_skips_when_charge_already_passed():
+    svc = ScheduledSubscriptionPushService()
+    pref = {"language": "en", "timezone": "UTC", "gender": "male"}
+    row = svc._build_row(
+        user_id="u1",
+        charge_at=NOW_UTC - timedelta(hours=1),
         tokens=["tok1"],
         pref=pref,
         now=NOW_UTC,
@@ -212,25 +219,14 @@ def test_build_row_skips_if_scheduled_time_already_passed():
     assert row is None
 
 
-def test_build_row_returns_full_row_when_in_future():
+def test_build_row_skips_when_charge_unknown():
     svc = ScheduledSubscriptionPushService()
-    pref = {
-        "lunch_time_minutes": 720,
-        "language": "vi",
-        "timezone": "Asia/Ho_Chi_Minh",
-        "gender": "female",
-    }
+    pref = {"language": "en", "timezone": "UTC", "gender": "male"}
     row = svc._build_row(
         user_id="u1",
-        days_left=1,
+        charge_at=None,
         tokens=["tok1"],
         pref=pref,
         now=NOW_UTC,
     )
-    assert row is not None
-    assert row["notification_type"] == "trial_expiry_1d"
-    assert row["status"] == "pending"
-    assert row["context"]["language_code"] == "vi"
-    assert row["context"]["gender"] == "female"
-    assert row["context"]["fcm_tokens"] == ["tok1"]
-    assert row["expires_at"] == row["scheduled_for_utc"] + timedelta(days=2)
+    assert row is None

--- a/tests/unit/infra/test_scheduled_notification_service.py
+++ b/tests/unit/infra/test_scheduled_notification_service.py
@@ -148,7 +148,7 @@ def test_render_trial_expiry_1d_en_female_returns_1_day_body():
 
     title, body = _render_message("trial_expiry_1d", 0, "female", "en")
     assert title == "Nutree"
-    assert "tomorrow" in body.lower()
+    assert "soon" in body.lower()
 
 
 def test_render_trial_expiry_2d_vi_male_returns_vietnamese():
@@ -164,7 +164,7 @@ def test_render_trial_expiry_1d_vi_female_returns_vietnamese():
 
     _, body = _render_message("trial_expiry_1d", 0, "female", "vi")
     assert "bạn ơi" in body
-    assert "mai" in body.lower()
+    assert "sắp" in body.lower()
 
 
 def test_render_unknown_type_falls_through_to_generic_stub():


### PR DESCRIPTION
## What

Trial-expiry push notifications now fire **once, ~2 hours before the trial converts to paid** — a last-minute reminder — instead of the previous two lunch-time pushes (2 days left + 1 day left).

## Why

Requested: keep a single trial push, timed close to the charge moment, sent once near trial expiry.

## Changes

- **`scheduled_subscription_push_service.py`** — replaced the T-2d / T-1d lunch-time windows with one pass:
  - Selects active subs charging within the next day (`find_expiring_in_window(from_days=0, to_days=1)`).
  - Schedules each at `expires_at - 2h`; clamps to `now` if the sub surfaces inside the lead window (still before charge) so a late-surfacing sub isn't skipped.
  - Dedup date pinned to the charge moment → repeated 60s ticks insert exactly one row per sub.
  - Dropped the now-unused lunch-time scheduling and `lunch_time_minutes` lookup.
- **`notification_messages.py`** — single push copy (en/vi, male/female) changed from *"trial ends tomorrow" / "Mai hết trial"* to *"your **free trial** ends soon" / "Sắp hết **free trial**"*.
- Tests updated accordingly.

## Decisions (in lieu of the original open questions)

- **Soft, non-time-specific copy** (no hard "you'll be charged in 2h" line). The dispatch due-query (`reminder_query_builder.find_due_notifications`) has no `expires_at` gate and deliberately keeps no lower bound, so after a long loop outage a pending push can deliver *late* — even after the charge. A soft "free trial ends soon" stays correct if delivered late; a hard time/charge claim would not. "free trial" adds honesty about the free→paid transition without inviting cancellation.
- **2h lead kept** as requested.

## Notes / possible follow-ups (not in this PR)

- **Unsociable hours:** `charge - 2h` is 2h before the absolute charge instant, so for users whose trial converts overnight the push can land at night local time. A quiet-hours floor (shift earlier) could be added if it proves noisy.
- **Late delivery:** see soft-copy rationale above. A staleness gate in the shared dispatch query would prevent post-charge sends for *all* notification types — intentionally out of scope here.
- The `trial_expiry_1d` type is retained (routes to the single message variant; dispatch + analytics continuity). The `2d` variant + dispatch normalization are left in place so in-flight legacy rows still render while they drain.
- No schema/migration changes.

## Testing

- Affected unit tests rewritten; full `tests/unit` suite green on Python 3.13: **1401 passed, 3 skipped** (also enforced by the pre-push hook).
- `black` + `ruff` clean on changed files.