### PR TITLE
fix: reconcile profile preference rows on update

### DIFF
--- a/src/infra/repositories/user_repository_async.py
+++ b/src/infra/repositories/user_repository_async.py
@@ -12,6 +12,7 @@ from src.domain.model.user import UserDomainModel, UserProfileDomainModel
 from src.domain.ports.user_repository_port import UserRepositoryPort
 from src.domain.utils.timezone_utils import utc_now
 from src.infra.database.models.user.profile import UserProfile
+from src.infra.database.models.user.profile_preference import UserProfilePreference
 from src.infra.database.models.user.user import User
 from src.infra.mappers.user_mapper import (
     UserMapper,
@@ -25,6 +26,31 @@ _USER_LOADS = (
     selectinload(User.profiles).selectinload(UserProfile.preference_entries),
     selectinload(User.subscriptions),
 )
+
+
+def _sync_profile_preference_entries(
+    entity: UserProfile,
+    profile_domain: UserProfileDomainModel,
+) -> None:
+    desired_entries = build_profile_preference_entries(profile_domain)
+    existing_by_key: dict[tuple[str, str], UserProfilePreference] = {
+        (entry.preference_type, entry.value): entry
+        for entry in entity.preference_entries
+    }
+
+    next_entries: list[UserProfilePreference] = []
+    for desired in desired_entries:
+        key = (desired.preference_type, desired.value)
+        existing = existing_by_key.pop(key, None)
+        if existing:
+            existing.position = desired.position
+            next_entries.append(existing)
+            continue
+
+        desired.profile_id = str(entity.id)
+        next_entries.append(desired)
+
+    entity.preference_entries = next_entries
 
 
 class AsyncUserRepository(UserRepositoryPort):
@@ -163,7 +189,7 @@ class AsyncUserRepository(UserRepositoryPort):
                     # Only mark a column dirty when its value truly changes.
                     if new_val != old_val:
                         setattr(entity, col_name, new_val)
-            entity.preference_entries = build_profile_preference_entries(profile_domain)
+            _sync_profile_preference_entries(entity, profile_domain)
 
         # Data hygiene: legacy rows may have NULL timestamps despite NOT NULL constraints.
         # Backfill them so any subsequent UPDATE does not violate constraints.

--- a/tests/integration/infra/repositories/test_user_repository_async.py
+++ b/tests/integration/infra/repositories/test_user_repository_async.py
@@ -1,12 +1,16 @@
 """Integration tests for AsyncUserRepository."""
 
-import pytest
 import uuid
 from datetime import datetime
 
-from src.infra.repositories.user_repository_async import AsyncUserRepository
-from src.infra.database.models.user.user import User
+import pytest
+from sqlalchemy import select
+
 from src.api.schemas.common.auth_enums import AuthProviderEnum
+from src.domain.model.user import UserProfileDomainModel
+from src.infra.database.models.user.profile_preference import UserProfilePreference
+from src.infra.database.models.user.user import User
+from src.infra.repositories.user_repository_async import AsyncUserRepository
 
 
 async def _insert_user(session, uid: str = "firebase-uid-001") -> User:
@@ -104,3 +108,49 @@ async def test_update_user_timezone(async_db_session):
 
     tz = await repo.get_user_timezone(user_id)
     assert tz == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_update_profile_reuses_existing_preference_rows(async_db_session):
+    user = await _insert_user(async_db_session, "firebase-uid-t08")
+    repo = AsyncUserRepository(async_db_session)
+
+    profile = UserProfileDomainModel(
+        user_id=uuid.UUID(user.id),
+        age=30,
+        gender="female",
+        height_cm=165,
+        weight_kg=60,
+        job_type="desk",
+        training_days_per_week=3,
+        training_minutes_per_session=45,
+        fitness_goal="maintenance",
+        meals_per_day=3,
+        dietary_preferences=["classic"],
+        pain_points=["No motivation"],
+        referral_sources=["tiktok"],
+        training_types=["swimming"],
+    )
+
+    saved = await repo.update_profile(profile)
+    saved.age = 31
+    saved.dietary_preferences = ["classic"]
+    saved.pain_points = ["No motivation"]
+    saved.referral_sources = ["tiktok"]
+    saved.training_types = ["swimming"]
+
+    updated = await repo.update_profile(saved)
+
+    result = await async_db_session.execute(
+        select(UserProfilePreference).where(
+            UserProfilePreference.profile_id == str(updated.id)
+        )
+    )
+    rows = result.scalars().all()
+    assert updated.age == 31
+    assert sorted((row.preference_type, row.value) for row in rows) == [
+        ("dietary_preferences", "classic"),
+        ("pain_points", "No motivation"),
+        ("referral_sources", "tiktok"),
+        ("training_types", "swimming"),
+    ]

--- a/tests/unit/infra/mappers/test_user_profile_preference_mapper.py
+++ b/tests/unit/infra/mappers/test_user_profile_preference_mapper.py
@@ -7,6 +7,9 @@ from src.infra.mappers.user_mapper import (
     UserProfileMapper,
     build_profile_preference_entries,
 )
+from src.infra.repositories.user_repository_async import (
+    _sync_profile_preference_entries,
+)
 
 
 def _profile_entity(**overrides) -> UserProfile:
@@ -122,4 +125,48 @@ def test_build_profile_preference_entries_skips_empty_values() -> None:
 
     assert [(entry.preference_type, entry.value) for entry in entries] == [
         ("pain_points", "busy")
+    ]
+
+
+def test_sync_profile_preference_entries_reuses_matching_rows() -> None:
+    profile_id = str(uuid4())
+    existing_classic = UserProfilePreference(
+        profile_id=profile_id,
+        preference_type="dietary_preferences",
+        value="classic",
+        position=0,
+    )
+    stale_pain_point = UserProfilePreference(
+        profile_id=profile_id,
+        preference_type="pain_points",
+        value="old",
+        position=0,
+    )
+    profile = _profile_entity(id=profile_id)
+    profile.preference_entries = [existing_classic, stale_pain_point]
+    domain = UserProfileDomainModel(
+        id=uuid4(),
+        user_id=uuid4(),
+        age=31,
+        gender="female",
+        height_cm=165,
+        weight_kg=60,
+        job_type="desk",
+        training_days_per_week=3,
+        training_minutes_per_session=45,
+        fitness_goal="maintenance",
+        meals_per_day=3,
+        dietary_preferences=["classic"],
+        pain_points=["new"],
+    )
+
+    _sync_profile_preference_entries(profile, domain)
+
+    assert profile.preference_entries[0] is existing_classic
+    assert [
+        (entry.preference_type, entry.value, entry.position)
+        for entry in profile.preference_entries
+    ] == [
+        ("dietary_preferences", "classic", 0),
+        ("pain_points", "new", 0),
     ]


### PR DESCRIPTION
## Summary
- Reconcile normalized user profile preference rows in place when updating an existing profile
- Preserve existing matching rows so repeat onboarding saves do not collide with uq_user_profile_preference_value
- Add unit and Postgres integration regressions for repeated profile preference updates

## Render findings
- Confirmed production onboarding error: duplicate key on user_profile_preferences.
- Confirmed cron error: missing notifications.context_schema_version in prod DB.
- Ran Render one-off migration job job-d8lt42bbc2fs73eauci0; post-migration cron logs show a successful run and no new errors after 2026-06-12T09:32:30Z.

## Verification
- .venv/bin/ruff check src/infra/repositories/user_repository_async.py tests/integration/infra/repositories/test_user_repository_async.py tests/unit/infra/mappers/test_user_profile_preference_mapper.py
- .venv/bin/python -m pytest tests/unit/infra/mappers/test_user_profile_preference_mapper.py -q
- .venv/bin/python -m py_compile src/infra/repositories/user_repository_async.py tests/integration/infra/repositories/test_user_repository_async.py tests/unit/infra/mappers/test_user_profile_preference_mapper.py
- Pre-push hook: 1564 passed, 3 skipped

Note: local Postgres integration test could not run in this shell because localhost Postgres rejects required SSL; the test is included for real DB environments.