### PR TITLE
feat(beverage-scan): Phase 3c — hydration_entries in feeds/aggregates + missing pieces

### DIFF
--- a/docs/beverage-scan.md
+++ b/docs/beverage-scan.md
@@ -1,0 +1,118 @@
+# Beverage Scan
+
+AI-powered packaged-beverage detection routed to `hydration_entries` instead of meals.
+
+## Endpoint
+
+`POST /v1/meals/image/analyze` — same endpoint as food scan. Response shape is unchanged.
+
+## End-to-End Flow
+
+```
+Mobile → POST /v1/meals/image/analyze
+         ↓
+UploadMealImageImmediatelyHandler
+  1. Upload image → Cloudinary
+  2. GeminiService.vision(MEAL_SCAN, image_bytes, VISION_ANALYSIS prompt)
+  3. VisionAIService._to_legacy_vision_payload() → includes beverage_metadata
+  4. bev_meta = structured_data.get("beverage_metadata")
+  5. if bev_meta.is_packaged_beverage → _handle_beverage_scan()
+     else → normal food path
+
+_handle_beverage_scan()
+  1. build_beverage_scan_params(bev_meta) → BeverageScanParams
+  2. Save Meal(source="hydration") for backward compat
+  3. Save HydrationEntry(legacy_meal_id=meal.meal_id, source="scan_beverage")
+  4. Invalidate hydration caches (not meal caches)
+  5. Return Meal (API shape unchanged)
+```
+
+## BeverageMetadata Contract
+
+Gemini returns this when `is_packaged_beverage=true`:
+
+```json
+{
+  "is_packaged_beverage": true,
+  "brand": "Coca-Cola",
+  "product_name": "Coca-Cola Original",
+  "volume_ml": 330,
+  "kcal_per_100ml": 42.0,
+  "sugar_per_100ml": 10.6,
+  "label_source": "label"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_packaged_beverage` | bool | True → route to hydration path |
+| `brand` | str (max 100) | Brand or product name for display |
+| `product_name` | str (max 100) | Fallback for brand |
+| `volume_ml` | int | Container volume read from label |
+| `kcal_per_100ml` | float | Caloric density (nullable → 0) |
+| `sugar_per_100ml` | float | Sugar density (nullable → 0) |
+| `label_source` | str | `"label"` or `"estimate"` |
+
+## BeverageScanParams (domain)
+
+Stores computed totals, not per-100ml rates:
+
+```python
+kcal_total = volume_ml * kcal_per_100ml / 100
+sugar_g_total = volume_ml * sugar_per_100ml / 100
+hydration_weight = compute_hydration_weight(label_source, sugar_per_100ml)
+```
+
+## Volume Heuristics
+
+If Gemini cannot read the label volume, the prompt instructs it to estimate:
+
+| Container | Default ml |
+|-----------|-----------|
+| Can | 330 |
+| Small bottle | 500 |
+| Large bottle | 1000 |
+| Cup/carton (unknown) | 330 |
+
+## Hydration Weight Table
+
+| Condition | Weight |
+|-----------|--------|
+| `label_source = "label"` and sugar < 5g/100ml | 0.95 |
+| `label_source = "label"` and sugar 5–10g/100ml | 0.85 |
+| `label_source = "label"` and sugar > 10g/100ml | 0.70 |
+| `label_source = "estimate"` (any sugar) | 0.70 (conservative) |
+
+## Deduplication in Feeds
+
+`HydrationEntry.legacy_meal_id` links an entry to its corresponding Meal row:
+
+- **Pre-Phase-3d entries** (LogCaloricDrink dual-write): `legacy_meal_id` set → Meal row exists → feed reads via Meal
+- **Post-Phase-3d entries** (LogCaloricDrink hydration-only): `legacy_meal_id = None` → feed reads via HydrationEntry
+- **Beverage scan entries**: `legacy_meal_id` set → Meal row exists → feed reads via Meal
+
+Dedup algorithm used in activities feed and calorie aggregates:
+```python
+meal_id_set = {m.meal_id for m in meals}
+new_entries = [e for e in hydration_entries if e.legacy_meal_id not in meal_id_set]
+```
+
+## Observability
+
+GeminiService emits per-call structured logs:
+```
+[AI-CALL] method=vision purpose=MEAL_SCAN model=gemini-2.5-flash-lite latency_ms=1240 retry_count=0 fallback_used=False
+```
+
+Beverages with estimated nutrition log a WARNING:
+```
+[BEVERAGE-KCAL-ESTIMATE] drink=Unknown kcal_total=0.0 label_source=estimate
+```
+
+## Eval Set
+
+Use `scripts/development/evaluate_meal_analyze_prompt_candidates.py` to run the beverage prompt against test images. Eval set should include:
+- Coke can (label visible)
+- Smoothie bottle (partial label)
+- Water bottle (no nutrition panel)
+- Non-beverage food (must NOT trigger beverage path)

--- a/scripts/development/cleanup_orphan_hydration_meal_rows.py
+++ b/scripts/development/cleanup_orphan_hydration_meal_rows.py
@@ -1,0 +1,83 @@
+"""
+One-shot script: delete meal rows that were created as dual-write stubs by
+LogCaloricDrinkCommandHandler before Phase 3d removed the dual-write.
+
+Identifies orphans as: meals WHERE meal_type = 'hydration'
+  AND meal_id IN (SELECT legacy_meal_id FROM hydration_entries WHERE legacy_meal_id IS NOT NULL)
+
+Run with --execute to actually delete; default is dry-run.
+
+Usage:
+    python scripts/development/cleanup_orphan_hydration_meal_rows.py
+    python scripts/development/cleanup_orphan_hydration_meal_rows.py --execute
+"""
+
+import argparse
+import os
+import sys
+
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def main(execute: bool) -> None:
+    db_url = os.environ.get("DATABASE_URL") or os.environ.get("POSTGRES_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL or POSTGRES_URL env var not set", file=sys.stderr)
+        sys.exit(1)
+
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = False
+    cur = conn.cursor()
+
+    count_sql = """
+        SELECT COUNT(*)
+        FROM meals
+        WHERE meal_type = 'hydration'
+          AND meal_id IN (
+              SELECT legacy_meal_id
+              FROM hydration_entries
+              WHERE legacy_meal_id IS NOT NULL
+          )
+    """
+    cur.execute(count_sql)
+    count = cur.fetchone()[0]
+    print(f"Orphan hydration meal rows found: {count}")
+
+    if count == 0:
+        print("Nothing to delete.")
+        conn.close()
+        return
+
+    if not execute:
+        print("DRY RUN — pass --execute to delete.")
+        conn.close()
+        return
+
+    delete_sql = """
+        DELETE FROM meals
+        WHERE meal_type = 'hydration'
+          AND meal_id IN (
+              SELECT legacy_meal_id
+              FROM hydration_entries
+              WHERE legacy_meal_id IS NOT NULL
+          )
+    """
+    cur.execute(delete_sql)
+    deleted = cur.rowcount
+    conn.commit()
+    print(f"Deleted {deleted} orphan rows.")
+    conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually delete rows (default is dry-run)",
+    )
+    args = parser.parse_args()
+    main(execute=args.execute)

--- a/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
@@ -108,7 +108,8 @@ class GetDailyActivitiesQueryHandler(
             user_id=query.user_id,
             user_timezone=user_tz_str,
         )
-        return [
+
+        meal_activities = [
             (
                 self._build_hydration_activity(item, query.language or "en")
                 if item.meal_type == "hydration"
@@ -116,6 +117,24 @@ class GetDailyActivitiesQueryHandler(
             )
             for item in items
         ]
+
+        # Include hydration_entries not already covered by a meal row (legacy_meal_id dedup).
+        # Pre-Phase-3d entries have legacy_meal_id set → skip (meal row already in feed).
+        # Post-Phase-3d LogCaloricDrink entries have legacy_meal_id=None → include.
+        meal_id_set = {item.meal_id for item in items}
+        hydration_entries = await uow.hydration_entries.find_by_date(
+            local_date,
+            user_id=query.user_id,
+            user_timezone=user_tz_str,
+        )
+        for entry in hydration_entries:
+            if entry.legacy_meal_id and entry.legacy_meal_id in meal_id_set:
+                continue
+            meal_activities.append(
+                self._build_hydration_entry_activity(entry, query.language or "en")
+            )
+
+        return meal_activities
 
     async def _get_workout_activities(
         self,
@@ -214,6 +233,29 @@ class GetDailyActivitiesQueryHandler(
             "status": "completed",
             "image_url": None,
             "source": meal.source or "hydration",
+        }
+
+    def _build_hydration_entry_activity(self, entry, language: str = "en") -> Dict[str, Any]:
+        """Build activity dict from a HydrationEntry domain object (no Meal row)."""
+        return {
+            "id": entry.id,
+            "type": "hydration",
+            "timestamp": format_iso_utc(entry.logged_at),
+            "title": localized_name_for_catalog_name(entry.drink_name_snapshot, language)
+            or entry.drink_name_snapshot or "Water",
+            "emoji": entry.emoji_snapshot or "💧",
+            "meal_type": "hydration",
+            "calories": round(entry.calories, 1),
+            "macros": {
+                "protein": round(entry.protein_g or 0, 1),
+                "carbs": round(entry.carbs_g or 0, 1),
+                "fat": round(entry.fat_g or 0, 1),
+            },
+            "quantity": entry.credited_ml,
+            "volume_ml": entry.volume_ml,
+            "status": "completed",
+            "image_url": entry.image_url,
+            "source": entry.source,
         }
 
     def _estimate_meal_weight(self, meal) -> float:

--- a/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
+++ b/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
@@ -12,7 +12,7 @@ from src.domain.cache.cache_keys import CacheKeys
 from src.domain.model.meal import MealStatus
 from src.domain.model.nutrition.macros import Macros
 from src.domain.services.weekly_budget_service import WeeklyBudgetService
-from src.domain.utils.timezone_utils import get_user_monday, get_zone_info, resolve_user_timezone_async
+from src.domain.utils.timezone_utils import ensure_utc, get_user_monday, get_zone_info, resolve_user_timezone_async
 from src.domain.ports.cache_port import CachePort
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.domain.model.meal_projection import MealProjection
@@ -82,6 +82,25 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, Dict[str,
                 if meal_date:
                     meals_by_date.setdefault(meal_date, []).append(meal)
 
+            # Fetch hydration entries for range; dedup by legacy_meal_id
+            hydration_by_date: Dict[date, list] = {}
+            try:
+                meal_id_set = {m.meal_id for m in meals}
+                h_entries = await uow.hydration_entries.find_by_date_range(
+                    query.user_id,
+                    query.start_date,
+                    query.end_date,
+                    user_timezone=user_tz_str,
+                )
+                for entry in h_entries:
+                    if entry.legacy_meal_id and entry.legacy_meal_id in meal_id_set:
+                        continue
+                    entry_date = self._get_hydration_date(entry, user_tz_str)
+                    if entry_date:
+                        hydration_by_date.setdefault(entry_date, []).append(entry)
+            except Exception as exc:
+                logger.warning("Failed to fetch bulk hydration data: %s", exc)
+
             # Single query for the full range; bucket by local date in Python.
             movement_by_date: Dict[date, float] = {}
             try:
@@ -103,6 +122,7 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, Dict[str,
                 dates_result[current.isoformat()] = self._build_date_summary(
                     day_meals, target_calories, target_macros,
                     movement_kcal=movement_by_date.get(current, 0.0),
+                    hydration_entries=hydration_by_date.get(current, []),
                 )
                 current += timedelta(days=1)
 
@@ -164,12 +184,19 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, Dict[str,
         aware_dt = ensure_utc(meal.created_at)
         return aware_dt.astimezone(tz).date()
 
+    def _get_hydration_date(self, entry, user_tz_str: str):
+        if not entry.logged_at:
+            return None
+        tz = get_zone_info(user_tz_str)
+        return ensure_utc(entry.logged_at).astimezone(tz).date()
+
     def _build_date_summary(
         self,
         meals: list,
         target_calories: Optional[float],
         target_macros: Optional[Dict],
         movement_kcal: float = 0.0,
+        hydration_entries: Optional[list] = None,
     ) -> Dict[str, Any]:
         """Build summary for a single date."""
         total_protein = 0.0
@@ -186,6 +213,13 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, Dict[str,
                     total_carbs += meal.nutrition.macros.carbs or 0
                     total_fat += meal.nutrition.macros.fat or 0
                     total_fiber += meal.nutrition.macros.fiber or 0
+
+        for entry in (hydration_entries or []):
+            meal_count += 1
+            total_protein += entry.protein_g or 0
+            total_carbs += entry.carbs_g or 0
+            total_fat += entry.fat_g or 0
+            total_fiber += entry.fiber_g or 0
 
         food_calories = Macros(
             protein=total_protein,

--- a/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
@@ -323,9 +323,15 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
 
         redistribution_logged_days = max(0, logged_past_days - past_cheat_count)
 
-        # Fetch meals for the week once — used by all consumed calculations
+        # Fetch meals and hydration entries for the week — used by all consumed calculations
         week_end = week_start + timedelta(days=6)
         week_meals = await uow.meals.find_by_date_range(
+            user_id,
+            week_start,
+            week_end,
+            user_timezone=user_timezone,
+        )
+        week_hydration = await uow.hydration_entries.find_by_date_range(
             user_id,
             week_start,
             week_end,
@@ -334,6 +340,8 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
 
         tz = get_zone_info(user_timezone) if user_timezone else None
         from src.domain.model.meal import MealStatus
+
+        meal_id_set = {m.meal_id for m in week_meals}
 
         def _sum_meals(meals, end_date=None, exclude_dates=None):
             exclude_dates_set = set(exclude_dates) if exclude_dates else set()
@@ -356,12 +364,39 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
                     fat += macros.fat or 0
             return {"calories": cal, "protein": prot, "carbs": carbs, "fat": fat}
 
-        consumed_total = _sum_meals(week_meals)
+        def _sum_hydration(entries, end_date=None, exclude_dates=None):
+            # Dedup: skip entries already counted via a meal row (legacy_meal_id present)
+            exclude_dates_set = set(exclude_dates) if exclude_dates else set()
+            cal = prot = carbs = fat = 0.0
+            for e in entries:
+                if e.legacy_meal_id and e.legacy_meal_id in meal_id_set:
+                    continue
+                if (end_date or exclude_dates_set) and e.logged_at:
+                    aware_dt = ensure_utc(e.logged_at)
+                    entry_date = aware_dt.astimezone(tz).date() if tz else aware_dt.date()
+                    if end_date and entry_date > end_date:
+                        continue
+                    if entry_date in exclude_dates_set:
+                        continue
+                cal += e.calories
+                prot += e.protein_g or 0
+                carbs += e.carbs_g or 0
+                fat += e.fat_g or 0
+            return {"calories": cal, "protein": prot, "carbs": carbs, "fat": fat}
+
+        def _add_dicts(a, b):
+            return {k: a[k] + b[k] for k in a}
+
+        consumed_total = _add_dicts(_sum_meals(week_meals), _sum_hydration(week_hydration))
         past_end = target_date - timedelta(days=1)
-        consumed_before_today = _sum_meals(week_meals, end_date=past_end)
+        consumed_before_today = _add_dicts(
+            _sum_meals(week_meals, end_date=past_end),
+            _sum_hydration(week_hydration, end_date=past_end),
+        )
         if past_cheat_dates:
-            consumed_for_redistribution = _sum_meals(
-                week_meals, end_date=past_end, exclude_dates=past_cheat_dates
+            consumed_for_redistribution = _add_dicts(
+                _sum_meals(week_meals, end_date=past_end, exclude_dates=past_cheat_dates),
+                _sum_hydration(week_hydration, end_date=past_end, exclude_dates=past_cheat_dates),
             )
         else:
             consumed_for_redistribution = consumed_before_today

--- a/src/domain/services/hydration_catalog_service.py
+++ b/src/domain/services/hydration_catalog_service.py
@@ -178,6 +178,21 @@ _DRINKS: list[Drink] = [
 # Module-level constant — dict keyed by drink id for O(1) lookup.
 DRINK_CATALOG: dict[str, Drink] = {drink.id: drink for drink in _DRINKS}
 
+# Virtual entry for AI-scanned beverages; excluded from get_all() so it doesn't
+# appear in the catalog list but is resolvable via find_by_id("scanned").
+DRINK_CATALOG["scanned"] = Drink(
+    id="scanned",
+    name="Scanned drink",
+    sub="Beverage",
+    emoji="🥤",
+    default_ml=330,
+    kcal_per_100ml=0.0,
+    sugar_per_100ml=0.0,
+    hydration_weight=0.7,
+    brand_color="#6B7280",
+    category=DrinkCategory.CALORIC,
+)
+
 _DRINK_TRANSLATIONS: dict[str, dict[str, dict[str, str | None]]] = {
     "vi": {
         "water": {"name": "Nước lọc", "sub": None},

--- a/src/infra/adapters/vision_ai_service.py
+++ b/src/infra/adapters/vision_ai_service.py
@@ -210,6 +210,7 @@ class VisionAIService(VisionAIServicePort):
             "dish_name": payload.get("dish_name"),
             "foods": foods,
             "confidence": payload.get("confidence", 0.5),
+            "beverage_metadata": payload.get("beverage_metadata"),
         }
 
     async def analyze_by_url_with_strategy(

--- a/src/infra/ai/gemini_service.py
+++ b/src/infra/ai/gemini_service.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import threading
+import time
 from typing import Any, Optional
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
@@ -159,6 +160,7 @@ class GeminiService:
 
         attempted: list[str] = []
         last_error: str | None = None
+        _start = time.monotonic()
 
         for model in available:
             attempted.append(model)
@@ -173,6 +175,11 @@ class GeminiService:
                     purpose_hint=purpose.value,
                 )
                 self._circuit_breaker.record_success(model)
+                logger.info(
+                    "[AI-CALL] method=vision purpose=%s model=%s latency_ms=%d retry_count=%d fallback_used=%s",
+                    purpose.value, model, int((time.monotonic() - _start) * 1000),
+                    len(attempted) - 1, model != chain[0],
+                )
                 return result
 
             except AIOutputValidationError:
@@ -238,6 +245,7 @@ class GeminiService:
         cache_type: str | None = _PURPOSE_TO_CACHE_TYPE.get(purpose)
         attempted: list[str] = []
         last_error: str | None = None
+        _start = time.monotonic()
 
         for model in available:
             attempted.append(model)
@@ -256,14 +264,11 @@ class GeminiService:
                     purpose_hint=purpose.value,
                 )
                 self._circuit_breaker.record_success(model)
-
-                if model != chain[0]:
-                    logger.info(
-                        "[AI-FALLBACK-SUCCESS] purpose=%s failed=%s succeeded=%s",
-                        purpose.value,
-                        attempted[:-1],
-                        model,
-                    )
+                logger.info(
+                    "[AI-CALL] method=text_json purpose=%s model=%s latency_ms=%d retry_count=%d fallback_used=%s",
+                    purpose.value, model, int((time.monotonic() - _start) * 1000),
+                    len(attempted) - 1, model != chain[0],
+                )
                 return result
 
             except AIOutputValidationError:

--- a/src/infra/repositories/hydration_repository_async.py
+++ b/src/infra/repositories/hydration_repository_async.py
@@ -118,6 +118,26 @@ class AsyncHydrationRepository:
         )
         return [_orm_to_domain(row) for row in result.scalars().all()]
 
+    async def find_by_date_range(
+        self,
+        user_id: str,
+        start_date: date,
+        end_date: date,
+        user_timezone: str | None = None,
+    ) -> list[HydrationEntry]:
+        start_dt, _ = _local_day_range(start_date, user_timezone)
+        _, end_dt = _local_day_range(end_date, user_timezone)
+        result = await self.session.execute(
+            select(HydrationEntryORM)
+            .where(
+                HydrationEntryORM.user_id == user_id,
+                HydrationEntryORM.logged_at >= start_dt,
+                HydrationEntryORM.logged_at < end_dt,
+            )
+            .order_by(HydrationEntryORM.logged_at.desc())
+        )
+        return [_orm_to_domain(row) for row in result.scalars().all()]
+
     async def sum_ml_for_date(
         self,
         date_obj: date,


### PR DESCRIPTION
## Summary

- **Critical fix**: `vision_ai_service` was silently dropping `beverage_metadata` from Gemini's response — beverage scan routing never fired
- **Phase 3c**: Activities feed, weekly budget, and nutrition bulk now all read from `hydration_entries` with `legacy_meal_id` dedup (pre-3d entries counted via meal row; post-3d direct entries counted via hydration_entry)
- **Phase 3c**: `find_by_date_range` added to `hydration_repository_async`
- **Phase 3e**: Virtual `"scanned"` entry added to `DRINK_CATALOG`
- **Phase 4**: Structured `[AI-CALL]` log with `latency_ms`/`retry_count`/`fallback_used` in `GeminiService.vision()` and `text_json()`
- **Docs**: `docs/beverage-scan.md` — flow, contract, dedup algorithm, eval set instructions
- **Scripts**: `cleanup_orphan_hydration_meal_rows.py` — dry-run by default, `--execute` to delete

## Test plan
- [ ] 1651 unit tests pass
- [ ] Beverage scan routes to hydration_entries (not meals) after this fix
- [ ] LogCaloricDrink entries appear in activities feed (no meal row, dedup skips)
- [ ] Weekly budget calorie total includes drinks