### PR TITLE
fix(nutrition): cap weekly budget redistribution

### DIFF
--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -194,7 +194,7 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
 
         # Invalidate ALL weekly budgets for this user
         # TDEE changes affect weekly targets
-        weekly_pattern = f"user:{user_id}:weekly_budget:*"
+        weekly_pattern = CacheKeys.weekly_budget_user_pattern(user_id)
         try:
             await self.cache_service.invalidate_pattern(weekly_pattern)
         except Exception as e:

--- a/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
@@ -192,6 +192,7 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
                 target_macros,
                 net_calories,
                 bmr,
+                user_tz_str,
             )
             if weekly_context:
                 result["weekly_context"] = weekly_context
@@ -218,15 +219,13 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
         target_macros: Dict,
         daily_consumed: float,
         bmr: float = 1800,
+        user_timezone: str = "UTC",
     ) -> Optional[Dict[str, Any]]:
-        """Get weekly budget context. weekly_budget is pre-fetched from the shared UoW."""
+        """Get weekly budget context using the weekly-budget adjustment path."""
         if not weekly_budget:
             return None
         try:
             week_start = get_user_monday(target_date, user_id)
-            remaining_days = WeeklyBudgetService.calculate_remaining_days(
-                week_start, target_date
-            )
 
             standard_daily_calories = target_calories
             standard_daily_protein = (
@@ -237,15 +236,21 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
             )
             standard_daily_fat = target_macros.get("fat", 70) if target_macros else 70
 
-            adjusted = WeeklyBudgetService.calculate_adjusted_daily(
-                weekly_budget,
-                standard_daily_calories,
-                standard_daily_carbs,
-                standard_daily_fat,
-                standard_daily_protein,
-                bmr=bmr,
-                remaining_days=remaining_days,
-            )
+            async with AsyncUnitOfWork() as uow:
+                effective = await WeeklyBudgetService.get_effective_adjusted_daily_async(
+                    uow=uow,
+                    user_id=user_id,
+                    week_start=week_start,
+                    target_date=target_date,
+                    weekly_budget=weekly_budget,
+                    base_daily_cal=standard_daily_calories,
+                    base_daily_protein=standard_daily_protein,
+                    base_daily_carbs=standard_daily_carbs,
+                    base_daily_fat=standard_daily_fat,
+                    bmr=bmr,
+                    user_timezone=user_timezone,
+                )
+            adjusted = effective.adjusted
 
             return {
                 "adjusted_target_calories": adjusted.calories,
@@ -253,7 +258,7 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
                 "adjusted_target_fat": adjusted.fat,
                 "daily_protein": adjusted.protein,
                 "bmr_floor_active": adjusted.bmr_floor_active,
-                "remaining_days": remaining_days,
+                "remaining_days": adjusted.remaining_days,
             }
         except Exception as e:
             logger.warning(f"Could not fetch weekly budget context: {e}")

--- a/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
+++ b/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
@@ -113,26 +113,31 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, Dict[str,
 
             weekly_summary = None
             if weekly_budget:
-                remaining_days = WeeklyBudgetService.calculate_remaining_days(week_start, today)
                 base_daily = target_calories or (weekly_budget.target_calories / 7)
-                adjusted = WeeklyBudgetService.calculate_adjusted_daily(
-                    weekly_budget,
-                    standard_daily_calories=base_daily,
-                    standard_daily_carbs=(target_macros or {}).get("carbs", 200),
-                    standard_daily_fat=(target_macros or {}).get("fat", 70),
-                    standard_daily_protein=(target_macros or {}).get("protein", 70),
+                effective = await WeeklyBudgetService.get_effective_adjusted_daily_async(
+                    uow=uow,
+                    user_id=query.user_id,
+                    week_start=week_start,
+                    target_date=today,
+                    weekly_budget=weekly_budget,
+                    base_daily_cal=base_daily,
+                    base_daily_protein=(target_macros or {}).get("protein", 70),
+                    base_daily_carbs=(target_macros or {}).get("carbs", 200),
+                    base_daily_fat=(target_macros or {}).get("fat", 70),
                     bmr=bmr,
-                    remaining_days=remaining_days,
+                    user_timezone=user_tz_str,
                 )
+                adjusted = effective.adjusted
+                consumed = effective.consumed_total
                 weekly_summary = {
                     "week_start_date": week_start.isoformat(),
                     "target_calories": weekly_budget.target_calories,
-                    "consumed_calories": weekly_budget.consumed_calories,
+                    "consumed_calories": round(consumed["calories"], 1),
                     "remaining_calories": round(
-                        weekly_budget.target_calories - weekly_budget.consumed_calories, 1
+                        weekly_budget.target_calories - consumed["calories"], 1
                     ),
                     "adjusted_daily_calories": adjusted.calories,
-                    "remaining_days": remaining_days,
+                    "remaining_days": adjusted.remaining_days,
                 }
 
             cache_version = self._compute_cache_version(dates_result, weekly_summary)

--- a/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
@@ -61,8 +61,11 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
                 # target_date is already a local date — no timezone re-lookup needed
                 week_start = get_user_monday(target_date, query.user_id)
 
-                # Cache check (requires week_start, computed above)
-                cache_key, ttl = CacheKeys.weekly_budget(query.user_id, week_start)
+                # Cache check uses target_date because adjusted targets and
+                # remaining days differ across dates in the same week.
+                cache_key, ttl = CacheKeys.weekly_budget(
+                    query.user_id, week_start, target_date
+                )
                 if self.cache_service:
                     cached = await self.cache_service.get_json(cache_key)
                     if cached is not None:
@@ -333,31 +336,33 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
         tz = get_zone_info(user_timezone) if user_timezone else None
         from src.domain.model.meal import MealStatus
 
-        def _sum_meals(meals, exclude_date=None, exclude_dates=None):
+        def _sum_meals(meals, end_date=None, exclude_dates=None):
             exclude_dates_set = set(exclude_dates) if exclude_dates else set()
             cal = prot = carbs = fat = 0.0
             for meal in meals:
                 if meal.status == MealStatus.READY and meal.nutrition:
-                    if (exclude_date or exclude_dates_set) and meal.created_at:
+                    if (end_date or exclude_dates_set) and meal.created_at:
                         aware_dt = ensure_utc(meal.created_at)
                         meal_local_date = (
                             aware_dt.astimezone(tz).date() if tz else aware_dt.date()
                         )
-                        if exclude_date and meal_local_date == exclude_date:
+                        if end_date and meal_local_date > end_date:
                             continue
                         if meal_local_date in exclude_dates_set:
                             continue
-                    cal += meal.nutrition.calories or 0
-                    prot += meal.nutrition.macros.protein or 0
-                    carbs += meal.nutrition.macros.carbs or 0
-                    fat += meal.nutrition.macros.fat or 0
+                    macros = meal.nutrition.macros
+                    cal += WeeklyBudgetService._derive_macro_calories(macros)
+                    prot += macros.protein or 0
+                    carbs += macros.carbs or 0
+                    fat += macros.fat or 0
             return {"calories": cal, "protein": prot, "carbs": carbs, "fat": fat}
 
         consumed_total = _sum_meals(week_meals)
-        consumed_before_today = _sum_meals(week_meals, exclude_date=target_date)
+        past_end = target_date - timedelta(days=1)
+        consumed_before_today = _sum_meals(week_meals, end_date=past_end)
         if past_cheat_dates:
             consumed_for_redistribution = _sum_meals(
-                week_meals, exclude_date=target_date, exclude_dates=past_cheat_dates
+                week_meals, end_date=past_end, exclude_dates=past_cheat_dates
             )
         else:
             consumed_for_redistribution = consumed_before_today

--- a/src/app/services/cache_invalidation_service.py
+++ b/src/app/services/cache_invalidation_service.py
@@ -51,6 +51,10 @@ class CacheInvalidationService:
                 else:
                     logger.error("Cache pattern invalidation failed for %s: %s", pattern, exc)
 
+    async def _invalidate_weekly_budget(self, user_id: str, week_start: date) -> None:
+        await self._invalidate_key(CacheKeys.weekly_budget(user_id, week_start)[0])
+        await self._invalidate_pattern(CacheKeys.weekly_budget_pattern(user_id, week_start))
+
     async def after_meal_write(self, user_id: str, meal_date: date) -> None:
         """Invalidate all caches affected by a meal create/edit/delete."""
         meal_week_start = _get_week_start(meal_date)
@@ -62,7 +66,7 @@ class CacheInvalidationService:
         )
         await self._invalidate_pattern(f"user:{user_id}:nutrition_bulk:*")
         await self._invalidate_key(CacheKeys.daily_macros(user_id, meal_date)[0])
-        await self._invalidate_key(CacheKeys.weekly_budget(user_id, meal_week_start)[0])
+        await self._invalidate_weekly_budget(user_id, meal_week_start)
 
         # Secondary keys (read on other screens, slight delay acceptable)
         await self._invalidate_key(CacheKeys.daily_breakdown(user_id, meal_week_start)[0])
@@ -70,7 +74,7 @@ class CacheInvalidationService:
 
         # Backdated meal: also invalidate current week
         if meal_week_start != current_week_start:
-            await self._invalidate_key(CacheKeys.weekly_budget(user_id, current_week_start)[0])
+            await self._invalidate_weekly_budget(user_id, current_week_start)
             await self._invalidate_key(CacheKeys.daily_breakdown(user_id, current_week_start)[0])
 
     async def after_movement_write(self, user_id: str, log_date: date) -> None:
@@ -86,12 +90,12 @@ class CacheInvalidationService:
         )
         await self._invalidate_pattern(f"user:{user_id}:nutrition_bulk:*")
         await self._invalidate_key(CacheKeys.daily_macros(user_id, log_date)[0])
-        await self._invalidate_key(CacheKeys.weekly_budget(user_id, week_start)[0])
+        await self._invalidate_weekly_budget(user_id, week_start)
         await self._invalidate_key(CacheKeys.daily_breakdown(user_id, week_start)[0])
 
         # Backdated movement: also invalidate current week
         if week_start != current_week_start:
-            await self._invalidate_key(CacheKeys.weekly_budget(user_id, current_week_start)[0])
+            await self._invalidate_weekly_budget(user_id, current_week_start)
             await self._invalidate_key(CacheKeys.daily_breakdown(user_id, current_week_start)[0])
 
     async def after_hydration_write(self, user_id: str, log_date: date) -> None:
@@ -117,13 +121,13 @@ class CacheInvalidationService:
         await self._invalidate_key(CacheKeys.weekly_hydration(user_id, week_start)[0])
 
         # Meal-related keys (caloric drinks affect energy balance)
-        await self._invalidate_key(CacheKeys.weekly_budget(user_id, week_start)[0])
+        await self._invalidate_weekly_budget(user_id, week_start)
         await self._invalidate_key(CacheKeys.daily_breakdown(user_id, week_start)[0])
         await self._invalidate_key(CacheKeys.user_streak(user_id)[0])
 
         # Backdated hydration: also invalidate current week
         if week_start != current_week_start:
-            await self._invalidate_key(CacheKeys.weekly_budget(user_id, current_week_start)[0])
+            await self._invalidate_weekly_budget(user_id, current_week_start)
             await self._invalidate_key(CacheKeys.daily_breakdown(user_id, current_week_start)[0])
 
     async def after_custom_macros_update(self, user_id: str) -> None:
@@ -141,5 +145,5 @@ class CacheInvalidationService:
         today = date.today()
         this_week = _get_week_start(today)
         next_week = this_week + timedelta(days=7)
-        await self._invalidate_key(CacheKeys.weekly_budget(user_id, this_week)[0])
-        await self._invalidate_key(CacheKeys.weekly_budget(user_id, next_week)[0])
+        await self._invalidate_weekly_budget(user_id, this_week)
+        await self._invalidate_weekly_budget(user_id, next_week)

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -70,6 +70,10 @@ class CacheKeys:
         return f"user:{user_id}:weekly_budget_v3:{week_start_date.isoformat()}:*"
 
     @staticmethod
+    def weekly_budget_user_pattern(user_id: str) -> str:
+        return f"user:{user_id}:weekly_budget_v3:*"
+
+    @staticmethod
     def nutrition_bulk(
         user_id: str, start_date: date, end_date: date
     ) -> tuple[str, int]:

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -47,12 +47,27 @@ class CacheKeys:
         )
 
     @staticmethod
-    def weekly_budget(user_id: str, week_start_date: date) -> tuple[str, int]:
-        """Cache key for weekly macro budget. 30 min TTL."""
+    def weekly_budget(
+        user_id: str, week_start_date: date, target_date: date | None = None
+    ) -> tuple[str, int]:
+        """Cache key for weekly budget responses. 30 min TTL.
+
+        The stored weekly budget is week-scoped, but the API response contains
+        target-date-specific fields such as remaining_days and adjusted targets.
+        """
+        date_suffix = (
+            week_start_date.isoformat()
+            if target_date is None
+            else f"{week_start_date.isoformat()}:{target_date.isoformat()}"
+        )
         return (
-            f"user:{user_id}:weekly_budget:{week_start_date.isoformat()}",
+            f"user:{user_id}:weekly_budget_v3:{date_suffix}",
             CacheKeys.TTL_30_MIN,
         )
+
+    @staticmethod
+    def weekly_budget_pattern(user_id: str, week_start_date: date) -> str:
+        return f"user:{user_id}:weekly_budget_v3:{week_start_date.isoformat()}:*"
 
     @staticmethod
     def nutrition_bulk(

--- a/src/domain/constants/meal_constants.py
+++ b/src/domain/constants/meal_constants.py
@@ -191,6 +191,10 @@ class WeeklyBudgetConstants:
     # -10% is within safe 0.5-1% BW/week range (Helms 2014)
     MAX_DAILY_DEFICIT_RATIO = 0.10
 
+    # Surplus cap: under-eating should not create extreme catch-up targets.
+    # Leftover weekly budget can remain unused instead of encouraging overeating.
+    MAX_DAILY_SURPLUS_RATIO = 0.25
+
     # Adjusted daily macro bounds (ratio of standard daily)
     MACRO_FLOOR_RATIO = 0.5  # Never below 50% of base
     MACRO_CEILING_RATIO = 1.5  # Never above 150% of base

--- a/src/domain/services/weekly_budget_service.py
+++ b/src/domain/services/weekly_budget_service.py
@@ -50,6 +50,7 @@ class WeeklyBudgetService:
         uow: Any,
         user_id: str,
         week_start: date,
+        end_date: Optional[date] = None,
         exclude_date: Optional[date] = None,
         exclude_dates: Optional[List[date]] = None,
         user_timezone: Optional[str] = None,
@@ -62,11 +63,12 @@ class WeeklyBudgetService:
             uow: Unit of work with meals repository
             user_id: User ID
             week_start: Monday of the week
+            end_date: Last local date to include. Defaults to week end.
             exclude_date: Skip meals on this user-local date (today lock)
             exclude_dates: Skip meals on these user-local dates (cheat days)
             user_timezone: IANA timezone for correct date boundary
         """
-        week_end = week_start + timedelta(days=6)
+        week_end = end_date or week_start + timedelta(days=6)
         tz = get_zone_info(user_timezone) if user_timezone else None
 
         meals = uow.meals.find_by_date_range(
@@ -84,20 +86,23 @@ class WeeklyBudgetService:
         exclude_dates_set = set(exclude_dates) if exclude_dates else set()
         for meal in meals:
             if meal.status == MealStatus.READY and meal.nutrition:
-                # Skip meals on excluded dates (today lock + cheat days)
-                if (exclude_date or exclude_dates_set) and meal.created_at:
+                # Skip meals outside/excluded local dates.
+                if (end_date or exclude_date or exclude_dates_set) and meal.created_at:
                     aware_dt = ensure_utc(meal.created_at)
                     meal_local_date = (
                         aware_dt.astimezone(tz).date() if tz else aware_dt.date()
                     )
+                    if end_date and meal_local_date > end_date:
+                        continue
                     if exclude_date and meal_local_date == exclude_date:
                         continue
                     if meal_local_date in exclude_dates_set:
                         continue
-                total_calories += meal.nutrition.calories or 0
-                total_protein += meal.nutrition.macros.protein or 0
-                total_carbs += meal.nutrition.macros.carbs or 0
-                total_fat += meal.nutrition.macros.fat or 0
+                macros = meal.nutrition.macros
+                total_protein += macros.protein or 0
+                total_carbs += macros.carbs or 0
+                total_fat += macros.fat or 0
+                total_calories += WeeklyBudgetService._derive_macro_calories(macros)
 
         return {
             "calories": total_calories,
@@ -111,12 +116,13 @@ class WeeklyBudgetService:
         uow: Any,
         user_id: str,
         week_start: date,
+        end_date: Optional[date] = None,
         exclude_date: Optional[date] = None,
         exclude_dates: Optional[List[date]] = None,
         user_timezone: Optional[str] = None,
     ) -> Dict[str, float]:
         """Async version of calculate_weekly_consumed for AsyncUnitOfWork."""
-        week_end = week_start + timedelta(days=6)
+        week_end = end_date or week_start + timedelta(days=6)
         tz = get_zone_info(user_timezone) if user_timezone else None
 
         meals = await uow.meals.find_by_date_range(
@@ -134,19 +140,22 @@ class WeeklyBudgetService:
         exclude_dates_set = set(exclude_dates) if exclude_dates else set()
         for meal in meals:
             if meal.status == MealStatus.READY and meal.nutrition:
-                if (exclude_date or exclude_dates_set) and meal.created_at:
+                if (end_date or exclude_date or exclude_dates_set) and meal.created_at:
                     aware_dt = ensure_utc(meal.created_at)
                     meal_local_date = (
                         aware_dt.astimezone(tz).date() if tz else aware_dt.date()
                     )
+                    if end_date and meal_local_date > end_date:
+                        continue
                     if exclude_date and meal_local_date == exclude_date:
                         continue
                     if meal_local_date in exclude_dates_set:
                         continue
-                total_calories += meal.nutrition.calories or 0
-                total_protein += meal.nutrition.macros.protein or 0
-                total_carbs += meal.nutrition.macros.carbs or 0
-                total_fat += meal.nutrition.macros.fat or 0
+                macros = meal.nutrition.macros
+                total_protein += macros.protein or 0
+                total_carbs += macros.carbs or 0
+                total_fat += macros.fat or 0
+                total_calories += WeeklyBudgetService._derive_macro_calories(macros)
 
         return {
             "calories": total_calories,
@@ -244,7 +253,7 @@ class WeeklyBudgetService:
             uow,
             user_id,
             week_start,
-            exclude_date=target_date,
+            end_date=past_end,
             user_timezone=user_timezone,
         )
 
@@ -254,7 +263,7 @@ class WeeklyBudgetService:
                 uow,
                 user_id,
                 week_start,
-                exclude_date=target_date,
+                end_date=past_end,
                 exclude_dates=past_cheat_dates,
                 user_timezone=user_timezone,
             )
@@ -410,7 +419,7 @@ class WeeklyBudgetService:
             uow,
             user_id,
             week_start,
-            exclude_date=target_date,
+            end_date=past_end,
             user_timezone=user_timezone,
         )
 
@@ -419,7 +428,7 @@ class WeeklyBudgetService:
                 uow,
                 user_id,
                 week_start,
-                exclude_date=target_date,
+                end_date=past_end,
                 exclude_dates=past_cheat_dates,
                 user_timezone=user_timezone,
             )
@@ -524,7 +533,22 @@ class WeeklyBudgetService:
         remaining_carbs = weekly_budget.remaining_carbs
         remaining_fat = weekly_budget.remaining_fat
 
-        adjusted_calories = remaining_calories / remaining_days
+        calorie_target = remaining_calories / remaining_days
+
+        # Deficit cap: never reduce more than MAX_DAILY_DEFICIT_RATIO below base.
+        min_allowed = standard_daily_calories * (
+            1 - WeeklyBudgetConstants.MAX_DAILY_DEFICIT_RATIO
+        )
+        max_allowed = standard_daily_calories * (
+            1 + WeeklyBudgetConstants.MAX_DAILY_SURPLUS_RATIO
+        )
+        calorie_target = min(max(calorie_target, min_allowed), max_allowed)
+
+        bmr_floor_active = False
+        if calorie_target < bmr_floor:
+            calorie_target = bmr_floor
+            bmr_floor_active = True
+
         adjusted_carbs = remaining_carbs / remaining_days
         adjusted_fat = remaining_fat / remaining_days
 
@@ -542,61 +566,43 @@ class WeeklyBudgetService:
         # Protein stays fixed regardless of weekly consumption
         adjusted_protein = standard_daily_protein
 
-        # Round macros to 1 decimal first
         rounded_protein = round(adjusted_protein, 1)
         rounded_carbs = round(adjusted_carbs, 1)
         rounded_fat = round(adjusted_fat, 1)
 
-        # Derive calories from rounded macros — single source of truth
+        rounded_carbs, rounded_fat = WeeklyBudgetService._fit_carbs_fat_to_calories(
+            calorie_target=calorie_target,
+            protein=rounded_protein,
+            carbs=rounded_carbs,
+            fat=rounded_fat,
+        )
+        rounded_carbs = WeeklyBudgetService._clamp_macro(
+            rounded_carbs,
+            minimum=standard_daily_carbs * floor,
+            maximum=standard_daily_carbs * ceil,
+        )
+        rounded_fat = WeeklyBudgetService._clamp_macro(
+            rounded_fat,
+            minimum=standard_daily_fat * floor,
+            maximum=standard_daily_fat * ceil,
+        )
+
+        # Final calories still come from macros, but the macros are fitted to
+        # the calorie-led redistribution target.
         adjusted_calories = (
             (rounded_protein * 4) + (rounded_carbs * 4) + (rounded_fat * 9)
         )
-
-        # Calorie cap: prevent macro inflation above calorie-level redistribution.
-        # When user over-eats expensive macros (fat=9cal/g) but under-eats cheap
-        # macros (carbs=4cal/g), independent macro redistribution can inflate
-        # calories above what pure calorie redistribution would give.
-        calorie_redistributed = remaining_calories / remaining_days
-        if (
-            adjusted_calories > calorie_redistributed
-            and calorie_redistributed < standard_daily_calories
+        while not bmr_floor_active and adjusted_calories > max_allowed and (
+            rounded_fat > standard_daily_fat * floor
+            or rounded_carbs > standard_daily_carbs * floor
         ):
-            protein_cal = rounded_protein * 4
-            non_protein_target = calorie_redistributed - protein_cal
-            non_protein_current = (rounded_carbs * 4) + (rounded_fat * 9)
-            if non_protein_current > 0 and non_protein_target > 0:
-                scale = non_protein_target / non_protein_current
-                rounded_carbs = round(rounded_carbs * scale, 1)
-                rounded_fat = round(rounded_fat * scale, 1)
-                adjusted_calories = (
-                    protein_cal + (rounded_carbs * 4) + (rounded_fat * 9)
-                )
-
-        # Deficit cap: never reduce more than MAX_DAILY_DEFICIT_RATIO below base
-        min_allowed = standard_daily_calories * (
-            1 - WeeklyBudgetConstants.MAX_DAILY_DEFICIT_RATIO
-        )
-        if adjusted_calories < min_allowed:
-            deficit_gap = min_allowed - adjusted_calories
-            # Scale carbs and fat up proportionally to meet minimum
-            carb_cal = rounded_carbs * 4
-            fat_cal = rounded_fat * 9
-            total_non_protein_cal = carb_cal + fat_cal
-            if total_non_protein_cal > 0:
-                carb_ratio = carb_cal / total_non_protein_cal
-                fat_ratio = fat_cal / total_non_protein_cal
-                rounded_carbs = round(rounded_carbs + (deficit_gap * carb_ratio) / 4, 1)
-                rounded_fat = round(rounded_fat + (deficit_gap * fat_ratio) / 9, 1)
-            # Re-derive calories from updated macros
+            if rounded_fat > standard_daily_fat * floor:
+                rounded_fat = round(rounded_fat - 0.1, 1)
+            elif rounded_carbs > standard_daily_carbs * floor:
+                rounded_carbs = round(rounded_carbs - 0.1, 1)
             adjusted_calories = (
                 (rounded_protein * 4) + (rounded_carbs * 4) + (rounded_fat * 9)
             )
-
-        # Check if we hit the BMR floor
-        bmr_floor_active = False
-        if adjusted_calories < bmr_floor:
-            adjusted_calories = bmr_floor
-            bmr_floor_active = True
 
         return AdjustedDailyTargets(
             calories=round(adjusted_calories, 1),
@@ -606,6 +612,42 @@ class WeeklyBudgetService:
             bmr_floor_active=bmr_floor_active,
             remaining_days=remaining_days,
         )
+
+    @staticmethod
+    def _fit_carbs_fat_to_calories(
+        *,
+        calorie_target: float,
+        protein: float,
+        carbs: float,
+        fat: float,
+    ) -> tuple[float, float]:
+        protein_calories = protein * 4
+        non_protein_target = calorie_target - protein_calories
+        non_protein_current = (carbs * 4) + (fat * 9)
+
+        if non_protein_target <= 0 or non_protein_current <= 0:
+            return carbs, fat
+
+        scale = non_protein_target / non_protein_current
+        return round(carbs * scale, 1), round(fat * scale, 1)
+
+    @staticmethod
+    def _clamp_macro(value: float, *, minimum: float, maximum: float) -> float:
+        return round(max(minimum, min(value, maximum)), 1)
+
+    @staticmethod
+    def _derive_macro_calories(macros: Any) -> float:
+        """Derive calories from macros using the canonical fiber-aware formula."""
+        protein = WeeklyBudgetService._safe_macro_value(getattr(macros, "protein", 0.0))
+        carbs = WeeklyBudgetService._safe_macro_value(getattr(macros, "carbs", 0.0))
+        fat = WeeklyBudgetService._safe_macro_value(getattr(macros, "fat", 0.0))
+        fiber = WeeklyBudgetService._safe_macro_value(getattr(macros, "fiber", 0.0))
+        net_carbs = max(0.0, carbs - fiber)
+        return protein * 4 + net_carbs * 4 + fiber * 2 + fat * 9
+
+    @staticmethod
+    def _safe_macro_value(value: Any) -> float:
+        return float(value) if isinstance(value, (int, float)) else 0.0
 
     @staticmethod
     def should_suggest_cheat_day(

--- a/tests/unit/app/services/test_cache_invalidation_service.py
+++ b/tests/unit/app/services/test_cache_invalidation_service.py
@@ -55,9 +55,11 @@ async def test_after_meal_write_invalidates_weekly_budget_and_breakdown(service,
     # June 2 2026 is a Tuesday; week_start is June 1
     week_start = date(2026, 6, 1)
     weekly_key = CacheKeys.weekly_budget("user1", week_start)[0]
+    weekly_pattern = CacheKeys.weekly_budget_pattern("user1", week_start)
     breakdown_key = CacheKeys.daily_breakdown("user1", week_start)[0]
     await service.after_meal_write("user1", date(2026, 6, 2))
     cache_mock.invalidate.assert_any_call(weekly_key)
+    cache_mock.invalidate_pattern.assert_any_call(weekly_pattern)
     cache_mock.invalidate.assert_any_call(breakdown_key)
 
 
@@ -130,12 +132,14 @@ async def test_after_movement_write_invalidates_daily_macros_and_weekly_budget(s
     week_start = date(2026, 6, 1)
     daily_key = CacheKeys.daily_macros("user2", log_date)[0]
     weekly_key = CacheKeys.weekly_budget("user2", week_start)[0]
+    weekly_pattern = CacheKeys.weekly_budget_pattern("user2", week_start)
     breakdown_key = CacheKeys.daily_breakdown("user2", week_start)[0]
 
     await service.after_movement_write("user2", log_date)
 
     cache_mock.invalidate.assert_any_call(daily_key)
     cache_mock.invalidate.assert_any_call(weekly_key)
+    cache_mock.invalidate_pattern.assert_any_call(weekly_pattern)
     cache_mock.invalidate.assert_any_call(breakdown_key)
 
 
@@ -177,12 +181,14 @@ async def test_after_hydration_write_also_purges_meal_related_keys(service, cach
     log_date = date(2026, 6, 2)
     week_start = date(2026, 6, 1)
     budget_key = CacheKeys.weekly_budget("user3", week_start)[0]
+    budget_pattern = CacheKeys.weekly_budget_pattern("user3", week_start)
     breakdown_key = CacheKeys.daily_breakdown("user3", week_start)[0]
     streak_key = CacheKeys.user_streak("user3")[0]
 
     await service.after_hydration_write("user3", log_date)
 
     cache_mock.invalidate.assert_any_call(budget_key)
+    cache_mock.invalidate_pattern.assert_any_call(budget_pattern)
     cache_mock.invalidate.assert_any_call(breakdown_key)
     cache_mock.invalidate.assert_any_call(streak_key)
 

--- a/tests/unit/domain/services/test_weekly_budget_async.py
+++ b/tests/unit/domain/services/test_weekly_budget_async.py
@@ -33,7 +33,7 @@ class TestCalculateWeeklyConsumedAsync:
 
         ready_meal = Mock()
         ready_meal.status = MealStatus.READY
-        ready_meal.nutrition.calories = 500
+        ready_meal.nutrition.calories = 9999
         ready_meal.nutrition.macros.protein = 30
         ready_meal.nutrition.macros.carbs = 60
         ready_meal.nutrition.macros.fat = 15
@@ -56,7 +56,7 @@ class TestCalculateWeeklyConsumedAsync:
             week_start=date(2026, 3, 9),
         )
 
-        assert result["calories"] == 500
+        assert result["calories"] == 495
         assert result["protein"] == 30
         assert result["carbs"] == 60
         assert result["fat"] == 15

--- a/tests/unit/domain/services/test_weekly_budget_service.py
+++ b/tests/unit/domain/services/test_weekly_budget_service.py
@@ -8,6 +8,7 @@ from datetime import date, datetime, timezone
 from typing import List, Optional
 from unittest.mock import MagicMock
 
+from src.domain.constants import WeeklyBudgetConstants
 from src.domain.model.meal import MealStatus
 from src.domain.model.weekly import WeeklyMacroBudget
 from src.domain.services.weekly_budget_service import (
@@ -151,7 +152,7 @@ class TestWeeklyBudgetService:
             remaining_days=6,
         )
 
-        assert result.calories == 1900
+        assert result.calories == pytest.approx(1900, abs=1)
         assert result.bmr_floor_active is True
 
     def test_deficit_cap_no_cap_needed(self):
@@ -277,8 +278,8 @@ class TestWeeklyBudgetService:
         )
         assert result.protein == 140  # never touched
 
-    def test_under_eating_no_cap(self):
-        """Under-eating (surplus) — no cap applied, surplus uncapped."""
+    def test_under_eating_surplus_is_capped(self):
+        """Under-eating raises targets, but not into extreme catch-up eating."""
         budget = WeeklyMacroBudget(
             weekly_budget_id="test-cap-surplus",
             user_id="user-1",
@@ -301,8 +302,13 @@ class TestWeeklyBudgetService:
             bmr=1400,
             remaining_days=4,
         )
-        # Surplus: adjusted should be ABOVE base (no upward cap)
+        # Raw redistribution would be 2750; cap and macro ceilings keep it safer.
         assert result.calories > 2000
+        assert result.calories <= 2000 * (
+            1 + WeeklyBudgetConstants.MAX_DAILY_SURPLUS_RATIO
+        )
+        assert result.carbs <= 200 * WeeklyBudgetConstants.MACRO_CEILING_RATIO
+        assert result.fat <= 70 * WeeklyBudgetConstants.MACRO_CEILING_RATIO
         assert result.bmr_floor_active is False
 
     def test_calorie_cap_fat_heavy_surplus(self):
@@ -347,11 +353,8 @@ class TestWeeklyBudgetService:
         # Fat should be below base (user over-ate fat)
         assert result.fat < 68.2
 
-    def test_calorie_cap_not_applied_when_under_eating(self):
-        """Calorie cap should NOT fire when user is under-eating overall.
-
-        calorie_redistributed > standard_daily → second condition fails.
-        """
+    def test_moderate_under_eating_still_raises_calories(self):
+        """Moderate under-eating raises target without exceeding surplus cap."""
         budget = WeeklyMacroBudget(
             weekly_budget_id="test-cap-under",
             user_id="user-1",
@@ -376,6 +379,71 @@ class TestWeeklyBudgetService:
         )
         # Under-eating: adjusted should be ABOVE base
         assert result.calories > 2456
+        assert result.calories <= 2456 * (
+            1 + WeeklyBudgetConstants.MAX_DAILY_SURPLUS_RATIO
+        )
+
+    def test_under_eating_raises_calories_even_when_fat_is_over(self):
+        """Calorie balance leads adjustment; one macro overage must not lower calories."""
+        budget = WeeklyMacroBudget(
+            weekly_budget_id="test-under-fat-over",
+            user_id="user-1",
+            week_start_date=date(2026, 6, 1),
+            target_calories=12495,  # 1785 * 7
+            target_protein=1099,  # 157 * 7
+            target_carbs=1127,  # 161 * 7
+            target_fat=399,  # 57 * 7
+            consumed_calories=1141,
+            consumed_protein=78,
+            consumed_carbs=58,
+            consumed_fat=66,  # fat over daily target, calories still under
+        )
+
+        result = WeeklyBudgetService.calculate_adjusted_daily(
+            weekly_budget=budget,
+            standard_daily_calories=1785,
+            standard_daily_carbs=161,
+            standard_daily_fat=57,
+            standard_daily_protein=157,
+            bmr=1400,
+            remaining_days=6,
+        )
+
+        assert result.calories > 1785
+        assert result.calories == pytest.approx((12495 - 1141) / 6, abs=2)
+        assert result.protein == 157
+
+    def test_extreme_under_eating_respects_macro_ceilings_after_fit(self):
+        """Calorie fitting must not push adaptive carbs/fat past safe ceilings."""
+        budget = WeeklyMacroBudget(
+            weekly_budget_id="test-extreme-under",
+            user_id="user-1",
+            week_start_date=date(2026, 6, 1),
+            target_calories=12495,
+            target_protein=1099,
+            target_carbs=1127,
+            target_fat=399,
+            consumed_calories=0,
+            consumed_protein=0,
+            consumed_carbs=0,
+            consumed_fat=0,
+        )
+
+        result = WeeklyBudgetService.calculate_adjusted_daily(
+            weekly_budget=budget,
+            standard_daily_calories=1785,
+            standard_daily_carbs=161,
+            standard_daily_fat=57,
+            standard_daily_protein=157,
+            bmr=1400,
+            remaining_days=2,
+        )
+
+        assert result.calories <= 1785 * (
+            1 + WeeklyBudgetConstants.MAX_DAILY_SURPLUS_RATIO
+        )
+        assert result.carbs <= 161 * WeeklyBudgetConstants.MACRO_CEILING_RATIO
+        assert result.fat <= 57 * WeeklyBudgetConstants.MACRO_CEILING_RATIO
 
     def test_calorie_cap_macros_balanced_no_cap(self):
         """When macros are balanced, macro-derived ≈ calorie-redistributed. No cap."""
@@ -532,7 +600,7 @@ class TestCalculateWeeklyConsumed:
             FakeMeal(
                 status=MealStatus.READY,
                 nutrition=FakeNutrition(
-                    calories=500,
+                    calories=9999,
                     macros=FakeNutritionMacros(protein=30, carbs=50, fat=20),
                 ),
                 created_at=datetime(2026, 3, 23, 12, 0, tzinfo=timezone.utc),
@@ -540,7 +608,7 @@ class TestCalculateWeeklyConsumed:
             FakeMeal(
                 status=MealStatus.READY,
                 nutrition=FakeNutrition(
-                    calories=700,
+                    calories=9999,
                     macros=FakeNutritionMacros(protein=40, carbs=80, fat=25),
                 ),
                 created_at=datetime(2026, 3, 24, 12, 0, tzinfo=timezone.utc),
@@ -552,7 +620,7 @@ class TestCalculateWeeklyConsumed:
             "user-1",
             date(2026, 3, 23),
         )
-        assert result["calories"] == 1200
+        assert result["calories"] == 1205
         assert result["protein"] == 70
         assert result["carbs"] == 130
         assert result["fat"] == 45
@@ -650,7 +718,38 @@ class TestCalculateWeeklyConsumed:
             user_timezone="UTC",
         )
         # Only March 24 meal counted
-        assert result["calories"] == 600
+        assert result["calories"] == 578
+
+    def test_end_date_excludes_future_meals(self):
+        meals = [
+            FakeMeal(
+                status=MealStatus.READY,
+                nutrition=FakeNutrition(
+                    calories=500,
+                    macros=FakeNutritionMacros(protein=30, carbs=50, fat=20),
+                ),
+                created_at=datetime(2026, 3, 23, 12, 0, tzinfo=timezone.utc),
+            ),
+            FakeMeal(
+                status=MealStatus.READY,
+                nutrition=FakeNutrition(
+                    calories=4000,
+                    macros=FakeNutritionMacros(protein=80, carbs=500, fat=180),
+                ),
+                created_at=datetime(2026, 3, 25, 12, 0, tzinfo=timezone.utc),
+            ),
+        ]
+        uow = FakeUoW(meals=meals)
+
+        result = WeeklyBudgetService.calculate_weekly_consumed(
+            uow,
+            "user-1",
+            date(2026, 3, 23),
+            end_date=date(2026, 3, 24),
+            user_timezone="UTC",
+        )
+
+        assert result["calories"] == 500
 
 
 class TestGetEffectiveAdjustedDaily:
@@ -929,6 +1028,50 @@ class TestGetEffectiveAdjustedDaily:
             cheat_dates=[],
         )
         # consumed_total includes both days
-        assert result.consumed_total["calories"] == 1200
+        assert result.consumed_total["calories"] == 1205
         # consumed_before_today excludes Tuesday
         assert result.consumed_before_today["calories"] == 500
+
+    def test_future_meals_do_not_affect_selected_date_adjustment(self):
+        """Tuesday target uses Monday only; Wednesday planned meals are ignored."""
+        week_start = date(2026, 3, 23)
+        tuesday = date(2026, 3, 24)
+        meals = [
+            FakeMeal(
+                status=MealStatus.READY,
+                nutrition=FakeNutrition(
+                    calories=1000,
+                    macros=FakeNutritionMacros(protein=50, carbs=120, fat=35),
+                ),
+                created_at=datetime(2026, 3, 23, 12, 0, tzinfo=timezone.utc),
+            ),
+            FakeMeal(
+                status=MealStatus.READY,
+                nutrition=FakeNutrition(
+                    calories=5000,
+                    macros=FakeNutritionMacros(protein=100, carbs=600, fat=244),
+                ),
+                created_at=datetime(2026, 3, 25, 12, 0, tzinfo=timezone.utc),
+            ),
+        ]
+        daily_counts = {date(2026, 3, 23): 1}
+        budget = _make_budget(week_start)
+        uow = FakeUoW(meals=meals, daily_counts=daily_counts)
+
+        result = WeeklyBudgetService.get_effective_adjusted_daily(
+            uow=uow,
+            user_id="user-1",
+            week_start=week_start,
+            target_date=tuesday,
+            weekly_budget=budget,
+            base_daily_cal=_BASE_CAL,
+            base_daily_protein=_BASE_P,
+            base_daily_carbs=_BASE_C,
+            base_daily_fat=_BASE_F,
+            bmr=_BMR,
+            user_timezone="UTC",
+            cheat_dates=[],
+        )
+
+        assert result.consumed_before_today["calories"] == 995
+        assert result.adjusted.calories == pytest.approx((14000 - 995) / 6, abs=2)

--- a/tests/unit/handlers/command_handlers/test_movement_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_movement_command_handlers.py
@@ -16,6 +16,7 @@ from src.app.handlers.command_handlers.log_movement_command_handler import (
     _validate_log_movement,
 )
 from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.domain.cache.cache_keys import CacheKeys
 
 
 def test_validate_log_movement_accepts_catalog_activity():
@@ -247,6 +248,10 @@ class _FakeCache:
         return 1
 
 
+def _weekly_budget_key(user_id="user-1", week_start=date(2026, 5, 25)):
+    return CacheKeys.weekly_budget(user_id, week_start)[0]
+
+
 @pytest.mark.asyncio
 async def test_log_movement_handler_saves_entry_and_invalidates_daily_caches():
     uow = _FakeUow()
@@ -275,7 +280,7 @@ async def test_log_movement_handler_saves_entry_and_invalidates_daily_caches():
     assert result["id"] == saved.id
     assert result["logged_at"] == "2026-05-30T05:00:00+00:00"
     assert "user:user-1:macros:2026-05-30" in cache.invalidated
-    assert "user:user-1:weekly_budget:2026-05-25" in cache.invalidated
+    assert _weekly_budget_key() in cache.invalidated
     assert "user:user-1:activities:2026-05-30:*" in cache.patterns
 
 
@@ -305,7 +310,7 @@ async def test_log_movement_without_target_date_uses_current_utc_time(monkeypatc
     assert saved.logged_at == fixed_now
     assert result["logged_at"] == "2026-05-30T23:30:00+00:00"
     assert "user:user-1:macros:2026-05-31" in cache.invalidated
-    assert "user:user-1:weekly_budget:2026-05-25" in cache.invalidated
+    assert _weekly_budget_key() in cache.invalidated
     assert "user:user-1:activities:2026-05-31:*" in cache.patterns
 
 
@@ -348,7 +353,7 @@ async def test_delete_movement_handler_deletes_commits_and_invalidates_daily_cac
     assert uow.movement_entries.deleted is True
     assert uow.committed is True
     assert "user:user-1:macros:2026-05-31" in cache.invalidated
-    assert "user:user-1:weekly_budget:2026-05-25" in cache.invalidated
+    assert _weekly_budget_key() in cache.invalidated
     assert "user:user-1:activities:2026-05-31:*" in cache.patterns
 
 
@@ -437,7 +442,7 @@ async def test_update_movement_handler_updates_and_invalidates_caches():
     assert result["include_in_balance"] is False
     assert uow.committed is True
     assert "user:user-1:macros:2026-05-31" in cache.invalidated
-    assert "user:user-1:weekly_budget:2026-05-25" in cache.invalidated
+    assert _weekly_budget_key() in cache.invalidated
 
 
 def test_validate_log_movement_rejects_kcal_above_absolute_max():

--- a/tests/unit/handlers/query_handlers/test_cached_query_handlers.py
+++ b/tests/unit/handlers/query_handlers/test_cached_query_handlers.py
@@ -101,8 +101,9 @@ class TestGetWeeklyBudgetQueryHandlerCache:
         handler = GetWeeklyBudgetQueryHandler(
             uow=injected_uow, cache_service=cache_service
         )
+        target_date = date(2024, 1, 2)
         query = GetWeeklyBudgetQuery(
-            user_id="u1", target_date=date(2024, 1, 1), header_timezone="UTC"
+            user_id="u1", target_date=target_date, header_timezone="UTC"
         )
 
         with patch(
@@ -145,8 +146,9 @@ class TestGetWeeklyBudgetQueryHandlerCache:
         mock_uow.__aexit__ = AsyncMock(return_value=False)
 
         handler = GetWeeklyBudgetQueryHandler(cache_service=cache_service)
+        target_date = date(2024, 1, 2)
         query = GetWeeklyBudgetQuery(
-            user_id="u1", target_date=date(2024, 1, 1), header_timezone="UTC"
+            user_id="u1", target_date=target_date, header_timezone="UTC"
         )
 
         with patch(
@@ -166,7 +168,10 @@ class TestGetWeeklyBudgetQueryHandlerCache:
             result = await handler.handle(query)
 
         assert result == cached_payload
-        cache_service.get_json.assert_awaited_once()
+        expected_key, _ = CacheKeys.weekly_budget(
+            "u1", date(2024, 1, 1), target_date
+        )
+        cache_service.get_json.assert_awaited_once_with(expected_key)
         cache_service.set_json.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -230,11 +235,14 @@ class TestGetWeeklyBudgetQueryHandlerCache:
         mock_uow.weekly_budgets.find_by_user_and_week.return_value = mock_budget
 
         handler = GetWeeklyBudgetQueryHandler(cache_service=cache_service)
+        target_date = date(2024, 1, 2)
         query = GetWeeklyBudgetQuery(
-            user_id="u1", target_date=date(2024, 1, 1), header_timezone="UTC"
+            user_id="u1", target_date=target_date, header_timezone="UTC"
         )
 
-        expected_key, expected_ttl = CacheKeys.weekly_budget("u1", week_start)
+        expected_key, expected_ttl = CacheKeys.weekly_budget(
+            "u1", week_start, target_date
+        )
 
         with patch(
             "src.app.handlers.query_handlers.get_weekly_budget_query_handler.AsyncUnitOfWork",


### PR DESCRIPTION
## Summary
- cap weekly budget calorie redistribution to prevent unsafe daily swings
- redistribute movement-adjusted macros with bounded calorie targets
- version weekly budget cache keys and invalidate nutrition caches for recalculation

## Validation
- Existing backend fix commit was cherry-picked cleanly from delivery into a feature branch based on origin/main.
- Secret scan on branch diff passed.