### PR TITLE
fix(ai): harden AI API reliability

### DIFF
--- a/plans/260608-2251-ai-api-reliability-hardening/phase-01-research-and-design.md
+++ b/plans/260608-2251-ai-api-reliability-hardening/phase-01-research-and-design.md
@@ -1,0 +1,50 @@
+---
+phase: 1
+title: Research and design
+status: completed
+priority: P1
+effort: 1h
+dependencies: []
+---
+
+# Phase 1: Research and design
+
+## Overview
+
+Lock the AI API failure modes and implementation boundaries before code changes.
+
+## Requirements
+
+- Functional: identify exact AI route/provider touchpoints and preserve stable success contracts.
+- Non-functional: keep solution small, testable, and compatible with existing Clean Architecture/CQRS patterns.
+
+## Architecture
+
+Route handlers should keep delegating through commands/queries. Domain/infra services should preserve typed AI exceptions instead of collapsing them into generic runtime errors. Cache metadata should live at the AI infrastructure boundary, not in API code.
+
+## Related Code Files
+
+- Read: `src/api/routes/v1/meals.py`
+- Read: `src/api/routes/v1/ingredients.py`
+- Read: `src/api/routes/v1/meal_suggestions.py`
+- Read: `src/infra/services/ai/ai_model_manager.py`
+- Read: `src/infra/services/ai/gemini_cache_manager.py`
+- Read: `src/infra/services/ai/providers/gemini_provider.py`
+- Read: `src/infra/adapters/vision_ai_service.py`
+
+## Implementation Steps
+
+1. Confirm route-level AI endpoints and dormant handler registrations.
+2. Confirm provider fallback/cache call chain.
+3. Confirm existing tests and gaps for cache fallback, image outage mapping, base64 validation, and route setup.
+4. Record red-team risks in `plan.md`.
+
+## Success Criteria
+
+- [ ] Every code touchpoint for implementation is listed.
+- [ ] Scope explicitly excludes new providers, migrations, and product UX redesign.
+- [ ] Red-team risks have mitigation notes.
+
+## Risk Assessment
+
+Main risk is confusing "AI outage" with "bad user image." Keep the distinction explicit in exceptions and tests.

--- a/plans/260608-2251-ai-api-reliability-hardening/phase-02-implement-reliability-fixes.md
+++ b/plans/260608-2251-ai-api-reliability-hardening/phase-02-implement-reliability-fixes.md
@@ -1,0 +1,56 @@
+---
+phase: 2
+title: Implement reliability fixes
+status: completed
+priority: P1
+effort: 3h
+dependencies:
+  - 1
+---
+
+# Phase 2: Implement reliability fixes
+
+## Overview
+
+Apply focused fixes to AI fallback/cache behavior, vision error semantics, ingredient payload validation, image-url analysis, and the Postgres route-test harness.
+
+## Requirements
+
+- Functional: provider fallback, image analysis, ingredient recognition, image-url analysis, and route tests behave correctly under the reviewed failure modes.
+- Non-functional: no public success response-shape changes; no unrelated refactors.
+
+## Architecture
+
+Keep API routes thin. Put provider/cache compatibility in `AIModelManager` and `GeminiCacheManager`. Put URL image byte fetching and typed exception preservation in `VisionAIService`. Put request body limits in Pydantic schemas and strict decode in command handler.
+
+## Related Code Files
+
+- Modify: `src/infra/services/ai/gemini_cache_manager.py`
+- Modify: `src/infra/services/ai/ai_model_manager.py`
+- Modify: `src/infra/adapters/vision_ai_service.py`
+- Modify: `src/api/schemas/request/ingredient_recognition_requests.py`
+- Modify: `src/app/handlers/command_handlers/recognize_ingredient_command_handler.py`
+- Modify: `tests/conftest.py`
+- Modify/Add tests under `tests/unit/infra/services/ai`, `tests/unit/infra/adapters`, `tests/unit/handlers/command_handlers`, and `tests/integration/routes`.
+
+## Implementation Steps
+
+1. Add cache metadata helpers that store and read cache names with model information while tolerating legacy string cache values.
+2. Update `AIModelManager.generate()` to pass cache only when the cache metadata model matches the current fallback model.
+3. Preserve `AIUnavailableError` through `VisionAIService.analyze_with_strategy()`.
+4. Implement safe image URL fetching before calling `generate_with_vision()`: HTTP(S), status, content type, and size checks.
+5. Add `IngredientRecognitionRequest.image_data` max length and strict base64 decode.
+6. Replace PostgreSQL-invalid `CREATE DATABASE IF NOT EXISTS` test setup with a PostgreSQL-compatible existence check/create.
+7. Add regression tests for each changed behavior.
+
+## Success Criteria
+
+- [ ] Fallback cache mismatch is covered by a unit test.
+- [ ] Vision outage mapping is covered by route or route-adjacent test.
+- [ ] URL image analysis passes actual response bytes to the vision model manager.
+- [ ] Ingredient oversized and invalid base64 payloads are rejected.
+- [ ] Test database setup no longer fails on PostgreSQL syntax.
+
+## Risk Assessment
+
+Cache metadata change has deployment risk if Redis contains legacy values. Read legacy values as cache-name-only and omit cache when the model cannot be verified.

--- a/plans/260608-2251-ai-api-reliability-hardening/phase-03-verify-and-ship.md
+++ b/plans/260608-2251-ai-api-reliability-hardening/phase-03-verify-and-ship.md
@@ -1,0 +1,51 @@
+---
+phase: 3
+title: Verify and ship
+status: completed
+priority: P1
+effort: 1h
+dependencies:
+  - 2
+---
+
+# Phase 3: Verify and ship
+
+## Overview
+
+Run focused verification, update plan state, commit, push, and open a PR.
+
+## Requirements
+
+- Functional: all acceptance criteria from `plan.md` verified by tests or explicit inspection.
+- Non-functional: no lint/syntax errors in touched files, no secrets staged, branch pushed for PR review.
+
+## Architecture
+
+Verification should cover the real API boundary where possible and the isolated provider/service units where DB or external APIs are mocked.
+
+## Related Code Files
+
+- Verify: touched `src/` files.
+- Verify: touched `tests/` files.
+- Verify: `plans/260608-2251-ai-api-reliability-hardening/*`.
+
+## Implementation Steps
+
+1. Run focused AI/provider/vision/handler tests with Python 3.11.
+2. Run route tests for meal suggestions and ingredients using the repo environment.
+3. Run ruff on touched Python files.
+4. Run `git diff --check` and inspect final diff.
+5. Mark plan phases complete with `ck plan check`.
+6. Stage, secret-scan, commit, push, and open PR against `main`.
+
+## Success Criteria
+
+- [ ] Focused tests pass.
+- [ ] Route tests pass or any remaining blocker is documented with concrete cause.
+- [ ] Ruff passes on touched files.
+- [ ] Git secret scan passes.
+- [ ] PR URL returned.
+
+## Risk Assessment
+
+If route tests require live services beyond local Postgres, stop and report the exact boundary rather than claiming full route confidence.

--- a/plans/260608-2251-ai-api-reliability-hardening/plan.md
+++ b/plans/260608-2251-ai-api-reliability-hardening/plan.md
@@ -1,0 +1,71 @@
+---
+title: AI API reliability hardening
+description: >-
+  Fix AI API fallback, error semantics, payload validation, and route-test
+  reliability
+status: completed
+priority: P2
+branch: codex/ai-api-reliability-hardening
+tags:
+  - ai
+  - reliability
+  - fastapi
+  - gemini
+blockedBy: []
+blocks: []
+created: '2026-06-08T15:51:35.166Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# AI API reliability hardening
+
+## Overview
+
+Harden the AI-facing API boundary after review findings around Gemini cache fallback, image analysis error mapping, ingredient payload validation, dormant image-url analysis, and route-test setup. This plan keeps existing public success response shapes stable while making provider outages observable and retryable.
+
+Expected output: a focused PR on `codex/ai-api-reliability-hardening` with code, tests, docs/plan notes, and a passing focused verification suite.
+
+Acceptance criteria:
+- Parse-text JSON recovery keeps passing and remains shared by Gemini provider extraction.
+- Cache-enabled Gemini fallback never passes a cache created for a different model.
+- `/v1/meals/image/analyze` returns `AI_UNAVAILABLE` 503 for provider outage and still returns `NOT_FOOD_IMAGE` for real validation failures.
+- Ingredient recognition rejects oversized or invalid base64 payloads before expensive decode work.
+- The registered image-by-URL command analyzes actual fetched image bytes or fails with a clear validation/runtime error.
+- AI route-level tests can run against Postgres test setup.
+- No DB schema, auth, or successful public response-shape change.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Research and design](./phase-01-research-and-design.md) | Completed |
+| 2 | [Implement reliability fixes](./phase-02-implement-reliability-fixes.md) | Completed |
+| 3 | [Verify and ship](./phase-03-verify-and-ship.md) | Completed |
+
+## Dependencies
+
+- Existing Redis cache strategy plan is completed and does not block this work.
+- Existing docs/specs confirm Gemini cache and vision fallback were previously added for cost and resilience; this plan narrows their failure modes instead of redesigning AI architecture.
+
+## Scope Boundary
+
+In scope:
+- AI model manager cache/fallback behavior.
+- Gemini cache metadata stored in Redis.
+- Vision service exception preservation and image URL byte handling.
+- Ingredient recognition request/handler validation.
+- Focused unit/API tests and Postgres test harness syntax.
+
+Out of scope:
+- New AI provider integrations.
+- New DB migrations.
+- Reworking meal suggestion recipe partial-failure product behavior.
+- Full prompt or nutrition pipeline redesign.
+
+## Red-Team Notes
+
+- Risk: changing cache storage format could invalidate old Redis values. Mitigation: support legacy string values as model-unknown caches and only use them when model metadata matches or cache is omitted.
+- Risk: preserving `AIUnavailableError` through vision may alter mobile error UX from 400 to 503. This is intended because outage is not a bad image.
+- Risk: fetching image URLs could create SSRF exposure. Mitigation: only allow HTTP(S), enforce response status/content type/size, and keep the existing provider byte path.
+- Risk: route-test setup may reveal broader database assumptions. Mitigation: fix only PostgreSQL-compatible database creation syntax and keep test schema setup unchanged.

--- a/src/api/schemas/request/ingredient_recognition_requests.py
+++ b/src/api/schemas/request/ingredient_recognition_requests.py
@@ -4,12 +4,17 @@ Ingredient recognition request DTOs.
 
 from pydantic import BaseModel, Field
 
+MAX_IMAGE_BASE64_LENGTH = 7 * 1024 * 1024
+
 
 class IngredientRecognitionRequest(BaseModel):
     """Request to recognize an ingredient from an image."""
 
     image_data: str = Field(
-        ..., description="Base64 encoded image data (JPEG or PNG)", min_length=1
+        ...,
+        description="Base64 encoded image data (JPEG or PNG)",
+        min_length=1,
+        max_length=MAX_IMAGE_BASE64_LENGTH,
     )
 
     class Config:

--- a/src/app/handlers/command_handlers/recognize_ingredient_command_handler.py
+++ b/src/app/handlers/command_handlers/recognize_ingredient_command_handler.py
@@ -3,11 +3,13 @@ Handler for ingredient recognition command.
 """
 
 import base64
+import binascii
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from src.app.commands.ingredient import RecognizeIngredientCommand
 from src.app.events.base import EventHandler, handles
+from src.domain.exceptions.ai_exceptions import AIUnavailableError
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
 from src.domain.services.translation.deepl_text_translation_service import (
     DeepLTextTranslationService,
@@ -16,17 +18,19 @@ from src.domain.strategies.meal_analysis_strategy import AnalysisStrategyFactory
 
 logger = logging.getLogger(__name__)
 
+MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
 
 @handles(RecognizeIngredientCommand)
 class RecognizeIngredientCommandHandler(
-    EventHandler[RecognizeIngredientCommand, Dict[str, Any]]
+    EventHandler[RecognizeIngredientCommand, dict[str, Any]]
 ):
     """Handler for recognizing ingredients from images."""
 
     def __init__(
         self,
         vision_service: VisionAIServicePort = None,
-        translation_service: Optional[DeepLTextTranslationService] = None,
+        translation_service: DeepLTextTranslationService | None = None,
     ):
         self.vision_service = vision_service
         self.translation_service = translation_service
@@ -38,7 +42,7 @@ class RecognizeIngredientCommandHandler(
             "translation_service", self.translation_service
         )
 
-    async def handle(self, command: RecognizeIngredientCommand) -> Dict[str, Any]:
+    async def handle(self, command: RecognizeIngredientCommand) -> dict[str, Any]:
         """
         Handle ingredient recognition from image.
 
@@ -56,8 +60,8 @@ class RecognizeIngredientCommandHandler(
         try:
             # Decode base64 image
             try:
-                image_bytes = base64.b64decode(command.image_data)
-            except Exception as e:
+                image_bytes = base64.b64decode(command.image_data, validate=True)
+            except (binascii.Error, ValueError) as e:
                 logger.warning(f"Failed to decode image data: {e}")
                 return {
                     "name": None,
@@ -67,9 +71,7 @@ class RecognizeIngredientCommandHandler(
                     "message": "Invalid image data format",
                 }
 
-            # Validate image size (max 5MB)
-            max_size_bytes = 5 * 1024 * 1024
-            if len(image_bytes) > max_size_bytes:
+            if len(image_bytes) > MAX_IMAGE_BYTES:
                 return {
                     "name": None,
                     "confidence": 0.0,
@@ -123,6 +125,8 @@ class RecognizeIngredientCommandHandler(
                 "message": None if success else "Could not identify ingredient",
             }
 
+        except AIUnavailableError:
+            raise
         except Exception as e:
             logger.error(f"Ingredient recognition failed: {e}")
             return {

--- a/src/infra/adapters/meal_generation_json_utils.py
+++ b/src/infra/adapters/meal_generation_json_utils.py
@@ -249,20 +249,36 @@ def clean_json_content(content: str) -> str:
             "[JSON-CLEAN-FALLBACK] no complete objects found | "
             "attempting simple recovery"
         )
-        # Find last complete key-value pair
-        last_valid = find_last_valid_json_position(content)
-        if last_valid > 0:
-            content = content[:last_valid]
-            logger.debug(f"[JSON-CLEAN-TRUNCATE] cut at last_valid={last_valid}")
+        # First preserve recoverable scalar values at the cutoff, then close
+        # the open containers. This handles AI output truncated right after a
+        # valid number/string/bool/null value.
+        candidate = re.sub(r",\s*$", "", content)
+        candidate = re.sub(r":\s*$", ": null", candidate)  # Fix hanging colons
+        candidate = re.sub(r",(\s*[}\]])", r"\1", candidate)
+        candidate = close_json_structures(candidate)
+        try:
+            json.loads(candidate)
+            content = candidate
+            logger.debug(f"[JSON-CLEAN-CLOSED] final_len={len(content)}")
+        except json.JSONDecodeError as e:
+            logger.debug(
+                f"[JSON-CLEAN-CLOSE-AS-IS-FAILED] error={e.msg} | pos={e.pos}"
+            )
 
-        # Remove trailing incomplete content
-        content = re.sub(r",\s*$", "", content)
-        content = re.sub(r":\s*$", ": null", content)  # Fix hanging colons
-        content = re.sub(r",(\s*[}\]])", r"\1", content)
+            # Find last complete key-value pair
+            last_valid = find_last_valid_json_position(content)
+            if last_valid > 0:
+                content = content[:last_valid]
+                logger.debug(f"[JSON-CLEAN-TRUNCATE] cut at last_valid={last_valid}")
 
-        # Close structures
-        content = close_json_structures(content)
-        logger.debug(f"[JSON-CLEAN-CLOSED] final_len={len(content)}")
+            # Remove trailing incomplete content
+            content = re.sub(r",\s*$", "", content)
+            content = re.sub(r":\s*$", ": null", content)  # Fix hanging colons
+            content = re.sub(r",(\s*[}\]])", r"\1", content)
+
+            # Close structures
+            content = close_json_structures(content)
+            logger.debug(f"[JSON-CLEAN-CLOSED] final_len={len(content)}")
 
     return content
 

--- a/src/infra/adapters/vision_ai_service.py
+++ b/src/infra/adapters/vision_ai_service.py
@@ -1,11 +1,15 @@
+import asyncio
 import json
 import logging
 import re
 from io import BytesIO
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from PIL import Image
 
+from src.domain.exceptions.ai_exceptions import AIUnavailableError
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
 from src.domain.strategies.meal_analysis_strategy import (
     AnalysisStrategyFactory,
@@ -14,6 +18,10 @@ from src.domain.strategies.meal_analysis_strategy import (
 from src.infra.services.ai.ai_model_manager import AIModelManager, ModelPurpose
 
 logger = logging.getLogger(__name__)
+
+MAX_URL_IMAGE_BYTES = 5 * 1024 * 1024
+URL_FETCH_TIMEOUT_SECONDS = 10
+ALLOWED_URL_IMAGE_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 
 
 class VisionAIService(VisionAIServicePort):
@@ -136,6 +144,8 @@ class VisionAIService(VisionAIServicePort):
                 system_message=strategy.get_analysis_prompt(),
                 max_tokens=1024,
             )
+        except AIUnavailableError:
+            raise
         except Exception as e:
             raise RuntimeError(
                 f"Failed to analyze image with {strategy.get_strategy_name()}: {str(e)}"
@@ -163,24 +173,32 @@ class VisionAIService(VisionAIServicePort):
         Raises:
             RuntimeError: If analysis fails
         """
-        try:
-            result = await self._ai_manager.generate_with_vision(
-                purpose=ModelPurpose.MEAL_SCAN,
-                prompt=strategy.get_user_message(),
-                image_data=image_url.encode("utf-8"),
-                system_message=strategy.get_analysis_prompt(),
-                max_tokens=1024,
-            )
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to analyze image URL with {strategy.get_strategy_name()}: {str(e)}"
-            ) from e
+        image_bytes = await self._fetch_image_url(image_url)
+        return await self.analyze_with_strategy(image_bytes, strategy)
 
-        return {
-            "raw_response": json.dumps(result),
-            "structured_data": result,
-            "strategy_used": strategy.get_strategy_name(),
-        }
+    async def _fetch_image_url(self, image_url: str) -> bytes:
+        """Fetch bounded image bytes from an HTTP(S) URL."""
+        parsed = urlparse(image_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Image URL must be an absolute HTTP(S) URL")
+
+        def _fetch() -> bytes:
+            request = Request(image_url, headers={"User-Agent": "MealTrack/1.0"})
+            with urlopen(request, timeout=URL_FETCH_TIMEOUT_SECONDS) as response:
+                content_type = response.headers.get_content_type()
+                if content_type not in ALLOWED_URL_IMAGE_CONTENT_TYPES:
+                    raise ValueError(f"Unsupported image URL content type: {content_type}")
+                image_bytes = response.read(MAX_URL_IMAGE_BYTES + 1)
+                if len(image_bytes) > MAX_URL_IMAGE_BYTES:
+                    raise ValueError("Image URL content too large (max 5MB)")
+                return image_bytes
+
+        try:
+            return await asyncio.to_thread(_fetch)
+        except ValueError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to fetch image URL: {str(e)}") from e
 
     async def analyze(self, image_bytes: bytes) -> dict[str, Any]:
         """

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -134,8 +134,8 @@ class AIModelManager:
             )
             available = [chain[0]]
 
-        # Look up warm Gemini context cache for this purpose
-        cache_name: str | None = None
+        # Gemini context caches are model-specific; lookup happens per attempt.
+        cache_type: str | None = None
         if self._cache_manager is not None:
             purpose_to_cache_type = {
                 ModelPurpose.RECIPE: "recipe",
@@ -144,13 +144,6 @@ class AIModelManager:
                 ModelPurpose.BARCODE: "text_parse",
             }
             cache_type = purpose_to_cache_type.get(purpose)
-            if cache_type and any(model.startswith("gemini") for model in available):
-                try:
-                    cache_name = await self._cache_manager.get_cache_name(cache_type)
-                except Exception as e:
-                    logger.warning(
-                        "[AI-CACHE-LOOKUP-FAILED] purpose=%s error=%s", purpose.value, e
-                    )
 
         attempted = []
         last_error = None
@@ -164,6 +157,7 @@ class AIModelManager:
 
             try:
                 logger.debug(f"[AI-ATTEMPT] purpose={purpose.value} | model={model}")
+                cache_name = await self._get_cache_name_for_model(cache_type, model)
 
                 result = await provider.generate(
                     model=model,
@@ -204,6 +198,26 @@ class AIModelManager:
             attempted_models=attempted,
             last_error=last_error,
         )
+
+    async def _get_cache_name_for_model(
+        self, cache_type: str | None, model: str
+    ) -> str | None:
+        """Return Gemini cache only when cache metadata matches the attempted model."""
+        if (
+            cache_type is None
+            or self._cache_manager is None
+            or not model.startswith("gemini")
+        ):
+            return None
+        try:
+            if hasattr(self._cache_manager, "get_cache_name_for_model"):
+                return await self._cache_manager.get_cache_name_for_model(
+                    cache_type, model
+                )
+            return None
+        except Exception as e:
+            logger.warning("[AI-CACHE-LOOKUP-FAILED] cache_type=%s error=%s", cache_type, e)
+            return None
 
     async def generate_with_vision(
         self,

--- a/src/infra/services/ai/gemini_cache_manager.py
+++ b/src/infra/services/ai/gemini_cache_manager.py
@@ -11,6 +11,10 @@ _CACHE_REDIS_KEYS = {
     "vision": "gemini_cache:vision",
     "text_parse": "gemini_cache:text_parse",
 }
+_CACHE_MODEL_REDIS_KEYS = {
+    cache_type: f"{redis_key}:model"
+    for cache_type, redis_key in _CACHE_REDIS_KEYS.items()
+}
 
 TTL_SECONDS = 3600
 REFRESH_BEFORE_EXPIRY = 600
@@ -35,10 +39,35 @@ class GeminiCacheManager:
             return None
         return raw  # decode_responses=True — already a str
 
-    async def _set_cache_name(self, cache_type: str, name: str) -> None:
-        """Persist a Gemini cache name to Redis with an extended TTL."""
+    async def get_cache_name_for_model(self, cache_type: str, model: str) -> str | None:
+        """Return the cache name only when it was created for the same model."""
+        name = await self.get_cache_name(cache_type)
+        if name is None:
+            return None
+
+        model_key = _CACHE_MODEL_REDIS_KEYS.get(cache_type)
+        if not model_key:
+            return None
+
+        cached_model = await self._redis.get(model_key)
+        if cached_model == model:
+            return name
+
+        logger.info(
+            "[GEMINI-CACHE] Skipping cache_type=%s for model=%s: cached_model=%s",
+            cache_type,
+            model,
+            cached_model or "unknown",
+        )
+        return None
+
+    async def _set_cache_name(self, cache_type: str, name: str, model: str) -> None:
+        """Persist Gemini cache metadata to Redis with an extended TTL."""
         redis_key = _CACHE_REDIS_KEYS[cache_type]
-        await self._redis.set(redis_key, name, ex=TTL_SECONDS + REFRESH_BEFORE_EXPIRY)
+        model_key = _CACHE_MODEL_REDIS_KEYS[cache_type]
+        ttl = TTL_SECONDS + REFRESH_BEFORE_EXPIRY
+        await self._redis.set(redis_key, name, ex=ttl)
+        await self._redis.set(model_key, model, ex=ttl)
 
     async def _create_cache(
         self, cache_type: str, system_prompt: str, model: str
@@ -126,13 +155,13 @@ class GeminiCacheManager:
 
     async def _warm_one(self, cache_type: str, prompt: str, model: str) -> None:
         """Create and store a single cache if it is not already warm."""
-        existing = await self.get_cache_name(cache_type)
+        existing = await self.get_cache_name_for_model(cache_type, model)
         if existing:
             logger.info("[GEMINI-CACHE] Already warm: cache_type=%s", cache_type)
             return
         name = await self._create_cache(cache_type, prompt, model)
         if name:
-            await self._set_cache_name(cache_type, name)
+            await self._set_cache_name(cache_type, name, model)
 
     async def refresh_loop(self) -> None:
         """Background task: refresh caches before TTL expiry. Run indefinitely."""
@@ -140,7 +169,7 @@ class GeminiCacheManager:
             await asyncio.sleep(REFRESH_BEFORE_EXPIRY)
             logger.info("[GEMINI-CACHE] Refreshing caches before TTL expiry")
             # Clear stale Redis entries so _warm_one creates fresh caches
-            for redis_key in _CACHE_REDIS_KEYS.values():
+            for redis_key in [*_CACHE_REDIS_KEYS.values(), *_CACHE_MODEL_REDIS_KEYS.values()]:
                 try:
                     await self._redis.delete(redis_key)
                 except Exception as e:

--- a/src/infra/services/ai/providers/gemini_provider.py
+++ b/src/infra/services/ai/providers/gemini_provider.py
@@ -1,15 +1,17 @@
 """Gemini implementation of AIProviderPort."""
 import asyncio
-import json
 import logging
 import re
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from src.domain.ports.ai_provider_port import AICapability, AIProviderPort
-from src.infra.services.ai.gemini_model_manager import GeminiModelManager
+from src.infra.adapters.meal_generation_json_utils import (
+    extract_json as extract_meal_generation_json,
+)
 from src.infra.services.ai.gemini_model_config import GeminiModelPurpose
+from src.infra.services.ai.gemini_model_manager import GeminiModelManager
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +45,14 @@ class GeminiProvider(AIProviderPort):
         return "gemini"
 
     @property
-    def supported_capabilities(self) -> Set[AICapability]:
+    def supported_capabilities(self) -> set[AICapability]:
         return {
             AICapability.TEXT_GENERATION,
             AICapability.VISION,
             AICapability.STRUCTURED_OUTPUT,
         }
 
-    def get_available_models(self) -> List[str]:
+    def get_available_models(self) -> list[str]:
         return self.AVAILABLE_MODELS.copy()
 
     async def generate(
@@ -59,12 +61,12 @@ class GeminiProvider(AIProviderPort):
         prompt: str,
         system_message: str,
         response_type: str = "json",
-        max_tokens: Optional[int] = None,
-        schema: Optional[type] = None,
-        purpose_hint: Optional[str] = None,  # ModelPurpose.value string
-        cache_name: Optional[str] = None,
+        max_tokens: int | None = None,
+        schema: type | None = None,
+        purpose_hint: str | None = None,  # ModelPurpose.value string
+        cache_name: str | None = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate text using Gemini."""
         if purpose_hint is not None:
             purpose = _PURPOSE_HINT_MAP.get(purpose_hint, GeminiModelPurpose.GENERAL)
@@ -118,10 +120,10 @@ class GeminiProvider(AIProviderPort):
         model: str,
         prompt: str,
         image_data: bytes,
-        system_message: Optional[str] = None,
-        purpose_hint: Optional[str] = None,   # NEW
+        system_message: str | None = None,
+        purpose_hint: str | None = None,   # NEW
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate with image input."""
         import base64
 
@@ -155,7 +157,7 @@ class GeminiProvider(AIProviderPort):
         response = await asyncio.to_thread(llm.invoke, messages)
         return self._extract_json(response.content)
 
-    def extract_error_code(self, error: Exception) -> Optional[Union[int, str]]:
+    def extract_error_code(self, error: Exception) -> int | str | None:
         """Extract status code or error type from exception."""
         error_str = str(error)
 
@@ -168,25 +170,6 @@ class GeminiProvider(AIProviderPort):
 
         return None
 
-    def _extract_json(self, content: str) -> Dict[str, Any]:
+    def _extract_json(self, content: str) -> dict[str, Any]:
         """Extract JSON from response content."""
-        try:
-            return json.loads(content)
-        except json.JSONDecodeError:
-            pass
-
-        json_match = re.search(r"```(?:json)?\s*([\s\S]*?)```", content)
-        if json_match:
-            try:
-                return json.loads(json_match.group(1).strip())
-            except json.JSONDecodeError:
-                pass
-
-        json_match = re.search(r"\{[\s\S]*\}", content)
-        if json_match:
-            try:
-                return json.loads(json_match.group(0))
-            except json.JSONDecodeError:
-                pass
-
-        raise ValueError(f"Could not extract JSON from response: {content[:200]}")
+        return extract_meal_generation_json(content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,31 +2,29 @@
 Global pytest configuration and fixtures.
 """
 
+from collections.abc import Generator
 from datetime import datetime
-from typing import Generator
 
 import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
+from tests.fixtures.database.test_config import (
+    create_test_engine,
+    get_test_database_url,
+)
+from tests.fixtures.mock_image_store import MockImageStore
 
-from src.domain.model import Macros, Meal, MealStatus, MealImage, Nutrition, FoodItem
+from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
 from src.domain.parsers.gpt_response_parser import GPTResponseParser
 from src.infra.database.config import Base
 
 # Import all models to ensure they're registered with Base metadata
 from src.infra.database.models.meal.meal import MealORM
-from src.infra.database.models.meal.meal_image import MealImageORM
-from src.infra.mappers.meal_mapper import meal_domain_to_orm, meal_image_domain_to_orm
 from src.infra.database.models.user.profile import UserProfile
 from src.infra.database.models.user.user import User
-from src.infra.event_bus import PyMediatorEventBus, EventBus
+from src.infra.event_bus import EventBus, PyMediatorEventBus
+from src.infra.mappers.meal_mapper import meal_domain_to_orm, meal_image_domain_to_orm
 from src.infra.repositories.meal_repository import MealRepository
-from tests.fixtures.database.test_config import (
-    get_test_database_url,
-    create_test_engine,
-)
-from tests.fixtures.mock_adapters.mock_vision_ai_service import MockVisionAIService
-from tests.fixtures.mock_image_store import MockImageStore
 
 
 class AsyncSyncRepoWrapper:
@@ -90,8 +88,8 @@ class TestUnitOfWork:
 def _is_db_available() -> bool:
     """Check if the test database is available."""
     try:
-        from tests.fixtures.database.test_config import get_test_database_url
         from sqlalchemy import create_engine, text
+        from tests.fixtures.database.test_config import get_test_database_url
 
         url = get_test_database_url()
         engine = create_engine(
@@ -213,7 +211,15 @@ def test_engine(worker_id, request):
         try:
             with temp_engine.connect() as conn:
                 db_name = get_test_database_url().rsplit("/", 1)[1].split("?")[0]
-                conn.execute(text(f"CREATE DATABASE IF NOT EXISTS {db_name}"))
+                if temp_engine.dialect.name == "postgresql":
+                    exists = conn.execute(
+                        text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
+                        {"db_name": db_name},
+                    ).scalar()
+                    if not exists:
+                        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+                elif temp_engine.dialect.name == "mysql":
+                    conn.execute(text(f"CREATE DATABASE IF NOT EXISTS `{db_name}`"))
         finally:
             temp_engine.dispose()
 
@@ -224,9 +230,11 @@ def test_engine(worker_id, request):
         if worker_id in ("master", "gw0"):
             # Drop all tables first to ensure clean state
             with engine.begin() as conn:
-                conn.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
+                if engine.dialect.name == "mysql":
+                    conn.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
                 Base.metadata.drop_all(bind=engine)
-                conn.execute(text("SET FOREIGN_KEY_CHECKS = 1"))
+                if engine.dialect.name == "mysql":
+                    conn.execute(text("SET FOREIGN_KEY_CHECKS = 1"))
 
             # Create all tables
             Base.metadata.create_all(bind=engine)
@@ -234,6 +242,7 @@ def test_engine(worker_id, request):
         # Other workers wait for tables to be created
         elif worker_id != "master":
             import time
+
             from sqlalchemy import inspect
 
             # Wait up to 30 seconds for tables to be created
@@ -318,7 +327,7 @@ def mock_scoped_session(test_session, request):
 
     # For integration tests, patch ScopedSession to return test_session
     # Store original __call__ method
-    original_call = getattr(ScopedSession, "__call__", None)
+    original_call = ScopedSession.__call__
 
     # Create a function that always returns test_session
     def mock_call(*args, **kwargs):
@@ -336,7 +345,7 @@ def mock_scoped_session(test_session, request):
         # Clean up
         try:
             ScopedSession.remove()
-        except:
+        except Exception:
             pass
 
 
@@ -346,7 +355,6 @@ def reset_event_bus_singleton():
     Reset the event bus singleton before each test to prevent state leakage.
     This ensures that event bus initialization happens fresh for each test.
     """
-    from src.api.dependencies.event_bus import _configured_event_bus
 
     # Reset singleton before test
     import src.api.dependencies.event_bus as event_bus_module
@@ -366,8 +374,10 @@ def mock_image_store() -> MockImageStore:
 
 
 @pytest.fixture
-def mock_vision_service() -> MockVisionAIService:
+def mock_vision_service():
     """Mock vision AI service for testing."""
+    from tests.fixtures.mock_adapters.mock_vision_ai_service import MockVisionAIService
+
     return MockVisionAIService()
 
 
@@ -407,42 +417,38 @@ def event_bus(
 ) -> EventBus:
     """Configured event bus for testing."""
     # Import handlers from modules
-    from src.app.handlers.command_handlers import (
-        EditMealCommandHandler,
-        AddCustomIngredientCommandHandler,
-        DeleteMealCommandHandler,
-        UploadMealImageImmediatelyHandler,
-        SaveUserOnboardingCommandHandler,
-    )
-    from src.app.handlers.query_handlers import (
-        GetMealByIdQueryHandler,
-        GetDailyMacrosQueryHandler,
-        GetUserProfileQueryHandler,
+    from src.app.commands.meal.edit_meal_command import (
+        AddCustomIngredientCommand,
+        EditMealCommand,
     )
 
     # Import commands and queries
     from src.app.commands.meal.upload_meal_image_immediately_command import (
         UploadMealImageImmediatelyCommand,
     )
-    from src.app.commands.meal.edit_meal_command import (
-        EditMealCommand,
-        AddCustomIngredientCommand,
-    )
-    from src.app.queries.meal.get_meal_by_id_query import GetMealByIdQuery
-    from src.app.queries.meal.get_daily_macros_query import GetDailyMacrosQuery
     from src.app.commands.user.save_user_onboarding_command import (
         SaveUserOnboardingCommand,
     )
+    from src.app.handlers.command_handlers import (
+        AddCustomIngredientCommandHandler,
+        DeleteMealCommandHandler,
+        EditMealCommandHandler,
+        SaveUserOnboardingCommandHandler,
+        UploadMealImageImmediatelyHandler,
+    )
+    from src.app.handlers.query_handlers import (
+        GetDailyMacrosQueryHandler,
+        GetMealByIdQueryHandler,
+        GetUserProfileQueryHandler,
+    )
+    from src.app.queries.meal.get_daily_macros_query import GetDailyMacrosQuery
+    from src.app.queries.meal.get_meal_by_id_query import GetMealByIdQuery
     from src.app.queries.user.get_user_profile_query import GetUserProfileQuery
-    from src.infra.repositories.user_repository import UserRepository
 
     event_bus = PyMediatorEventBus()
 
     # Create test UoW using the test session (doesn't close session on exit)
     test_uow = TestUnitOfWork(session=test_session)
-
-    # Create repositories
-    user_repository = UserRepository(test_session)
 
     # Register meal edit command handlers
     event_bus.register_handler(

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -86,6 +86,29 @@ def test_meals_analyze_rejects_too_large(monkeypatch, client: TestClient):
     assert r.json()["detail"]["error_code"] == "FILE_SIZE_EXCEEDS_MAXIMUM"
 
 
+def test_meals_analyze_ai_unavailable_returns_503(client: TestClient):
+    from src.api.dependencies.event_bus import get_configured_event_bus
+    from src.domain.exceptions.ai_exceptions import AIUnavailableError
+
+    class _UnavailableBus:
+        async def send(self, msg):
+            raise AIUnavailableError(
+                "All vision models failed for meal_scan",
+                attempted_models=["gemini-2.5-flash-lite", "gemini-2.5-flash"],
+                last_error="503 UNAVAILABLE",
+            )
+
+    client.app.dependency_overrides[get_configured_event_bus] = lambda: _UnavailableBus()
+
+    r = client.post(
+        "/v1/meals/image/analyze",
+        files={"file": ("x.jpg", b"image-bytes", "image/jpeg")},
+    )
+
+    assert r.status_code == 503
+    assert r.json()["detail"]["error_code"] == "AI_UNAVAILABLE"
+
+
 def test_user_profiles_onboarding_invalid_birth_date(client: TestClient):
     payload = {
         "birth_year": 2000,

--- a/tests/unit/api/test_small_v1_routers.py
+++ b/tests/unit/api/test_small_v1_routers.py
@@ -4,8 +4,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.dependencies.auth import get_current_user_id
-from src.api.exceptions import ValidationException
 from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.exceptions import ValidationException
 from src.api.routes.v1 import activities as activities_mod
 from src.api.routes.v1 import cheat_days as cheat_days_mod
 from src.api.routes.v1 import foods as foods_mod
@@ -184,6 +184,26 @@ def test_ingredients_recognize_handle_exception(ingredients_app):
         json={"image_data": "abc"},
     )
     assert r.status_code == 500
+
+
+def test_ingredients_recognize_ai_unavailable(ingredients_app):
+    from src.domain.exceptions.ai_exceptions import AIUnavailableError
+
+    class _Bad:
+        async def send(self, msg):
+            raise AIUnavailableError(
+                "All vision models failed",
+                attempted_models=["gemini-2.5-flash-lite", "gemini-2.5-flash"],
+                last_error="503 UNAVAILABLE",
+            )
+
+    ingredients_app.dependency_overrides[get_configured_event_bus] = lambda: _Bad()
+    r = TestClient(ingredients_app).post(
+        "/v1/ingredients/recognize",
+        json={"image_data": "abc"},
+    )
+    assert r.status_code == 503
+    assert r.json()["detail"]["error_code"] == "AI_UNAVAILABLE"
 
 
 def test_cheat_days_handle_exception(cheat_app):

--- a/tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py
@@ -1,0 +1,67 @@
+import base64
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.schemas.request.ingredient_recognition_requests import (
+    MAX_IMAGE_BASE64_LENGTH,
+    IngredientRecognitionRequest,
+)
+from src.app.commands.ingredient import RecognizeIngredientCommand
+from src.app.handlers.command_handlers.recognize_ingredient_command_handler import (
+    RecognizeIngredientCommandHandler,
+)
+from src.domain.exceptions.ai_exceptions import AIUnavailableError
+
+
+@pytest.mark.asyncio
+async def test_recognize_ingredient_rejects_invalid_base64_before_ai_call():
+    vision_service = Mock()
+    vision_service.analyze_with_strategy = AsyncMock()
+    handler = RecognizeIngredientCommandHandler(vision_service=vision_service)
+
+    result = await handler.handle(
+        RecognizeIngredientCommand(image_data="not base64!!", language="en")
+    )
+
+    assert result["success"] is False
+    assert result["message"] == "Invalid image data format"
+    vision_service.analyze_with_strategy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recognize_ingredient_rejects_decoded_image_over_5mb():
+    vision_service = Mock()
+    vision_service.analyze_with_strategy = AsyncMock()
+    handler = RecognizeIngredientCommandHandler(vision_service=vision_service)
+    oversized = base64.b64encode(b"x" * (5 * 1024 * 1024 + 1)).decode("ascii")
+
+    result = await handler.handle(
+        RecognizeIngredientCommand(image_data=oversized, language="en")
+    )
+
+    assert result["success"] is False
+    assert result["message"] == "Image too large (max 5MB)"
+    vision_service.analyze_with_strategy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recognize_ingredient_preserves_ai_unavailable():
+    unavailable = AIUnavailableError(
+        "All vision models failed",
+        attempted_models=["gemini-2.5-flash-lite", "gemini-2.5-flash"],
+        last_error="503 UNAVAILABLE",
+    )
+    vision_service = Mock()
+    vision_service.analyze_with_strategy = AsyncMock(side_effect=unavailable)
+    handler = RecognizeIngredientCommandHandler(vision_service=vision_service)
+    valid_image = base64.b64encode(b"image").decode("ascii")
+
+    with pytest.raises(AIUnavailableError):
+        await handler.handle(RecognizeIngredientCommand(image_data=valid_image))
+
+
+def test_ingredient_request_rejects_oversized_base64_payload():
+    with pytest.raises(ValidationError):
+        IngredientRecognitionRequest(image_data="a" * (MAX_IMAGE_BASE64_LENGTH + 1))

--- a/tests/unit/infra/adapters/test_vision_ai_service.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service.py
@@ -104,15 +104,52 @@ async def test_analyze_with_strategy_passes_max_tokens_1024():
 
 @pytest.mark.asyncio
 async def test_analyze_by_url_passes_max_tokens_1024():
-    """analyze_by_url_with_strategy must also pass max_tokens=1024."""
+    """URL analysis must fetch bytes and pass max_tokens=1024."""
+    service = _make_service()
+    from src.domain.strategies.meal_analysis_strategy import AnalysisStrategyFactory
+    strategy = AnalysisStrategyFactory.create_basic_strategy()
+    image_bytes = _make_jpeg(400, 300)
+
+    mock_response = MagicMock()
+    mock_response.headers.get_content_type.return_value = "image/jpeg"
+    mock_response.read.return_value = image_bytes
+    mock_response.__enter__.return_value = mock_response
+    with patch(
+        "src.infra.adapters.vision_ai_service.urlopen",
+        return_value=mock_response,
+    ):
+        await service.analyze_by_url_with_strategy("http://example.com/food.jpg", strategy)
+
+    call_kwargs = service._ai_manager.generate_with_vision.call_args.kwargs
+    assert call_kwargs.get("max_tokens") == 1024
+    assert call_kwargs["image_data"] == image_bytes
+
+
+@pytest.mark.asyncio
+async def test_analyze_by_url_rejects_non_http_url():
     service = _make_service()
     from src.domain.strategies.meal_analysis_strategy import AnalysisStrategyFactory
     strategy = AnalysisStrategyFactory.create_basic_strategy()
 
-    await service.analyze_by_url_with_strategy("http://example.com/food.jpg", strategy)
+    with pytest.raises(ValueError, match="HTTP"):
+        await service.analyze_by_url_with_strategy("file:///tmp/food.jpg", strategy)
 
-    call_kwargs = service._ai_manager.generate_with_vision.call_args.kwargs
-    assert call_kwargs.get("max_tokens") == 1024
+
+@pytest.mark.asyncio
+async def test_analyze_by_url_rejects_non_image_content_type():
+    service = _make_service()
+    from src.domain.strategies.meal_analysis_strategy import AnalysisStrategyFactory
+    strategy = AnalysisStrategyFactory.create_basic_strategy()
+
+    mock_response = MagicMock()
+    mock_response.headers.get_content_type.return_value = "text/html"
+    mock_response.__enter__.return_value = mock_response
+
+    with patch(
+        "src.infra.adapters.vision_ai_service.urlopen",
+        return_value=mock_response,
+    ), pytest.raises(ValueError, match="content type"):
+        await service.analyze_by_url_with_strategy("https://example.com/page", strategy)
 
 
 def test_recipe_token_limit_is_1200():

--- a/tests/unit/infra/adapters/test_vision_ai_service_resilience.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service_resilience.py
@@ -1,7 +1,10 @@
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
-from unittest.mock import Mock, AsyncMock, patch
-from src.infra.adapters.vision_ai_service import VisionAIService
+
+from src.domain.exceptions.ai_exceptions import AIUnavailableError
 from src.domain.strategies.meal_analysis_strategy import MealAnalysisStrategy
+from src.infra.adapters.vision_ai_service import VisionAIService
 
 
 @pytest.fixture
@@ -81,8 +84,29 @@ async def test_analyze_with_strategy_raises_runtime_error_on_failure(service, mo
         await service.analyze_with_strategy(b"fake_image", mock_strategy)
 
 
+@pytest.mark.asyncio
+async def test_analyze_with_strategy_preserves_ai_unavailable(
+    service, mock_ai_manager, mock_strategy
+):
+    unavailable = AIUnavailableError(
+        "All vision models failed",
+        attempted_models=["gemini-2.5-flash-lite", "gemini-2.5-flash"],
+        last_error="503 UNAVAILABLE",
+    )
+    mock_ai_manager.generate_with_vision = AsyncMock(side_effect=unavailable)
+
+    with pytest.raises(AIUnavailableError) as exc_info:
+        await service.analyze_with_strategy(b"fake_image", mock_strategy)
+
+    assert exc_info.value.attempted_models == [
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-flash",
+    ]
+
+
 def test_compress_image_still_works(service):
     from io import BytesIO
+
     from PIL import Image
 
     img = Image.new("RGB", (400, 300), color=(128, 64, 32))

--- a/tests/unit/infra/services/ai/providers/test_gemini_provider.py
+++ b/tests/unit/infra/services/ai/providers/test_gemini_provider.py
@@ -1,5 +1,7 @@
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock, AsyncMock, patch
+
 from src.domain.ports.ai_provider_port import AICapability
 from src.infra.services.ai.providers.gemini_provider import GeminiProvider
 
@@ -87,6 +89,34 @@ class TestGenerate:
         assert call_kwargs["model_name"] == "gemini-2.5-flash-lite"
 
 
+class TestJsonExtraction:
+    def test_recovers_parse_text_response_truncated_after_scalar(self, provider):
+        content = """{
+  "emoji": "🍮",
+  "items": [
+    {
+      "name": "Đậu xanh nấu (Cooked mung beans)",
+      "quantity": 80,
+      "unit": "g",
+      "english_unit": "g",
+      "calories": 105"""
+
+        result = provider._extract_json(content)
+
+        assert result == {
+            "emoji": "🍮",
+            "items": [
+                {
+                    "name": "Đậu xanh nấu (Cooked mung beans)",
+                    "quantity": 80,
+                    "unit": "g",
+                    "english_unit": "g",
+                    "calories": 105,
+                }
+            ],
+        }
+
+
 class TestGenerateWithVision:
     @pytest.mark.asyncio
     async def test_generate_with_vision_forwards_selected_fallback_model(
@@ -128,8 +158,8 @@ class TestErrorExtraction:
 
 def test_purpose_temperatures_defined():
     from src.infra.services.ai.gemini_model_config import (
-        GeminiModelPurpose,
         PURPOSE_TEMPERATURES,
+        GeminiModelPurpose,
     )
     assert PURPOSE_TEMPERATURES[GeminiModelPurpose.BARCODE] == 0.1
     assert PURPOSE_TEMPERATURES[GeminiModelPurpose.MEAL_NAMES] == 0.7

--- a/tests/unit/infra/services/ai/test_ai_model_manager.py
+++ b/tests/unit/infra/services/ai/test_ai_model_manager.py
@@ -166,6 +166,37 @@ class TestGenerate:
         mock_circuit_breaker.record_success.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_generate_omits_cache_when_fallback_model_does_not_match(
+        self, manager, mock_gemini_provider
+    ):
+        mock_gemini_provider.generate = AsyncMock(
+            side_effect=[Exception("cache/model mismatch"), {"result": "fallback"}]
+        )
+        cache_manager = Mock()
+        cache_manager.get_cache_name_for_model = AsyncMock(
+            side_effect=["cachedContents/primary", None]
+        )
+        manager.set_cache_manager(cache_manager)
+
+        result = await manager.generate(
+            purpose=ModelPurpose.PARSE_TEXT,
+            prompt="test",
+            system_message="system",
+        )
+
+        assert result == {"result": "fallback"}
+        assert mock_gemini_provider.generate.call_args_list[0].kwargs["cache_name"] == (
+            "cachedContents/primary"
+        )
+        assert mock_gemini_provider.generate.call_args_list[1].kwargs["cache_name"] is None
+        cache_manager.get_cache_name_for_model.assert_any_await(
+            "text_parse", "gemini-2.5-flash-lite"
+        )
+        cache_manager.get_cache_name_for_model.assert_any_await(
+            "text_parse", "gemini-2.5-flash"
+        )
+
+    @pytest.mark.asyncio
     async def test_generate_raises_when_all_fail(
         self, manager, mock_gemini_provider, mock_circuit_breaker
     ):

--- a/tests/unit/infra/services/ai/test_gemini_cache_manager.py
+++ b/tests/unit/infra/services/ai/test_gemini_cache_manager.py
@@ -1,8 +1,34 @@
 """Unit tests for GeminiCacheManager."""
 
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_google_genai(monkeypatch):
+    """Provide a patchable google.genai module when google-genai is not installed."""
+    import google
+
+    genai_module = types.ModuleType("google.genai")
+    genai_types_module = types.ModuleType("google.genai.types")
+
+    class CreateCachedContentConfig:
+        def __init__(self, displayName, contents, ttl, system_instruction=None):
+            self.display_name = displayName
+            self.contents = contents
+            self.ttl = ttl
+            self.system_instruction = system_instruction
+
+    genai_types_module.CreateCachedContentConfig = CreateCachedContentConfig
+    genai_module.Client = MagicMock()
+    genai_module.types = genai_types_module
+
+    monkeypatch.setattr(google, "genai", genai_module, raising=False)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_module)
+    monkeypatch.setitem(sys.modules, "google.genai.types", genai_types_module)
 
 
 @pytest.fixture
@@ -38,6 +64,42 @@ async def test_get_cache_name_returns_stored_name(cache_manager, mock_redis):
 
 
 @pytest.mark.asyncio
+async def test_get_cache_name_for_model_returns_matching_cache(cache_manager, mock_redis):
+    """Model-aware lookup returns cache only when metadata matches."""
+    mock_redis.get.side_effect = ["cachedContents/abc123", "gemini-2.5-flash-lite"]
+
+    result = await cache_manager.get_cache_name_for_model(
+        "recipe", "gemini-2.5-flash-lite"
+    )
+
+    assert result == "cachedContents/abc123"
+
+
+@pytest.mark.asyncio
+async def test_get_cache_name_for_model_skips_mismatched_cache(cache_manager, mock_redis):
+    """Fallback model must not reuse a cache created for another Gemini model."""
+    mock_redis.get.side_effect = ["cachedContents/abc123", "gemini-2.5-flash-lite"]
+
+    result = await cache_manager.get_cache_name_for_model(
+        "recipe", "gemini-2.5-flash"
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_cache_name_for_model_skips_legacy_cache(cache_manager, mock_redis):
+    """Legacy cache names without model metadata are intentionally not reused."""
+    mock_redis.get.side_effect = ["cachedContents/legacy", None]
+
+    result = await cache_manager.get_cache_name_for_model(
+        "recipe", "gemini-2.5-flash-lite"
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_get_cache_name_returns_none_for_unknown_type(cache_manager, mock_redis):
     """get_cache_name returns None for unknown cache types without hitting Redis."""
     result = await cache_manager.get_cache_name("nonexistent_type")
@@ -48,7 +110,7 @@ async def test_get_cache_name_returns_none_for_unknown_type(cache_manager, mock_
 @pytest.mark.asyncio
 async def test_warm_one_skips_if_already_cached(cache_manager, mock_redis):
     """_warm_one does not call _create_cache when cache already exists in Redis."""
-    mock_redis.get.return_value = "cachedContents/existing123"
+    mock_redis.get.side_effect = ["cachedContents/existing123", "gemini-2.5-flash"]
 
     with patch.object(
         cache_manager, "_create_cache", new_callable=AsyncMock
@@ -78,7 +140,9 @@ async def test_warm_one_creates_and_stores_cache(cache_manager, mock_redis):
         mock_create.assert_awaited_once_with(
             "recipe", "some system prompt", "gemini-2.5-flash"
         )
-        mock_set.assert_awaited_once_with("recipe", "cachedContents/new456")
+        mock_set.assert_awaited_once_with(
+            "recipe", "cachedContents/new456", "gemini-2.5-flash"
+        )
 
 
 @pytest.mark.asyncio
@@ -103,11 +167,20 @@ async def test_set_cache_name_stores_with_ttl(cache_manager, mock_redis):
         TTL_SECONDS,
     )
 
-    await cache_manager._set_cache_name("recipe", "cachedContents/xyz")
-    mock_redis.set.assert_awaited_once_with(
+    await cache_manager._set_cache_name(
+        "recipe", "cachedContents/xyz", "gemini-2.5-flash-lite"
+    )
+    ttl = TTL_SECONDS + REFRESH_BEFORE_EXPIRY
+    assert mock_redis.set.await_count == 2
+    mock_redis.set.assert_any_await(
         "gemini_cache:recipe",
         "cachedContents/xyz",
-        ex=TTL_SECONDS + REFRESH_BEFORE_EXPIRY,
+        ex=ttl,
+    )
+    mock_redis.set.assert_any_await(
+        "gemini_cache:recipe:model",
+        "gemini-2.5-flash-lite",
+        ex=ttl,
     )
 
 


### PR DESCRIPTION
## Summary
- make Gemini context-cache usage model-aware so fallback models do not reuse incompatible cached content
- preserve AIUnavailableError through vision and ingredient flows so provider outages return 503
- harden ingredient/base64 and image-url validation, share parse-text JSON recovery through Gemini provider
- fix Postgres-aware test DB creation for route tests

## Tests
- python3.11 -m pytest tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/infra/services/ai/test_ai_model_manager.py tests/unit/infra/services/ai/test_provider_circuit_breaker.py tests/unit/infra/services/ai/test_gemini_cache_manager.py tests/unit/infra/services/ai/test_schemas.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/infra/adapters/test_vision_ai_service_resilience.py tests/unit/infra/adapters/test_meal_generation_service_resilience.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py tests/unit/api/test_small_v1_routers.py -q
- ./.venv/bin/python -m pytest tests/unit/api/test_app_smoke_routes.py tests/unit/api/test_meal_suggestions_routes.py tests/unit/api/test_discover_parallel_images.py tests/integration/routes/test_ingredients_api.py -q
- ./.venv/bin/ruff check src/infra/adapters/meal_generation_json_utils.py src/infra/services/ai/providers/gemini_provider.py src/infra/services/ai/gemini_cache_manager.py src/infra/services/ai/ai_model_manager.py src/infra/adapters/vision_ai_service.py src/api/schemas/request/ingredient_recognition_requests.py src/app/handlers/command_handlers/recognize_ingredient_command_handler.py tests/conftest.py tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/infra/services/ai/test_gemini_cache_manager.py tests/unit/infra/services/ai/test_ai_model_manager.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/infra/adapters/test_vision_ai_service_resilience.py tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py tests/unit/api/test_app_smoke_routes.py tests/unit/api/test_small_v1_routers.py
- python3.11 -m py_compile src/infra/adapters/meal_generation_json_utils.py src/infra/services/ai/providers/gemini_provider.py src/infra/services/ai/gemini_cache_manager.py src/infra/services/ai/ai_model_manager.py src/infra/adapters/vision_ai_service.py src/api/schemas/request/ingredient_recognition_requests.py src/app/handlers/command_handlers/recognize_ingredient_command_handler.py
- git push pre-push hook: 1517 passed, 3 skipped
