### PR TITLE
Codex/delivery llm nutrition output contracts 260613

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,6 +1,6 @@
 # Backend Codebase Summary
 
-**Generated:** June 1, 2026
+**Generated:** June 13, 2026
 **Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)
 **Language:** Python 3.11+ | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
 
@@ -53,8 +53,9 @@
 
 ---
 
-## Recent Features (May 2026)
+## Recent Features (June 2026)
 
+- **Canonical AI Nutrition Contracts + Validation Retry:** `src/domain/model/ai/nutrition_contracts.py` defines image and text nutrition contracts with bounded food counts, strict quantity validation, and backend-calorie authority; invalid structured meal image/text output now retries exactly once before a controlled `AIOutputValidationError`, while ingredient recognition keeps its unstructured `{name, confidence, category}` contract and the legacy parser no longer silently drops invalid AI food items.
 - **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry pushes at T-2d and T-1d; notifications rescheduled on timezone changes; cron push (`src/cron/push.py`) precomputes notification rows, schedules trial-expiry rows, dispatches due rows through database row claiming, and cleans expired rows
 - **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; PostHog lifecycle mirroring
 - **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` — fire-and-forget async capture; enabled by `POSTHOG_API_KEY`

--- a/docs/journals/260613-1415-llm-nutrition-contracts-phase-1.md
+++ b/docs/journals/260613-1415-llm-nutrition-contracts-phase-1.md
@@ -1,0 +1,36 @@
+---
+title: "LLM Nutrition Output Contracts Phase 1"
+date: "2026-06-13 14:15"
+phase: "phase-01-provider-structured-vision-spike"
+component: "AI provider contract"
+status: "completed"
+---
+
+## Context
+
+Phase 1 of `plans/260613-1359-llm-nutrition-output-contracts/plan.md` was limited to the provider boundary. The goal was to spike structured vision output without changing downstream parsing, storage, or domain rules.
+
+## What Happened
+
+We added optional keyword-only `schema` support to the AI vision contract, forwarded it through `AIModelManager`, and taught `GeminiProvider` to use `with_structured_output(schema, include_raw=True)` for multimodal requests when a schema is present. The raw JSON path stayed intact for calls that do not provide a schema. That kept the change narrow instead of turning Phase 1 into a hidden parser rewrite.
+
+## Decisions
+
+- Keep the change at the provider contract only.
+- Make `schema` optional and keyword-only so existing callers do not break.
+- Preserve the no-schema raw JSON flow exactly as-is.
+- Use structured output only for vision/multimodal calls, not for every AI path.
+
+## Verification
+
+- 64 related tests passed via `uv`.
+- `ruff`, `mypy`, `black --check`, and `py_compile` all passed on the touched source.
+- Tester subagent reported only an environment issue: project `uv` works, host Python is not suitable.
+- Code reviewer found no issues.
+
+## Next
+
+- Phase 2 should define the canonical AI nutrition contracts.
+- The current parser fallback stays isolated until later phases replace it.
+- Future work should keep the provider boundary stable; expanding scope here would have been premature and noisy.
+

--- a/docs/journals/260613-1719-llm-nutrition-contracts-phase-2.md
+++ b/docs/journals/260613-1719-llm-nutrition-contracts-phase-2.md
@@ -1,0 +1,47 @@
+# LLM Nutrition Contracts Phase 2
+
+**Date**: 2026-06-13 17:19
+**Severity**: High
+**Component**: AI nutrition output contracts
+**Status**: Resolved
+
+## What Happened
+
+Phase 2 landed the canonical nutrition contracts for both image and text AI output. The image contract now requires a non-empty foods list and bounded `quantity_g`, while the text contract preserves the current UX by keeping `quantity` and `unit` and normalizing current flat macro fields into nested `macros`. AI-reported calories are ignored because backend macro math remains the source of truth. The legacy `GPTResponseParser` also stopped silently dropping invalid food quantities, so bad output now fails instead of being partially saved and patched later.
+
+## The Brutal Truth
+
+The previous behavior was too forgiving in the worst possible way: it made broken model output look usable. That is exactly how you end up with corrupted nutrition data and no clean failure boundary. The annoying part was that review caught a runtime partial-save risk after the first pass. We had to fix that before calling the phase done, which was the right outcome even if it meant the parser had to get less “helpful.”
+
+## Technical Details
+
+- Canonical contracts added for image and text nutrition AI output.
+- Image contract rejects empty foods and impossible `quantity_g` values.
+- Text contract keeps `quantity`/`unit` for UX and normalizes flat macro fields into nested macros.
+- AI calories are ignored; calories stay derived from macros in the backend.
+- `GPTResponseParser` now fails invalid food quantities instead of filtering them out.
+- Verification: focused suite `65 passed`, broader Phase 1+2 suite `110 passed`, and touched-slice `ruff`, `mypy`, `black --check`, and `py_compile` all passed.
+- Full-repo `ruff`, `mypy`, and `black --check` remain blocked by unrelated existing hygiene issues.
+
+## What We Tried
+
+We first relied on parser-side cleanup, which looked safe until review showed it could still save partial data. That approach was rejected because silent repair hides defects instead of surfacing them. The fix was to make invalid AI output fail hard at the contract boundary so Phase 3 retry orchestration can own repair behavior explicitly.
+
+## Root Cause Analysis
+
+The root cause was over-trusting the parser to sanitize model output. That was a design mistake, not a minor bug. Once invalid quantities were being filtered before validation, the system could not distinguish “good enough” from “silently broken,” and that is how runtime partial-save risk slipped through.
+
+## Lessons Learned
+
+- Do not hide model defects inside parser cleanup.
+- If output is invalid, fail at the contract boundary and let retry logic decide recovery.
+- Preserve UX in the text contract, but do not let UX convenience weaken validation.
+- Treat review findings about partial saves as real until proven otherwise.
+
+## Next Steps
+
+Phase 3 should own validation retry orchestration and repair behavior. The implementation team should keep the contract boundary strict and move recovery logic out of the parser so bad AI output is either retried or rejected on purpose.
+
+**Status:** DONE
+**Summary:** Canonical image/text nutrition contracts shipped, invalid AI quantities now fail fast, and the partial-save risk was fixed after review.
+**Concerns:** Full-repo `ruff`, `mypy`, and `black --check` are still blocked by unrelated existing hygiene issues.

--- a/docs/journals/260613-1749-llm-nutrition-contracts-phase-3.md
+++ b/docs/journals/260613-1749-llm-nutrition-contracts-phase-3.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-13 17:49
+status: resolved
+component: llm-nutrition-output-contracts
+phase: 3
+---
+
+# Phase 3 LLM Nutrition Output Contracts
+
+## Context
+
+Phase 3 closed the gap between flaky LLM output and the meal analysis contract. The work centered on validation/retry orchestration for vision and text nutrition flows, with one controlled retry for invalid structured output and no retry for provider outages.
+
+## What Happened
+
+We treated invalid AI output as a contract failure, not parser cleanup. That changed the behavior from "best effort parsing" to "validate, repair once, then fail cleanly." Ingredient recognition stayed on its existing unstructured contract and was not forced into the nutrition schema. FatSecret divergence checks also stopped trusting AI-reported calories and now compare against backend-derived macro calories.
+
+## Decisions
+
+Retry exactly once for invalid structured output. Keep provider outages separate so fallback behavior stays intact. Keep ingredient recognition outside the nutrition contract because it is a different payload shape and mixing it in would have been a sloppy regression. Preserve the existing DTO shape for text parsing after validation so the API surface does not drift.
+
+## Validation
+
+The focused regression slice passed at 21 tests. The expanded Phase 1-3 AI boundary suite passed at 155 tests. Touched-file `ruff check`, `mypy`, `black --check`, and `py_compile` all passed. That is the part that mattered: the contract changes held under the boundary tests instead of just looking right in code review.
+
+## Next
+
+Phase 3 is done. Move to Phase 4 and keep the same rule: if the model violates the output contract, fail the contract first and only repair it once.

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,8 +1,8 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
-**Version:** 0.6.2
-**Last Updated:** May 15, 2026
-**Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: configurable referral commissions, BMR floor protection, custom unit normalization, email Universal Links, AsyncUnitOfWork concurrency guard.
+**Version:** 0.6.5
+**Last Updated:** June 13, 2026
+**Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: configurable referral commissions, BMR floor protection, custom unit normalization, email Universal Links, AsyncUnitOfWork concurrency guard, AI nutrition validation retries.
 
 ---
 
@@ -117,6 +117,8 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 0.6.5 | Jun 13, 2026 | Added validation retry orchestration for structured AI nutrition output, with exactly one repair attempt for meal image scan and text parse flows, controlled `AIOutputValidationError` handling, preserved ingredient-recognition's unstructured contract, and kept calorie divergence checks anchored to backend-derived macro calories. |
+| 0.6.4 | Jun 13, 2026 | Added canonical AI nutrition contracts for image and text flows, rejected impossible over-limit food quantities at validation time, preserved current text-parse macro compatibility, and removed silent invalid-food filtering from the legacy parser. |
 | 0.6.2 | May 15, 2026 | Configurable referral commissions (`REFERRAL_COMMISSIONS` env var, per-currency JSON). Custom unit-to-grams fix in nutrition calculation. BMR floor raised to 85% of standard daily; cutting deficit 500→300 kcal; clinical minimums 1200F/1500M. Email Universal Links (apple-app-site-association, /app-download). AsyncUnitOfWork concurrency guard (asyncio.Lock). Variable-length referral codes (3–15 chars). |
 | 0.6.0 | Mar 14, 2026 | Nutrition accuracy (5-phase implementation): fiber-aware calories, food density conversion, macro validation, food reference evolution, meal decomposition. Custom macro targets per profile. Date of birth tracking. Adjusted daily target from weekly budget in suggestions. 3 new services, 3 new migrations (034-037), 28+ modified/new files. |
 | 0.5.0 | Feb 3, 2026 | Updated metrics across all layers: API (76 files, 8,605 LOC), App (140 files, 6,229 LOC), Domain (133 files, 14,556 LOC), Infra (80 files, 8,895 LOC). Total: 430 files, ~38K LOC. Fixed metric inconsistencies from previous documentation. |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,6 +1,6 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.3
+**Version:** 0.6.4
 **Last Updated:** June 13, 2026
 **Status:** Production-ready. 430 source files, ~38K LOC across 4 layers (API: 76, App: 140, Domain: 133, Infra: 80). 681+ tests, 70%+ coverage.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
@@ -31,6 +31,9 @@
       image URL, email, and webhook provider identifiers from representative
       application logs.
 
+### June 2026: Vision Parser Resilience
+- [x] Canonical AI nutrition contracts now reject impossible over-limit food quantities before domain hydration, invalid AI items now fail instead of being silently repaired, and structured meal image/text output retries exactly once before raising controlled `AIOutputValidationError`.
+
 ### June 2026: Normalized Database Foundation
 - [x] Added normalized profile preferences, hydration entries, saved suggestion items/steps, meal instruction steps, food serving sizes, and food nutrient tables.
 - [x] Added typed payout workflow fields while retaining raw payout details pending a later security/contract pass.
@@ -39,7 +42,7 @@
 - [x] Local Postgres upgrade verified to Alembic head `20260609000006`.
 
 ### June 2026: Neon Direct Pool + Async Library Alignment
-- [x] Explicit DB connection mode resolver: `direct_pool` uses `AsyncAdaptedQueuePool` against direct Neon URL; `neon_pooler` uses `NullPool` with PgBouncer-safe asyncpg settings.
+- [x] Explicit DB connection mode resolver: `direct_pool` uses a dedicated async queue pool against the direct Neon URL; `neon_pooler` uses `NullPool` with PgBouncer-safe asyncpg settings.
 - [x] `APP_DATABASE_URL` is the app runtime URL; `DATABASE_URL_DIRECT` is migration/admin only — no silent priority drift.
 - [x] `FoodDataService` converted from `requests` to `httpx.AsyncClient`.
 - [x] Cloudinary blocking SDK calls wrapped with `asyncio.to_thread` off-loop boundary.
@@ -50,7 +53,7 @@
 
 ### June 2026: Async Repository Consolidation
 - [x] Runtime database access consolidated to async SQLAlchemy: FastAPI dependencies, cron jobs, handlers, repositories, and UoW use `AsyncSession`.
-- [x] Deleted sync `UnitOfWork`, sync database config, and legacy sync repositories after replacing remaining test consumers with explicit test-only facades.
+- [x] Deleted the sync unit-of-work runtime, sync database config, and legacy sync repositories after replacing remaining test consumers with explicit test-only facades.
 - [x] Architecture guard now expects zero sync DB runtime imports in `src` and no broad sync repository transition allowlist.
 - [x] Default validation: `pytest -q` passes (`1499 passed, 3 skipped`).
 

--- a/plans/260613-1359-llm-nutrition-output-contracts/phase-01-provider-structured-vision-spike.md
+++ b/plans/260613-1359-llm-nutrition-output-contracts/phase-01-provider-structured-vision-spike.md
@@ -1,0 +1,118 @@
+---
+phase: 1
+title: "Provider Structured Vision Spike"
+status: completed
+effort: "0.5d"
+---
+
+# Phase 1: Provider Structured Vision Spike
+
+## Context Links
+
+- Brainstorm: `plans/reports/260613-1350-llm-nutrition-contract-brainstorm.md`
+- Provider text structured path: `src/infra/services/ai/providers/gemini_provider.py`
+- Provider port: `src/domain/ports/ai_provider_port.py`
+- Manager fallback path: `src/infra/services/ai/ai_model_manager.py`
+- Vision adapter: `src/infra/adapters/vision_ai_service.py`
+- Tests: `tests/unit/infra/services/ai/providers/test_gemini_provider.py`
+- Tests: `tests/unit/infra/services/ai/test_ai_model_manager.py`
+
+## Overview
+
+Prove and implement schema plumbing for multimodal vision calls before changing
+the domain parser. Text generation already supports `schema` through
+`with_structured_output`; vision currently invokes Gemini and extracts raw JSON.
+This phase makes `generate_with_vision(..., schema=...)` real while preserving
+the existing raw JSON path when no schema is passed.
+
+Priority: P1.
+
+## Requirements
+
+- Add optional `schema: type | None` to `AIProviderPort.generate_with_vision`.
+- Pass `schema` through `AIModelManager.generate_with_vision`.
+- In `GeminiProvider.generate_with_vision`, when schema exists:
+  - Build the same multimodal message payload used today.
+  - Call `llm.with_structured_output(schema, include_raw=True)`.
+  - Return `parsed.model_dump()` for Pydantic models, or `dict(parsed)`.
+  - Raise a controlled error if parsed output is `None`.
+- Keep the current no-schema path and `_extract_json` behavior unchanged.
+- Preserve circuit breaker success/failure behavior and model fallback.
+- Unit tests only; do not require live Gemini credentials.
+
+## Architecture
+
+Provider interface stays provider-agnostic. The structured-output capability is
+already represented by `AICapability.STRUCTURED_OUTPUT`; this phase extends the
+vision method to use that same capability instead of adding a new service layer.
+
+Data flow:
+
+```text
+VisionAIService
+  -> AIModelManager.generate_with_vision(schema=...)
+  -> GeminiProvider.generate_with_vision(schema=...)
+  -> ChatGoogleGenerativeAI.with_structured_output(...)
+  -> validated dict
+```
+
+## Related Code Files
+
+Modify:
+
+- `src/domain/ports/ai_provider_port.py`
+- `src/infra/services/ai/ai_model_manager.py`
+- `src/infra/services/ai/providers/gemini_provider.py`
+- `tests/unit/domain/ports/test_ai_provider_port.py`
+- `tests/unit/infra/services/ai/test_ai_model_manager.py`
+- `tests/unit/infra/services/ai/providers/test_gemini_provider.py`
+
+## Implementation Steps
+
+1. Write failing provider-port/unit tests proving `generate_with_vision` accepts
+   and forwards a `schema` argument.
+2. Add manager test: `AIModelManager.generate_with_vision(..., schema=DummyModel)`
+   passes schema to the selected provider and still records success.
+3. Add Gemini provider test using a fake LLM where `with_structured_output` is
+   called with the schema and receives the multimodal messages.
+4. Add Gemini provider regression test for the no-schema raw JSON path.
+5. Implement the port, manager, and provider signature changes.
+6. Make structured vision return a plain dict from parsed Pydantic output.
+7. Keep exception handling generic enough for circuit breaker fallback, but do
+   not swallow schema/validation failures in this phase.
+8. Run the focused tests.
+
+## Success Criteria
+
+- [x] `generate_with_vision(..., schema=...)` is available on the domain port.
+- [x] AI model manager forwards the schema to the active provider.
+- [x] Gemini provider uses structured output for multimodal messages when schema exists.
+- [x] Gemini provider raw JSON extraction remains unchanged when schema is omitted.
+- [x] No live external AI call is needed for test coverage.
+- [x] Focused tests pass.
+
+## Completion Notes
+
+- Implemented `schema` as a keyword-only vision argument to avoid breaking
+  existing positional provider calls.
+- Verified no-schema vision behavior still uses raw JSON extraction.
+- Tester gate: focused provider tests passed with project venv; environment-only
+  concern for non-venv Python.
+- Code-review gate: no findings.
+
+## Risk Assessment
+
+- Risk: LangChain structured output behaves differently for multimodal messages.
+  Mitigation: isolate this in provider tests first; keep no-schema fallback path
+  untouched until later phases prove the new path.
+- Risk: Provider signature change breaks fake providers in tests.
+  Mitigation: update all local fake provider implementations in the same patch.
+
+## Security Considerations
+
+- Do not log image bytes, base64 payloads, or full user food descriptions.
+- Structured-output errors may include field names, not raw image content.
+
+## Next Steps
+
+Proceed to Phase 2 only after schema plumbing is tested locally.

--- a/plans/260613-1359-llm-nutrition-output-contracts/phase-02-canonical-ai-nutrition-contracts.md
+++ b/plans/260613-1359-llm-nutrition-output-contracts/phase-02-canonical-ai-nutrition-contracts.md
@@ -1,0 +1,140 @@
+---
+phase: 2
+title: "Canonical AI Nutrition Contracts"
+status: completed
+effort: "0.5-1d"
+---
+
+# Phase 2: Canonical AI Nutrition Contracts
+
+## Context Links
+
+- Current vision schema: `src/domain/parsers/vision_response_models.py`
+- Older GPT schema: `src/domain/model/ai/gpt_response.py`
+- Existing structured recipe schemas: `src/infra/services/ai/schemas.py`
+- Domain nutrition invariant: `src/domain/model/nutrition/nutrition.py`
+- Macro calorie derivation: `src/domain/model/nutrition/macros.py`
+- Schema tests: `tests/unit/domain/parsers/test_vision_response_models.py`
+- Infra schema tests: `tests/unit/infra/services/ai/test_schemas.py`
+
+## Overview
+
+Create one explicit nutrition-output contract family for AI responses. The repo
+currently has overlapping schema concepts, and the temporary vision model drops
+invalid quantities before validation. This phase defines contracts that reject
+bad output instead of repairing it silently.
+
+Priority: P1.
+
+## Requirements
+
+- Add canonical AI nutrition contracts in domain-owned code so application and
+  infra can both import them without infra-to-domain cycles.
+- Keep task-specific contracts instead of forcing every flow into one shape:
+  - `VisionNutritionResponse` for image meal scan.
+  - `MealTextNutritionResponse` for natural-language parse.
+  - Existing `RecipeDetailsResponse` remains explicit, but tests must prove AI
+    nutrition fields are ignored or treated as metadata.
+- For vision food estimates, prefer normalized grams:
+  - `quantity_g: float = Field(gt=0, le=MAX_FOOD_ITEM_QUANTITY)`.
+  - Domain mapping can store `unit="g"`.
+- For text parse, preserve display UX:
+  - Keep `quantity` and `unit` for user-facing text parse.
+  - Add optional `quantity_g` when known.
+  - Validate quantity with unit-aware semantic rules in Phase 3.
+- Macros use grams and support optional `fiber_g` and `sugar_g`.
+- AI-reported calories must not become source-of-truth calories.
+- Remove or replace validators that drop invalid foods before validation.
+
+## Architecture
+
+Recommended module:
+
+- `src/domain/model/ai/nutrition_contracts.py`
+
+Recommended models:
+
+- `AINutritionMacros`
+- `VisionFoodEstimate`
+- `VisionNutritionResponse`
+- `MealTextFoodEstimate`
+- `MealTextNutritionResponse`
+- `AIOutputValidationContext` or equivalent lightweight dataclass if needed by tests
+
+Keep `src/infra/services/ai/schemas.py` for meal suggestion and recipe schemas
+unless Phase 4 finds a direct nutrition-flow dependency that benefits from a
+small import redirect.
+
+## Related Code Files
+
+Modify:
+
+- `src/domain/model/ai/__init__.py`
+- `src/domain/model/ai/gpt_response.py` or stop production imports from it
+- `src/domain/parsers/vision_response_models.py` or replace imports with new contracts
+- `src/infra/services/ai/schemas.py`
+- `tests/unit/domain/parsers/test_vision_response_models.py`
+- `tests/unit/infra/services/ai/test_schemas.py`
+
+Create if needed:
+
+- `src/domain/model/ai/nutrition_contracts.py`
+- `tests/unit/domain/model/ai/test_nutrition_contracts.py`
+
+## Implementation Steps
+
+1. Write failing tests for `VisionNutritionResponse`:
+   - accepts realistic food quantities.
+   - rejects `quantity_g=150000`.
+   - rejects empty names, negative macros, too many food items.
+   - does not include source-of-truth calories.
+2. Write failing tests for `MealTextNutritionResponse`:
+   - accepts display quantity/unit and optional `quantity_g`.
+   - rejects malformed item lists.
+   - preserves emoji validation boundary for later handler use.
+3. Write recipe-schema regression tests:
+   - recipe details can include AI calorie metadata if already supported.
+   - downstream deterministic nutrition remains the only source of saved calories.
+4. Implement canonical contracts with Pydantic `Field` constraints.
+5. Remove pre-validation dropping from the temporary vision schema, or redirect
+   callers/tests to the new canonical contract and leave the old module as a
+   compatibility shim without silent correction.
+6. Export contracts from `src/domain/model/ai/__init__.py`.
+7. Run schema-focused tests.
+
+## Success Criteria
+
+- [x] Canonical image and text nutrition contracts exist and are tested.
+- [x] `quantity_g=150000` fails contract validation.
+- [x] Invalid foods are not silently removed by Pydantic validators.
+- [x] AI calories are excluded from domain calorie authority.
+- [x] Existing recipe structured-output tests still pass.
+- [x] Focused schema tests pass.
+
+## Completion Notes
+
+- Added canonical contracts in `src/domain/model/ai/nutrition_contracts.py`.
+- Tightened legacy parser behavior so invalid AI food items fail instead of
+  being silently removed.
+- Preserved current text-parse compatibility by folding flat macro fields into
+  canonical nested macros.
+- Reviewer follow-up found no blockers after fixes.
+- Validation: focused Phase 1+2 regression suite passed with 110 tests.
+
+## Risk Assessment
+
+- Risk: Contract too strict harms UX. Mitigation: keep text display units and
+  move unit-specific plausibility into Phase 3 retry semantics.
+- Risk: Duplicate schemas remain. Mitigation: make production imports converge
+  during Phase 4 and leave only compatibility shims if needed.
+
+## Security Considerations
+
+- Contracts should constrain list sizes and text lengths to prevent oversized AI
+  payloads from flowing deeper into handlers.
+- Error messages should identify fields without echoing large raw payloads.
+
+## Next Steps
+
+Proceed to Phase 3 after contracts reject the production failure shape in unit
+tests.

--- a/plans/260613-1359-llm-nutrition-output-contracts/phase-03-validation-retry-orchestration.md
+++ b/plans/260613-1359-llm-nutrition-output-contracts/phase-03-validation-retry-orchestration.md
@@ -1,0 +1,150 @@
+---
+phase: 3
+title: "Validation Retry Orchestration"
+status: completed
+effort: "1d"
+---
+
+# Phase 3: Validation Retry Orchestration
+
+## Context Links
+
+- Vision adapter: `src/infra/adapters/vision_ai_service.py`
+- Text parse handler: `src/app/handlers/command_handlers/parse_meal_text_handler.py`
+- Meal generation adapter: `src/infra/adapters/meal_generation_service.py`
+- AI exceptions: `src/domain/exceptions/ai_exceptions.py`
+- Prompt definitions: `src/domain/services/prompts/system_prompts.py`
+- Vision tests: `tests/unit/infra/adapters/test_vision_ai_service.py`
+- Text handler tests: `tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py`
+
+## Overview
+
+Add the user-preserving behavior: invalid AI output gets one automatic repair
+attempt, then a controlled failure. This is the core difference between a
+well-designed LLM boundary and the current parser workaround.
+
+Priority: P1.
+
+## Requirements
+
+- Distinguish provider outages from invalid AI output.
+- Retry invalid structured output exactly once.
+- Retry prompt includes compact correction context:
+  - field path or validation summary.
+  - instruction to return the full corrected response.
+  - no raw image bytes, no full base64, no oversized payload logging.
+- Retry success follows normal UX.
+- Retry failure raises a controlled application/domain exception.
+- Do not retry:
+  - circuit-breaker provider outage already handled by fallback chain.
+  - low confidence alone.
+  - FatSecret lookup mismatch.
+- Add semantic validation beyond Pydantic:
+  - realistic quantity bounds by contract.
+  - item count.
+  - non-negative macros.
+  - optional macro-vs-quantity sanity where local rules exist.
+
+## Architecture
+
+Use a small shared validation/retry helper only if it removes duplication
+between image and text flows. Otherwise keep retry orchestration near the AI call
+site for readability:
+
+- Vision: `VisionAIService.analyze_with_strategy`.
+- Text: `ParseMealTextHandler.handle` or a focused private method around
+  `MealGenerationService.generate_meal_plan_async`.
+
+Recommended exception:
+
+- `AIOutputValidationError` in `src/domain/exceptions/ai_exceptions.py`
+  carrying purpose, attempt count, and sanitized validation details.
+
+## Related Code Files
+
+Modify:
+
+- `src/domain/exceptions/ai_exceptions.py`
+- `src/infra/adapters/vision_ai_service.py`
+- `src/app/handlers/command_handlers/parse_meal_text_handler.py`
+- `src/infra/adapters/meal_generation_service.py` if schema plumbing is needed
+- `src/domain/services/prompts/system_prompts.py`
+- `tests/unit/infra/adapters/test_vision_ai_service.py`
+- `tests/unit/infra/adapters/test_vision_ai_service_resilience.py`
+- `tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py`
+
+Create if needed:
+
+- `src/domain/services/ai_output_validation_service.py`
+- `tests/unit/domain/services/test_ai_output_validation_service.py`
+
+## Implementation Steps
+
+1. [x] Write failing vision service tests:
+   - first structured output invalid, retry valid, method returns normal payload.
+   - first and retry both invalid, method raises `AIOutputValidationError`.
+   - provider `AIUnavailableError` still propagates without validation retry.
+2. [x] Write failing text parse tests:
+   - invalid AI text parse output retries once.
+   - retry success preserves current DTO behavior.
+   - retry failure maps to controlled error behavior expected by routes/tests.
+3. [x] Add `AIOutputValidationError` with sanitized detail fields.
+4. [x] Add validation detail summarizer for Pydantic/semantic errors.
+5. [x] Implement retry loop in vision path using `schema=VisionNutritionResponse`.
+6. [x] Implement text schema call using `schema=MealTextNutritionResponse`.
+7. [x] Add correction-prompt helper that appends validation detail to existing
+   prompt without replacing the system prompt.
+8. [x] Ensure logs include purpose, strategy/model if available, and attempt count.
+9. [x] Run focused service and handler tests.
+
+## Implementation Notes
+
+- Added `AIOutputValidationError` and shared validation helpers for sanitized
+  details and retry prompt context.
+- Image meal analysis uses `VisionNutritionResponse` and retries invalid
+  structured output exactly once.
+- Ingredient recognition keeps its existing unstructured `{name, confidence,
+  category}` contract and does not receive the meal nutrition schema.
+- Text parsing uses `MealTextNutritionResponse`, retries invalid structured
+  output exactly once, and maps validated macros back to the existing DTO shape.
+- FatSecret divergence checks now compare against backend-derived macro
+  calories, not AI-reported calorie extras.
+- API exception mapping returns friendly `AI_OUTPUT_INVALID` guidance without
+  leaking field-level validation details.
+
+## Success Criteria
+
+- [x] Invalid vision output triggers exactly one retry.
+- [x] Invalid text parse output triggers exactly one retry.
+- [x] Retry success returns the same user-facing success shape as today.
+- [x] Retry failure raises/mapping is controlled; raw parser/domain exception does not leak.
+- [x] Provider outage fallback behavior is unchanged.
+- [x] Logs are useful and sanitized.
+
+## Verification
+
+- `uv run pytest tests/unit/infra/adapters/test_vision_ai_service_resilience.py tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py -q`
+  - Result: 21 passed.
+- `uv run pytest tests/unit/api/test_exceptions_unexpected.py tests/unit/domain/exceptions/test_ai_exceptions.py tests/unit/domain/services/test_ai_output_validation_service.py tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/domain/parsers/test_gpt_response_parser.py tests/unit/domain/parsers/test_vision_response_models.py tests/unit/domain/ports/test_ai_provider_port.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/infra/adapters/test_vision_ai_service_resilience.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py tests/unit/infra/services/ai/test_ai_model_manager.py tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/infra/services/ai/test_schemas.py -q`
+  - Result: 155 passed.
+- Touched-file `ruff check`, `mypy`, `black --check`, and `py_compile`
+  passed.
+
+## Risk Assessment
+
+- Risk: Retry adds latency. Mitigation: retry only invalid structured output,
+  never every scan.
+- Risk: Error handling conflates invalid output with provider outage. Mitigation:
+  separate exception types and tests for both paths.
+- Risk: Repeating same bad output. Mitigation: include field-specific correction
+  detail and cap retries at one.
+
+## Security Considerations
+
+- No raw images or full user meal text in validation logs.
+- Avoid returning internal validation detail directly to clients; use friendly
+  API guidance.
+
+## Next Steps
+
+Proceed to Phase 4 after image and text retry behavior is covered by tests.

--- a/plans/260613-1359-llm-nutrition-output-contracts/phase-04-flow-integration-and-parser-replacement.md
+++ b/plans/260613-1359-llm-nutrition-output-contracts/phase-04-flow-integration-and-parser-replacement.md
@@ -1,0 +1,123 @@
+---
+phase: 4
+title: "Flow Integration And Parser Replacement"
+status: pending
+effort: "1-2d"
+---
+
+# Phase 4: Flow Integration And Parser Replacement
+
+## Context Links
+
+- Immediate upload handler: `src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py`
+- Background event handler: `src/app/handlers/event_handlers/meal_analysis_event_handler.py`
+- Analyze by URL handler: `src/app/handlers/command_handlers/analyze_meal_image_by_url_command_handler.py`
+- Scan by URL handler: `src/app/handlers/command_handlers/scan_by_url_command_handler.py`
+- Parser: `src/domain/parsers/gpt_response_parser.py`
+- Parser tests: `tests/unit/domain/parsers/test_gpt_response_parser.py`
+- Upload handler tests: `tests/unit/handlers/command_handlers/`
+
+## Overview
+
+Wire the validated contracts into every meal-analysis flow and remove the
+parser-side workaround. The parser becomes deterministic mapping from a
+validated AI contract into domain nutrition, not a silent repair engine.
+
+Priority: P1.
+
+## Requirements
+
+- Image flows use `VisionNutritionResponse`:
+  - immediate upload.
+  - background meal analysis.
+  - analyze-by-url.
+  - scan-by-url.
+- Text parse uses `MealTextNutritionResponse`.
+- Recipe generation keeps explicit structured schemas and deterministic
+  nutrition calculation.
+- Parser no longer drops over-limit foods as final behavior.
+- Domain `FoodItem` invariant remains in place as final guard.
+- API clients receive controlled errors on repeated invalid AI output.
+- Existing successful payload shapes remain compatible where API responses
+  already depend on them.
+
+## Architecture
+
+Target image flow:
+
+```text
+handler
+  -> VisionAIService.analyze_with_strategy
+  -> structured schema + validation retry
+  -> GPTResponseParser.parse_to_nutrition(validated payload)
+  -> Nutrition/FoodItem domain models
+  -> persistence/event flow
+```
+
+The parser should accept the post-validation shape. If backward compatibility is
+needed during migration, support old keys only as a compatibility path with
+strict validation, not with silent item deletion.
+
+## Related Code Files
+
+Modify:
+
+- `src/domain/parsers/gpt_response_parser.py`
+- `src/domain/parsers/vision_response_models.py`
+- `src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py`
+- `src/app/handlers/event_handlers/meal_analysis_event_handler.py`
+- `src/app/handlers/command_handlers/analyze_meal_image_by_url_command_handler.py`
+- `src/app/handlers/command_handlers/scan_by_url_command_handler.py`
+- `src/app/handlers/command_handlers/parse_meal_text_handler.py`
+- `tests/unit/domain/parsers/test_gpt_response_parser.py`
+- relevant handler tests under `tests/unit/handlers/command_handlers/`
+
+## Implementation Steps
+
+1. Write failing parser regression tests:
+   - over-limit quantity raises parsing/validation error instead of being dropped.
+   - valid `quantity_g` maps to `FoodItem(quantity=..., unit="g")`.
+   - calories still derive from `Macros.total_calories`.
+2. Write handler tests for repeated invalid AI output:
+   - immediate image upload returns controlled failure.
+   - by-url scan/analyze returns controlled failure.
+   - background event logs/fails without leaking raw exceptions.
+3. Update parser normalization to deterministic mapping only.
+4. Remove `_has_supported_quantity` filtering and any Pydantic validator that
+   strips invalid foods before field validation.
+5. Update image handlers to consume the validated service payload.
+6. Update text parse handler to consume `MealTextNutritionResponse` while
+   preserving current DTO shape and localization behavior.
+7. Confirm recipe pipeline still ignores AI nutrition values and uses
+   deterministic lookup/calculation.
+8. Run parser, handler, and recipe tests.
+
+## Success Criteria
+
+- [ ] `quantity=150000` or `quantity_g=150000` cannot be saved.
+- [ ] Invalid AI output is retried before the parser is reached.
+- [ ] Parser does not silently drop invalid items as final behavior.
+- [ ] Successful image, text, and recipe flows keep current user-facing behavior.
+- [ ] Backend-derived calories remain the only persisted/returned calorie source.
+- [ ] Focused parser and handler tests pass.
+
+## Risk Assessment
+
+- Risk: Handler response expectations differ across immediate/background flows.
+  Mitigation: test each flow explicitly instead of relying only on parser tests.
+- Risk: Backward compatibility path accidentally keeps silent cleanup. Mitigation:
+  add a failing test that proves impossible quantity raises after retry failure.
+- Risk: Text parse UX regresses by losing localized units. Mitigation: keep text
+  display quantity/unit in the text contract and DTO mapping.
+
+## Security Considerations
+
+- User-facing errors should say the analysis needs a clearer photo or more
+  context, not expose validation internals.
+- Persistence should never receive raw unvalidated AI payloads as trusted domain
+  state.
+
+## Next Steps
+
+Proceed to Phase 5 after all production AI nutrition entrypoints use explicit
+contracts.

--- a/plans/260613-1359-llm-nutrition-output-contracts/phase-05-evaluation-observability-and-documentation.md
+++ b/plans/260613-1359-llm-nutrition-output-contracts/phase-05-evaluation-observability-and-documentation.md
@@ -1,0 +1,97 @@
+---
+phase: 5
+title: "Evaluation Observability And Documentation"
+status: pending
+effort: "0.5d"
+---
+
+# Phase 5: Evaluation Observability And Documentation
+
+## Context Links
+
+- Prompt eval loop: `src/domain/services/meal_analysis/prompt_eval_loop.py`
+- Roadmap: `docs/project-roadmap.md`
+- PDR: `docs/project-overview-pdr.md`
+- Testing standards: `docs/testing-standards.md`
+- Architecture docs: `docs/architecture/index.md`
+
+## Overview
+
+Make the new LLM boundary observable and documented. The goal is to know when AI
+output quality is bad, not just avoid crashes.
+
+Priority: P1.
+
+## Requirements
+
+- Prompt evaluation includes schema/semantic validation pass rate, not only
+  parser success.
+- Runtime logs distinguish:
+  - provider outage.
+  - structured-output parse failure.
+  - semantic nutrition validation failure.
+  - retry success.
+  - retry exhausted.
+- Logs include purpose, strategy, model when available, attempt count, and
+  sanitized field paths.
+- Project docs record the architecture decision and bug fix impact.
+- Final verification covers source, tests, and static checks.
+
+## Architecture
+
+Observability should sit at orchestration boundaries, not inside domain value
+objects. Domain models keep invariants; adapters/handlers record invalid AI
+output rates and retry outcomes.
+
+## Related Code Files
+
+Modify:
+
+- `src/domain/services/meal_analysis/prompt_eval_loop.py`
+- tests for prompt eval loop under `tests/unit/domain/services/meal_analysis/`
+- `docs/project-roadmap.md`
+- `docs/project-overview-pdr.md`
+- optionally `docs/architecture/index.md` or linked AI architecture docs if present
+
+Create if needed:
+
+- `tests/unit/domain/services/meal_analysis/test_prompt_eval_loop.py`
+
+## Implementation Steps
+
+1. Write failing prompt-eval tests:
+   - candidate with schema-invalid payload scores lower than valid candidate.
+   - result exposes validation success rate.
+   - threshold enforcement can fail on validation rate separately from token cost.
+2. Extend `PromptEvalResult` with validation metrics while preserving old fields
+   where tests or callers use them.
+3. Add sanitized logging in Phase 3/4 code paths if not already covered.
+4. Update roadmap/PDR changelog entries with the final architecture fix.
+5. Run focused tests.
+6. Run final verification gate from `plan.md`.
+7. Review docs impact and unresolved questions before implementation handoff.
+
+## Success Criteria
+
+- [ ] Prompt eval can detect schema/semantic failures.
+- [ ] Invalid-output retry paths emit sanitized logs.
+- [ ] Docs explain the contract-first LLM boundary and why parser filtering was not enough.
+- [ ] Focused tests pass.
+- [ ] Final verification gate passes or failures are documented with exact blockers.
+
+## Risk Assessment
+
+- Risk: Metrics become too broad for current telemetry stack. Mitigation: start
+  with structured logs and prompt-eval fields; defer external metrics backend.
+- Risk: Docs overstate provider guarantees. Mitigation: describe Gemini as a
+  probabilistic extractor plus deterministic validation, not a trusted source.
+
+## Security Considerations
+
+- Observability must not store raw images, base64 payloads, or large meal text.
+- Validation snippets should use field paths and short error codes.
+
+## Next Steps
+
+After this phase, prepare implementation summary and optionally create a focused
+branch/PR if the user wants shipping workflow next.

--- a/plans/260613-1359-llm-nutrition-output-contracts/plan.md
+++ b/plans/260613-1359-llm-nutrition-output-contracts/plan.md
@@ -1,0 +1,63 @@
+---
+title: "LLM Nutrition Output Contracts"
+description: "Replace parser-side AI cleanup with structured nutrition contracts, bounded validation retry, deterministic mapping, and observability across image, text, and recipe AI flows."
+status: in-progress
+priority: P1
+branch: ""
+tags: [ai, nutrition, structured-output, validation, ux]
+blockedBy: []
+blocks: []
+created: "2026-06-13T06:59:38.595Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# LLM Nutrition Output Contracts
+
+## Overview
+
+Build a contract-first boundary for MealTrack nutrition AI. Gemini returned
+`quantity=150000`; the temporary parser filter prevents a crash but can silently
+save incomplete nutrition. The final design makes invalid model output visible,
+retryable once, then either maps deterministic validated data into domain models
+or returns controlled guidance to the user.
+
+Source report: `plans/reports/260613-1350-llm-nutrition-contract-brainstorm.md`
+
+## Decisions
+
+- `quantity=150000` is invalid AI output, not a food item.
+- Preserve UX with one automatic retry before user-facing fallback.
+- Scope image scan, text parse, and recipe AI output contracts.
+- Backend derives calories from macros; AI calories are ignored metadata only.
+- Keep domain invariants as the last guard, not the primary LLM validator.
+- No DB schema change, mobile change, nutrition database redesign, or provider migration.
+
+## Phases
+
+| Phase | Name | Status | Effort |
+|-------|------|--------|--------|
+| 1 | [Provider Structured Vision Spike](./phase-01-provider-structured-vision-spike.md) | Completed | 0.5d |
+| 2 | [Canonical AI Nutrition Contracts](./phase-02-canonical-ai-nutrition-contracts.md) | Completed | 0.5-1d |
+| 3 | [Validation Retry Orchestration](./phase-03-validation-retry-orchestration.md) | Completed | 1d |
+| 4 | [Flow Integration And Parser Replacement](./phase-04-flow-integration-and-parser-replacement.md) | Pending | 1-2d |
+| 5 | [Evaluation Observability And Documentation](./phase-05-evaluation-observability-and-documentation.md) | Pending | 0.5d |
+
+## Dependencies
+
+Related plan: `plans/260612-1046-service-initiated-bandwidth-reduction/plan.md`.
+Both plans may touch `gemini_provider.py`, `ai_model_manager.py`, and
+`vision_ai_service.py`. No hard block: execute this plan's Phase 1 before any
+optional URL-Gemini provider changes, or merge provider signature changes in one
+patch.
+
+## Validation Gate
+
+- `uv run pytest tests/unit/infra/services/ai tests/unit/infra/adapters tests/unit/domain/parsers tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py -q`
+- `uv run ruff check src tests`
+- `uv run mypy src`
+- `uv run python -m py_compile $(find src -name '*.py')`
+
+## Unresolved Questions
+
+None.

--- a/plans/reports/260613-1350-llm-nutrition-contract-brainstorm.md
+++ b/plans/reports/260613-1350-llm-nutrition-contract-brainstorm.md
@@ -1,0 +1,237 @@
+---
+type: brainstorm-report
+date: 2026-06-13
+status: approved-for-planning
+topic: llm-nutrition-output-contracts
+---
+
+# LLM Nutrition Output Contract Brainstorm
+
+## Summary
+
+MealTrack should treat Gemini as a probabilistic extractor, not a trusted
+nutrition engine. The proper fix is contract-first LLM orchestration:
+structured output, deterministic validation, one bounded retry, then domain
+mapping. Parser cleanup is only a last safety guard.
+
+Recommended next step: `/ck:plan --tdd` because this changes critical nutrition
+behavior, AI provider contracts, and retry semantics.
+
+## Problem
+
+Production failure:
+
+- Gemini returned `quantity=150000`.
+- Parser accepted the payload until `FoodItem` domain validation rejected it.
+- Previous local patch filtered impossible food items after model output.
+- That prevents a crash, but it can silently save incomplete or misleading
+nutrition.
+
+Root issue: the LLM boundary lacks a strong output contract and semantic
+validation loop.
+
+## Requirements
+
+Expected output:
+
+- A design for robust image/text/recipe AI nutrition output handling.
+- Implementation plan later, not in this brainstorm.
+
+Acceptance criteria:
+
+- `quantity=150000` never creates a saved food item.
+- Invalid model output triggers one automatic retry.
+- Retry success returns normal meal UX.
+- Retry failure returns controlled user-facing guidance.
+- No raw parser/domain exception leaks to API clients.
+- Calories remain backend-derived from macros.
+- Image, text, and recipe AI flows use explicit contracts.
+
+Scope:
+
+- In scope: vision scan, text parse, recipe output contracts, AI provider
+  schema support, validation retry, parser/domain boundary.
+- Out of scope now: DB schema changes, mobile UI changes, nutrition database
+  redesign, broad model-provider migration.
+
+Non-negotiable constraints:
+
+- Preserve user experience over strict fail-fast behavior.
+- Follow Clean Architecture and CQRS boundaries.
+- Keep domain invariants as final guard.
+- Do not trust AI-reported calories as source of truth.
+- Prefer simple bounded retries over multi-pass agent repair.
+
+Touchpoints:
+
+- `src/infra/services/ai/providers/gemini_provider.py`
+- `src/infra/services/ai/ai_model_manager.py`
+- `src/infra/adapters/vision_ai_service.py`
+- `src/domain/parsers/gpt_response_parser.py`
+- `src/domain/parsers/vision_response_models.py`
+- `src/domain/model/ai/gpt_response.py`
+- `src/infra/services/ai/schemas.py`
+- upload/scan-by-url/background meal analysis handlers
+- parser/provider/handler tests
+
+## Findings
+
+- Text generation already supports `schema` via `with_structured_output`.
+- Vision generation currently sends multimodal prompt input but parses raw JSON
+  text afterward.
+- Existing recipe work is closer to the right architecture: AI proposes recipe
+  ingredients; deterministic code computes nutrition.
+- The codebase has duplicate AI response schema concepts. This creates drift.
+- Prompt-only instructions like "realistic quantity" are insufficient.
+
+References:
+
+- Gemini structured outputs:
+  https://ai.google.dev/gemini-api/docs/structured-output
+- LangChain Gemini multimodal input:
+  https://docs.langchain.com/oss/python/integrations/chat/google_generative_ai
+- LangChain structured output:
+  https://reference.langchain.com/python/langchain-google-genai/chat_models/ChatGoogleGenerativeAI/with_structured_output
+
+## Evaluated Approaches
+
+### Option A: Keep parser filtering
+
+Pros:
+
+- Smallest patch.
+- Prevents immediate crash.
+- Low implementation risk.
+
+Cons:
+
+- Silently hides model failure.
+- Can save incomplete meal nutrition.
+- Does not improve LLM reliability.
+- Hard to observe invalid-output rates.
+
+Verdict: temporary seatbelt only, not final design.
+
+### Option B: Clamp invalid values
+
+Pros:
+
+- Simple.
+- Avoids exceptions.
+
+Cons:
+
+- Invents food quantities.
+- Corrupts macros and calories.
+- Worse than dropping because it manufactures confidence.
+
+Verdict: reject.
+
+### Option C: Contract-first LLM boundary with bounded retry
+
+Pros:
+
+- Fits well-designed LLM architecture.
+- Makes invalid output visible and retryable.
+- Preserves UX through automatic retry.
+- Keeps domain model clean and deterministic.
+- Scales across image, text, and recipe flows.
+
+Cons:
+
+- More files touched.
+- Requires provider contract changes.
+- Needs tests for both schema and semantic validation.
+- Need spike/verification for structured multimodal output path.
+
+Verdict: recommended.
+
+## Final Recommendation
+
+Implement Option C.
+
+Pipeline:
+
+```text
+prompt + media/context
+  -> structured model call
+  -> Pydantic contract validation
+  -> semantic nutrition validation
+  -> one bounded retry on invalid AI output
+  -> deterministic domain mapping
+  -> domain invariant
+```
+
+Design decisions:
+
+- Add `schema` support to `generate_with_vision`.
+- Use Gemini/LangChain structured output for multimodal meal scan responses.
+- Consolidate duplicated response models into one AI schema module.
+- Use task-specific contracts:
+  - `VisionNutritionResponse`
+  - `MealTextNutritionResponse`
+  - `RecipeDetailsResponse`
+- Prefer grams for AI nutrition output: `quantity_g`.
+- Let domain mapping convert `quantity_g` to `FoodItem(quantity=..., unit="g")`.
+- AI may provide macros. Backend derives calories from macros.
+- AI-reported `calories` should be removed or treated as ignored metadata.
+- `quantity=150000` is invalid AI output, not a food item.
+- Retry once with correction context. No unbounded repair loop.
+- If retry fails, return user-safe guidance to retake photo or add context.
+- Parser remains defensive but must not silently turn invalid model output into
+  trusted nutrition.
+
+## Implementation Considerations
+
+- Provider layer should return already-validated dicts or Pydantic dumps.
+- Validation errors should include field path, model name, strategy, and attempt.
+- Logs must avoid raw image content and large user food payloads.
+- Existing fast-path retry should distinguish provider outage from invalid AI
+  output.
+- Backward compatibility may need a temporary raw-JSON fallback while tests prove
+  multimodal structured output works reliably.
+- Prompt eval loop should be expanded beyond parse success.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| LangChain structured vision path behaves differently from text path | Start with provider-level spike/test |
+| Schema too strict causes UX failures | One retry, friendly fallback, observe invalid-output rate |
+| Schema too loose repeats same bug | Semantic validation after schema validation |
+| More latency from retry | Retry only invalid structured output, not every low-confidence scan |
+| Duplicate contracts drift again | One canonical AI schema module |
+
+## Validation Criteria
+
+Tests should cover:
+
+- `generate_with_vision(..., schema=VisionNutritionResponse)` passes schema to
+  provider.
+- Gemini provider uses structured output for multimodal messages.
+- Invalid quantity raises validation before domain mapping.
+- Invalid AI output triggers one retry.
+- Retry success saves meal normally.
+- Retry failure returns controlled application error.
+- Parser no longer silently drops impossible over-limit food items as final
+  behavior.
+- Text parsing and recipe generation follow explicit contracts.
+- Calories derive from macros in backend.
+
+Operational validation:
+
+- Track invalid output rate by model, strategy, prompt version.
+- Track retry recovery rate.
+- Alert if invalid output spikes after prompt/model changes.
+
+## Next Steps
+
+1. Create `/ck:plan --tdd` from this report.
+2. First phase should be a provider-level structured multimodal output spike.
+3. Then consolidate contracts and write failing tests around `150000`.
+4. Replace parser workaround with contract validation and retry behavior.
+5. Update docs/roadmap after implementation.
+
+## Unresolved Questions
+
+None.

--- a/plans/reports/docs-260613-llm-nutrition-contracts-phase-2.md
+++ b/plans/reports/docs-260613-llm-nutrition-contracts-phase-2.md
@@ -1,0 +1,28 @@
+# Docs Update Report: LLM Nutrition Contracts Phase 2
+
+## Assessment
+
+Docs impact: minor.
+
+Phase 2 changed AI nutrition validation semantics, but the phase plan and journal already covered the implementation details. The evergreen docs only needed a small correction for stale parser wording plus a refreshed codebase summary.
+
+## Changes Made
+
+- Updated `docs/project-roadmap.md` to describe canonical AI nutrition contracts rejecting invalid over-limit quantities instead of silently repairing them.
+- Updated `docs/project-overview-pdr.md` version history entry for `0.6.4` to match the Phase 2 contract boundary change.
+- Refreshed `docs/codebase-summary.md` with the current generated date and a new recent-feature note for canonical AI nutrition contracts.
+- Regenerated `repomix-output.xml` for the current repository snapshot.
+
+## Validation
+
+- Ran `node $HOME/.claude/scripts/validate-docs.cjs docs/`.
+- The touched roadmap warnings were cleared.
+- Remaining validator warnings are pre-existing in other docs files and were left untouched to keep scope minimal.
+
+## Concerns
+
+- `docs/database-guide.md`, `docs/external-services.md`, `docs/hydration-api-gaps.md`, `docs/movement-release-readiness.md`, and `docs/troubleshooting.md` still contain unrelated validator warnings.
+
+**Status:** DONE
+**Summary:** Applied minimal evergreen docs updates for Phase 2 and verified the touched docs with the validator.
+**Concerns:** Pre-existing doc validation warnings remain outside the touched files.

--- a/plans/reports/docs-260613-llm-nutrition-contracts-phase-3.md
+++ b/plans/reports/docs-260613-llm-nutrition-contracts-phase-3.md
@@ -1,0 +1,47 @@
+# Docs Impact Report: LLM Nutrition Output Contracts Phase 3
+
+**Date:** 2026-06-13
+**Scope:** docs only
+**Decision:** Docs impact is minor, but updating the top-level docs was warranted because Phase 3 changed the user-facing AI failure contract.
+
+## Current State Assessment
+
+- Phase 2 docs already covered canonical AI nutrition contracts and backend-derived calories.
+- Phase 3 adds a stricter runtime behavior: invalid structured AI output retries exactly once for meal image scan and text parse, then fails through controlled `AIOutputValidationError`.
+- Ingredient recognition keeps the unstructured `{name, confidence, category}` contract.
+- FatSecret divergence checks in text parsing now compare against backend-derived macro calories.
+
+## Changes Made
+
+- Updated [`docs/project-overview-pdr.md`](../../docs/project-overview-pdr.md) to record the validation-retry behavior in the overview, status line, and version history.
+- Updated [`docs/project-roadmap.md`](../../docs/project-roadmap.md) to mark the Vision Parser Resilience phase as including the one-retry validation contract.
+- Updated [`docs/codebase-summary.md`](../../docs/codebase-summary.md) to summarize the new validation retry behavior alongside the existing canonical nutrition contracts.
+- Regenerated `repomix-output.xml` as required by workspace documentation workflow.
+
+## Gaps Identified
+
+- Existing docs validation still reports unrelated stale references in:
+  - `docs/database-guide.md`
+  - `docs/hydration-api-gaps.md`
+  - `docs/movement-release-readiness.md`
+  - `docs/troubleshooting.md`
+  - `docs/external-services.md`
+- Those warnings are pre-existing and not caused by this phase.
+
+## Recommendations
+
+1. Keep the current docs delta as-is.
+2. Handle the validator warnings in a separate cleanup pass so this phase stays narrowly documented.
+3. If Phase 4 changes parser flow again, update the same three top-level docs rather than creating a new ad hoc note.
+
+## Metrics
+
+- Docs files updated: 3
+- Source files touched: 0
+- Test files touched: 0
+- Doc validator: passed with unrelated pre-existing warnings
+- Overall docs impact: minor
+
+## Unresolved Questions
+
+- None.

--- a/plans/reports/pm-260613-1415-llm-nutrition-contracts-phase-1.md
+++ b/plans/reports/pm-260613-1415-llm-nutrition-contracts-phase-1.md
@@ -1,0 +1,44 @@
+---
+type: pm-status-report
+date: 2026-06-13
+plan: plans/260613-1359-llm-nutrition-output-contracts
+phase: 1
+status: completed
+---
+
+# Session Report: LLM Nutrition Contracts Phase 1
+
+## Work Completed
+
+- [x] Added keyword-only `schema` support to `AIProviderPort.generate_with_vision`.
+- [x] Forwarded vision schemas through `AIModelManager.generate_with_vision`.
+- [x] Added Gemini multimodal structured-output path with `with_structured_output(schema, include_raw=True)`.
+- [x] Preserved no-schema raw JSON extraction path.
+- [x] Added provider port, manager forwarding, Gemini structured path, empty parsed output, and raw path regression tests.
+
+## Verification
+
+| Gate | Result |
+|------|--------|
+| Focused + nearby tests | 64 passed |
+| Tester subagent | DONE_WITH_CONCERNS, env-only concern |
+| Code reviewer subagent | DONE, no findings |
+| Ruff touched files | passed |
+| Mypy touched source | passed |
+| Black check touched files | passed |
+| py_compile touched source | passed |
+
+## Docs Impact
+
+Minor. Plan files updated. Project docs update deferred until the full LLM
+contract behavior ships in later phases.
+
+## Next Session
+
+1. Execute Phase 2: canonical AI nutrition contracts.
+2. Keep the earlier parser-filter workaround isolated until Phase 4 replaces it.
+3. Use `uv run` or project venv for tests; host Python is not suitable.
+
+## Unresolved Questions
+
+None.

--- a/plans/reports/pm-260613-1719-llm-nutrition-contracts-phase-2.md
+++ b/plans/reports/pm-260613-1719-llm-nutrition-contracts-phase-2.md
@@ -1,0 +1,63 @@
+---
+type: project-management
+plan: plans/260613-1359-llm-nutrition-output-contracts
+phase: 2
+status: completed
+created: "2026-06-13T17:19:00+07:00"
+---
+
+# Phase 2 Status: Canonical AI Nutrition Contracts
+
+## Summary
+
+Phase 2 completed. Canonical image/text nutrition contracts exist, legacy parser
+item-dropping is removed, and current text parse flat macro output remains
+compatible through contract normalization.
+
+## Completed Work
+
+| Area | Result |
+|------|--------|
+| Canonical contracts | Added `AINutritionMacros`, `VisionNutritionResponse`, `MealTextNutritionResponse` |
+| Image validation | Requires non-empty foods; rejects impossible `quantity_g` |
+| Text validation | Requires non-empty items; preserves display `quantity`/`unit` |
+| Text compatibility | Folds flat `protein/carbs/fat` into canonical nested `macros` |
+| Parser behavior | Invalid legacy food quantities now fail instead of partial-save filtering |
+| Calorie authority | AI `calories` ignored by nutrition contracts; backend macro-derived calories remain authority |
+| Recipe schemas | Existing structured-output schema tests still pass |
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `uv run pytest tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/domain/parsers/test_gpt_response_parser.py tests/unit/domain/parsers/test_vision_response_models.py tests/unit/infra/services/ai/test_schemas.py -q` | 65 passed |
+| `uv run pytest tests/unit/domain/ports/test_ai_provider_port.py tests/unit/infra/services/ai/test_ai_model_manager.py tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/domain/parsers/test_gpt_response_parser.py tests/unit/domain/parsers/test_vision_response_models.py tests/unit/infra/services/ai/test_schemas.py -q` | 110 passed |
+| `uv run ruff check` on touched Phase 2 files | passed |
+| `uv run mypy` on touched Phase 2 source files | passed |
+| `uv run black --check` on touched Phase 2 files | passed |
+| `uv run python -m py_compile` on touched Phase 2 source files | passed |
+
+## Review
+
+Initial review flagged runtime partial-save risk because the parser still
+filtered invalid foods before validation. Fixed in this phase. Follow-up review
+reported no blockers.
+
+## Known Repo-Wide Hygiene
+
+Full-repo checks were attempted for thoroughness but remain blocked by existing
+unrelated issues:
+
+| Check | Existing result |
+|-------|-----------------|
+| `uv run ruff check src tests` | 1924 repo-wide issues |
+| `uv run mypy src` | 719 repo-wide errors |
+| `uv run black --check src tests` | 171 files would be reformatted |
+
+## Next
+
+Proceed to Phase 3: validation retry orchestration.
+
+## Unresolved Questions
+
+None.

--- a/plans/reports/pm-260613-1746-llm-nutrition-contracts-phase-3.md
+++ b/plans/reports/pm-260613-1746-llm-nutrition-contracts-phase-3.md
@@ -1,0 +1,48 @@
+# Phase 3 PM Report: LLM Nutrition Output Contracts
+
+## Summary
+
+Phase 3 completed. Invalid structured AI nutrition output now retries exactly
+once for meal image scan and text parse flows, then fails through a controlled
+`AIOutputValidationError` path. Provider outages remain separate and are not
+retried as validation failures.
+
+## Progress
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Vision meal scan retry | Complete | Uses `VisionNutritionResponse`; invalid nutrition output retries once. |
+| Ingredient recognition regression guard | Complete | Keeps unstructured `{name, confidence, category}` contract. |
+| Text parse retry | Complete | Uses `MealTextNutritionResponse`; invalid text output retries once. |
+| FatSecret divergence guard | Complete | Compares FatSecret calories against backend-derived macro calories. |
+| API fallback mapping | Complete | Maps invalid AI output to friendly `AI_OUTPUT_INVALID` without field leaks. |
+| Plan sync | Complete | Phase 3 checklist and overview status updated. |
+
+## Validation
+
+| Command | Result |
+|---------|--------|
+| `uv run pytest tests/unit/infra/adapters/test_vision_ai_service_resilience.py tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py -q` | 21 passed |
+| Expanded Phase 1-3 AI boundary pytest slice | 155 passed |
+| Touched-file `ruff check` | Passed |
+| Touched-source `mypy` | Passed |
+| Touched-file `black --check` | Passed |
+| Touched-source `py_compile` | Passed |
+
+## Known Baseline
+
+Repo-wide quality commands still have pre-existing unrelated failures:
+
+- `uv run ruff check src tests`
+- `uv run mypy src`
+- `uv run black --check src tests`
+
+These are not introduced by Phase 3; touched-file checks passed.
+
+## Next
+
+Proceed to Phase 4: flow integration and parser replacement.
+
+## Unresolved Questions
+
+None.

--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -10,11 +10,14 @@ exception_handlers.py owns that log after route try/except blocks are removed.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from fastapi import HTTPException, status
 
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +28,8 @@ class MealTrackException(Exception):
     def __init__(
         self,
         message: str,
-        error_code: Optional[str] = None,
-        details: Optional[Dict[str, Any]] = None,
+        error_code: str | None = None,
+        details: dict[str, Any] | None = None,
     ):
         self.message = message
         self.error_code = error_code or self.__class__.__name__
@@ -127,6 +130,32 @@ def handle_exception(exc: Exception) -> HTTPException:
                 "error_code": "AI_UNAVAILABLE",
                 "message": "AI meal generation is temporarily unavailable",
                 "details": {"attempted_models": exc.attempted_models},
+            },
+        )
+
+    if isinstance(exc, AIOutputValidationError):
+        logger.warning(
+            "AI output validation failed: %s",
+            exc,
+            extra={
+                "error_code": "AI_OUTPUT_INVALID",
+                "purpose": exc.purpose,
+                "attempt_count": exc.attempt_count,
+                "validation_details": exc.validation_details,
+            },
+        )
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error_code": "AI_OUTPUT_INVALID",
+                "message": (
+                    "AI could not produce valid nutrition analysis. "
+                    "Please try a clearer photo or more specific meal description."
+                ),
+                "details": {
+                    "purpose": exc.purpose,
+                    "attempt_count": exc.attempt_count,
+                },
             },
         )
 

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -16,7 +16,13 @@ from src.app.handlers.command_handlers.meal_text_parsing_utils import (
     parse_fatsecret_nutrition,
 )
 from src.app.schemas.meal_schemas import ParsedFoodItemDto, ParseMealTextResponseDto
+from src.domain.exceptions.ai_exceptions import AIOutputValidationError
+from src.domain.model.ai.nutrition_contracts import MealTextNutritionResponse
 from src.domain.ports.meal_generation_service_port import MealGenerationServicePort
+from src.domain.services.ai_output_validation_service import (
+    build_validation_retry_prompt,
+    validate_ai_output,
+)
 from src.domain.services.emoji_validator import validate_emoji
 from src.domain.services.nutrition_calculation_service import (
     clamp_nutrition_values,
@@ -29,6 +35,8 @@ from src.domain.services.translation.deepl_text_translation_service import (
 )
 
 logger = logging.getLogger(__name__)
+PARSE_TEXT_VALIDATION_PURPOSE = "parse_text"
+MAX_VALIDATION_ATTEMPTS = 2
 
 
 def _parse_text_fatsecret_timeout_seconds() -> float:
@@ -54,6 +62,8 @@ class ParseMealTextHandler(
     async def handle(self, command: ParseMealTextCommand) -> ParseMealTextResponseDto:
         # Sanitize user input
         sanitized_text = sanitize_user_description(command.text)
+        if not sanitized_text:
+            raise ValueError("Invalid or empty meal description.")
 
         # Add refinement context if current_items provided
         if command.current_items:
@@ -68,26 +78,13 @@ class ParseMealTextHandler(
             language=command.language
         )
 
-        raw = await self._meal_generation_service.generate_meal_plan_async(
+        validated_payload, raw_payload = await self._generate_parse_text_payload(
             prompt=sanitized_text,
-            system_message=system_prompt,
-            response_type="json",
-            max_tokens=2048,
-            model_purpose="parse_text",
-            thinking_budget=0,
+            system_prompt=system_prompt,
         )
 
-        # Extract JSON from response — may be {emoji, items: [...]} or plain [...]
-        emoji = None
-        if isinstance(raw, dict):
-            emoji = validate_emoji(raw.get("emoji"))
-            parsed_items = raw.get("items", [])
-            if not isinstance(parsed_items, list):
-                parsed_items = [parsed_items]
-        elif isinstance(raw, list):
-            parsed_items = raw
-        else:
-            parsed_items = extract_json_from_response(str(raw))
+        emoji = validate_emoji(validated_payload.get("emoji"))
+        parsed_items = self._to_flat_parse_text_items(validated_payload, raw_payload)
 
         # Enhance items with USDA/FatSecret cascade lookup
         enhanced_items = []
@@ -140,6 +137,103 @@ class ParseMealTextHandler(
             total_fat=total_fat,
             emoji=emoji,
         )
+
+    async def _generate_parse_text_payload(
+        self, *, prompt: str, system_prompt: str
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        retry_system_prompt = system_prompt
+        for attempt in range(1, MAX_VALIDATION_ATTEMPTS + 1):
+            try:
+                raw = await self._meal_generation_service.generate_meal_plan_async(
+                    prompt=prompt,
+                    system_message=retry_system_prompt,
+                    response_type="json",
+                    max_tokens=2048,
+                    schema=MealTextNutritionResponse,
+                    model_purpose="parse_text",
+                    thinking_budget=0,
+                )
+                raw_payload = self._extract_parse_text_payload(raw)
+                validated_payload = validate_ai_output(
+                    raw_payload,
+                    schema=MealTextNutritionResponse,
+                    purpose=PARSE_TEXT_VALIDATION_PURPOSE,
+                    attempt_count=attempt,
+                )
+                if attempt > 1:
+                    logger.info(
+                        "[AI-OUTPUT-VALIDATION-RETRY-SUCCESS] purpose=%s attempt=%s",
+                        PARSE_TEXT_VALIDATION_PURPOSE,
+                        attempt,
+                    )
+                return validated_payload, raw_payload
+            except AIOutputValidationError as exc:
+                logger.warning(
+                    "[AI-OUTPUT-VALIDATION-FAILED] purpose=%s attempt=%s details=%s",
+                    PARSE_TEXT_VALIDATION_PURPOSE,
+                    attempt,
+                    exc.validation_details,
+                )
+                if attempt >= MAX_VALIDATION_ATTEMPTS:
+                    raise AIOutputValidationError(
+                        "Invalid AI output after validation retry",
+                        purpose=PARSE_TEXT_VALIDATION_PURPOSE,
+                        attempt_count=attempt,
+                        validation_details=exc.validation_details,
+                    ) from exc
+                retry_system_prompt = build_validation_retry_prompt(system_prompt, exc)
+
+        raise RuntimeError("Failed to parse meal text after validation retry")
+
+    def _extract_parse_text_payload(self, raw: Any) -> dict[str, Any]:
+        if isinstance(raw, dict):
+            payload = dict(raw)
+        elif isinstance(raw, list):
+            payload = {"items": raw}
+        else:
+            extracted = extract_json_from_response(str(raw))
+            payload = {"items": extracted} if isinstance(extracted, list) else extracted
+
+        if not isinstance(payload, dict):
+            raise AIOutputValidationError(
+                "Invalid AI structured output",
+                purpose=PARSE_TEXT_VALIDATION_PURPOSE,
+                attempt_count=1,
+                validation_details=["response root must be an object or item list"],
+            )
+        return payload
+
+    def _to_flat_parse_text_items(
+        self, validated_payload: dict[str, Any], _raw_payload: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        flat_items = []
+        for item in validated_payload.get("items", []):
+            macros = item.get("macros", {})
+            flat_item = {
+                "name": item.get("name"),
+                "quantity": item.get("quantity"),
+                "unit": item.get("unit"),
+                "english_unit": item.get("english_unit"),
+                "protein": macros.get("protein_g", 0.0),
+                "carbs": macros.get("carbs_g", 0.0),
+                "fat": macros.get("fat_g", 0.0),
+                "calories": self._derive_calories_from_macros(macros),
+            }
+            if item.get("quantity_g") is not None:
+                flat_item["quantity_g"] = item["quantity_g"]
+
+            flat_items.append(flat_item)
+
+        return flat_items
+
+    @staticmethod
+    def _derive_calories_from_macros(macros: dict[str, Any]) -> float:
+        protein = float(macros.get("protein_g", 0.0) or 0.0)
+        carbs = float(macros.get("carbs_g", 0.0) or 0.0)
+        fiber = float(macros.get("fiber_g", 0.0) or 0.0)
+        fat = float(macros.get("fat_g", 0.0) or 0.0)
+        digestible_carbs = max(carbs - fiber, 0.0)
+        return round(protein * 4 + digestible_carbs * 4 + fiber * 2 + fat * 9, 2)
 
     # Max ratio between FatSecret and AI estimate before rejecting FatSecret
     _FATSECRET_DIVERGENCE_THRESHOLD = 3.0
@@ -224,6 +318,9 @@ class ParseMealTextHandler(
         self, items: list[dict[str, Any]], language: str
     ) -> None:
         """Detect and batch-translate any remaining English food names using DeepL."""
+        if self._translation_service is None:
+            return
+
         english_indices = [
             i for i, item in enumerate(items) if self._is_english(item.get("name", ""))
         ]

--- a/src/domain/exceptions/ai_exceptions.py
+++ b/src/domain/exceptions/ai_exceptions.py
@@ -1,6 +1,6 @@
 """AI-related exception classes for resilience layer."""
 
-from typing import Any, List, Optional
+from typing import Any
 
 
 class AIError(Exception):
@@ -15,8 +15,8 @@ class AIUnavailableError(AIError):
     def __init__(
         self,
         message: str,
-        attempted_models: Optional[List[str]] = None,
-        last_error: Optional[str] = None,
+        attempted_models: list[str] | None = None,
+        last_error: str | None = None,
     ) -> None:
         super().__init__(message)
         self.attempted_models = attempted_models or []
@@ -37,9 +37,36 @@ class AIPartialResultError(AIError):
     def __init__(
         self,
         message: str,
-        successful: Optional[List[Any]] = None,
-        failed: Optional[List[Any]] = None,
+        successful: list[Any] | None = None,
+        failed: list[Any] | None = None,
     ) -> None:
         super().__init__(message)
         self.successful = successful or []
         self.failed = failed or []
+
+
+class AIOutputValidationError(AIError):
+    """Raised when an AI response fails the expected structured output contract."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        purpose: str,
+        attempt_count: int,
+        validation_details: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.purpose = purpose
+        self.attempt_count = attempt_count
+        self.validation_details = validation_details or []
+
+    def __str__(self) -> str:
+        parts = [
+            super().__str__(),
+            f"purpose={self.purpose}",
+            f"attempt_count={self.attempt_count}",
+        ]
+        if self.validation_details:
+            parts.append(f"validation_details={self.validation_details}")
+        return " | ".join(parts)

--- a/src/domain/model/ai/__init__.py
+++ b/src/domain/model/ai/__init__.py
@@ -2,16 +2,26 @@
 AI bounded context - Domain models for GPT/AI interactions.
 """
 
-from .gpt_response import GPTMacros, GPTFoodItem, GPTAnalysisResponse
+from .gpt_response import GPTAnalysisResponse, GPTFoodItem, GPTMacros
 from .gpt_response_errors import (
     GPTResponseError,
     GPTResponseFormatError,
-    GPTResponseValidationError,
-    GPTResponseParsingError,
     GPTResponseIncompleteError,
+    GPTResponseParsingError,
+    GPTResponseValidationError,
+)
+from .nutrition_contracts import (
+    AINutritionMacros,
+    MealTextFoodEstimate,
+    MealTextNutritionResponse,
+    VisionFoodEstimate,
+    VisionNutritionResponse,
 )
 
 __all__ = [
+    "AINutritionMacros",
+    "MealTextFoodEstimate",
+    "MealTextNutritionResponse",
     "GPTMacros",
     "GPTFoodItem",
     "GPTAnalysisResponse",
@@ -20,4 +30,6 @@ __all__ = [
     "GPTResponseValidationError",
     "GPTResponseParsingError",
     "GPTResponseIncompleteError",
+    "VisionFoodEstimate",
+    "VisionNutritionResponse",
 ]

--- a/src/domain/model/ai/gpt_response.py
+++ b/src/domain/model/ai/gpt_response.py
@@ -5,8 +5,6 @@ This module provides strongly-typed schemas for validating GPT responses,
 improving type safety and error handling in the parsing process.
 """
 
-from typing import List, Optional
-
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -52,21 +50,19 @@ class GPTAnalysisResponse(BaseModel):
     """Complete GPT analysis response structure."""
 
     dish_name: str = Field(..., description="Overall dish name or food list")
-    foods: List[GPTFoodItem] = Field(
-        ..., min_items=1, max_items=8, description="List of analyzed foods"
+    foods: list[GPTFoodItem] = Field(
+        ..., min_length=1, max_length=8, description="List of analyzed foods"
     )
     total_calories: float = Field(..., ge=0, description="Total calories")
     confidence: float = Field(..., ge=0, le=1, description="Overall confidence")
 
     # Optional fields for enhanced analysis
-    portion_adjustment: Optional[str] = Field(
-        None, description="Portion adjustment note"
-    )
-    weight_adjustment: Optional[str] = Field(None, description="Weight adjustment note")
-    ingredient_based: Optional[bool] = Field(
+    portion_adjustment: str | None = Field(None, description="Portion adjustment note")
+    weight_adjustment: str | None = Field(None, description="Weight adjustment note")
+    ingredient_based: bool | None = Field(
         None, description="Whether ingredient-based analysis"
     )
-    total_weight_grams: Optional[float] = Field(
+    total_weight_grams: float | None = Field(
         None, gt=0, description="Total weight if provided"
     )
 

--- a/src/domain/model/ai/gpt_response_errors.py
+++ b/src/domain/model/ai/gpt_response_errors.py
@@ -5,13 +5,13 @@ This module defines specific exception types for different parsing failures,
 improving error handling and debugging.
 """
 
-from typing import Optional, Dict, Any
+from typing import Any
 
 
 class GPTResponseError(Exception):
     """Base exception for all GPT response parsing errors."""
 
-    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
         super().__init__(message)
         self.details = details or {}
 

--- a/src/domain/model/ai/nutrition_contracts.py
+++ b/src/domain/model/ai/nutrition_contracts.py
@@ -1,0 +1,164 @@
+"""Canonical AI nutrition output contracts.
+
+These schemas validate AI output before it is mapped into domain nutrition
+models. They intentionally ignore AI-reported calories because calories are
+derived from backend macros.
+"""
+
+from typing import Any
+
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+from src.domain.model.nutrition import MAX_FOOD_ITEM_QUANTITY
+
+MAX_AI_FOOD_ITEMS = 8
+MAX_TEXT_PARSE_ITEMS = 20
+MAX_AI_MACRO_GRAMS = 5000.0
+
+
+def _strip_required_text(value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("must not be empty")
+    return stripped
+
+
+class AINutritionMacros(BaseModel):
+    """Macronutrients reported by AI, in grams."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    protein_g: float = Field(
+        ...,
+        ge=0,
+        le=MAX_AI_MACRO_GRAMS,
+        validation_alias=AliasChoices("protein_g", "protein"),
+        description="Protein grams",
+    )
+    carbs_g: float = Field(
+        ...,
+        ge=0,
+        le=MAX_AI_MACRO_GRAMS,
+        validation_alias=AliasChoices("carbs_g", "carbs"),
+        description="Carbohydrate grams",
+    )
+    fat_g: float = Field(
+        ...,
+        ge=0,
+        le=MAX_AI_MACRO_GRAMS,
+        validation_alias=AliasChoices("fat_g", "fat"),
+        description="Fat grams",
+    )
+    fiber_g: float = Field(
+        0.0,
+        ge=0,
+        le=MAX_AI_MACRO_GRAMS,
+        validation_alias=AliasChoices("fiber_g", "fiber"),
+        description="Fiber grams",
+    )
+    sugar_g: float = Field(
+        0.0,
+        ge=0,
+        le=MAX_AI_MACRO_GRAMS,
+        validation_alias=AliasChoices("sugar_g", "sugar"),
+        description="Sugar grams",
+    )
+
+
+class VisionFoodEstimate(BaseModel):
+    """Single food estimate extracted from an image."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(..., min_length=1, max_length=200)
+    quantity_g: float = Field(..., gt=0, le=MAX_FOOD_ITEM_QUANTITY)
+    macros: AINutritionMacros
+    confidence: float = Field(1.0, ge=0, le=1)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return _strip_required_text(value)
+
+
+class VisionNutritionResponse(BaseModel):
+    """Structured image meal-analysis response."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    dish_name: str | None = Field(None, max_length=200)
+    foods: list[VisionFoodEstimate] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_AI_FOOD_ITEMS,
+        description="Foods visible in the image",
+    )
+    confidence: float = Field(0.5, ge=0, le=1)
+
+
+class MealTextFoodEstimate(BaseModel):
+    """Single item parsed from natural-language meal text."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(..., min_length=1, max_length=200)
+    quantity: float = Field(..., gt=0, le=MAX_FOOD_ITEM_QUANTITY)
+    unit: str = Field(..., min_length=1, max_length=50)
+    english_unit: str | None = Field(None, max_length=50)
+    quantity_g: float | None = Field(None, gt=0, le=MAX_FOOD_ITEM_QUANTITY)
+    macros: AINutritionMacros
+
+    @model_validator(mode="before")
+    @classmethod
+    def fold_flat_macros(cls, data: Any) -> Any:
+        """Accept the current text prompt shape while storing canonical macros."""
+        if not isinstance(data, dict) or "macros" in data:
+            return data
+
+        flat_macros = {
+            key: data[key]
+            for key in (
+                "protein_g",
+                "protein",
+                "carbs_g",
+                "carbs",
+                "fat_g",
+                "fat",
+                "fiber_g",
+                "fiber",
+                "sugar_g",
+                "sugar",
+            )
+            if key in data
+        }
+        if flat_macros:
+            data = dict(data)
+            data["macros"] = flat_macros
+        return data
+
+    @field_validator("name", "unit", "english_unit")
+    @classmethod
+    def validate_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _strip_required_text(value)
+
+
+class MealTextNutritionResponse(BaseModel):
+    """Structured natural-language meal parse response."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    emoji: str | None = Field(None, max_length=16)
+    items: list[MealTextFoodEstimate] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_TEXT_PARSE_ITEMS,
+    )

--- a/src/domain/model/nutrition/__init__.py
+++ b/src/domain/model/nutrition/__init__.py
@@ -5,11 +5,12 @@ Nutrition bounded context - Domain models for nutritional information.
 from .food import Food
 from .macros import Macros
 from .micros import Micros
-from .nutrition import Nutrition, FoodItem
+from .nutrition import MAX_FOOD_ITEM_QUANTITY, FoodItem, Nutrition
 
 __all__ = [
     "Nutrition",
     "FoodItem",
+    "MAX_FOOD_ITEM_QUANTITY",
     "Macros",
     "Micros",
     "Food",

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from dataclasses import dataclass
 
 from .macros import Macros
 from .micros import Micros
+
+MAX_FOOD_ITEM_QUANTITY = 10000.0
 
 
 @dataclass
@@ -14,9 +15,9 @@ class FoodItem:
     quantity: float
     unit: str
     macros: Macros
-    micros: Optional[Micros] = None
+    micros: Micros | None = None
     confidence: float = 1.0  # 0.0-1.0 confidence score from AI or lookup
-    fdc_id: Optional[int] = None  # USDA FDC ID if available
+    fdc_id: int | None = None  # USDA FDC ID if available
     is_custom: bool = False  # Whether this is a custom ingredient
 
     def __post_init__(self):
@@ -27,7 +28,7 @@ class FoodItem:
             raise ValueError(
                 f"Food item name too long (max 200 chars): {len(self.name)}"
             )
-        if self.quantity <= 0 or self.quantity > 10000:
+        if self.quantity <= 0 or self.quantity > MAX_FOOD_ITEM_QUANTITY:
             raise ValueError(f"Quantity must be between 0 and 10000: {self.quantity}")
         if not 0 <= self.confidence <= 1:
             raise ValueError(f"Confidence must be between 0 and 1: {self.confidence}")
@@ -41,7 +42,7 @@ class FoodItem:
         """Derive calories from macros: P*4 + C*4 + F*9."""
         return self.macros.total_calories
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary format."""
         result = {
             "id": self.id,
@@ -65,8 +66,8 @@ class Nutrition:
     """Value object representing full nutritional information for a meal."""
 
     macros: Macros
-    micros: Optional[Micros] = None
-    food_items: Optional[List[FoodItem]] = None
+    micros: Micros | None = None
+    food_items: list[FoodItem] | None = None
     confidence_score: float = 1.0  # 0.0-1.0 overall confidence score
 
     def __post_init__(self):
@@ -88,7 +89,7 @@ class Nutrition:
         """Derive calories from macros: P*4 + C*4 + F*9."""
         return self.macros.total_calories
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary format."""
         result = {
             "calories": self.calories,

--- a/src/domain/parsers/gpt_response_parser.py
+++ b/src/domain/parsers/gpt_response_parser.py
@@ -4,7 +4,11 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+from src.domain.model.nutrition import (
+    FoodItem,
+    Macros,
+    Nutrition,
+)
 from src.domain.parsers.vision_response_models import VisionAnalyzeResponse
 from src.domain.services.emoji_validator import validate_emoji
 
@@ -80,35 +84,12 @@ class GPTResponseParser:
             ) from e
 
     def _normalize_structured_data(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Normalize structured data before validation.
-
-        Filters out food items with quantity explicitly set to 0 or negative
-        (AI sometimes returns 0), and limits to MAX_FOOD_ITEMS.
-        Foods with missing quantity field are NOT filtered - they will fail
-        validation as expected.
-        """
-        normalized_data = dict(data)
-        foods = normalized_data.get("foods")
-        if isinstance(foods, list):
-            # Filter out foods where quantity is explicitly 0 or negative
-            # (but keep foods with missing quantity - they fail validation correctly)
-            valid_foods = [
-                f for f in foods
-                if not isinstance(f, dict)
-                or "quantity" not in f
-                or (
-                    isinstance(f.get("quantity"), (int, float))
-                    and f["quantity"] > 0
-                )
-            ]
-            if len(foods) > self.MAX_FOOD_ITEMS:
-                valid_foods = valid_foods[: self.MAX_FOOD_ITEMS]
-            normalized_data["foods"] = valid_foods
-        return normalized_data
+        """Normalize structured data without repairing invalid AI food items."""
+        return dict(data)
 
     def _parse_food_items(self, data: dict[str, Any]) -> list[FoodItem]:
         """Parse food items from GPT response data."""
-        food_items = []
+        food_items: list[FoodItem] = []
         foods = data.get("foods")
         if not isinstance(foods, list):
             return food_items
@@ -131,8 +112,6 @@ class GPTResponseParser:
             )
 
             quantity = float(food_data["quantity"])
-            if quantity <= 0:
-                continue
 
             # Create FoodItem with confidence score
             confidence = 1.0  # Default confidence
@@ -140,7 +119,7 @@ class GPTResponseParser:
                 confidence = min(max(0.0, float(food_data["confidence"])), 1.0)
 
             food_item = FoodItem(
-                id=uuid.uuid4(),  # Generate UUID for editing support
+                id=str(uuid.uuid4()),  # Generate UUID for editing support
                 name=food_data["name"],
                 quantity=quantity,
                 unit=food_data["unit"],

--- a/src/domain/parsers/vision_response_models.py
+++ b/src/domain/parsers/vision_response_models.py
@@ -1,8 +1,8 @@
-"""Pydantic models for vision response validation."""
+"""Pydantic models for legacy vision response validation."""
 
-from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
 
-from pydantic import BaseModel, Field, model_validator
+from src.domain.model.nutrition import MAX_FOOD_ITEM_QUANTITY
 
 
 class MacrosResponse(BaseModel):
@@ -17,44 +17,22 @@ class FoodItemResponse(BaseModel):
     """Food item extracted from vision analysis."""
 
     name: str = Field(..., description="Food item name")
-    quantity: float = Field(..., gt=0, description="Quantity of food")
+    quantity: float = Field(
+        ..., gt=0, le=MAX_FOOD_ITEM_QUANTITY, description="Quantity of food"
+    )
     unit: str = Field(..., description="Unit of measurement")
     macros: MacrosResponse = Field(..., description="Macronutrient breakdown")
 
 
 class VisionAnalyzeResponse(BaseModel):
-    """Structured response for vision analysis."""
+    """Legacy structured response for vision analysis.
 
-    dish_name: Optional[str] = Field(None, description="Dish name")
-    foods: Optional[List[FoodItemResponse]] = Field(
-        None, max_items=8, description="List of foods"
+    Invalid AI output must fail validation here. Retry orchestration happens
+    before domain mapping, not by silently dropping invalid foods.
+    """
+
+    dish_name: str | None = Field(None, description="Dish name")
+    foods: list[FoodItemResponse] | None = Field(
+        None, max_length=8, description="List of foods"
     )
     confidence: float = Field(0.5, description="Overall confidence score")
-
-    @model_validator(mode="before")
-    @classmethod
-    def drop_zero_quantity_foods(cls, values: Any) -> Any:
-        """Strip food items with quantity <= 0 before field-level validation.
-
-        GPT occasionally returns quantity=0 for trace ingredients. Removing
-        them here prevents a ValidationError from propagating to the caller.
-        """
-        if not isinstance(values, dict):
-            return values
-        foods = values.get("foods")
-        if isinstance(foods, list):
-            values["foods"] = [
-                f for f in foods
-                if not isinstance(f, dict)
-                or "quantity" not in f  # missing field → let Pydantic reject it
-                or _coerce_quantity(f["quantity"]) > 0  # present but <= 0 → drop silently
-            ]
-        return values
-
-
-def _coerce_quantity(raw: Any) -> float:
-    """Return the numeric value of a quantity field, or 0.0 if not parseable."""
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        return 0.0

--- a/src/domain/ports/ai_provider_port.py
+++ b/src/domain/ports/ai_provider_port.py
@@ -1,7 +1,8 @@
 """Abstract interface for AI providers."""
+
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 
 class AICapability(Enum):
@@ -27,11 +28,11 @@ class AIProviderPort(ABC):
 
     @property
     @abstractmethod
-    def supported_capabilities(self) -> Set[AICapability]:
+    def supported_capabilities(self) -> set[AICapability]:
         """Set of capabilities this provider supports."""
 
     @abstractmethod
-    def get_available_models(self) -> List[str]:
+    def get_available_models(self) -> list[str]:
         """Return list of model identifiers available from this provider."""
 
     @abstractmethod
@@ -41,10 +42,10 @@ class AIProviderPort(ABC):
         prompt: str,
         system_message: str,
         response_type: str = "json",
-        max_tokens: Optional[int] = None,
-        schema: Optional[type] = None,
+        max_tokens: int | None = None,
+        schema: type | None = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Generate text completion.
 
@@ -69,9 +70,11 @@ class AIProviderPort(ABC):
         model: str,
         prompt: str,
         image_data: bytes,
-        system_message: Optional[str] = None,
+        system_message: str | None = None,
+        *,
+        schema: type | None = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Generate completion with image input.
 
@@ -80,6 +83,7 @@ class AIProviderPort(ABC):
             prompt: User prompt
             image_data: Image bytes
             system_message: Optional system instructions
+            schema: Optional Pydantic model for structured output
 
         Returns:
             Generated content as dictionary

--- a/src/domain/services/ai_output_validation_service.py
+++ b/src/domain/services/ai_output_validation_service.py
@@ -1,0 +1,76 @@
+"""Validation helpers for structured AI output contracts."""
+
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from src.domain.exceptions.ai_exceptions import AIOutputValidationError
+
+MAX_VALIDATION_DETAILS = 5
+MAX_VALIDATION_DETAIL_CHARS = 120
+
+
+def validate_ai_output(
+    payload: Any,
+    *,
+    schema: type[BaseModel],
+    purpose: str,
+    attempt_count: int,
+) -> dict[str, Any]:
+    """Validate AI payload against a Pydantic contract and return a clean dump."""
+    try:
+        model = schema.model_validate(payload)
+    except (TypeError, ValueError, ValidationError) as exc:
+        raise AIOutputValidationError(
+            "Invalid AI structured output",
+            purpose=purpose,
+            attempt_count=attempt_count,
+            validation_details=summarize_validation_error(exc),
+        ) from exc
+    return model.model_dump()
+
+
+def summarize_validation_error(exc: Exception) -> list[str]:
+    """Return compact, payload-free validation details for logs and retry prompts."""
+    if isinstance(exc, ValidationError):
+        details = []
+        for error in exc.errors()[:MAX_VALIDATION_DETAILS]:
+            location = _format_location(error.get("loc", ()))
+            message = _sanitize_detail(str(error.get("msg", "invalid value")))
+            details.append(f"{location}: {message}" if location else message)
+        return details or ["invalid structured output"]
+
+    detail = _sanitize_detail(str(exc))
+    return [detail or "invalid structured output"]
+
+
+def build_validation_retry_prompt(
+    base_prompt: str, error: AIOutputValidationError
+) -> str:
+    """Append field-specific correction context without raw payload data."""
+    details = "\n".join(f"- {detail}" for detail in error.validation_details)
+    if not details:
+        details = "- structured output did not match the required schema"
+
+    return (
+        f"{base_prompt}\n\n"
+        "Your previous structured response did not match the required schema.\n"
+        "Fix these validation issues:\n"
+        f"{details}\n"
+        "Return the full corrected response as valid JSON only."
+    )
+
+
+def _format_location(location: Any) -> str:
+    if not isinstance(location, (tuple, list)):
+        return str(location)
+    return ".".join(str(part) for part in location)
+
+
+def _sanitize_detail(detail: str) -> str:
+    sanitized = " ".join(detail.split())
+    if "input_value=" in sanitized:
+        sanitized = sanitized.split("input_value=", 1)[0].rstrip(" ,")
+    if len(sanitized) > MAX_VALIDATION_DETAIL_CHARS:
+        sanitized = f"{sanitized[:MAX_VALIDATION_DETAIL_CHARS].rstrip()}..."
+    return sanitized

--- a/src/infra/adapters/vision_ai_service.py
+++ b/src/infra/adapters/vision_ai_service.py
@@ -9,10 +9,19 @@ from urllib.request import Request, urlopen
 
 from PIL import Image
 
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
+from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
+from src.domain.services.ai_output_validation_service import (
+    build_validation_retry_prompt,
+    validate_ai_output,
+)
 from src.domain.strategies.meal_analysis_strategy import (
     AnalysisStrategyFactory,
+    IngredientIdentificationStrategy,
     MealAnalysisStrategy,
 )
 from src.infra.config.settings import get_settings
@@ -23,6 +32,8 @@ logger = logging.getLogger(__name__)
 MAX_URL_IMAGE_BYTES = 5 * 1024 * 1024
 URL_FETCH_TIMEOUT_SECONDS = 10
 ALLOWED_URL_IMAGE_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
+VISION_VALIDATION_PURPOSE = "meal_scan"
+MAX_VALIDATION_ATTEMPTS = 2
 
 
 class VisionAIService(VisionAIServicePort):
@@ -41,7 +52,7 @@ class VisionAIService(VisionAIServicePort):
     def _compress_image(self, image_bytes: bytes) -> bytes:
         """Compress image for faster upload."""
         try:
-            img = Image.open(BytesIO(image_bytes))
+            img: Image.Image = Image.open(BytesIO(image_bytes))
             w, h = img.size
 
             if (
@@ -53,7 +64,10 @@ class VisionAIService(VisionAIServicePort):
 
             if max(w, h) > 768:
                 ratio = 768 / max(w, h)
-                img = img.resize((int(w * ratio), int(h * ratio)), Image.LANCZOS)
+                img = img.resize(
+                    (int(w * ratio), int(h * ratio)),
+                    Image.Resampling.LANCZOS,
+                )
 
             if img.mode != "RGB":
                 img = img.convert("RGB")
@@ -154,6 +168,72 @@ class VisionAIService(VisionAIServicePort):
         """
         image_bytes = self._compress_image(image_bytes)
 
+        if isinstance(strategy, IngredientIdentificationStrategy):
+            return await self._analyze_without_nutrition_contract(image_bytes, strategy)
+
+        base_prompt = strategy.get_user_message()
+        prompt = base_prompt
+
+        for attempt in range(1, MAX_VALIDATION_ATTEMPTS + 1):
+            try:
+                result = await self._ai_manager.generate_with_vision(
+                    purpose=ModelPurpose.MEAL_SCAN,
+                    prompt=prompt,
+                    image_data=image_bytes,
+                    system_message=strategy.get_analysis_prompt(),
+                    max_tokens=self._max_output_tokens,
+                    schema=VisionNutritionResponse,
+                )
+                validated = validate_ai_output(
+                    result,
+                    schema=VisionNutritionResponse,
+                    purpose=VISION_VALIDATION_PURPOSE,
+                    attempt_count=attempt,
+                )
+                structured_data = self._to_legacy_vision_payload(validated)
+                if attempt > 1:
+                    logger.info(
+                        "[AI-OUTPUT-VALIDATION-RETRY-SUCCESS] "
+                        "purpose=%s strategy=%s attempt=%s",
+                        VISION_VALIDATION_PURPOSE,
+                        strategy.get_strategy_name(),
+                        attempt,
+                    )
+                return {
+                    "raw_response": json.dumps(structured_data),
+                    "structured_data": structured_data,
+                    "strategy_used": strategy.get_strategy_name(),
+                }
+            except AIOutputValidationError as exc:
+                logger.warning(
+                    "[AI-OUTPUT-VALIDATION-FAILED] purpose=%s strategy=%s attempt=%s "
+                    "details=%s",
+                    VISION_VALIDATION_PURPOSE,
+                    strategy.get_strategy_name(),
+                    attempt,
+                    exc.validation_details,
+                )
+                if attempt >= MAX_VALIDATION_ATTEMPTS:
+                    raise AIOutputValidationError(
+                        "Invalid AI output after validation retry",
+                        purpose=VISION_VALIDATION_PURPOSE,
+                        attempt_count=attempt,
+                        validation_details=exc.validation_details,
+                    ) from exc
+                prompt = build_validation_retry_prompt(base_prompt, exc)
+            except AIUnavailableError:
+                raise
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to analyze image with {strategy.get_strategy_name()}: {str(e)}"
+                ) from e
+
+        raise RuntimeError("Failed to analyze image after validation retry")
+
+    async def _analyze_without_nutrition_contract(
+        self, image_bytes: bytes, strategy: MealAnalysisStrategy
+    ) -> dict[str, Any]:
+        """Run non-nutrition vision strategies with their own response contract."""
         try:
             result = await self._ai_manager.generate_with_vision(
                 purpose=ModelPurpose.MEAL_SCAN,
@@ -162,6 +242,16 @@ class VisionAIService(VisionAIServicePort):
                 system_message=strategy.get_analysis_prompt(),
                 max_tokens=self._max_output_tokens,
             )
+            structured_data = (
+                result
+                if isinstance(result, dict)
+                else self._extract_json_from_response(str(result))
+            )
+            return {
+                "raw_response": json.dumps(structured_data),
+                "structured_data": structured_data,
+                "strategy_used": strategy.get_strategy_name(),
+            }
         except AIUnavailableError:
             raise
         except Exception as e:
@@ -169,10 +259,29 @@ class VisionAIService(VisionAIServicePort):
                 f"Failed to analyze image with {strategy.get_strategy_name()}: {str(e)}"
             ) from e
 
+    def _to_legacy_vision_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Map canonical image contract to the current parser-compatible payload."""
+        foods = []
+        for food in payload.get("foods", []):
+            macros = food.get("macros", {})
+            foods.append(
+                {
+                    "name": food.get("name"),
+                    "quantity": food.get("quantity_g"),
+                    "unit": "g",
+                    "macros": {
+                        "protein": macros.get("protein_g", 0.0),
+                        "carbs": macros.get("carbs_g", 0.0),
+                        "fat": macros.get("fat_g", 0.0),
+                    },
+                    "confidence": food.get("confidence", 1.0),
+                }
+            )
+
         return {
-            "raw_response": json.dumps(result),
-            "structured_data": result,
-            "strategy_used": strategy.get_strategy_name(),
+            "dish_name": payload.get("dish_name"),
+            "foods": foods,
+            "confidence": payload.get("confidence", 0.5),
         }
 
     async def analyze_by_url_with_strategy(

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -5,7 +5,10 @@ import threading
 from enum import Enum
 from typing import Any, Optional
 
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
 from src.domain.ports.ai_provider_port import AICapability
 from src.observability import log_event
 from src.infra.services.ai.provider_circuit_breaker import (
@@ -182,6 +185,8 @@ class AIModelManager:
 
                 return result
 
+            except AIOutputValidationError:
+                raise
             except Exception as e:
                 last_error = str(e)
                 error_code = provider.extract_error_code(e)
@@ -218,7 +223,9 @@ class AIModelManager:
                 )
             return None
         except Exception as e:
-            logger.warning("[AI-CACHE-LOOKUP-FAILED] cache_type=%s error=%s", cache_type, e)
+            logger.warning(
+                "[AI-CACHE-LOOKUP-FAILED] cache_type=%s error=%s", cache_type, e
+            )
             return None
 
     async def generate_with_vision(
@@ -227,6 +234,8 @@ class AIModelManager:
         prompt: str,
         image_data: bytes,
         system_message: str | None = None,
+        *,
+        schema: type | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Generate with vision, with automatic fallback."""
@@ -255,6 +264,7 @@ class AIModelManager:
                     prompt=prompt,
                     image_data=image_data,
                     system_message=system_message,
+                    schema=schema,
                     purpose_hint=purpose.value,  # NEW
                     **kwargs,
                 )
@@ -262,6 +272,8 @@ class AIModelManager:
                 self._circuit_breaker.record_success(model)
                 return result
 
+            except AIOutputValidationError:
+                raise
             except Exception as e:
                 last_error = str(e)
                 error_code = provider.extract_error_code(e)

--- a/src/infra/services/ai/providers/gemini_provider.py
+++ b/src/infra/services/ai/providers/gemini_provider.py
@@ -1,12 +1,16 @@
 """Gemini implementation of AIProviderPort."""
+
 import asyncio
 import logging
 import re
 from typing import Any
 
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from pydantic import ValidationError
 
+from src.domain.exceptions.ai_exceptions import AIOutputValidationError
 from src.domain.ports.ai_provider_port import AICapability, AIProviderPort
+from src.domain.services.ai_output_validation_service import summarize_validation_error
 from src.infra.adapters.ai_json_utils import (
     extract_json as extract_ai_json,
 )
@@ -21,14 +25,14 @@ MODEL_PURPOSE_MAP = {
 }
 
 _PURPOSE_HINT_MAP: dict[str, GeminiModelPurpose] = {
-    "recipe":          GeminiModelPurpose.RECIPE,
-    "barcode":         GeminiModelPurpose.BARCODE,
-    "meal_names":      GeminiModelPurpose.MEAL_NAMES,
-    "discovery":       GeminiModelPurpose.MEAL_NAMES,
-    "parse_text":      GeminiModelPurpose.GENERAL,
+    "recipe": GeminiModelPurpose.RECIPE,
+    "barcode": GeminiModelPurpose.BARCODE,
+    "meal_names": GeminiModelPurpose.MEAL_NAMES,
+    "discovery": GeminiModelPurpose.MEAL_NAMES,
+    "parse_text": GeminiModelPurpose.GENERAL,
     "ingredient_scan": GeminiModelPurpose.GENERAL,
-    "meal_scan":       GeminiModelPurpose.GENERAL,
-    "general":         GeminiModelPurpose.GENERAL,
+    "meal_scan": GeminiModelPurpose.GENERAL,
+    "general": GeminiModelPurpose.GENERAL,
 }
 
 
@@ -77,7 +81,7 @@ class GeminiProvider(AIProviderPort):
         if not schema and response_type == "json":
             response_mime_type = "application/json"
 
-        extra_kwargs = {}
+        extra_kwargs: dict[str, Any] = {}
         if cache_name:
             extra_kwargs["cached_content"] = cache_name
 
@@ -90,7 +94,7 @@ class GeminiProvider(AIProviderPort):
         )
 
         # When using explicit cache, system message is already in cache — omit it to avoid duplication errors
-        messages = []
+        messages: list[BaseMessage] = []
         if cache_name:
             # system content is already in the Gemini cache — omit to avoid 400 error
             pass
@@ -100,10 +104,23 @@ class GeminiProvider(AIProviderPort):
 
         if schema:
             llm_structured = llm.with_structured_output(schema, include_raw=True)
-            result = await asyncio.to_thread(llm_structured.invoke, messages)
+            try:
+                result = await asyncio.to_thread(llm_structured.invoke, messages)
+            except (ValueError, ValidationError) as exc:
+                raise AIOutputValidationError(
+                    "Invalid AI structured output",
+                    purpose=purpose_hint or "general",
+                    attempt_count=1,
+                    validation_details=summarize_validation_error(exc),
+                ) from exc
             parsed = result.get("parsed") if isinstance(result, dict) else result
             if parsed is None:
-                raise ValueError("Structured output returned None")
+                raise AIOutputValidationError(
+                    "Invalid AI structured output",
+                    purpose=purpose_hint or "general",
+                    attempt_count=1,
+                    validation_details=["structured output returned empty result"],
+                )
             if hasattr(parsed, "model_dump"):
                 return parsed.model_dump()
             return dict(parsed)
@@ -121,7 +138,9 @@ class GeminiProvider(AIProviderPort):
         prompt: str,
         image_data: bytes,
         system_message: str | None = None,
-        purpose_hint: str | None = None,   # NEW
+        purpose_hint: str | None = None,  # NEW
+        *,
+        schema: type | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Generate with image input."""
@@ -141,7 +160,7 @@ class GeminiProvider(AIProviderPort):
         image_b64 = base64.b64encode(image_data).decode("utf-8")
         image_url = f"data:image/jpeg;base64,{image_b64}"
 
-        messages = []
+        messages: list[BaseMessage] = []
         if system_message:
             messages.append(SystemMessage(content=system_message))
 
@@ -153,6 +172,31 @@ class GeminiProvider(AIProviderPort):
                 ]
             )
         )
+
+        if schema:
+            llm_structured = llm.with_structured_output(schema, include_raw=True)
+            try:
+                result = await asyncio.to_thread(llm_structured.invoke, messages)
+            except (ValueError, ValidationError) as exc:
+                raise AIOutputValidationError(
+                    "Invalid AI structured output",
+                    purpose=purpose_hint or "meal_scan",
+                    attempt_count=1,
+                    validation_details=summarize_validation_error(exc),
+                ) from exc
+            parsed = result.get("parsed") if isinstance(result, dict) else result
+            if parsed is None:
+                raise AIOutputValidationError(
+                    "Invalid AI structured output",
+                    purpose=purpose_hint or "meal_scan",
+                    attempt_count=1,
+                    validation_details=[
+                        "structured vision output returned empty result"
+                    ],
+                )
+            if hasattr(parsed, "model_dump"):
+                return parsed.model_dump()
+            return dict(parsed)
 
         response = await asyncio.to_thread(llm.invoke, messages)
         return self._extract_json(response.content)

--- a/tests/unit/api/test_exceptions_unexpected.py
+++ b/tests/unit/api/test_exceptions_unexpected.py
@@ -3,7 +3,10 @@
 from fastapi import HTTPException, status
 
 from src.api.exceptions import handle_exception
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
 
 
 def test_handle_exception_unexpected_returns_500():
@@ -34,3 +37,24 @@ def test_handle_exception_ai_unavailable_returns_503_without_provider_error():
         "attempted_models": ["gemini-2.5-flash-lite", "gemini-2.5-flash"],
     }
     assert "RESOURCE_EXHAUSTED" not in str(exc.detail)
+
+
+def test_handle_exception_ai_output_validation_returns_422_without_field_details():
+    exc = handle_exception(
+        AIOutputValidationError(
+            "Invalid AI output after validation retry",
+            purpose="meal_scan",
+            attempt_count=2,
+            validation_details=["foods.0.quantity_g: Input should be <= 10000"],
+        )
+    )
+
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc.detail["error_code"] == "AI_OUTPUT_INVALID"
+    assert "clearer photo" in exc.detail["message"]
+    assert exc.detail["details"] == {
+        "purpose": "meal_scan",
+        "attempt_count": 2,
+    }
+    assert "quantity_g" not in str(exc.detail)

--- a/tests/unit/domain/exceptions/test_ai_exceptions.py
+++ b/tests/unit/domain/exceptions/test_ai_exceptions.py
@@ -1,5 +1,6 @@
 from src.domain.exceptions.ai_exceptions import (
     AIError,
+    AIOutputValidationError,
     AIPartialResultError,
     AIUnavailableError,
 )
@@ -56,3 +57,21 @@ def test_ai_partial_result_error_default_values():
     err = AIPartialResultError("partial")
     assert err.successful == []
     assert err.failed == []
+
+
+def test_ai_output_validation_error_stores_sanitized_context():
+    err = AIOutputValidationError(
+        "Invalid AI output",
+        purpose="meal_scan",
+        attempt_count=2,
+        validation_details=["foods.0.quantity_g: Input should be <= 10000"],
+    )
+
+    assert isinstance(err, AIError)
+    assert err.purpose == "meal_scan"
+    assert err.attempt_count == 2
+    assert err.validation_details == ["foods.0.quantity_g: Input should be <= 10000"]
+    assert str(err) == (
+        "Invalid AI output | purpose=meal_scan | attempt_count=2 | "
+        "validation_details=['foods.0.quantity_g: Input should be <= 10000']"
+    )

--- a/tests/unit/domain/model/ai/test_nutrition_contracts.py
+++ b/tests/unit/domain/model/ai/test_nutrition_contracts.py
@@ -1,0 +1,193 @@
+"""Tests for canonical AI nutrition output contracts."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.domain.model.ai.nutrition_contracts import (
+    AINutritionMacros,
+    MealTextNutritionResponse,
+    VisionNutritionResponse,
+)
+
+
+def _valid_macros() -> dict[str, float]:
+    return {
+        "protein_g": 35.0,
+        "carbs_g": 42.0,
+        "fat_g": 12.0,
+        "fiber_g": 4.0,
+        "sugar_g": 3.0,
+    }
+
+
+class TestAINutritionMacros:
+    def test_accepts_macro_grams(self):
+        macros = AINutritionMacros.model_validate(_valid_macros())
+
+        assert macros.protein_g == pytest.approx(35.0)
+        assert macros.fiber_g == pytest.approx(4.0)
+        assert macros.sugar_g == pytest.approx(3.0)
+
+    def test_defaults_optional_fiber_and_sugar_to_zero(self):
+        macros = AINutritionMacros.model_validate(
+            {"protein_g": 10.0, "carbs_g": 20.0, "fat_g": 5.0}
+        )
+
+        assert macros.fiber_g == pytest.approx(0.0)
+        assert macros.sugar_g == pytest.approx(0.0)
+
+    def test_rejects_negative_macros(self):
+        with pytest.raises(ValidationError):
+            AINutritionMacros.model_validate(
+                {"protein_g": -1.0, "carbs_g": 20.0, "fat_g": 5.0}
+            )
+
+
+class TestVisionNutritionResponse:
+    def test_accepts_realistic_food_quantities(self):
+        response = VisionNutritionResponse.model_validate(
+            {
+                "dish_name": "Chicken rice bowl",
+                "foods": [
+                    {
+                        "name": "Grilled chicken",
+                        "quantity_g": 150.0,
+                        "macros": _valid_macros(),
+                        "confidence": 0.92,
+                    }
+                ],
+                "confidence": 0.88,
+                "calories": 9999,
+            }
+        )
+
+        assert response.dish_name == "Chicken rice bowl"
+        assert response.foods[0].quantity_g == pytest.approx(150.0)
+        assert response.foods[0].macros.protein_g == pytest.approx(35.0)
+        assert "calories" not in response.model_dump()
+
+    def test_rejects_impossible_quantity_g(self):
+        with pytest.raises(ValidationError):
+            VisionNutritionResponse.model_validate(
+                {
+                    "foods": [
+                        {
+                            "name": "Rice",
+                            "quantity_g": 150000.0,
+                            "macros": _valid_macros(),
+                        }
+                    ]
+                }
+            )
+
+    def test_rejects_empty_food_name(self):
+        with pytest.raises(ValidationError):
+            VisionNutritionResponse.model_validate(
+                {
+                    "foods": [
+                        {
+                            "name": " ",
+                            "quantity_g": 120.0,
+                            "macros": _valid_macros(),
+                        }
+                    ]
+                }
+            )
+
+    def test_rejects_more_than_eight_foods(self):
+        with pytest.raises(ValidationError):
+            VisionNutritionResponse.model_validate(
+                {
+                    "foods": [
+                        {
+                            "name": f"Food {index}",
+                            "quantity_g": 10.0,
+                            "macros": _valid_macros(),
+                        }
+                        for index in range(9)
+                    ]
+                }
+            )
+
+    def test_rejects_empty_foods(self):
+        with pytest.raises(ValidationError):
+            VisionNutritionResponse.model_validate({"foods": []})
+
+    def test_rejects_missing_foods(self):
+        with pytest.raises(ValidationError):
+            VisionNutritionResponse.model_validate({"dish_name": "Unknown meal"})
+
+
+class TestMealTextNutritionResponse:
+    def test_accepts_display_quantity_unit_and_optional_quantity_g(self):
+        response = MealTextNutritionResponse.model_validate(
+            {
+                "emoji": "🍜",
+                "items": [
+                    {
+                        "name": "Pho",
+                        "quantity": 1.0,
+                        "unit": "bowl",
+                        "english_unit": "bowl",
+                        "quantity_g": 550.0,
+                        "macros": _valid_macros(),
+                        "calories": 9999,
+                    }
+                ],
+            }
+        )
+
+        assert response.emoji == "🍜"
+        assert response.items[0].quantity == pytest.approx(1.0)
+        assert response.items[0].unit == "bowl"
+        assert response.items[0].quantity_g == pytest.approx(550.0)
+        assert "calories" not in response.model_dump()["items"][0]
+
+    def test_accepts_missing_quantity_g_for_display_only_items(self):
+        response = MealTextNutritionResponse.model_validate(
+            {
+                "items": [
+                    {
+                        "name": "Egg",
+                        "quantity": 2.0,
+                        "unit": "piece",
+                        "macros": _valid_macros(),
+                    }
+                ]
+            }
+        )
+
+        assert response.items[0].quantity_g is None
+
+    def test_folds_current_flat_macro_shape_into_canonical_macros(self):
+        response = MealTextNutritionResponse.model_validate(
+            {
+                "items": [
+                    {
+                        "name": "Eggs",
+                        "quantity": 2.0,
+                        "unit": "large",
+                        "english_unit": "large",
+                        "protein": 12.6,
+                        "carbs": 0.7,
+                        "fat": 9.5,
+                        "calories": 144,
+                    }
+                ]
+            }
+        )
+
+        item = response.items[0]
+        assert item.macros.protein_g == pytest.approx(12.6)
+        assert item.macros.carbs_g == pytest.approx(0.7)
+        assert item.macros.fat_g == pytest.approx(9.5)
+        assert "protein" not in item.model_dump()
+        assert "calories" not in item.model_dump()
+
+    def test_rejects_empty_items(self):
+        with pytest.raises(ValidationError):
+            MealTextNutritionResponse.model_validate({"items": []})
+
+    def test_rejects_malformed_items(self):
+        with pytest.raises(ValidationError):
+            MealTextNutritionResponse.model_validate({"items": {"name": "Pho"}})

--- a/tests/unit/domain/parsers/test_gpt_response_parser.py
+++ b/tests/unit/domain/parsers/test_gpt_response_parser.py
@@ -2,9 +2,11 @@
 
 import pytest
 
+from src.domain.parsers.gpt_response_parser import GPTResponseParsingError
+
 
 class TestGPTResponseParserFoodLimit:
-    def test_caps_food_items_to_max(self, gpt_parser):
+    def test_rejects_food_items_over_max(self, gpt_parser):
         foods = [
             {
                 "name": f"Food {i}",
@@ -24,16 +26,8 @@ class TestGPTResponseParserFoodLimit:
             }
         }
 
-        nutrition = gpt_parser.parse_to_nutrition(gpt_response)
-
-        assert nutrition.food_items is not None
-        assert len(nutrition.food_items) == 8
-        assert [item.name for item in nutrition.food_items] == [
-            f"Food {i}" for i in range(8)
-        ]
-        assert nutrition.macros.protein == pytest.approx(8.0)
-        assert nutrition.macros.carbs == pytest.approx(16.0)
-        assert nutrition.macros.fat == pytest.approx(24.0)
+        with pytest.raises(GPTResponseParsingError):
+            gpt_parser.parse_to_nutrition(gpt_response)
 
 
 class TestGPTResponseParserDishNameCompatibility:
@@ -140,8 +134,8 @@ class TestGPTResponseParserStrictSchemaMode:
 
 
 class TestGPTResponseParserZeroQuantity:
-    def test_filters_out_zero_quantity_food_items(self, gpt_parser):
-        """AI sometimes returns quantity=0, which should be filtered out."""
+    def test_rejects_zero_quantity_food_items(self, gpt_parser):
+        """AI quantity=0 should fail validation instead of producing partial meals."""
         gpt_response = {
             "structured_data": {
                 "dish_name": "Mixed Plate",
@@ -169,19 +163,11 @@ class TestGPTResponseParserZeroQuantity:
             }
         }
 
-        nutrition = gpt_parser.parse_to_nutrition(gpt_response)
+        with pytest.raises(GPTResponseParsingError):
+            gpt_parser.parse_to_nutrition(gpt_response)
 
-        assert nutrition.food_items is not None
-        assert len(nutrition.food_items) == 2
-        assert nutrition.food_items[0].name == "Valid Food"
-        assert nutrition.food_items[1].name == "Another Valid Food"
-        # Macros should only include valid foods
-        assert nutrition.macros.protein == pytest.approx(18.0)
-        assert nutrition.macros.carbs == pytest.approx(35.0)
-        assert nutrition.macros.fat == pytest.approx(8.0)
-
-    def test_filters_out_negative_quantity_food_items(self, gpt_parser):
-        """Negative quantities should also be filtered out."""
+    def test_rejects_negative_quantity_food_items(self, gpt_parser):
+        """Negative quantities should fail validation."""
         gpt_response = {
             "structured_data": {
                 "dish_name": "Test Meal",
@@ -203,8 +189,31 @@ class TestGPTResponseParserZeroQuantity:
             }
         }
 
-        nutrition = gpt_parser.parse_to_nutrition(gpt_response)
+        with pytest.raises(GPTResponseParsingError):
+            gpt_parser.parse_to_nutrition(gpt_response)
 
-        assert nutrition.food_items is not None
-        assert len(nutrition.food_items) == 1
-        assert nutrition.food_items[0].name == "Valid Food"
+    def test_rejects_over_max_quantity_food_items(self, gpt_parser):
+        """Impossible AI quantities should fail validation."""
+        gpt_response = {
+            "structured_data": {
+                "dish_name": "Mixed Plate",
+                "foods": [
+                    {
+                        "name": "Valid Food",
+                        "quantity": 100,
+                        "unit": "g",
+                        "macros": {"protein": 10, "carbs": 20, "fat": 5},
+                    },
+                    {
+                        "name": "Impossible Quantity",
+                        "quantity": 150000,
+                        "unit": "g",
+                        "macros": {"protein": 500, "carbs": 1000, "fat": 200},
+                    },
+                ],
+                "confidence": 0.9,
+            }
+        }
+
+        with pytest.raises(GPTResponseParsingError):
+            gpt_parser.parse_to_nutrition(gpt_response)

--- a/tests/unit/domain/parsers/test_vision_response_models.py
+++ b/tests/unit/domain/parsers/test_vision_response_models.py
@@ -123,71 +123,135 @@ def test_out_of_range_confidence_is_allowed_for_parser_clamping():
     assert result.confidence == pytest.approx(1.2)
 
 
-def test_zero_float_quantity_is_silently_dropped():
-    """GPT sometimes returns quantity=0.0 for trace ingredients — must not raise."""
+def test_zero_float_quantity_fails_validation():
+    """Invalid AI output must fail validation instead of silently dropping foods."""
     payload = {
         "foods": [
-            {"name": "Rice", "quantity": 1.0, "unit": "cup", "macros": {"protein": 3, "carbs": 45, "fat": 0}},
-            {"name": "Sauce", "quantity": 0.0, "unit": "tbsp", "macros": {"protein": 0, "carbs": 0, "fat": 0}},
+            {
+                "name": "Rice",
+                "quantity": 1.0,
+                "unit": "cup",
+                "macros": {"protein": 3, "carbs": 45, "fat": 0},
+            },
+            {
+                "name": "Sauce",
+                "quantity": 0.0,
+                "unit": "tbsp",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
         ]
     }
 
-    result = VisionAnalyzeResponse.model_validate(payload)
-
-    assert len(result.foods) == 1
-    assert result.foods[0].name == "Rice"
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(payload)
 
 
-def test_zero_integer_quantity_is_silently_dropped():
+def test_zero_integer_quantity_fails_validation():
     payload = {
         "foods": [
-            {"name": "Rice", "quantity": 200, "unit": "g", "macros": {"protein": 4, "carbs": 40, "fat": 1}},
-            {"name": "Ghost", "quantity": 0, "unit": "g", "macros": {"protein": 0, "carbs": 0, "fat": 0}},
+            {
+                "name": "Rice",
+                "quantity": 200,
+                "unit": "g",
+                "macros": {"protein": 4, "carbs": 40, "fat": 1},
+            },
+            {
+                "name": "Ghost",
+                "quantity": 0,
+                "unit": "g",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
         ]
     }
 
-    result = VisionAnalyzeResponse.model_validate(payload)
-
-    assert len(result.foods) == 1
-    assert result.foods[0].name == "Rice"
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(payload)
 
 
-def test_negative_quantity_is_silently_dropped():
+def test_negative_quantity_fails_validation():
     payload = {
         "foods": [
-            {"name": "Rice", "quantity": 200, "unit": "g", "macros": {"protein": 4, "carbs": 40, "fat": 1}},
-            {"name": "Bad", "quantity": -1.0, "unit": "g", "macros": {"protein": 0, "carbs": 0, "fat": 0}},
+            {
+                "name": "Rice",
+                "quantity": 200,
+                "unit": "g",
+                "macros": {"protein": 4, "carbs": 40, "fat": 1},
+            },
+            {
+                "name": "Bad",
+                "quantity": -1.0,
+                "unit": "g",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
         ]
     }
 
-    result = VisionAnalyzeResponse.model_validate(payload)
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(payload)
 
-    assert len(result.foods) == 1
 
-
-def test_non_numeric_quantity_is_silently_dropped():
-    """String quantity that can't be parsed as positive float is dropped."""
+def test_non_numeric_quantity_fails_validation():
+    """String quantity that can't be parsed as positive float must fail."""
     payload = {
         "foods": [
-            {"name": "Rice", "quantity": 200, "unit": "g", "macros": {"protein": 4, "carbs": 40, "fat": 1}},
-            {"name": "Bad", "quantity": "unknown", "unit": "g", "macros": {"protein": 0, "carbs": 0, "fat": 0}},
+            {
+                "name": "Rice",
+                "quantity": 200,
+                "unit": "g",
+                "macros": {"protein": 4, "carbs": 40, "fat": 1},
+            },
+            {
+                "name": "Bad",
+                "quantity": "unknown",
+                "unit": "g",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
         ]
     }
 
-    result = VisionAnalyzeResponse.model_validate(payload)
-
-    assert len(result.foods) == 1
-    assert result.foods[0].name == "Rice"
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(payload)
 
 
-def test_all_zero_quantity_foods_results_in_empty_list():
+def test_over_max_quantity_fails_validation():
     payload = {
         "foods": [
-            {"name": "A", "quantity": 0.0, "unit": "g", "macros": {"protein": 0, "carbs": 0, "fat": 0}},
-            {"name": "B", "quantity": 0, "unit": "g", "macros": {"protein": 0, "carbs": 0, "fat": 0}},
+            {
+                "name": "Rice",
+                "quantity": 200,
+                "unit": "g",
+                "macros": {"protein": 4, "carbs": 40, "fat": 1},
+            },
+            {
+                "name": "Bad",
+                "quantity": 150000,
+                "unit": "g",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
         ]
     }
 
-    result = VisionAnalyzeResponse.model_validate(payload)
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(payload)
 
-    assert result.foods == []
+
+def test_all_zero_quantity_foods_fails_validation():
+    payload = {
+        "foods": [
+            {
+                "name": "A",
+                "quantity": 0.0,
+                "unit": "g",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
+            {
+                "name": "B",
+                "quantity": 0,
+                "unit": "g",
+                "macros": {"protein": 0, "carbs": 0, "fat": 0},
+            },
+        ]
+    }
+
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(payload)

--- a/tests/unit/domain/ports/test_ai_provider_port.py
+++ b/tests/unit/domain/ports/test_ai_provider_port.py
@@ -1,6 +1,9 @@
-import pytest
+import inspect
 from abc import ABC
-from src.domain.ports.ai_provider_port import AIProviderPort, AICapability
+
+import pytest
+
+from src.domain.ports.ai_provider_port import AICapability, AIProviderPort
 
 
 def test_ai_provider_port_is_abstract():
@@ -13,6 +16,13 @@ def test_ai_capability_enum_values():
     assert AICapability.TEXT_GENERATION.value == "text_generation"
     assert AICapability.VISION.value == "vision"
     assert AICapability.STRUCTURED_OUTPUT.value == "structured_output"
+
+
+def test_generate_with_vision_accepts_structured_output_schema():
+    signature = inspect.signature(AIProviderPort.generate_with_vision)
+
+    assert "schema" in signature.parameters
+    assert signature.parameters["schema"].default is None
 
 
 class ConcreteProvider(AIProviderPort):
@@ -32,7 +42,9 @@ class ConcreteProvider(AIProviderPort):
     async def generate(self, model, prompt, system_message, **kwargs):
         return {"result": "test"}
 
-    async def generate_with_vision(self, model, prompt, image_data, **kwargs):
+    async def generate_with_vision(
+        self, model, prompt, image_data, system_message=None, *, schema=None, **kwargs
+    ):
         raise NotImplementedError("Vision not supported")
 
 

--- a/tests/unit/domain/services/test_ai_output_validation_service.py
+++ b/tests/unit/domain/services/test_ai_output_validation_service.py
@@ -1,0 +1,72 @@
+import pytest
+
+from src.domain.exceptions.ai_exceptions import AIOutputValidationError
+from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
+from src.domain.services.ai_output_validation_service import (
+    build_validation_retry_prompt,
+    validate_ai_output,
+)
+
+
+def test_validate_ai_output_returns_contract_dump():
+    payload = {
+        "dish_name": "Rice bowl",
+        "foods": [
+            {
+                "name": "rice",
+                "quantity_g": 180,
+                "macros": {"protein": 4, "carbs": 50, "fat": 1},
+            }
+        ],
+    }
+
+    result = validate_ai_output(
+        payload,
+        schema=VisionNutritionResponse,
+        purpose="meal_scan",
+        attempt_count=1,
+    )
+
+    assert result["foods"][0]["quantity_g"] == pytest.approx(180)
+    assert "calories" not in result
+
+
+def test_validate_ai_output_raises_sanitized_error_details():
+    payload = {
+        "foods": [
+            {
+                "name": "rice",
+                "quantity_g": 150000,
+                "macros": {"protein": 4, "carbs": 50, "fat": 1},
+            }
+        ],
+    }
+
+    with pytest.raises(AIOutputValidationError) as exc_info:
+        validate_ai_output(
+            payload,
+            schema=VisionNutritionResponse,
+            purpose="meal_scan",
+            attempt_count=1,
+        )
+
+    assert exc_info.value.purpose == "meal_scan"
+    assert exc_info.value.attempt_count == 1
+    assert exc_info.value.validation_details
+    assert "foods.0.quantity_g" in exc_info.value.validation_details[0]
+    assert "150000" not in exc_info.value.validation_details[0]
+
+
+def test_build_validation_retry_prompt_uses_compact_correction_context():
+    error = AIOutputValidationError(
+        "Invalid AI output",
+        purpose="meal_scan",
+        attempt_count=1,
+        validation_details=["foods.0.quantity_g: Input should be <= 10000"],
+    )
+
+    prompt = build_validation_retry_prompt("Analyze this image.", error)
+
+    assert prompt.startswith("Analyze this image.")
+    assert "Return the full corrected response" in prompt
+    assert "foods.0.quantity_g" in prompt

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -5,34 +5,56 @@ from src.app.commands.meal.parse_meal_text_command import ParseMealTextCommand
 from src.app.handlers.command_handlers.parse_meal_text_handler import (
     ParseMealTextHandler,
 )
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
+from src.domain.model.ai.nutrition_contracts import MealTextNutritionResponse
 from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
 
 
 class _FakeMealGenerationService:
-    def __init__(self):
+    def __init__(self, responses=None):
         self.call_kwargs = None
+        self.calls = []
+        self._responses = list(responses) if responses is not None else None
 
     async def generate_meal_plan_async(self, **kwargs):
         self.call_kwargs = kwargs
-        return {
-            "items": [
-                {
-                    "name": "Pho bowl",
-                    "quantity": 1,
-                    "unit": "one very full noodle bowl",
-                    "english_unit": "one very full noodle bowl",
-                    "calories": 560,
-                    "protein": 30,
-                    "carbs": 80,
-                    "fat": 12,
-                }
-            ]
-        }
+        self.calls.append(kwargs)
+        if self._responses is not None:
+            response = self._responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+        return _valid_parse_text_response()
+
+
+def _valid_parse_text_response():
+    return {
+        "items": [
+            {
+                "name": "Pho bowl",
+                "quantity": 1,
+                "unit": "one very full noodle bowl",
+                "english_unit": "one very full noodle bowl",
+                "calories": 560,
+                "protein": 30,
+                "carbs": 80,
+                "fat": 12,
+            }
+        ]
+    }
 
 
 class _FakeFatSecretService:
     async def search_foods(self, *args, **kwargs):
         return []
+
+
+class _HighCalorieFatSecretService:
+    async def search_foods(self, *args, **kwargs):
+        return [{"food_name": "Pho concentrate"}]
 
 
 @pytest.mark.asyncio
@@ -75,3 +97,148 @@ async def test_parse_text_unit_stays_compatible_with_prompt_manual_save():
     }
 
     assert CreateManualMealFromFoodsRequest.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_parse_text_retries_invalid_ai_output_once():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Pho bowl",
+                        "quantity": 150000,
+                        "unit": "bowl",
+                        "protein": 30,
+                        "carbs": 80,
+                        "fat": 12,
+                    }
+                ]
+            },
+            _valid_parse_text_response(),
+        ]
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_FakeFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="1 bowl pho", user_id="user-1", language="en")
+    )
+
+    assert len(meal_generation_service.calls) == 2
+    assert meal_generation_service.calls[0]["schema"] is MealTextNutritionResponse
+    assert meal_generation_service.calls[1]["schema"] is MealTextNutritionResponse
+    assert (
+        "Return the full corrected response"
+        in meal_generation_service.calls[1]["system_message"]
+    )
+    assert "items.0.quantity" in meal_generation_service.calls[1]["system_message"]
+    assert response.items[0].name == "Pho bowl"
+    assert response.items[0].protein == 30
+    assert response.total_carbs == 80
+
+
+@pytest.mark.asyncio
+async def test_parse_text_raises_controlled_error_after_retry_failure():
+    invalid = {
+        "items": [
+            {
+                "name": "Pho bowl",
+                "quantity": 150000,
+                "unit": "bowl",
+                "protein": 30,
+                "carbs": 80,
+                "fat": 12,
+            }
+        ]
+    }
+    meal_generation_service = _FakeMealGenerationService(responses=[invalid, invalid])
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_FakeFatSecretService(),
+    )
+
+    with pytest.raises(AIOutputValidationError) as exc_info:
+        await handler.handle(
+            ParseMealTextCommand(text="1 bowl pho", user_id="user-1", language="en")
+        )
+
+    assert len(meal_generation_service.calls) == 2
+    assert exc_info.value.purpose == "parse_text"
+    assert exc_info.value.attempt_count == 2
+    assert "items.0.quantity" in exc_info.value.validation_details[0]
+
+
+@pytest.mark.asyncio
+async def test_parse_text_does_not_retry_provider_outage():
+    unavailable = AIUnavailableError(
+        "All parse text models failed",
+        attempted_models=["gemini-2.5-flash-lite", "gemini-2.5-flash"],
+        last_error="503 UNAVAILABLE",
+    )
+    meal_generation_service = _FakeMealGenerationService(responses=[unavailable])
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_FakeFatSecretService(),
+    )
+
+    with pytest.raises(AIUnavailableError):
+        await handler.handle(
+            ParseMealTextCommand(text="1 bowl pho", user_id="user-1", language="en")
+        )
+
+    assert len(meal_generation_service.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_text_rejects_fatsecret_using_backend_derived_calories(
+    monkeypatch,
+):
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Pho bowl",
+                        "quantity": 1,
+                        "unit": "bowl",
+                        "english_unit": "bowl",
+                        "protein": 10,
+                        "carbs": 10,
+                        "fat": 0,
+                    }
+                ]
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.parse_meal_text_handler."
+        "parse_fatsecret_nutrition",
+        lambda _food: {"calories": 1000, "protein": 0, "carbs": 0, "fat": 100},
+    )
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.parse_meal_text_handler."
+        "scale_per_100g_nutrition",
+        lambda *args, **kwargs: {
+            "calories": 1000,
+            "protein": 0,
+            "carbs": 0,
+            "fat": 100,
+        },
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_HighCalorieFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="1 bowl pho", user_id="user-1", language="en")
+    )
+    item = response.items[0]
+
+    assert item.data_source == "ai_estimate"
+    assert item.protein == 10
+    assert item.carbs == 10
+    assert item.fat == 0

--- a/tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py
@@ -62,6 +62,36 @@ async def test_recognize_ingredient_preserves_ai_unavailable():
         await handler.handle(RecognizeIngredientCommand(image_data=valid_image))
 
 
+@pytest.mark.asyncio
+async def test_recognize_ingredient_uses_ingredient_identification_strategy():
+    vision_service = Mock()
+    vision_service.analyze_with_strategy = AsyncMock(
+        return_value={
+            "structured_data": {
+                "name": "broccoli",
+                "confidence": 0.92,
+                "category": "vegetable",
+            }
+        }
+    )
+    handler = RecognizeIngredientCommandHandler(vision_service=vision_service)
+    valid_image = base64.b64encode(b"image").decode("ascii")
+
+    result = await handler.handle(
+        RecognizeIngredientCommand(image_data=valid_image, language="en")
+    )
+
+    strategy = vision_service.analyze_with_strategy.await_args.args[1]
+    assert strategy.get_strategy_name() == "IngredientIdentification"
+    assert result == {
+        "name": "broccoli",
+        "confidence": 0.92,
+        "category": "vegetable",
+        "success": True,
+        "message": None,
+    }
+
+
 def test_ingredient_request_rejects_oversized_base64_payload():
     with pytest.raises(ValidationError):
         IngredientRecognitionRequest(image_data="a" * (MAX_IMAGE_BASE64_LENGTH + 1))

--- a/tests/unit/infra/adapters/test_vision_ai_service.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service.py
@@ -19,11 +19,25 @@ def _make_jpeg(width: int, height: int, quality: int = 95) -> bytes:
     return buf.getvalue()
 
 
+def _valid_vision_response() -> dict:
+    return {
+        "dish_name": "test",
+        "foods": [
+            {
+                "name": "rice",
+                "quantity_g": 180,
+                "macros": {"protein": 4, "carbs": 50, "fat": 1},
+            }
+        ],
+        "confidence": 0.8,
+    }
+
+
 def _make_service(max_output_tokens: int | None = None) -> VisionAIService:
     with patch(_MGR_PATCH) as mock_cls:
         mock_manager = MagicMock()
         mock_manager.generate_with_vision = AsyncMock(
-            return_value={"dish_name": "test", "ingredients": []}
+            return_value=_valid_vision_response()
         )
         mock_cls.get_instance.return_value = mock_manager
         return VisionAIService(max_output_tokens=max_output_tokens)

--- a/tests/unit/infra/adapters/test_vision_ai_service_resilience.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service_resilience.py
@@ -2,17 +2,36 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
-from src.domain.strategies.meal_analysis_strategy import MealAnalysisStrategy
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
+from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
+from src.domain.strategies.meal_analysis_strategy import (
+    AnalysisStrategyFactory,
+    MealAnalysisStrategy,
+)
 from src.infra.adapters.vision_ai_service import VisionAIService
+
+
+def _valid_vision_response():
+    return {
+        "dish_name": "test meal",
+        "foods": [
+            {
+                "name": "rice",
+                "quantity_g": 180,
+                "macros": {"protein": 4, "carbs": 50, "fat": 1},
+            }
+        ],
+        "confidence": 0.8,
+    }
 
 
 @pytest.fixture
 def mock_ai_manager():
     manager = Mock()
-    manager.generate_with_vision = AsyncMock(
-        return_value={"dish_name": "test meal", "calories": 500}
-    )
+    manager.generate_with_vision = AsyncMock(return_value=_valid_vision_response())
     return manager
 
 
@@ -27,9 +46,7 @@ def mock_strategy():
 
 @pytest.fixture
 def service(mock_ai_manager):
-    with patch(
-        "src.infra.adapters.vision_ai_service.AIModelManager"
-    ) as mock_cls:
+    with patch("src.infra.adapters.vision_ai_service.AIModelManager") as mock_cls:
         mock_cls.get_instance.return_value = mock_ai_manager
         return VisionAIService()
 
@@ -50,15 +67,21 @@ async def test_analyze_with_strategy(service, mock_ai_manager, mock_strategy):
 
 
 @pytest.mark.asyncio
-async def test_analyze_with_strategy_returns_structured_data(service, mock_ai_manager, mock_strategy):
+async def test_analyze_with_strategy_returns_structured_data(
+    service, mock_ai_manager, mock_strategy
+):
     result = await service.analyze_with_strategy(b"fake_image", mock_strategy)
 
-    assert result["structured_data"] == {"dish_name": "test meal", "calories": 500}
+    assert result["structured_data"]["dish_name"] == "test meal"
+    assert result["structured_data"]["foods"][0]["quantity"] == 180
+    assert result["structured_data"]["foods"][0]["unit"] == "g"
     assert "raw_response" in result
 
 
 @pytest.mark.asyncio
-async def test_analyze_with_strategy_calls_correct_purpose(service, mock_ai_manager, mock_strategy):
+async def test_analyze_with_strategy_calls_correct_purpose(
+    service, mock_ai_manager, mock_strategy
+):
     from src.infra.services.ai.ai_model_manager import ModelPurpose
 
     await service.analyze_with_strategy(b"fake_image", mock_strategy)
@@ -68,7 +91,9 @@ async def test_analyze_with_strategy_calls_correct_purpose(service, mock_ai_mana
 
 
 @pytest.mark.asyncio
-async def test_analyze_with_strategy_passes_prompt_from_strategy(service, mock_ai_manager, mock_strategy):
+async def test_analyze_with_strategy_passes_prompt_from_strategy(
+    service, mock_ai_manager, mock_strategy
+):
     await service.analyze_with_strategy(b"fake_image", mock_strategy)
 
     call_kwargs = mock_ai_manager.generate_with_vision.call_args
@@ -77,8 +102,12 @@ async def test_analyze_with_strategy_passes_prompt_from_strategy(service, mock_a
 
 
 @pytest.mark.asyncio
-async def test_analyze_with_strategy_raises_runtime_error_on_failure(service, mock_ai_manager, mock_strategy):
-    mock_ai_manager.generate_with_vision = AsyncMock(side_effect=Exception("AI failure"))
+async def test_analyze_with_strategy_raises_runtime_error_on_failure(
+    service, mock_ai_manager, mock_strategy
+):
+    mock_ai_manager.generate_with_vision = AsyncMock(
+        side_effect=Exception("AI failure")
+    )
 
     with pytest.raises(RuntimeError, match="Failed to analyze image"):
         await service.analyze_with_strategy(b"fake_image", mock_strategy)
@@ -102,6 +131,106 @@ async def test_analyze_with_strategy_preserves_ai_unavailable(
         "gemini-2.5-flash-lite",
         "gemini-2.5-flash",
     ]
+    assert mock_ai_manager.generate_with_vision.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_analyze_with_strategy_retries_invalid_structured_output_once(
+    service, mock_ai_manager, mock_strategy
+):
+    mock_ai_manager.generate_with_vision = AsyncMock(
+        side_effect=[
+            {
+                "dish_name": "Rice bowl",
+                "foods": [
+                    {
+                        "name": "rice",
+                        "quantity_g": 150000,
+                        "macros": {"protein": 4, "carbs": 50, "fat": 1},
+                    }
+                ],
+            },
+            {
+                "dish_name": "Rice bowl",
+                "foods": [
+                    {
+                        "name": "rice",
+                        "quantity_g": 180,
+                        "macros": {"protein": 4, "carbs": 50, "fat": 1},
+                    }
+                ],
+                "confidence": 0.8,
+            },
+        ]
+    )
+
+    result = await service.analyze_with_strategy(b"fake_image", mock_strategy)
+
+    assert mock_ai_manager.generate_with_vision.await_count == 2
+    first_call = mock_ai_manager.generate_with_vision.await_args_list[0].kwargs
+    second_call = mock_ai_manager.generate_with_vision.await_args_list[1].kwargs
+    assert first_call["schema"] is VisionNutritionResponse
+    assert second_call["schema"] is VisionNutritionResponse
+    assert "Return the full corrected response" in second_call["prompt"]
+    assert "foods.0.quantity_g" in second_call["prompt"]
+    assert result["structured_data"]["foods"][0]["quantity"] == 180
+    assert result["structured_data"]["foods"][0]["unit"] == "g"
+    assert result["structured_data"]["foods"][0]["macros"] == {
+        "protein": 4.0,
+        "carbs": 50.0,
+        "fat": 1.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_analyze_with_strategy_raises_controlled_error_after_retry_failure(
+    service, mock_ai_manager, mock_strategy
+):
+    invalid = {
+        "dish_name": "Rice bowl",
+        "foods": [
+            {
+                "name": "rice",
+                "quantity_g": 150000,
+                "macros": {"protein": 4, "carbs": 50, "fat": 1},
+            }
+        ],
+    }
+    mock_ai_manager.generate_with_vision = AsyncMock(side_effect=[invalid, invalid])
+
+    with pytest.raises(AIOutputValidationError) as exc_info:
+        await service.analyze_with_strategy(b"fake_image", mock_strategy)
+
+    assert mock_ai_manager.generate_with_vision.await_count == 2
+    assert exc_info.value.purpose == "meal_scan"
+    assert exc_info.value.attempt_count == 2
+    assert "foods.0.quantity_g" in exc_info.value.validation_details[0]
+
+
+@pytest.mark.asyncio
+async def test_ingredient_identification_keeps_unstructured_contract(
+    service, mock_ai_manager
+):
+    mock_ai_manager.generate_with_vision = AsyncMock(
+        return_value={
+            "name": "broccoli",
+            "confidence": 0.94,
+            "category": "vegetable",
+        }
+    )
+    strategy = AnalysisStrategyFactory.create_ingredient_identification_strategy()
+
+    result = await service.analyze_with_strategy(b"fake_image", strategy)
+
+    call_kwargs = mock_ai_manager.generate_with_vision.await_args.kwargs
+    assert "schema" not in call_kwargs
+    assert mock_ai_manager.generate_with_vision.await_count == 1
+    assert result["strategy_used"] == "IngredientIdentification"
+    assert result["structured_data"] == {
+        "name": "broccoli",
+        "confidence": 0.94,
+        "category": "vegetable",
+    }
 
 
 def test_compress_image_still_works(service):

--- a/tests/unit/infra/services/ai/providers/test_gemini_provider.py
+++ b/tests/unit/infra/services/ai/providers/test_gemini_provider.py
@@ -1,7 +1,10 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel
 
+from src.domain.exceptions.ai_exceptions import AIOutputValidationError
 from src.domain.ports.ai_provider_port import AICapability
 from src.infra.services.ai.providers.gemini_provider import GeminiProvider
 
@@ -146,6 +149,92 @@ class TestGenerateWithVision:
 
         call_kwargs = mock_model_manager.get_model_for_purpose.call_args[1]
         assert call_kwargs["model_name"] == "gemini-2.5-flash-lite"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_uses_structured_output_schema(
+        self, provider, mock_model_manager
+    ):
+        class DummyVisionResponse(BaseModel):
+            result: str
+
+        captured_messages = []
+        mock_structured_llm = Mock()
+        mock_structured_llm.invoke = Mock(
+            side_effect=lambda messages: captured_messages.extend(messages)
+            or {"parsed": DummyVisionResponse(result="ok")}
+        )
+        mock_llm = Mock()
+        mock_llm.with_structured_output = Mock(return_value=mock_structured_llm)
+        mock_model_manager.get_model_for_purpose.return_value = mock_llm
+
+        result = await provider.generate_with_vision(
+            model="gemini-2.5-flash-lite",
+            prompt="analyze this meal",
+            image_data=b"fake-image",
+            system_message="system instructions",
+            purpose_hint="meal_scan",
+            schema=DummyVisionResponse,
+        )
+
+        assert result == {"result": "ok"}
+        mock_llm.with_structured_output.assert_called_once_with(
+            DummyVisionResponse, include_raw=True
+        )
+        assert any(isinstance(message, SystemMessage) for message in captured_messages)
+        human_message = next(
+            message
+            for message in captured_messages
+            if isinstance(message, HumanMessage)
+        )
+        assert human_message.content[0] == {
+            "type": "text",
+            "text": "analyze this meal",
+        }
+        assert human_message.content[1]["type"] == "image_url"
+        assert human_message.content[1]["image_url"]["url"].startswith(
+            "data:image/jpeg;base64,"
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_raises_when_structured_output_is_empty(
+        self, provider, mock_model_manager
+    ):
+        class DummyVisionResponse(BaseModel):
+            result: str
+
+        mock_structured_llm = Mock()
+        mock_structured_llm.invoke = Mock(return_value={"parsed": None})
+        mock_llm = Mock()
+        mock_llm.with_structured_output = Mock(return_value=mock_structured_llm)
+        mock_model_manager.get_model_for_purpose.return_value = mock_llm
+
+        with pytest.raises(AIOutputValidationError) as exc_info:
+            await provider.generate_with_vision(
+                model="gemini-2.5-flash-lite",
+                prompt="analyze",
+                image_data=b"fake-image",
+                schema=DummyVisionResponse,
+            )
+        assert exc_info.value.purpose == "meal_scan"
+        assert "empty result" in exc_info.value.validation_details[0]
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_without_schema_uses_raw_json_path(
+        self, provider, mock_model_manager
+    ):
+        mock_llm = Mock()
+        mock_llm.invoke = Mock(return_value=Mock(content='{"result": "ok"}'))
+        mock_llm.with_structured_output = Mock()
+        mock_model_manager.get_model_for_purpose.return_value = mock_llm
+
+        result = await provider.generate_with_vision(
+            model="gemini-2.5-flash-lite",
+            prompt="analyze",
+            image_data=b"fake-image",
+        )
+
+        assert result == {"result": "ok"}
+        mock_llm.with_structured_output.assert_not_called()
 
 
 class TestErrorExtraction:

--- a/tests/unit/infra/services/ai/test_ai_model_manager.py
+++ b/tests/unit/infra/services/ai/test_ai_model_manager.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from src.domain.exceptions.ai_exceptions import AIUnavailableError
 from src.infra.services.ai.ai_model_manager import AIModelManager, ModelPurpose
@@ -41,12 +42,15 @@ def mock_circuit_breaker():
 
 @pytest.fixture
 def manager(mock_gemini_provider, mock_circuit_breaker):
-    with patch(
-        "src.infra.services.ai.ai_model_manager.GeminiProvider",
-        return_value=mock_gemini_provider,
-    ), patch(
-        "src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker",
-        return_value=mock_circuit_breaker,
+    with (
+        patch(
+            "src.infra.services.ai.ai_model_manager.GeminiProvider",
+            return_value=mock_gemini_provider,
+        ),
+        patch(
+            "src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker",
+            return_value=mock_circuit_breaker,
+        ),
     ):
         return AIModelManager()
 
@@ -188,7 +192,9 @@ class TestGenerate:
         assert mock_gemini_provider.generate.call_args_list[0].kwargs["cache_name"] == (
             "cachedContents/primary"
         )
-        assert mock_gemini_provider.generate.call_args_list[1].kwargs["cache_name"] is None
+        assert (
+            mock_gemini_provider.generate.call_args_list[1].kwargs["cache_name"] is None
+        )
         cache_manager.get_cache_name_for_model.assert_any_await(
             "text_parse", "gemini-2.5-flash-lite"
         )
@@ -255,3 +261,22 @@ class TestVision:
             image_data=b"fake_image",
         )
         assert result == {"result": "vision_success"}
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_forwards_schema(
+        self, manager, mock_gemini_provider
+    ):
+        class DummyVisionResponse(BaseModel):
+            result: str
+
+        await manager.generate_with_vision(
+            purpose=ModelPurpose.MEAL_SCAN,
+            prompt="analyze",
+            image_data=b"fake_image",
+            system_message="system",
+            schema=DummyVisionResponse,
+        )
+
+        call_kwargs = mock_gemini_provider.generate_with_vision.call_args.kwargs
+        assert call_kwargs["schema"] is DummyVisionResponse
+        assert call_kwargs["purpose_hint"] == "meal_scan"

--- a/tests/unit/infra/services/ai/test_schemas.py
+++ b/tests/unit/infra/services/ai/test_schemas.py
@@ -6,13 +6,13 @@ Tests validate 6-name generation and removal of description field.
 import pytest
 from pydantic import ValidationError
 
+from src.domain.model.ai.gpt_response import GPTAnalysisResponse
 from src.infra.services.ai.schemas import (
+    IngredientItem,
     MealNamesResponse,
     RecipeDetailsResponse,
-    IngredientItem,
     RecipeStepItem,
 )
-from src.domain.model.ai.gpt_response import GPTAnalysisResponse
 
 
 class TestMealNamesResponse:
@@ -99,6 +99,29 @@ class TestRecipeDetailsResponse:
         assert response.protein == 45.5
         assert response.carbs == 25.0
         assert response.fat == 18.0
+
+    def test_ai_nutrition_fields_remain_metadata(self):
+        response = RecipeDetailsResponse(
+            ingredients=[
+                IngredientItem(name="Chicken breast", amount=200, unit="g"),
+                IngredientItem(name="Rice", amount=150, unit="g"),
+                IngredientItem(name="Broccoli", amount=100, unit="g"),
+            ],
+            recipe_steps=[
+                RecipeStepItem(step=1, instruction="Cook rice", duration_minutes=12),
+                RecipeStepItem(step=2, instruction="Cook chicken", duration_minutes=10),
+            ],
+            prep_time_minutes=25,
+            calories=9999,
+            protein=999.0,
+            carbs=999.0,
+            fat=999.0,
+        )
+
+        assert response.calories == 9999
+        assert response.protein == 999.0
+        assert response.carbs == 999.0
+        assert response.fat == 999.0
 
     def test_rejects_missing_ingredients(self):
         """Invalid: missing ingredients."""


### PR DESCRIPTION
## Summary
- Add canonical AI nutrition output contracts for vision meal scans and natural-language meal text parsing.
- Reject impossible quantities/macros before domain hydration, retry invalid structured model output exactly once, then fail through controlled `AIOutputValidationError`.
- Preserve ingredient recognition as its existing unstructured `{name, confidence, category}` flow instead of forcing it through the meal nutrition schema.
- Keep backend as calorie source of truth by deriving calories from validated macros for FatSecret divergence checks.
- Map final invalid AI output to friendly `AI_OUTPUT_INVALID` guidance without leaking field-level validation details.

## Validation
- `uv run pytest tests/unit/api/test_exceptions_unexpected.py tests/unit/domain/exceptions/test_ai_exceptions.py tests/unit/domain/services/test_ai_output_validation_service.py tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/domain/parsers/test_gpt_response_parser.py tests/unit/domain/parsers/test_vision_response_models.py tests/unit/domain/ports/test_ai_provider_port.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/infra/adapters/test_vision_ai_service_resilience.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py tests/unit/handlers/command_handlers/test_recognize_ingredient_command_handler.py tests/unit/infra/services/ai/test_ai_model_manager.py tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/infra/services/ai/test_schemas.py -q`
  - `156 passed`
- Pre-push hook full unit suite
  - `1649 passed, 3 skipped`

## Notes
- Merged and tested against `origin/delivery` before pushing this branch.
- Broad repo-wide lint/type/format baselines still have unrelated existing noise; touched-file checks passed during implementation.