### PR TITLE
fix(reliability): notification dispatch, activity cache, event-bus logging

### DIFF
--- a/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
@@ -60,6 +60,7 @@ class GetDailyActivitiesQueryHandler(
         meal_activities: List[Dict[str, Any]] = []
         workout_activities: List[Dict[str, Any]] = []
 
+        fetch_ok = False
         try:
             async with AsyncUnitOfWork() as uow:
                 user_tz_str = await resolve_user_timezone_async(
@@ -80,6 +81,7 @@ class GetDailyActivitiesQueryHandler(
                 workout_activities = await self._get_workout_activities(
                     query, uow, tz, local_date
                 )
+                fetch_ok = True
         except Exception as e:
             logger.error(f"Error getting activities: {str(e)}", exc_info=True)
 
@@ -87,7 +89,9 @@ class GetDailyActivitiesQueryHandler(
         logger.info(
             f"Retrieved {len(activities)} activities for user {query.user_id} on {local_date}"
         )
-        if self.cache_service:
+        # Only cache a fully-successful fetch. Caching on the error path would
+        # pin an empty/partial feed for the whole TTL after a transient DB blip.
+        if self.cache_service and fetch_ok:
             await self.cache_service.set_json(cache_key, activities, ttl)
         return activities
 

--- a/src/infra/event_bus/pymediator_event_bus.py
+++ b/src/infra/event_bus/pymediator_event_bus.py
@@ -172,8 +172,11 @@ class PyMediatorEventBus(EventBus):
             return result
 
         except MealTrackException as e:
+            # Controlled application exceptions (not-found, validation, etc.) are
+            # converted to proper HTTP responses and logged by the API layer. Keep
+            # this at debug so routine 4xx control flow doesn't spam WARNING. The
+            # re-raise preserves all existing handling.
             logger.debug(f"Application exception handling {event_type.__name__}: {str(e)}")
-            logger.warning(f"Error handling {event_type.__name__}: {str(e)}")
             raise
         except Exception as e:
             logger.error(

--- a/src/infra/services/cron_notification_dispatch_service.py
+++ b/src/infra/services/cron_notification_dispatch_service.py
@@ -92,11 +92,12 @@ class CronNotificationDispatchService:
                 logger.warning("Failed to fetch hydration data batch: %s", exc)
 
         # Render messages per notification and group by (type, title, body)
-        groups: dict[tuple[str, str, str], dict[str, list[str]]] = defaultdict(
-            lambda: {"tokens": [], "ids": []}
+        groups: dict[tuple[str, str, str], dict[str, list]] = defaultdict(
+            lambda: {"tokens": [], "ids": [], "row_ids": []}
         )
-        sent_ids = []
-        failed_ids = []
+        sent_ids = []  # delivered (sent without FCM, or FCM batch confirmed success)
+        failed_ids = []  # no usable tokens — give up
+        retry_ids = []  # FCM batch failed wholesale — return to queue for next tick
 
         for notif in due:
             ctx = notif.context  # JSONB dict from PostgreSQL
@@ -134,7 +135,7 @@ class CronNotificationDispatchService:
                 group = groups[(notif.notification_type, title, body)]
                 group["tokens"].extend(tokens)
                 group["ids"].append(str(notif.id))
-                sent_ids.append(notif.id)
+                group["row_ids"].append(notif.id)
                 continue
             else:
                 # meal_reminder_* — real-time DB data
@@ -152,7 +153,7 @@ class CronNotificationDispatchService:
             group = groups[(notif.notification_type, title, body)]
             group["tokens"].extend(tokens)
             group["ids"].append(str(notif.id))
-            sent_ids.append(notif.id)
+            group["row_ids"].append(notif.id)
 
         # Batch FCM — 500 tokens per call.
         # DB stores trial_expiry_2d / trial_expiry_1d so the UNIQUE
@@ -167,6 +168,11 @@ class CronNotificationDispatchService:
                 "notification_count": str(len(group["ids"])),
             }
             tokens = group["tokens"]
+            # A batch is delivered only if every chunk's FCM call succeeds. A
+            # wholesale send failure (network/auth) returns success=False with no
+            # failed_tokens; those rows must NOT be marked sent or they are lost
+            # forever with zero delivery — return them to the queue to retry.
+            group_delivered = True
             for chunk in _chunked(tokens, 500):
                 result = self._firebase.send_multicast(
                     tokens=chunk,
@@ -175,16 +181,29 @@ class CronNotificationDispatchService:
                     notification_type=fcm_type,
                     data=data,
                 )
+                if not result.get("success"):
+                    group_delivered = False
                 if result.get("failed_tokens"):
                     await self._handle_failed_tokens(result["failed_tokens"])
+            if group_delivered:
+                sent_ids.extend(group["row_ids"])
+            else:
+                retry_ids.extend(group["row_ids"])
 
-        # Mark sent/failed
-        if sent_ids or failed_ids:
-            await asyncio.to_thread(self._mark_notifications, sent_ids, failed_ids)
+        # Mark sent / failed / retry
+        if sent_ids or failed_ids or retry_ids:
+            await asyncio.to_thread(
+                self._mark_notifications, sent_ids, failed_ids, retry_ids
+            )
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 
-    def _mark_notifications(self, sent_ids: list[str], failed_ids: list[str]) -> None:
+    def _mark_notifications(
+        self,
+        sent_ids: list,
+        failed_ids: list,
+        retry_ids: list | None = None,
+    ) -> None:
         with UnitOfWork() as uow:
             if sent_ids:
                 uow.session.execute(
@@ -203,6 +222,17 @@ class CronNotificationDispatchService:
                         WHERE status = 'processing' AND id IN :ids
                         """).bindparams(bindparam("ids", expanding=True)),
                     {"ids": failed_ids},
+                )
+            if retry_ids:
+                # FCM send failed wholesale — return rows to the queue so the next
+                # cron tick re-claims and re-sends them instead of losing them.
+                uow.session.execute(
+                    text("""
+                        UPDATE notifications
+                        SET status = 'pending'
+                        WHERE status = 'processing' AND id IN :ids
+                        """).bindparams(bindparam("ids", expanding=True)),
+                    {"ids": retry_ids},
                 )
 
     def cleanup_expired_notifications(self) -> None:

--- a/tests/unit/infra/test_cron_notification_dispatch_service.py
+++ b/tests/unit/infra/test_cron_notification_dispatch_service.py
@@ -55,6 +55,53 @@ async def test_send_loop_marks_notifications_sent():
     )
 
 
+@pytest.mark.asyncio
+async def test_wholesale_fcm_failure_requeues_instead_of_marking_sent():
+    """A whole-batch FCM failure must requeue rows (pending), never mark 'sent'.
+
+    Regression guard: send_multicast returning success=False with no failed_tokens
+    (transient Firebase/network/auth outage) previously marked the notification
+    'sent' with zero delivery and no retry. The row must go to retry_ids instead.
+    """
+    from src.infra.services.cron_notification_dispatch_service import (
+        CronNotificationDispatchService,
+    )
+
+    mock_notif = MagicMock()
+    mock_notif.notification_type = "trial_expiry_2d"
+    mock_notif.context = {
+        "fcm_tokens": ["tok1"],
+        "gender": "male",
+        "language_code": "en",
+    }
+    mock_notif.id = "trial-notif-1"
+    mock_notif.user_id = "user-1"
+
+    mock_firebase = MagicMock()
+    mock_firebase.send_multicast = MagicMock(
+        return_value={"success": False, "reason": "send_error"}
+    )
+
+    svc = CronNotificationDispatchService.__new__(CronNotificationDispatchService)
+    svc._firebase = mock_firebase
+    svc._mark_notifications = MagicMock()
+
+    with patch(
+        "src.infra.services.cron_notification_dispatch_service.ReminderQueryBuilder"
+    ) as mock_qb, patch(
+        "src.infra.services.cron_notification_dispatch_service.UnitOfWork"
+    ) as mock_uow:
+        mock_qb.find_due_notifications.return_value = [mock_notif]
+        mock_uow.return_value.__enter__.return_value.session = MagicMock()
+
+        await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
+
+    mock_firebase.send_multicast.assert_called_once()
+    sent_ids, failed_ids, retry_ids = svc._mark_notifications.call_args.args
+    assert "trial-notif-1" not in sent_ids, "must not mark sent on FCM failure"
+    assert "trial-notif-1" in retry_ids, "must requeue for retry on FCM failure"
+
+
 def test_render_message_daily_summary_zero_logs():
     from src.infra.services.cron_notification_dispatch_service import _render_message
 


### PR DESCRIPTION
## Summary
Release-day reliability fixes from a full regression review of `delivery` vs `main`. All three are isolated, unit-validated (1475 passed), and behavior-preserving on the happy path.

## Changes
1. **Notifications — stop silently dropping pushes on FCM outage** (`cron_notification_dispatch_service.py`)
   - Previously, rows were marked `sent` *before* the FCM batch result was checked. A wholesale `send_multicast` failure (transient Firebase/network/auth) returns `{success: False}` with no `failed_tokens`, so the dispatcher marked them `sent` with zero delivery and no retry.
   - Now: a batch is marked `sent` only when every chunk reports `success`; wholesale failures reset the rows to `pending` so the next 2-min cron tick re-sends. Sharpest impact was the one-shot trial-expiry push (~2h before charge).
   - Adds `test_wholesale_fcm_failure_requeues_instead_of_marking_sent`.

2. **Activities — don't cache an empty feed on DB error** (`get_daily_activities_query_handler.py`)
   - The handler caught exceptions then unconditionally cached the (empty/partial) result, pinning a blank feed for the full TTL after any transient DB blip. Now it only writes cache on a fully-successful fetch.

3. **Event bus — cut routine 4xx log noise** (`pymediator_event_bus.py`)
   - Controlled application exceptions (not-found/validation) were double-logged at DEBUG **and** WARNING. Dropped the redundant WARNING; the re-raise is unchanged.

## Test
- `pytest tests/unit` → **1475 passed, 3 skipped** (pre-push hook).
- `lint-imports` → 4/4 contracts kept.

## Notes
- A separate follow-up PR will address cache-invalidation commit ordering (14 write handlers) with integration-test validation, plus two minor nutrition hardenings.