### PR TITLE
fix: stabilize async loop handling and meal summaries

### DIFF
--- a/src/app/handlers/query_handlers/get_daily_breakdown_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_breakdown_query_handler.py
@@ -12,6 +12,7 @@ from src.app.events.base import EventHandler, handles
 from src.app.queries.meal.get_daily_breakdown_query import GetDailyBreakdownQuery
 from src.domain.cache.cache_keys import CacheKeys
 from src.domain.model.meal import MealStatus
+from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition.macros import Macros
 from src.domain.ports.cache_port import CachePort
 from src.domain.utils.timezone_utils import (
@@ -20,7 +21,6 @@ from src.domain.utils.timezone_utils import (
     resolve_user_timezone_async,
 )
 from src.infra.database.uow_async import AsyncUnitOfWork
-from src.domain.model.meal_projection import MealProjection
 
 logger = logging.getLogger(__name__)
 
@@ -138,9 +138,9 @@ class GetDailyBreakdownQueryHandler(
             )
             from src.app.queries.tdee import GetUserTdeeQuery
 
-            result = await GetUserTdeeQueryHandler().handle(
-                GetUserTdeeQuery(user_id=user_id)
-            )
+            result = await GetUserTdeeQueryHandler(
+                cache_service=self.cache_service
+            ).handle(GetUserTdeeQuery(user_id=user_id))
             cal = result.get("target_calories", 2000.0)
             macros = result.get("macros", {})
             return (
@@ -157,7 +157,13 @@ class GetDailyBreakdownQueryHandler(
         if not self.cache_service:
             return None
         cache_key, _ = CacheKeys.daily_breakdown(user_id, week_start)
-        return await self.cache_service.get_json(cache_key)
+        try:
+            return await self.cache_service.get_json(cache_key)
+        except Exception as exc:
+            logger.warning(
+                "Failed to read daily breakdown cache for %s: %s", user_id, exc
+            )
+            return None
 
     async def _write_cache(
         self, user_id: str, week_start: date, payload: Dict[str, Any]
@@ -165,4 +171,9 @@ class GetDailyBreakdownQueryHandler(
         if not self.cache_service:
             return
         cache_key, ttl = CacheKeys.daily_breakdown(user_id, week_start)
-        await self.cache_service.set_json(cache_key, payload, ttl)
+        try:
+            await self.cache_service.set_json(cache_key, payload, ttl)
+        except Exception as exc:
+            logger.warning(
+                "Failed to write daily breakdown cache for %s: %s", user_id, exc
+            )

--- a/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
@@ -5,23 +5,23 @@ Auto-extracted for better maintainability.
 
 import logging
 from datetime import date, datetime, timedelta
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from src.app.events.base import EventHandler, handles
 from src.app.queries.meal import GetDailyMacrosQuery
 from src.domain.cache.cache_keys import CacheKeys
 from src.domain.model.meal import MealStatus
+from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition.macros import Macros
+from src.domain.ports.cache_port import CachePort
 from src.domain.services.weekly_budget_service import WeeklyBudgetService
 from src.domain.utils.timezone_utils import (
     get_user_monday,
     get_zone_info,
     resolve_user_timezone_async,
 )
-from src.domain.ports.cache_port import CachePort
 from src.infra.database.uow_async import AsyncUnitOfWork
-from src.domain.model.meal_projection import MealProjection
 
 logger = logging.getLogger(__name__)
 
@@ -107,27 +107,38 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
                 user_profile = await uow.users.get_profile(UUID(query.user_id))
                 water_goal_ml = (
                     user_profile.daily_water_goal_ml
-                    if user_profile and hasattr(user_profile, "daily_water_goal_ml") and user_profile.daily_water_goal_ml is not None and user_profile.daily_water_goal_ml > 0
+                    if user_profile
+                    and hasattr(user_profile, "daily_water_goal_ml")
+                    and user_profile.daily_water_goal_ml is not None
+                    and user_profile.daily_water_goal_ml > 0
                     else 2000
                 )
             except Exception as exc:
-                logger.warning("Failed to fetch hydration data for user %s: %s", query.user_id, exc)
+                logger.warning(
+                    "Failed to fetch hydration data for user %s: %s", query.user_id, exc
+                )
                 consumed_water_ml = 0
                 water_goal_ml = 2000
 
             # Fetch movement kcal burned for this day
             movement_kcal_burned = 0.0
             try:
-                from datetime import time, timezone as tz_module
+                from datetime import time
+                from datetime import timezone as tz_module
+
                 start_local = datetime.combine(target_date, time.min, tzinfo=user_tz)
                 end_local = start_local + timedelta(days=1)
-                movement_kcal_burned = await uow.movement_entries.sum_included_kcal_for_range(
-                    query.user_id,
-                    start_local.astimezone(tz_module.utc),
-                    end_local.astimezone(tz_module.utc),
+                movement_kcal_burned = (
+                    await uow.movement_entries.sum_included_kcal_for_range(
+                        query.user_id,
+                        start_local.astimezone(tz_module.utc),
+                        end_local.astimezone(tz_module.utc),
+                    )
                 )
             except Exception as exc:
-                logger.warning("Failed to fetch movement data for user %s: %s", query.user_id, exc)
+                logger.warning(
+                    "Failed to fetch movement data for user %s: %s", query.user_id, exc
+                )
 
         # TDEE lookup — behind Redis cache, rarely opens DB
         target_calories = None
@@ -140,7 +151,7 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
             )
             from src.app.queries.tdee import GetUserTdeeQuery
 
-            tdee_handler = GetUserTdeeQueryHandler()
+            tdee_handler = GetUserTdeeQueryHandler(cache_service=self.cache_service)
             tdee_result = await tdee_handler.handle(
                 GetUserTdeeQuery(user_id=query.user_id)
             )
@@ -237,18 +248,20 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
             standard_daily_fat = target_macros.get("fat", 70) if target_macros else 70
 
             async with AsyncUnitOfWork() as uow:
-                effective = await WeeklyBudgetService.get_effective_adjusted_daily_async(
-                    uow=uow,
-                    user_id=user_id,
-                    week_start=week_start,
-                    target_date=target_date,
-                    weekly_budget=weekly_budget,
-                    base_daily_cal=standard_daily_calories,
-                    base_daily_protein=standard_daily_protein,
-                    base_daily_carbs=standard_daily_carbs,
-                    base_daily_fat=standard_daily_fat,
-                    bmr=bmr,
-                    user_timezone=user_timezone,
+                effective = (
+                    await WeeklyBudgetService.get_effective_adjusted_daily_async(
+                        uow=uow,
+                        user_id=user_id,
+                        week_start=week_start,
+                        target_date=target_date,
+                        weekly_budget=weekly_budget,
+                        base_daily_cal=standard_daily_calories,
+                        base_daily_protein=standard_daily_protein,
+                        base_daily_carbs=standard_daily_carbs,
+                        base_daily_fat=standard_daily_fat,
+                        bmr=bmr,
+                        user_timezone=user_timezone,
+                    )
                 )
             adjusted = effective.adjusted
 
@@ -268,7 +281,11 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
         if not self.cache_service:
             return None
         cache_key, _ = CacheKeys.daily_macros(user_id, target_date)
-        return await self.cache_service.get_json(cache_key)
+        try:
+            return await self.cache_service.get_json(cache_key)
+        except Exception as exc:
+            logger.warning("Failed to read daily macros cache for %s: %s", user_id, exc)
+            return None
 
     async def _write_cache(
         self, user_id: str, target_date: date, payload: Dict[str, Any]
@@ -276,4 +293,9 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, Dict[str, Any
         if not self.cache_service:
             return
         cache_key, ttl = CacheKeys.daily_macros(user_id, target_date)
-        await self.cache_service.set_json(cache_key, payload, ttl)
+        try:
+            await self.cache_service.set_json(cache_key, payload, ttl)
+        except Exception as exc:
+            logger.warning(
+                "Failed to write daily macros cache for %s: %s", user_id, exc
+            )

--- a/src/infra/cache/redis_client.py
+++ b/src/infra/cache/redis_client.py
@@ -4,14 +4,16 @@ Async Redis client with connection pooling.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Optional
+from typing import Awaitable, Callable, Optional, TypeVar
 from urllib.parse import urlparse
 
 import redis.asyncio as redis
 from redis.exceptions import RedisError
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 def _safe_redis_log_label(url: str) -> str:
@@ -34,23 +36,60 @@ class RedisClient:
         socket_connect_timeout: float = 5.0,
     ):
         self._redis_url = redis_url
-        self.pool = redis.ConnectionPool.from_url(
-            redis_url,
-            max_connections=max_connections,
-            decode_responses=True,
-            socket_timeout=socket_timeout,
-            socket_connect_timeout=socket_connect_timeout,
-        )
+        self._max_connections = max_connections
+        self._socket_timeout = socket_timeout
+        self._socket_connect_timeout = socket_connect_timeout
+        self._loop_id: Optional[int] = None
+        self.pool = self._create_pool()
         self.client: Optional[redis.Redis] = None
+
+    def _create_pool(self) -> redis.ConnectionPool:
+        return redis.ConnectionPool.from_url(
+            self._redis_url,
+            max_connections=self._max_connections,
+            decode_responses=True,
+            socket_timeout=self._socket_timeout,
+            socket_connect_timeout=self._socket_connect_timeout,
+        )
+
+    @staticmethod
+    def _current_loop_id() -> int:
+        return id(asyncio.get_running_loop())
+
+    async def _reset_client(self) -> None:
+        old_client = self.client
+        old_pool = self.pool
+        self.client = None
+        self._loop_id = None
+
+        if old_client:
+            try:
+                await old_client.aclose()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Redis client close failed during reset: %s", exc)
+        try:
+            await old_pool.disconnect()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Redis pool disconnect failed during reset: %s", exc)
+
+        self.pool = self._create_pool()
 
     async def connect(self) -> None:
         """Initialize the Redis connection."""
-        if self.client is not None:
+        current_loop_id = self._current_loop_id()
+        if (
+            self.client is not None
+            and getattr(self, "_loop_id", current_loop_id) == current_loop_id
+        ):
             return
+        if self.client is not None:
+            logger.warning("Redis client loop changed; reconnecting cache client")
+            await self._reset_client()
 
         self.client = redis.Redis(connection_pool=self.pool)
         try:
             await self.client.ping()
+            self._loop_id = current_loop_id
             logger.info("Redis connected (%s)", _safe_redis_log_label(self._redis_url))
         except RedisError as exc:  # pragma: no cover - connection errors logged
             logger.error(
@@ -60,6 +99,38 @@ class RedisClient:
             )
             raise
 
+    async def _with_client(
+        self,
+        operation_name: str,
+        operation: Callable[[redis.Redis], Awaitable[T]],
+        fallback: T,
+        key: Optional[str] = None,
+    ) -> T:
+        log_key = f" for key {key}" if key else ""
+        for attempt in range(2):
+            try:
+                await self.connect()
+                if not self.client:
+                    return fallback
+                return await operation(self.client)
+            except RuntimeError as exc:
+                if "attached to a different loop" in str(exc) and attempt == 0:
+                    logger.warning(
+                        "Redis %s loop mismatch%s; reconnecting",
+                        operation_name,
+                        log_key,
+                    )
+                    await self._reset_client()
+                    continue
+                logger.warning(
+                    "Redis %s runtime error%s: %s", operation_name, log_key, exc
+                )
+                return fallback
+            except RedisError as exc:
+                logger.warning("Redis %s error%s: %s", operation_name, log_key, exc)
+                return fallback
+        return fallback
+
     async def disconnect(self) -> None:
         """Close Redis connections."""
         if self.client:
@@ -67,110 +138,95 @@ class RedisClient:
             self.client = None
 
         await self.pool.disconnect()
+        self._loop_id = None
         logger.info("Redis disconnected")
 
     async def get(self, key: str) -> Optional[str]:
         """Retrieve a cached value."""
-        if not self.client:
-            return None
-        try:
-            return await self.client.get(key)
-        except RedisError as exc:
-            logger.warning("Redis GET error for key %s: %s", key, exc)
-            return None
+        return await self._with_client("GET", lambda client: client.get(key), None, key)
 
     async def set(self, key: str, value: str, ttl: Optional[int] = None) -> bool:
         """Store a value with optional TTL."""
-        if not self.client:
-            return False
-        try:
+
+        async def operation(client: redis.Redis) -> bool:
             if ttl:
-                await self.client.setex(key, ttl, value)
+                await client.setex(key, ttl, value)
             else:
-                await self.client.set(key, value)
+                await client.set(key, value)
             return True
-        except RedisError as exc:
-            logger.warning("Redis SET error for key %s: %s", key, exc)
-            return False
+
+        return await self._with_client("SET", operation, False, key)
 
     async def delete(self, key: str) -> bool:
         """Delete a cached key."""
-        if not self.client:
-            return False
-        try:
-            await self.client.delete(key)
+
+        async def operation(client: redis.Redis) -> bool:
+            await client.delete(key)
             return True
-        except RedisError as exc:
-            logger.warning("Redis DELETE error for key %s: %s", key, exc)
-            return False
+
+        return await self._with_client("DELETE", operation, False, key)
 
     async def delete_pattern(self, pattern: str) -> int:
         """Delete keys matching a pattern using non-blocking SCAN."""
-        if not self.client:
-            return 0
-        try:
+
+        async def operation(client: redis.Redis) -> int:
             deleted = 0
-            async for key in self.client.scan_iter(match=pattern):
-                await self.client.delete(key)
+            async for key in client.scan_iter(match=pattern):
+                await client.delete(key)
                 deleted += 1
             if deleted:
                 logger.debug("Deleted %d keys matching %s", deleted, pattern)
             return deleted
-        except RedisError as exc:
-            logger.warning("Redis delete_pattern error for %s: %s", pattern, exc)
-            return 0
+
+        return await self._with_client("delete_pattern", operation, 0, pattern)
 
     async def exists(self, key: str) -> bool:
         """Return True if a key exists."""
-        if not self.client:
-            return False
-        try:
-            return bool(await self.client.exists(key))
-        except RedisError as exc:
-            logger.warning("Redis EXISTS error for key %s: %s", key, exc)
-            return False
+
+        async def operation(client: redis.Redis) -> bool:
+            return bool(await client.exists(key))
+
+        return await self._with_client("EXISTS", operation, False, key)
 
     async def hset_with_ttl(self, key: str, mapping: dict, ttl: int) -> bool:
         """Set a hash and its TTL in a single pipeline round-trip."""
-        if not self.client:
-            return False
-        try:
-            async with self.client.pipeline(transaction=False) as pipe:
+
+        async def operation(client: redis.Redis) -> bool:
+            async with client.pipeline(transaction=False) as pipe:
                 pipe.hset(key, mapping=mapping)
                 pipe.expire(key, ttl)
                 await pipe.execute()
             return True
-        except RedisError as exc:
-            logger.warning("Redis HSET pipeline error for key %s: %s", key, exc)
-            return False
+
+        return await self._with_client("HSET pipeline", operation, False, key)
 
     async def hset_batch(self, items: list[tuple[str, dict, int]]) -> bool:
         """Set multiple hashes with TTL in a single pipeline. items: [(key, mapping, ttl)]."""
-        if not self.client:
-            return False
         if not items:
             return True
-        try:
-            async with self.client.pipeline(transaction=False) as pipe:
+
+        async def operation(client: redis.Redis) -> bool:
+            async with client.pipeline(transaction=False) as pipe:
                 for key, mapping, ttl in items:
                     pipe.hset(key, mapping=mapping)
                     pipe.expire(key, ttl)
                 await pipe.execute()
             return True
-        except RedisError as exc:
-            logger.warning("Redis batch HSET pipeline error: %s", exc)
-            return False
+
+        return await self._with_client("batch HSET pipeline", operation, False)
 
     async def hgetall_batch(self, keys: list[str]) -> list[dict]:
         """Fetch all fields of multiple hashes in a single pipeline. Returns list aligned to keys."""
-        if not self.client or not keys:
+        if not keys:
             return [{} for _ in keys]
-        try:
-            async with self.client.pipeline(transaction=False) as pipe:
+
+        async def operation(client: redis.Redis) -> list[dict]:
+            async with client.pipeline(transaction=False) as pipe:
                 for key in keys:
                     pipe.hgetall(key)
                 results = await pipe.execute()
             return [r or {} for r in results]
-        except RedisError as exc:
-            logger.warning("Redis batch HGETALL pipeline error: %s", exc)
-            return [{} for _ in keys]
+
+        return await self._with_client(
+            "batch HGETALL pipeline", operation, [{} for _ in keys]
+        )

--- a/src/infra/database/config_async.py
+++ b/src/infra/database/config_async.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from dotenv import load_dotenv
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import NullPool, AsyncAdaptedQueuePool
+from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
 
 load_dotenv()
 
@@ -87,6 +87,10 @@ ASYNC_DATABASE_URL, _connect_args = _sanitize_asyncpg_url_and_connect_args(
 _IS_NEON_POOLER = (
     "-pooler" in ASYNC_DATABASE_URL and os.getenv("DATABASE_URL_DIRECT") is None
 )
+_USE_ASYNC_QUEUE_POOL = (
+    os.getenv("ASYNC_DB_USE_QUEUE_POOL", "false").strip().lower() == "true"
+    and not _IS_NEON_POOLER
+)
 
 _UVICORN_WORKERS = int(os.getenv("UVICORN_WORKERS", "4"))
 _ASYNC_POOL_SIZE = int(os.getenv("ASYNC_POOL_SIZE_PER_WORKER", "3"))
@@ -94,14 +98,17 @@ _ASYNC_POOL_OVERFLOW = int(os.getenv("ASYNC_POOL_MAX_OVERFLOW", "2"))
 _ASYNC_POOL_TIMEOUT = int(os.getenv("POOL_TIMEOUT", "10"))
 
 try:
-    if _IS_NEON_POOLER:
+    if not _USE_ASYNC_QUEUE_POOL:
         async_engine = create_async_engine(
             ASYNC_DATABASE_URL,
             echo=False,
             poolclass=NullPool,
             connect_args=_connect_args,
         )
-        logger.info("Async engine: NullPool (Neon pooler detected)")
+        logger.info(
+            "Async engine: NullPool (loop-safe async connections, neon_pooler=%s)",
+            _IS_NEON_POOLER,
+        )
     else:
         async_engine = create_async_engine(
             ASYNC_DATABASE_URL,

--- a/src/infra/repositories/meal_repository.py
+++ b/src/infra/repositories/meal_repository.py
@@ -2,31 +2,31 @@ import logging
 from datetime import date, datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
-from sqlalchemy import func, update
-from sqlalchemy.orm import Session, joinedload, selectinload, noload
+from sqlalchemy import and_, func, or_, update
+from sqlalchemy.orm import Session, joinedload, noload, selectinload
 
 from src.domain.model.meal import Meal, MealStatus
 from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition import Nutrition
 from src.domain.ports.meal_repository_port import MealRepositoryPort
 from src.domain.utils.timezone_utils import get_zone_info, utc_now
-from src.infra.database.utils.datetime_helper import local_date_expr
 from src.infra.database.models.enums import MealStatusEnum
-from src.infra.database.models.meal.meal import MealORM
-from src.infra.database.models.meal.meal_image import MealImageORM
 from src.infra.database.models.meal.food_item_translation_model import (
     FoodItemTranslationORM,
 )
+from src.infra.database.models.meal.meal import MealORM
+from src.infra.database.models.meal.meal_image import MealImageORM
 from src.infra.database.models.meal.meal_translation_model import MealTranslationORM
 from src.infra.database.models.nutrition.food_item import FoodItemORM
 from src.infra.database.models.nutrition.nutrition import NutritionORM
+from src.infra.database.utils.datetime_helper import local_date_expr
 from src.infra.mappers import MealStatusMapper
 from src.infra.mappers.meal_mapper import (
-    meal_orm_to_domain,
+    food_item_domain_to_orm,
     meal_domain_to_orm,
     meal_image_domain_to_orm,
+    meal_orm_to_domain,
     nutrition_domain_to_orm,
-    food_item_domain_to_orm,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,16 @@ _PROJECTION_OPTS: dict = {
         joinedload(MealORM.translations),
     ),
 }
+
+
+def _domain_hydratable_active_meal_filter():
+    return and_(
+        MealORM.status != MealStatusEnum.INACTIVE,
+        or_(
+            MealORM.status != MealStatusEnum.READY,
+            and_(MealORM.ready_at.is_not(None), MealORM.nutrition.has()),
+        ),
+    )
 
 
 class MealRepository(MealRepositoryPort):
@@ -299,7 +309,7 @@ class MealRepository(MealRepositoryPort):
             query = query.filter(MealORM.user_id == user_id)
 
         db_meals = (
-            query.filter(MealORM.status != MealStatusEnum.INACTIVE)
+            query.filter(_domain_hydratable_active_meal_filter())
             .order_by(MealORM.created_at.desc())
             .limit(limit)
             .all()
@@ -340,7 +350,7 @@ class MealRepository(MealRepositoryPort):
         )
 
         db_meals = (
-            query.filter(MealORM.status != MealStatusEnum.INACTIVE)
+            query.filter(_domain_hydratable_active_meal_filter())
             .order_by(MealORM.created_at.asc())
             .limit(limit)
             .all()
@@ -375,7 +385,7 @@ class MealRepository(MealRepositoryPort):
                 MealORM.user_id == user_id,
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
             .group_by(date_expr)
             .all()
@@ -403,7 +413,7 @@ class MealRepository(MealRepositoryPort):
             self.db.query(date_expr)
             .filter(
                 MealORM.user_id == user_id,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
             .distinct()
             .order_by(date_expr.desc())

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -4,32 +4,32 @@ import logging
 from datetime import date, datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
-from sqlalchemy import func, update, select, delete
+from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload, joinedload, noload
+from sqlalchemy.orm import joinedload, noload, selectinload
 
 from src.domain.model.meal import Meal, MealStatus
+from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition import Nutrition
 from src.domain.ports.meal_repository_port import MealRepositoryPort
 from src.domain.utils.timezone_utils import get_zone_info, utc_now
 from src.infra.database.models.enums import MealStatusEnum
-from src.infra.database.models.meal.meal import MealORM
-from src.infra.database.models.meal.meal_image import MealImageORM
 from src.infra.database.models.meal.food_item_translation_model import (
     FoodItemTranslationORM,
 )
+from src.infra.database.models.meal.meal import MealORM
+from src.infra.database.models.meal.meal_image import MealImageORM
 from src.infra.database.models.meal.meal_translation_model import MealTranslationORM
 from src.infra.database.models.nutrition.food_item import FoodItemORM
 from src.infra.database.models.nutrition.nutrition import NutritionORM
 from src.infra.mappers import MealStatusMapper
 from src.infra.mappers.meal_mapper import (
-    meal_orm_to_domain,
+    food_item_domain_to_orm,
     meal_domain_to_orm,
     meal_image_domain_to_orm,
+    meal_orm_to_domain,
     nutrition_domain_to_orm,
-    food_item_domain_to_orm,
 )
-from src.domain.model.meal_projection import MealProjection
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,16 @@ _PROJECTION_OPTS: dict = {
         joinedload(MealORM.translations),
     ),
 }
+
+
+def _domain_hydratable_active_meal_filter():
+    return and_(
+        MealORM.status != MealStatusEnum.INACTIVE,
+        or_(
+            MealORM.status != MealStatusEnum.READY,
+            and_(MealORM.ready_at.is_not(None), MealORM.nutrition.has()),
+        ),
+    )
 
 
 class AsyncMealRepository(MealRepositoryPort):
@@ -223,7 +233,7 @@ class AsyncMealRepository(MealRepositoryPort):
             .where(
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
         )
         if user_id:
@@ -243,7 +253,9 @@ class AsyncMealRepository(MealRepositoryPort):
     ) -> List[Meal]:
         """Return all meals (food + hydration) for a date, sorted by timestamp DESC."""
         tz = get_zone_info(user_timezone) if user_timezone else timezone.utc
-        start_dt = datetime.combine(date_obj, datetime.min.time(), tzinfo=tz).astimezone(timezone.utc)
+        start_dt = datetime.combine(
+            date_obj, datetime.min.time(), tzinfo=tz
+        ).astimezone(timezone.utc)
         end_dt = start_dt + timedelta(days=1)
 
         result = await self.session.execute(
@@ -254,13 +266,11 @@ class AsyncMealRepository(MealRepositoryPort):
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
                 MealORM.status.in_([MealStatusEnum.READY, MealStatusEnum.ENRICHING]),
+                _domain_hydratable_active_meal_filter(),
             )
             .order_by(MealORM.created_at.desc())
         )
-        return [
-            meal_orm_to_domain(m)
-            for m in result.unique().scalars().all()
-        ]
+        return [meal_orm_to_domain(m) for m in result.unique().scalars().all()]
 
     async def sum_hydration_ml_for_date(
         self,
@@ -270,17 +280,18 @@ class AsyncMealRepository(MealRepositoryPort):
     ) -> int:
         """Return total hydration ml logged for a single date."""
         tz = get_zone_info(user_timezone) if user_timezone else timezone.utc
-        start_dt = datetime.combine(date_obj, datetime.min.time(), tzinfo=tz).astimezone(timezone.utc)
+        start_dt = datetime.combine(
+            date_obj, datetime.min.time(), tzinfo=tz
+        ).astimezone(timezone.utc)
         end_dt = start_dt + timedelta(days=1)
 
         result = await self.session.execute(
-            select(func.coalesce(func.sum(MealORM.quantity), 0))
-            .where(
+            select(func.coalesce(func.sum(MealORM.quantity), 0)).where(
                 MealORM.user_id == user_id,
                 MealORM.meal_type == "hydration",
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
         )
         return result.scalar_one()
@@ -294,9 +305,12 @@ class AsyncMealRepository(MealRepositoryPort):
     ) -> Dict[date, int]:
         """Return per-date hydration totals (ml) for a date range."""
         tz = get_zone_info(user_timezone) if user_timezone else timezone.utc
-        start_dt = datetime.combine(start_date, datetime.min.time(), tzinfo=tz).astimezone(timezone.utc)
+        start_dt = datetime.combine(
+            start_date, datetime.min.time(), tzinfo=tz
+        ).astimezone(timezone.utc)
         end_dt = (
-            datetime.combine(end_date, datetime.min.time(), tzinfo=tz) + timedelta(days=1)
+            datetime.combine(end_date, datetime.min.time(), tzinfo=tz)
+            + timedelta(days=1)
         ).astimezone(timezone.utc)
 
         if user_timezone and user_timezone != "UTC":
@@ -311,7 +325,7 @@ class AsyncMealRepository(MealRepositoryPort):
                 MealORM.meal_type == "hydration",
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
             .group_by(date_expr)
         )
@@ -347,7 +361,7 @@ class AsyncMealRepository(MealRepositoryPort):
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
                 MealORM.user_id == user_id,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
             .order_by(MealORM.created_at.asc())
             .limit(limit)
@@ -382,7 +396,7 @@ class AsyncMealRepository(MealRepositoryPort):
                 MealORM.user_id == user_id,
                 MealORM.created_at >= start_dt,
                 MealORM.created_at < end_dt,
-                MealORM.status != MealStatusEnum.INACTIVE,
+                _domain_hydratable_active_meal_filter(),
             )
             .group_by(date_expr)
         )
@@ -405,7 +419,8 @@ class AsyncMealRepository(MealRepositoryPort):
         result = await self.session.execute(
             select(date_expr)
             .where(
-                MealORM.user_id == user_id, MealORM.status != MealStatusEnum.INACTIVE
+                MealORM.user_id == user_id,
+                _domain_hydratable_active_meal_filter(),
             )
             .distinct()
             .order_by(date_expr.desc())

--- a/tests/unit/handlers/query_handlers/test_daily_breakdown_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_daily_breakdown_query_handler.py
@@ -50,16 +50,20 @@ async def test_uses_single_range_query_for_week():
     )
     mock_uow.meals.find_by_date = AsyncMock()
 
-    with patch(
-        "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.AsyncUnitOfWork",
-        return_value=mock_uow,
-    ), patch(
-        "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.resolve_user_timezone_async",
-        new=AsyncMock(return_value="UTC"),
-    ), patch.object(
-        handler,
-        "_get_base_daily_targets",
-        AsyncMock(return_value=(2000.0, 100.0, 200.0, 70.0)),
+    with (
+        patch(
+            "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.AsyncUnitOfWork",
+            return_value=mock_uow,
+        ),
+        patch(
+            "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.resolve_user_timezone_async",
+            new=AsyncMock(return_value="UTC"),
+        ),
+        patch.object(
+            handler,
+            "_get_base_daily_targets",
+            AsyncMock(return_value=(2000.0, 100.0, 200.0, 70.0)),
+        ),
     ):
         result = await handler.handle(query)
 
@@ -89,14 +93,63 @@ async def test_returns_cached_week_without_querying_meals():
     mock_uow.__aexit__ = AsyncMock(return_value=False)
     mock_uow.meals.find_by_date_range = AsyncMock()
 
-    with patch(
-        "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.AsyncUnitOfWork",
-        return_value=mock_uow,
-    ), patch(
-        "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.resolve_user_timezone_async",
-        new=AsyncMock(return_value="UTC"),
+    with (
+        patch(
+            "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.AsyncUnitOfWork",
+            return_value=mock_uow,
+        ),
+        patch(
+            "src.app.handlers.query_handlers.get_daily_breakdown_query_handler.resolve_user_timezone_async",
+            new=AsyncMock(return_value="UTC"),
+        ),
     ):
         result = await handler.handle(query)
 
     assert result == cached
     mock_uow.meals.find_by_date_range.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_base_daily_targets_passes_cache_service_to_tdee_handler():
+    cache = MagicMock()
+    cache.get_json = AsyncMock(return_value=None)
+    cache.set_json = AsyncMock()
+    handler = GetDailyBreakdownQueryHandler(cache_service=cache)
+
+    with patch(
+        "src.app.handlers.query_handlers.get_user_tdee_query_handler.GetUserTdeeQueryHandler"
+    ) as mock_tdee_cls:
+        mock_tdee = MagicMock()
+        mock_tdee.handle = AsyncMock(
+            return_value={
+                "target_calories": 2100.0,
+                "macros": {"protein": 120.0, "carbs": 220.0, "fat": 70.0},
+            }
+        )
+        mock_tdee_cls.return_value = mock_tdee
+
+        result = await handler._get_base_daily_targets(
+            "22222222-2222-2222-2222-222222222222"
+        )
+
+    mock_tdee_cls.assert_called_once_with(cache_service=cache)
+    assert result == (2100.0, 120.0, 220.0, 70.0)
+
+
+@pytest.mark.asyncio
+async def test_cache_failures_are_non_fatal():
+    cache = MagicMock()
+    cache.get_json = AsyncMock(side_effect=RuntimeError("attached to a different loop"))
+    cache.set_json = AsyncMock(side_effect=RuntimeError("attached to a different loop"))
+    handler = GetDailyBreakdownQueryHandler(cache_service=cache)
+
+    result = await handler._try_get_cached_result(
+        "22222222-2222-2222-2222-222222222222", date(2026, 4, 13)
+    )
+    await handler._write_cache(
+        "22222222-2222-2222-2222-222222222222",
+        date(2026, 4, 13),
+        {"days": []},
+    )
+
+    assert result is None

--- a/tests/unit/handlers/query_handlers/test_daily_macros_uow_consolidation.py
+++ b/tests/unit/handlers/query_handlers/test_daily_macros_uow_consolidation.py
@@ -51,6 +51,7 @@ async def test_cache_miss_opens_uow_once():
             )
             mock_tdee_cls.return_value = mock_tdee
             await handler.handle(query)
+            mock_tdee_cls.assert_called_once_with(cache_service=handler.cache_service)
 
     assert (
         mock_cls.call_count == 1
@@ -96,7 +97,30 @@ async def test_weekly_budget_fetched_in_shared_uow():
             )
             mock_tdee_cls.return_value = mock_tdee
             await handler.handle(query)
+            mock_tdee_cls.assert_called_once_with(cache_service=handler.cache_service)
 
     first_uow = uow_instances[0]
     first_uow.meals.find_by_date.assert_awaited_once()
     first_uow.weekly_budgets.find_by_user_and_week.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_read_failure_is_non_fatal():
+    handler = _make_handler()
+    handler.cache_service.get_json = AsyncMock(
+        side_effect=RuntimeError("attached to a different loop")
+    )
+
+    result = await handler._try_get_cached_result("u1", date(2026, 4, 18))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_write_failure_is_non_fatal():
+    handler = _make_handler()
+    handler.cache_service.set_json = AsyncMock(
+        side_effect=RuntimeError("attached to a different loop")
+    )
+
+    await handler._write_cache("u1", date(2026, 4, 18), {"ok": True})

--- a/tests/unit/infra/database/test_config_async.py
+++ b/tests/unit/infra/database/test_config_async.py
@@ -19,6 +19,7 @@ async def test_get_async_db_raises_clear_error_when_session_factory_missing(
 def test_async_url_rewrite_psycopg2_to_asyncpg(monkeypatch):
     monkeypatch.setenv("DATABASE_URL_DIRECT", "postgresql+psycopg2://user:pw@host/db")
     import importlib
+
     import src.infra.database.config_async as cfg
 
     importlib.reload(cfg)
@@ -29,6 +30,7 @@ def test_async_url_rewrite_psycopg2_to_asyncpg(monkeypatch):
 def test_async_url_rewrite_plain_postgresql(monkeypatch):
     monkeypatch.setenv("DATABASE_URL_DIRECT", "postgresql://user:pw@host/db")
     import importlib
+
     import src.infra.database.config_async as cfg
 
     importlib.reload(cfg)
@@ -38,7 +40,40 @@ def test_async_url_rewrite_plain_postgresql(monkeypatch):
 def test_async_url_rewrite_postgres_shorthand(monkeypatch):
     monkeypatch.setenv("DATABASE_URL_DIRECT", "postgres://user:pw@host/db")
     import importlib
+
     import src.infra.database.config_async as cfg
 
     importlib.reload(cfg)
     assert cfg.ASYNC_DATABASE_URL.startswith("postgresql+asyncpg://")
+
+
+def test_async_engine_defaults_to_null_pool_for_loop_safety(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL_DIRECT", "postgresql://user:pw@host/db")
+    monkeypatch.delenv("ASYNC_DB_USE_QUEUE_POOL", raising=False)
+    import importlib
+
+    from sqlalchemy.pool import NullPool
+
+    import src.infra.database.config_async as cfg
+
+    importlib.reload(cfg)
+
+    assert isinstance(cfg.async_engine.sync_engine.pool, NullPool)
+
+
+def test_async_engine_queue_pool_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL_DIRECT", "postgresql://user:pw@host/db")
+    monkeypatch.setenv("ASYNC_DB_USE_QUEUE_POOL", "true")
+    import importlib
+
+    from sqlalchemy.pool import AsyncAdaptedQueuePool
+
+    import src.infra.database.config_async as cfg
+
+    importlib.reload(cfg)
+
+    try:
+        assert isinstance(cfg.async_engine.sync_engine.pool, AsyncAdaptedQueuePool)
+    finally:
+        monkeypatch.setenv("ASYNC_DB_USE_QUEUE_POOL", "false")
+        importlib.reload(cfg)

--- a/tests/unit/infra/test_redis_client_timeout.py
+++ b/tests/unit/infra/test_redis_client_timeout.py
@@ -1,7 +1,8 @@
 """Unit test: RedisClient ConnectionPool must include socket timeouts."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from src.infra.cache.redis_client import RedisClient
 
@@ -51,10 +52,45 @@ def test_connection_pool_timeout_custom_value():
 
 
 @pytest.mark.asyncio
+async def test_get_reconnects_when_cached_client_belongs_to_old_loop():
+    """Loop-bound async Redis clients must be replaced before request use."""
+    old_client = MagicMock()
+    old_client.aclose = AsyncMock()
+    old_pool = MagicMock()
+    old_pool.disconnect = AsyncMock()
+
+    new_pool = MagicMock()
+    new_client = MagicMock()
+    new_client.ping = AsyncMock(return_value=True)
+    new_client.get = AsyncMock(return_value="cached-value")
+
+    with (
+        patch(
+            "src.infra.cache.redis_client.redis.ConnectionPool.from_url",
+            return_value=new_pool,
+        ),
+        patch("src.infra.cache.redis_client.redis.Redis", return_value=new_client),
+    ):
+        client = RedisClient(redis_url="redis://localhost:6379")
+        client.client = old_client
+        client.pool = old_pool
+        client._loop_id = -1
+
+        result = await client.get("cache-key")
+
+    assert result == "cached-value"
+    old_client.aclose.assert_awaited_once()
+    old_pool.disconnect.assert_awaited_once()
+    new_client.ping.assert_awaited_once()
+    new_client.get.assert_awaited_once_with("cache-key")
+
+
+@pytest.mark.asyncio
 async def test_delete_pattern_uses_scan_not_keys():
     """delete_pattern must use scan_iter, never client.keys (blocking)."""
-    from src.infra.cache.redis_client import RedisClient
     from unittest.mock import AsyncMock
+
+    from src.infra.cache.redis_client import RedisClient
 
     client = RedisClient.__new__(RedisClient)
 

--- a/tests/unit/repositories/test_meal_repository_projections.py
+++ b/tests/unit/repositories/test_meal_repository_projections.py
@@ -1,22 +1,24 @@
 """Tests that MealRepository projection parameter controls relationship loading."""
-from unittest.mock import MagicMock
-from datetime import date
-from datetime import datetime
+
 import uuid
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
 
-import pytest
-
-from src.infra.repositories.meal_repository import MealRepository, MealProjection
-from src.domain.model import Meal, MealStatus, MealImage, Nutrition, Macros, FoodItem
+from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
+from src.infra.database.models.enums import MealStatusEnum
+from src.infra.database.models.meal.meal import MealORM
+from src.infra.database.models.meal.meal_image import MealImageORM
+from src.infra.database.models.nutrition.nutrition import NutritionORM
+from src.infra.repositories.meal_repository import MealProjection, MealRepository
 
 
 def _make_repo():
     session = MagicMock()
-    session.query.return_value.options.return_value.filter.return_value\
-        .filter.return_value.filter.return_value.order_by.return_value\
-        .limit.return_value.all.return_value = []
-    session.query.return_value.options.return_value.filter.return_value\
-        .first.return_value = None
+    query = session.query.return_value
+    options = query.options.return_value
+    date_query = options.filter.return_value.filter.return_value.filter.return_value
+    date_query.order_by.return_value.limit.return_value.all.return_value = []
+    options.filter.return_value.first.return_value = None
     return MealRepository(session)
 
 
@@ -31,7 +33,9 @@ def test_find_by_date_accepts_projection_parameter():
     """find_by_date must accept a projection keyword argument without error."""
     repo = _make_repo()
     # Should not raise TypeError
-    repo.find_by_date(date(2026, 4, 18), user_id="u1", projection=MealProjection.MACROS_ONLY)
+    repo.find_by_date(
+        date(2026, 4, 18), user_id="u1", projection=MealProjection.MACROS_ONLY
+    )
 
 
 def test_find_by_id_accepts_projection_parameter():
@@ -45,17 +49,17 @@ def test_projection_opt_counts():
     from src.infra.repositories.meal_repository import _PROJECTION_OPTS, MealProjection
 
     # MACROS_ONLY: noload(image) + nutrition chain selectinload
-    assert len(_PROJECTION_OPTS[MealProjection.MACROS_ONLY]) == 2, (
-        "MACROS_ONLY must have 2 load options (noload image, nutrition chain)"
-    )
+    assert (
+        len(_PROJECTION_OPTS[MealProjection.MACROS_ONLY]) == 2
+    ), "MACROS_ONLY must have 2 load options (noload image, nutrition chain)"
     # FULL: image + nutrition chain
-    assert len(_PROJECTION_OPTS[MealProjection.FULL]) == 2, (
-        "FULL must have 2 load options (image, nutrition chain)"
-    )
+    assert (
+        len(_PROJECTION_OPTS[MealProjection.FULL]) == 2
+    ), "FULL must have 2 load options (image, nutrition chain)"
     # FULL_WITH_TRANSLATIONS: image + nutrition chain + translations
-    assert len(_PROJECTION_OPTS[MealProjection.FULL_WITH_TRANSLATIONS]) == 3, (
-        "FULL_WITH_TRANSLATIONS must have 3 load options (image, nutrition chain, translations)"
-    )
+    assert (
+        len(_PROJECTION_OPTS[MealProjection.FULL_WITH_TRANSLATIONS]) == 3
+    ), "FULL_WITH_TRANSLATIONS must have 3 load options (image, nutrition chain, translations)"
 
 
 def test_save_new_meal_inserts_food_items_once(test_session):
@@ -109,3 +113,68 @@ def test_save_new_meal_inserts_food_items_once(test_session):
         .all()
     )
     assert len(inserted_items) == 2
+
+
+def test_date_range_skips_ready_rows_without_required_domain_data(test_session):
+    """Malformed legacy READY rows must not crash summary/feed queries."""
+    repository = MealRepository(test_session)
+    user_id = str(uuid.uuid4())
+    target_date = date.today()
+    created_at = datetime.combine(target_date, datetime.min.time(), tzinfo=timezone.utc)
+
+    invalid_meal_id = str(uuid.uuid4())
+    valid_meal_id = str(uuid.uuid4())
+    invalid_image_id = str(uuid.uuid4())
+    valid_image_id = str(uuid.uuid4())
+
+    test_session.add_all(
+        [
+            MealImageORM(
+                image_id=invalid_image_id,
+                format="jpeg",
+                size_bytes=1,
+                url="https://example.com/invalid.jpg",
+            ),
+            MealImageORM(
+                image_id=valid_image_id,
+                format="jpeg",
+                size_bytes=1,
+                url="https://example.com/valid.jpg",
+            ),
+            MealORM(
+                meal_id=invalid_meal_id,
+                user_id=user_id,
+                status=MealStatusEnum.READY,
+                image_id=invalid_image_id,
+                created_at=created_at,
+                updated_at=created_at,
+                ready_at=created_at,
+                dish_name="Missing Nutrition",
+            ),
+            MealORM(
+                meal_id=valid_meal_id,
+                user_id=user_id,
+                status=MealStatusEnum.READY,
+                image_id=valid_image_id,
+                created_at=created_at,
+                updated_at=created_at,
+                ready_at=created_at,
+                dish_name="Complete Meal",
+            ),
+            NutritionORM(
+                meal_id=valid_meal_id,
+                protein=25.0,
+                carbs=40.0,
+                fat=12.0,
+                confidence_score=0.95,
+            ),
+        ]
+    )
+    test_session.flush()
+
+    meals = repository.find_by_date_range(user_id, target_date, target_date)
+
+    assert [meal.meal_id for meal in meals] == [valid_meal_id]
+    assert repository.get_daily_meal_counts(user_id, target_date, target_date) == {
+        target_date: 1
+    }


### PR DESCRIPTION

## Summary
- make async Redis cache operations loop-aware and degrade cache failures instead of surfacing 500s
- default async SQLAlchemy sessions to NullPool unless queue pooling is explicitly opted in
- skip malformed READY meal rows lacking required domain data from meal summary/feed projections
- pass cache service into nested TDEE handlers and make daily summary cache failures non-fatal

## Verification
- `GOOGLE_API_KEY=dummy git push -u origin codex/fix-async-loop-meal-summaries` (pre-push hook: 1503 passed, 3 skipped)
- `uv run --python /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 pytest tests/unit/handlers/query_handlers/test_daily_macros_uow_consolidation.py tests/unit/handlers/query_handlers/test_daily_breakdown_query_handler.py tests/unit/infra/database/test_config_async.py tests/unit/infra/test_redis_client_timeout.py tests/unit/infra/test_redis_hash_ops.py tests/unit/repositories/test_meal_repository_projections.py tests/unit/handlers/query_handlers/test_cached_query_handlers.py tests/unit/handlers/query_handlers/test_movement_balance_integration.py -q` (46 passed)
- `uv run --python /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 ruff check --select I,F ...` (passed)
- `uv run --python /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 python -m compileall -q ...` (passed)
- `git diff --cached --check` (passed)
- staged secret-keyword scan: no matches
