### PR TITLE
fix: preserve profile preferences on user save

### DIFF
--- a/src/infra/repositories/user_repository_async.py
+++ b/src/infra/repositories/user_repository_async.py
@@ -27,6 +27,31 @@ _USER_LOADS = (
     selectinload(User.subscriptions),
 )
 
+_USER_SAVE_COLUMNS = (
+    "firebase_uid",
+    "email",
+    "username",
+    "password_hash",
+    "provider",
+    "is_active",
+    "onboarding_completed",
+    "last_accessed",
+    "timezone",
+    "first_name",
+    "last_name",
+    "phone_number",
+    "display_name",
+    "photo_url",
+    "deleted_at",
+)
+
+
+def _copy_user_save_columns(entity: User, updated: User) -> None:
+    for col_name in _USER_SAVE_COLUMNS:
+        new_val = getattr(updated, col_name)
+        if getattr(entity, col_name) != new_val:
+            setattr(entity, col_name, new_val)
+
 
 def _sync_profile_preference_entries(
     entity: UserProfile,
@@ -61,13 +86,23 @@ class AsyncUserRepository(UserRepositoryPort):
 
     async def save(self, user_domain: UserDomainModel) -> UserDomainModel:
         user_entity = UserMapper.to_persistence(user_domain)
-        user_entity.profiles = [
-            UserProfileMapper.to_persistence(p) for p in user_domain.profiles
-        ]
-        if user_entity.id is None:
-            self.session.add(user_entity)
+
+        if user_entity.id is not None:
+            result = await self.session.execute(
+                select(User).options(*_USER_LOADS).where(User.id == str(user_entity.id))
+            )
+            existing_entity = result.scalars().first()
         else:
-            user_entity = await self.session.merge(user_entity)
+            existing_entity = None
+
+        if existing_entity:
+            _copy_user_save_columns(existing_entity, user_entity)
+            user_entity = existing_entity
+        else:
+            user_entity.profiles = [
+                UserProfileMapper.to_persistence(p) for p in user_domain.profiles
+            ]
+            self.session.add(user_entity)
         try:
             await self.session.flush()
             # Re-fetch with eager loading to satisfy lazy="raise" on profiles/subscriptions

--- a/tests/integration/infra/repositories/test_user_repository_async.py
+++ b/tests/integration/infra/repositories/test_user_repository_async.py
@@ -154,3 +154,48 @@ async def test_update_profile_reuses_existing_preference_rows(async_db_session):
         ("referral_sources", "tiktok"),
         ("training_types", "swimming"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_save_existing_user_preserves_profile_preference_rows(async_db_session):
+    user = await _insert_user(async_db_session, "firebase-uid-t09")
+    repo = AsyncUserRepository(async_db_session)
+
+    profile = UserProfileDomainModel(
+        user_id=uuid.UUID(user.id),
+        age=30,
+        gender="female",
+        height_cm=165,
+        weight_kg=60,
+        job_type="desk",
+        training_days_per_week=3,
+        training_minutes_per_session=45,
+        fitness_goal="maintenance",
+        meals_per_day=3,
+        dietary_preferences=["classic"],
+        pain_points=["No motivation"],
+        referral_sources=["tiktok"],
+        training_types=["swimming"],
+    )
+    saved_profile = await repo.update_profile(profile)
+
+    loaded_user = await repo.find_by_firebase_uid("firebase-uid-t09")
+    assert loaded_user is not None
+    loaded_user.onboarding_completed = True
+    loaded_user.last_accessed = datetime.utcnow()
+
+    updated_user = await repo.save(loaded_user)
+
+    result = await async_db_session.execute(
+        select(UserProfilePreference).where(
+            UserProfilePreference.profile_id == str(saved_profile.id)
+        )
+    )
+    rows = result.scalars().all()
+    assert updated_user.onboarding_completed is True
+    assert sorted((row.preference_type, row.value) for row in rows) == [
+        ("dietary_preferences", "classic"),
+        ("pain_points", "No motivation"),
+        ("referral_sources", "tiktok"),
+        ("training_types", "swimming"),
+    ]

--- a/tests/unit/infra/mappers/test_user_profile_preference_mapper.py
+++ b/tests/unit/infra/mappers/test_user_profile_preference_mapper.py
@@ -1,13 +1,16 @@
 from uuid import uuid4
 
+from src.domain.model.auth.auth_provider import AuthProvider
 from src.domain.model.user import UserProfileDomainModel
 from src.infra.database.models.user.profile import UserProfile
 from src.infra.database.models.user.profile_preference import UserProfilePreference
+from src.infra.database.models.user.user import User
 from src.infra.mappers.user_mapper import (
     UserProfileMapper,
     build_profile_preference_entries,
 )
 from src.infra.repositories.user_repository_async import (
+    _copy_user_save_columns,
     _sync_profile_preference_entries,
 )
 
@@ -170,3 +173,43 @@ def test_sync_profile_preference_entries_reuses_matching_rows() -> None:
         ("dietary_preferences", "classic", 0),
         ("pain_points", "new", 0),
     ]
+
+
+def test_copy_user_save_columns_preserves_loaded_profiles() -> None:
+    profile = _profile_entity()
+    existing = User(
+        id=str(uuid4()),
+        firebase_uid="firebase-old",
+        email="old@example.com",
+        username="old-user",
+        password_hash="old-hash",
+        provider=AuthProvider.GOOGLE,
+        is_active=True,
+        onboarding_completed=False,
+        timezone="UTC",
+    )
+    existing.profiles = [profile]
+
+    updated = User(
+        id=existing.id,
+        firebase_uid="firebase-new",
+        email="new@example.com",
+        username="new-user",
+        password_hash="new-hash",
+        provider=AuthProvider.APPLE,
+        is_active=False,
+        onboarding_completed=True,
+        timezone="America/Los_Angeles",
+    )
+
+    _copy_user_save_columns(existing, updated)
+
+    assert existing.firebase_uid == "firebase-new"
+    assert existing.email == "new@example.com"
+    assert existing.username == "new-user"
+    assert existing.password_hash == "new-hash"
+    assert existing.provider == AuthProvider.APPLE
+    assert existing.is_active is False
+    assert existing.onboarding_completed is True
+    assert existing.timezone == "America/Los_Angeles"
+    assert existing.profiles == [profile]


### PR DESCRIPTION
## Summary
- update existing-user saves to copy only user account columns instead of merging loaded profile children
- keep profile preference rows owned by explicit profile updates to avoid duplicate inserts during onboarding completion
- add regression coverage for the existing-user save path with normalized profile preferences

## Render evidence
- Production web logs show 500s on PUT /v1/users/firebase/.../onboarding/complete
- Root cause log: duplicate key value violates unique constraint "uq_user_profile_preference_value"

## Verification
- .venv/bin/python -m pytest tests/unit/infra/mappers/test_user_profile_preference_mapper.py -q
- .venv/bin/ruff check src/infra/repositories/user_repository_async.py tests/unit/infra/mappers/test_user_profile_preference_mapper.py tests/integration/infra/repositories/test_user_repository_async.py
- .venv/bin/python -m compileall -q src/infra/repositories/user_repository_async.py src/app/handlers/command_handlers/complete_onboarding_command_handler.py src/app/handlers/command_handlers/update_user_last_accessed_command_handler.py
- .venv/bin/python -m pytest tests/unit/handlers/command_handlers/test_sync_user_command_handler.py tests/unit/handlers/command_handlers/test_delete_user_command_handler.py tests/unit/handlers/command_handlers/test_user_command_handlers.py -q
- git push hook: 1565 passed, 3 skipped