### PR TITLE
docs: update backend codebase documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,12 @@ Monorepo submodule. 4-layer Clean + CQRS + PyMediator event bus.
 | Item | Value |
 |------|-------|
 | **Framework** | FastAPI 0.115+ / Python 3.11+ |
-| **Database** | MySQL 8.0 + SQLAlchemy 2.0 |
+| **Database** | PostgreSQL (Neon) + SQLAlchemy 2.0 async runtime (asyncpg) |
 | **Migrations** | Alembic |
 | **Event Bus** | PyMediator (singleton) |
 | **AI** | Google Gemini (multi-model) |
 | **Auth** | Firebase JWT |
-| **Cache** | Redis (cache-aside) |
+| **Cache** | Redis (optional cache-aside) |
 
 ## Critical Commands (Daily Use)
 
@@ -25,7 +25,7 @@ alembic upgrade head
 alembic revision --autogenerate -m "description"
 
 # Code quality (run before commit)
-black src/ tests/ && flake8 src/ && mypy src/ && pytest
+black src/ tests/ && ruff check src/ && mypy src/ && pytest
 ```
 
 ## MUST-Follow Rules (Non-Inferable)
@@ -56,9 +56,9 @@ black src/ tests/ && flake8 src/ && mypy src/ && pytest
 |-------|------|-------|
 | System architecture | `docs/system-architecture.md` | <300 |
 | CQRS patterns | `docs/cqrs-guide.md` | <200 |
-| API endpoints | `docs/api-endpoints.md` | <150 |
+| API endpoints | `docs/api-endpoints.md` | <300 |
 | Database schema | `docs/database-guide.md` | <250 |
-| External services | `docs/external-services.md` | <150 |
+| External services | `docs/external-services.md` | <350 |
 | Code standards | `docs/code-standards.md` | <300 |
 | Testing standards | `docs/testing-standards.md` | <250 |
-| Troubleshooting | `docs/troubleshooting.md` | <100 |
+| Troubleshooting | `docs/troubleshooting.md` | <300 |

--- a/README.md
+++ b/README.md
@@ -1,60 +1,50 @@
 # MealTrack Backend
 
-A sophisticated FastAPI-based microservice for meal tracking and nutritional analysis.
+FastAPI backend for meal tracking, nutrition analysis, weekly targets, hydration, movement, and subscription-backed premium features.
 
 ## Quick Links
 
-- **[Project Overview & PDR](./docs/project-overview-pdr.md)** - Vision, goals, and requirements.
-- **[System Architecture](./docs/architecture/index.md)** - Multi-layer architecture and data flow.
-- **[Code Standards](./docs/standards/index.md)** - Development guidelines and patterns.
-- **[Codebase Summary](./docs/codebase-summary.md)** - Directory structure and file organization.
-- **[Project Roadmap](./docs/project-roadmap.md)** - Future plans and completed features.
+- [Project Overview & PDR](./docs/project-overview-pdr.md)
+- [System Architecture](./docs/system-architecture.md)
+- [Code Standards](./docs/code-standards.md)
+- [Codebase Summary](./docs/codebase-summary.md)
+- [Project Roadmap](./docs/project-roadmap.md)
 
-## 🚀 Features
+## Highlights
 
-- **AI-Powered Meal Analysis**: Vision-based food recognition with 6 analysis strategies (basic, portion-aware, ingredient-aware, weight-aware, user-context-aware, combined).
-- **12 REST Route Modules**: 50+ endpoints covering meals, users, profiles, chat, notifications, meal plans, suggestions, activities, ingredients, webhooks.
-- **CQRS Architecture**: 29 commands, 23 queries, 10+ domain events with PyMediator event bus (singleton pattern).
-- **Intelligent Planning**: AI-generated weekly plans with dietary preferences, cooking time constraints, and ingredient-based generation.
-- **Vector Search**: Pinecone semantic search with 1024-dim embeddings (llama-text-embed-v2).
-- **Real-time Chat**: WebSocket + REST endpoints with streaming AI responses via MessageOrchestrationService.
-- **Multi-Language Support**: 7 languages (en, vi, es, fr, de, ja, zh) with translation service.
-- **Smart Notifications**: FCM push with timezone-aware scheduling and preferences.
+- AI meal analysis with image upload, signed upload tokens, and scan-by-URL analysis.
+- Live API surface: 26 router registrations and 83 endpoint decorators across meals, users, profiles, suggestions, hydration, movement, nutrition, referrals, promo codes, health, monitoring, webhooks, and support routes.
+- CQRS with PyMediator singleton event buses and async SQLAlchemy UoW boundaries.
+- PostgreSQL/Neon async runtime with pgvector-enabled local compose and Redis-backed optional cache-aside paths.
+- Multi-provider integrations for Firebase, Gemini, Cloudinary, RevenueCat, PostHog, Sentry, DeepL, FatSecret, OpenFoodFacts, Brave Search, Resend, and image generators.
+- 1,600+ collected tests across the repo.
 
-## 🛠 Technology Stack
+## Technology
 
-- **Core**: FastAPI 0.115+ (Python 3.11+), SQLAlchemy 2.0 async runtime (`AsyncSession`, `AsyncUnitOfWork`).
-- **Database**: PostgreSQL (Neon) with SQLAlchemy 2.0, Redis 7.0 for selective optional caching; required state documented separately.
-- **AI**: Google Gemini 2.5 Flash (multi-model for rate distribution), Pinecone Inference API (1024-dim).
-- **Infrastructure**: Firebase (JWT Auth + FCM), Cloudinary (image storage), RevenueCat (subscriptions).
-- **Event Bus**: PyMediator with singleton registry for CQRS.
-- **Testing**: pytest (1,499+ tests), ruff (linting), mypy (type checking).
+- FastAPI 0.115+ on Python 3.11+
+- SQLAlchemy 2.0 async runtime with asyncpg
+- PostgreSQL (Neon) as the primary database
+- Redis 7 for optional caching and AI-cost optimization
+- Alembic migrations
+- PyMediator event bus
 
-## 🏗 Architecture
+## Architecture
 
-Follows a **4-Layer Clean Architecture** with **CQRS** and **Event-Driven Design**:
+The backend follows 4-layer Clean Architecture with CQRS:
 
-1. **API Layer** (74 files, ~8,241 LOC): HTTP routing, Pydantic validation, 8 mappers, 3-layer middleware.
-2. **Application Layer** (136 files, ~5,968 LOC): CQRS - 29 commands, 23 queries, 10+ events, 40+ handlers.
-3. **Domain Layer** (130 files, ~14,079 LOC): 50+ domain services, 8 bounded contexts, 17 port interfaces, 6 analysis strategies.
-4. **Infrastructure Layer** (77 files, ~8,671 LOC): 11 database models, 10+ repositories, external service adapters, Redis cache, PyMediator event bus with singleton registry.
+1. API layer: routing, validation, middleware, dependency injection.
+2. Application layer: commands, queries, handlers, and background event handlers.
+3. Domain layer: business logic, entities, services, ports, and policies.
+4. Infrastructure layer: database, cache, adapters, external services, and observability.
 
-## 🚦 Getting Started
+## Getting Started
 
 ```bash
-# Clone and enter repo
-git clone <repo-url> && cd backend
-
-# Install dependencies
 pip install -r requirements.txt
-
-# Setup environment
-cp .env.example .env # Configure variables
-
-# Run migrations and start server
-python -m alembic upgrade head
+cp .env.example .env
+alembic upgrade head
 uvicorn src.api.main:app --reload
 ```
 
-- **Swagger Docs**: http://localhost:8000/docs
-- **Tests**: `pytest --cov=src`
+- Swagger docs: `http://localhost:8000/docs`
+- Tests: `pytest`

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,6 +1,6 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** May 27, 2026
+**Last Updated:** June 17, 2026
 **Base URL:** `http://localhost:8000` (dev) or deployed host
 **API Docs:** `/docs` (Swagger UI)
 **Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
@@ -13,9 +13,10 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | GET | `/health` | Basic health check |
-| GET | `/health/db-pool` | DB pool metrics |
-| GET | `/health/db-connections` | DB connection stats |
-| GET | `/health/notifications` | FCM health |
+| GET | `/v1/health` | Versioned health check |
+| GET | `/v1/health/db-pool` | DB pool metrics |
+| GET | `/v1/health/db-connections` | DB connection stats |
+| GET | `/v1/health/notifications` | FCM health |
 | GET | `/v1/monitoring/cache/metrics` | Redis cache metrics |
 
 ## App & Universal Links
@@ -32,6 +33,8 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/meals/image/analyze` | Analyze meal from image (immediate upload) |
+| GET | `/v1/meals/upload-token` | Create signed direct-upload token |
+| POST | `/v1/meals/scan-by-url` | Analyze meal from an existing image URL |
 | POST | `/v1/meals/manual` | Create meal from USDA foods |
 | POST | `/v1/meals/parse-text` | Parse meal from text description |
 | GET | `/v1/meals/streak` | Get meal logging streak |
@@ -64,7 +67,7 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | GET | `/v1/users/firebase/{firebase_uid}` | Get user profile by Firebase UID |
 | GET | `/v1/users/firebase/{firebase_uid}/status` | Get user status |
 | PUT | `/v1/users/firebase/{firebase_uid}/last-accessed` | Update last accessed |
-| PUT | `/v1/users/metrics` | Update user metrics |
+| PUT | `/v1/users/firebase/{firebase_uid}/onboarding/complete` | Complete onboarding |
 | PUT | `/v1/users/timezone` | Update user timezone |
 | PATCH | `/v1/users/language` | Update user language |
 | DELETE | `/v1/users/firebase/{firebase_uid}` | Delete user account |
@@ -75,7 +78,6 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/v1/meal-suggestions/generate` | Generate 3 personalized suggestions |
 | POST | `/v1/meal-suggestions/discover` | Meal discovery (6 meals/batch with images) |
 | POST | `/v1/meal-suggestions/recipes` | Generate recipe batch |
 | POST | `/v1/meal-suggestions/save` | Save a meal suggestion |
@@ -100,6 +102,41 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | GET | `/v1/foods/{fdc_id}/details` | Get food details by FDC ID |
 | GET | `/v1/foods/barcode/{barcode}` | Barcode lookup (6-step cascade) |
 | POST | `/v1/ingredients/recognize` | Recognize ingredients from image |
+| GET | `/v1/ingredients/health` | Ingredient recognition health |
+
+---
+
+## Hydration
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/hydration/catalog` | Get drink catalog |
+| POST | `/v1/hydration/log` | Log water intake |
+| POST | `/v1/hydration/log/drink` | Log caloric drink intake |
+| GET | `/v1/hydration/daily` | Daily hydration summary |
+| GET | `/v1/hydration/weekly` | Weekly hydration summary |
+| DELETE | `/v1/hydration/{entry_id}` | Delete hydration entry |
+
+---
+
+## Movement
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/movement/catalog` | Get movement activity catalog |
+| POST | `/v1/movement/log` | Log movement entry |
+| GET | `/v1/movement/daily` | Daily movement summary |
+| PATCH | `/v1/movement/{entry_id}` | Update movement entry |
+| DELETE | `/v1/movement/{entry_id}` | Delete movement entry |
+
+---
+
+## Nutrition
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/nutrition/bulk` | Bulk nutrition lookup |
+| GET | `/v1/nutrition/presence` | Get activity/nutrition presence |
 
 ---
 
@@ -127,6 +164,7 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | GET | `/v1/activities/daily` | Get daily activities |
+| GET | `/v1/activities/bulk` | Get activities for multiple days |
 
 ---
 
@@ -152,6 +190,15 @@ Codes are 3–15 characters. Commission rates set via `REFERRAL_COMMISSIONS` env
 | GET | `/v1/referrals/my-code` | Get user's referral code |
 | GET | `/v1/referrals/stats` | Get referral stats |
 | POST | `/v1/referrals/payout` | Request referral payout |
+
+---
+
+## Promo Codes
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/promo-codes/validate` | Validate promo code |
+| POST | `/v1/promo-codes/redeem` | Redeem promo code |
 
 ---
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,7 +1,7 @@
 # Backend Code Standards — Python Style & Conventions
 
-**Last Updated:** May 27, 2026
-**Scope:** All code in `src/` (430 files, ~38.5K LOC)  
+**Last Updated:** June 17, 2026
+**Scope:** All code in `src/` (620 Python files, ~52.6K LOC)
 **Applies To:** Typing, naming, imports, code organization, error handling
 
 ---

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,91 +1,83 @@
 # Backend Codebase Summary
 
-**Generated:** June 1, 2026
-**Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)
-**Language:** Python 3.11+ | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
+**Generated:** June 17, 2026
+**Status:** Production-ready snapshot of the live backend codebase
+**Runtime:** FastAPI 0.115+ on Python 3.11+ with async SQLAlchemy 2.0
 
 ---
 
-## Codebase Metrics
+## Current Metrics
 
 | Metric | Value |
 |--------|-------|
-| Total Source Files | 430 Python files |
-| API Layer | 76 files, ~8,605 LOC |
-| Application Layer | 140 files, ~6,229 LOC |
-| Domain Layer | 133 files, ~14,556 LOC |
-| Infrastructure Layer | 80 files, ~8,895 LOC |
-| Total LOC (src/) | ~38,300 LOC |
-| Test Files | 92 files |
-| Total Test Cases | 681+ tests |
-| Test Coverage | 70%+ maintained |
-| API Endpoints | 60+ REST endpoints across 17 route modules |
-| CQRS Commands | 30 commands across 11 domains |
-| CQRS Queries | 31 query definitions |
-| Domain Events | 19 event definitions |
-| Handlers | 51 handlers with @handles decorator (28+ cmd, 24+ query, 1 event) |
-| Application Services | 3 (MessageOrchestrationService, AIResponseCoordinator, ChatNotificationService) |
-| Domain Services | 50+ service files |
-| Bounded Contexts | 8 contexts (Meal, Nutrition, User, Planning, Conversation, Notification, AI, Chat) |
-| Analysis Strategies | 6 strategies (basic, portion, ingredient, weight, user-context, combined) |
-| Database Tables | 13+ (core + notification_sent_log for dedup) |
-| Repositories | 10+ with smart sync and eager loading |
-| Port Interfaces | 17 port interfaces for dependency inversion |
-| External Integrations | 9 (Gemini, Pinecone, Firebase, Cloudinary, RevenueCat, PostHog, Redis, MySQL, Sentry) |
+| Source files | 620 Python files in `src/` |
+| Source LOC | ~52.6K LOC in `src/` |
+| Test files | 291 Python files in `tests/` |
+| Collected tests | 1,600+ collected tests |
+| API routers | 26 router registrations in `src/api/main.py` |
+| API endpoints | 83 endpoint decorators under `src/api/routes/` |
+| CQRS command files | 51 |
+| CQRS query files | 50 |
+| CQRS event files | 15 |
+| CQRS handler files | 87 |
+| Domain service files | 50 |
+| Port files | 26 |
+| Database model files | 47 |
+| ORM table declarations | 36 |
+
+---
+
+## Layer Snapshot
+
+| Layer | Files | LOC | Notes |
+|-------|-------|-----|-------|
+| API | 89 | ~10.4K | Routes, middleware, schemas, dependency wiring, and API mappers |
+| Application | 208 | ~11.0K | Commands, queries, handlers, and orchestration services |
+| Domain | 160 | ~15.5K | Entities, services, ports, policies, and bounded contexts |
+| Infrastructure | 154 | ~15.0K | Database, cache, adapters, observability, and service integrations |
+
+---
+
+## Live API Surface
+
+The current HTTP surface includes:
+
+- Meal logging and analysis: image upload, upload-token, scan-by-url, manual meals, parse-text, streak, weekly budget, and daily macros.
+- User and profile management: Firebase sync, onboarding completion, metrics, TDEE, language, timezone, and account deletion.
+- Discovery and planning: meal suggestions discover, recipes, and save.
+- Nutrition and activity tracking: nutrition bulk/presence, activities daily/bulk, hydration, and movement.
+- Support routes: foods, ingredients, notifications, feature flags, saved suggestions, cheat days, referrals, promo codes, unified code validation, monitoring, health, app download, and well-known links.
+
+---
+
+## Core Runtime Notes
+
+- Runtime DB access uses PostgreSQL/Neon via `src/infra/database/config_async.py` and `asyncpg`.
+- Redis is optional and used for cache-aside and AI-context caching, not as the source of truth.
+- Database migrations are Alembic-managed and run before app startup through the entrypoint/pre-deploy flow.
+- The event bus is a singleton PyMediator registry wired from `src/api/dependencies/event_bus.py`.
 
 ---
 
 ## Key Directories
 
-| Directory | Files | Purpose |
-|-----------|-------|---------|
-| `src/api/routes/v1/` | 17 | 60+ REST endpoints |
-| `src/api/schemas/` | 34 | Pydantic DTOs |
-| `src/app/commands/` | 30 | Write operations |
-| `src/app/queries/` | 31 | Read operations |
-| `src/app/handlers/` | 51+ | CQRS handlers |
-| `src/domain/model/` | 44 | Domain entities (8 bounded contexts) |
-| `src/domain/services/` | 50+ | Domain services |
-| `src/infra/database/models/` | 13+ | Database tables |
-| `src/infra/repositories/` | 10+ | Data access |
-| `src/infra/services/` | 8+ | External services |
-| `tests/` | 92 | 681+ tests (70%+ coverage) |
+| Directory | Purpose |
+|-----------|---------|
+| `src/api/main.py` | FastAPI app bootstrap and router registration |
+| `src/api/routes/` | HTTP endpoints and route modules |
+| `src/app/` | CQRS commands, queries, and handlers |
+| `src/domain/` | Domain logic, services, and ports |
+| `src/infra/` | Database, cache, adapters, observability, and external services |
+| `tests/` | Unit, integration, architecture, and migration tests |
 
 ---
 
-## Recent Features (May 2026)
+## Verification Sources
 
-- **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry pushes at T-2d and T-1d; notifications rescheduled on timezone changes; cron push (`src/cron/push.py`) precomputes notification rows, schedules trial-expiry rows, dispatches due rows through database row claiming, and cleans expired rows
-- **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; PostHog lifecycle mirroring
-- **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` — fire-and-forget async capture; enabled by `POSTHOG_API_KEY`
-- **Parallel Recipe Generator:** `src/domain/services/meal_suggestion/parallel_recipe_generator.py` with per-recipe attempt logic in `recipe_attempt_builder.py`; 3-phase pipeline: name generation → parallel recipe generation → translation
-- **Cron Lifecycle Email Service:** `src/cron/email.py` runs re-engagement and trial-expiry lifecycle emails via `CronLifecycleEmailService`
-- **Configurable Referral Commission:** `REFERRAL_COMMISSIONS` env var (JSON dict, per-currency, default 2 USD)
-- **Variable-Length Referral Codes:** 3–15 character codes
-
----
-
-## Entry Points
-
-- **FastAPI app:** `src/api/main.py`
-- **CLI**: `python -m src.api.main` or `uvicorn src.api.main:app --reload`
-- **Tests:** `pytest` or `pytest -m unit`
-- **Migrations:** `alembic upgrade head` or `alembic revision --autogenerate -m "..."`
-
----
-
-## Core Domain Services
-
-| Service | Purpose |
-|---------|---------|
-| TdeeCalculationService | TDEE + macro calculations (auto-formula selection) |
-| MealCoreService | Meal lifecycle & state machine |
-| NutritionCalculationService | Nutrition aggregation from food items |
-| SuggestionOrchestrationService | Session-based meal suggestions (4h Redis TTL) |
-| MealGenerationService | Multi-model Gemini for meal generation |
-| TranslationService | 7-language support (en, vi, es, fr, de, ja, zh) |
-| MealDiscoveryService | Image-based meal discovery |
-
----
-
-See detailed docs: `system-architecture.md`, `cqrs-guide.md`, `database-guide.md`, `external-services.md`
+- `src/api/main.py`
+- `src/api/routes/`
+- `src/api/dependencies/event_bus.py`
+- `src/infra/database/config_async.py`
+- `src/infra/config/settings.py`
+- `docker-compose.yml`
+- `pyproject.toml`

--- a/docs/cqrs-guide.md
+++ b/docs/cqrs-guide.md
@@ -1,9 +1,9 @@
 # Backend CQRS Pattern Guide
 
-**Last Updated:** May 6, 2026
+**Last Updated:** June 17, 2026
 **Event Bus:** PyMediator with singleton registry pattern
-**Handlers:** 51+ across commands, queries, and events
-**Domains:** 11 (Chat, Meal, Daily Meal, Meal Plan, Meal Suggestion, User, Notification, Ingredient, TDEE, Activity, Food)
+**Handlers:** 87 handler files across commands, queries, and events
+**Domains:** Activity, Cheat Day, Codes, Daily Meal, Food, Hydration, Ingredient, Meal, Meal Plan, Meal Suggestion, Movement, Notification, Nutrition, Promo Code, Referral, Saved Suggestion, TDEE, User, Weight
 
 ---
 
@@ -109,7 +109,7 @@ await event_bus.publish(MealCreatedEvent(...))          # fire-and-forget
 ### Two Event Buses
 
 1. **Food Search Bus**: Lightweight, food queries only
-2. **Configured Bus**: Full CQRS with 40+ handlers registered
+2. **Configured Bus**: Full CQRS bus registered from `src/api/dependencies/event_bus.py`
 
 ---
 

--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -1,9 +1,9 @@
 # Backend Database Guide
 
-**Last Updated:** June 10, 2026
+**Last Updated:** June 17, 2026
 **Engine:** PostgreSQL (Neon) + SQLAlchemy 2.0 async runtime (asyncpg)
-**Migrations:** Alembic with auto-migration on startup
-**Tables:** 30+ (core tables + normalized profile/hydration/recipe/food/referral tables)
+**Migrations:** Alembic via deployment entrypoint/pre-deploy flow
+**Tables:** 36 ORM table declarations across core, normalized tracking, referral, notification, and cache models
 
 ---
 
@@ -65,9 +65,9 @@ DATABASE_URL = "postgresql+asyncpg://user:pass@host/db"
 
 async_engine = create_async_engine(
     DATABASE_URL,
-    pool_size=20,       # Base connections
-    max_overflow=10,    # Additional under load
-    pool_recycle=3600,  # Recycle hourly
+    pool_size=3,        # Default per worker
+    max_overflow=2,     # Default per worker
+    pool_recycle=120,   # Default recycle interval
     pool_pre_ping=True, # Verify before use
 )
 
@@ -162,12 +162,16 @@ alembic revision --autogenerate -m "description"  # Create new
 alembic downgrade -1                              # Rollback one
 ```
 
-Auto-migrate runs on startup with retry logic. Use timestamp naming for new migrations.
+Deployments run migrations before application startup through `docker-entrypoint.sh`
+for non-production environments or through a production pre-deploy job. Use
+timestamp naming for new migrations and keep app runtime URLs separate from
+migration/admin URLs.
 
 **Recent migrations:**
 
 | Version | Changes |
 |---------|---------|
+| 20260610000001 | Add affiliate_event_outbox for cross-service affiliate lifecycle dispatch |
 | 20260609000006 | Add normalized read-path indexes for active FCM tokens, notification reschedule/delete, and stale processing reclaim |
 | 20260609000005 | Add normalized food serving/nutrient tables, payout typed workflow fields, notification context schema version |
 | 20260609000004 | Add normalized saved suggestion ingredients/steps and meal recipe instruction steps |
@@ -205,7 +209,7 @@ concurrent requests.
 
 - Indexes on `firebase_uid`, `status`, date columns, and `user_id` foreign keys
 - `joinedload` / `selectinload` for known relationship paths
-- Connection pool: 20 base + 10 overflow, recycled hourly
+- Direct-pool defaults: 3 base + 2 overflow connections per worker, recycled every 120 seconds
 - Redis cache-aside for frequently read data (see `external-services.md`)
 
 ---

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,7 +1,7 @@
 # Backend External Services Integration
 
-**Last Updated:** June 13, 2026
-**Services:** Firebase, Cloudinary, Google Gemini, RevenueCat, PostHog, Redis, Sentry
+**Last Updated:** June 17, 2026
+**Services:** Firebase, Cloudinary, Google Gemini, RevenueCat, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, Brave Search, Pexels, Unsplash, Resend, Cloudflare Workers AI, Google Imagen, Pollinations, nutree-affiliate
 **Failure handling:** Optional integrations degrade when safe. Firebase Auth and the primary DB fail fast. Redis optional caches degrade by bypassing cache; any Redis-backed required state must be documented and health-checked separately.
 
 ---
@@ -56,8 +56,7 @@
 |---------|-------|---------|
 | General / Recipe / Barcode | `gemini-2.5-flash` | `GEMINI_MODEL` |
 | Meal names | `gemini-2.5-flash-lite` | `GEMINI_MODEL_NAMES` |
-| Recipe primary | `gemini-2.5-flash` | `GEMINI_MODEL_RECIPE_PRIMARY` |
-| Recipe secondary | `gemini-2.5-flash` | `GEMINI_MODEL_RECIPE_SECONDARY` |
+| Recipe generation | `gemini-2.5-flash-lite` | `GEMINI_MODEL_RECIPE` |
 
 ### Vision AI (Meal Analysis)
 - 6 analysis strategies: basic, portion-aware, ingredient-aware, weight-aware, user-context, combined
@@ -123,7 +122,7 @@
 
 - **Default posture:** Do not cache unless the value passes the cache admission checklist in `docs/superpowers/specs/2026-05-21-redis-optimize-design.md`.
 - **Pattern:** Cache-aside only for optional read caches where DB/API fallback is correct.
-- **Connection Pool:** 50 connections | **Default TTL:** 1 hour
+- **Connection Pool:** 10 connections by default (`REDIS_MAX_CONNECTIONS`) | **Default TTL:** 1 hour
 - **Error Handling:** Optional caches degrade by bypassing Redis. Required Redis-backed state must be documented and health-checked separately.
 
 **Config:** `REDIS_URL=redis://host:port/db`
@@ -228,7 +227,7 @@ event types, environment, durations, sizes, counts, and error class names.
 
 See `database-guide.md` for schema, connection pool, and migration details.
 
-**Config:** `DATABASE_URL=postgresql+asyncpg://user:pass@host/db`
+**Config:** `APP_DATABASE_URL=postgresql://user:pass@host/db` for app runtime; `DATABASE_URL_DIRECT` is migration/admin only.
 
 ---
 
@@ -236,9 +235,9 @@ See `database-guide.md` for schema, connection pool, and migration details.
 
 ```
 GET /health                    # Basic health (200 if running)
-GET /health/db-pool            # DB pool metrics
-GET /health/db-connections     # PostgreSQL connection stats
-GET /health/notifications      # FCM health
+GET /v1/health/db-pool         # DB pool metrics
+GET /v1/health/db-connections  # PostgreSQL connection stats
+GET /v1/health/notifications   # FCM health
 ```
 
 ---

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,14 +1,14 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
-**Version:** 0.6.2
-**Last Updated:** May 15, 2026
-**Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: configurable referral commissions, BMR floor protection, custom unit normalization, email Universal Links, AsyncUnitOfWork concurrency guard.
+**Version:** 0.6.4
+**Last Updated:** June 17, 2026
+**Status:** Production-ready. 620 Python files and ~52.6K LOC in `src/`; current suite has 291 Python test files and 1,600+ collected tests. Latest: async PostgreSQL/Neon runtime alignment, observability connector, normalized database foundation, hydration/movement APIs, affiliate outbox, and refreshed codebase documentation.
 
 ---
 
 ## Executive Summary
 
-MealTrack Backend is a FastAPI-based service powering intelligent meal tracking and nutritional analysis. It implements Clean Architecture with CQRS pattern across 4 layers (430 files, ~38K LOC), integrating AI vision (Gemini 2.5 Flash with 6 analysis strategies) and chat (streaming responses via MessageOrchestrationService, AIResponseCoordinator) for real-time food recognition and personalized nutrition planning. The system handles 50+ REST endpoints across 12 route modules, supports 7 languages, and maintains 70%+ test coverage with 681+ tests. Latest stats: API (76 files, 8,605 LOC), App (140 files, 6,229 LOC), Domain (133 files, 14,556 LOC), Infra (80 files, 8,895 LOC).
+MealTrack Backend is a FastAPI service powering meal tracking, nutritional analysis, weekly calorie budgeting, hydration, movement, referrals, promo codes, notifications, and subscription state. It implements Clean Architecture with CQRS across API, application, domain, and infrastructure layers, integrating Gemini-based AI meal analysis, PostgreSQL/pgvector storage, Redis-backed optional cache-aside paths, and operational observability. The current HTTP surface has 26 router registrations and 83 endpoint decorators across meals, users, profiles, suggestions, hydration, movement, nutrition, referrals, promo codes, health, monitoring, webhooks, and support routes.
 
 ---
 
@@ -33,19 +33,23 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 - Gemini 2.5 Flash with strategy pattern for flexible context handling.
 - Returns results in <3 seconds through state machine (PROCESSING → ANALYZING → READY/FAILED).
 
-### 2. RESTful API (60+ Endpoints across 17 Route Modules)
-- **Meals**: image/analyze, manual, parse-text, streak, weekly/daily-breakdown, weekly/budget, daily/macros, /{id} (GET/DELETE), ingredients (PUT).
+### 2. RESTful API (83 Endpoint Decorators across 26 Router Registrations)
+- **Meals**: image/analyze, upload-token, scan-by-url, manual, parse-text, streak, weekly/daily-breakdown, weekly/budget, daily/macros, /{id} (GET/DELETE), ingredients (PUT).
 - **User Profiles**: create, metrics (GET/POST), TDEE, custom-macros.
-- **Users**: sync, Firebase UID lookups, metrics, timezone, language, delete.
-- **Meal Suggestions**: generate (3/session, 4h TTL), discover (6 meals + images), recipes, save.
+- **Users**: sync, Firebase UID lookups, onboarding completion, timezone, language, delete.
+- **Meal Suggestions**: discover (6 meals + images), recipes, save.
 - **Saved Suggestions**: list, save, delete.
 - **Foods**: USDA FDC search, details by FDC ID, barcode lookup (6-step cascade).
-- **Ingredients**: image-based recognition.
+- **Ingredients**: image-based recognition, health.
 - **TDEE**: preview calculation.
 - **Weight Entries**: list, log, delete, sync.
-- **Activities**: daily activities.
+- **Activities**: daily and bulk activities.
+- **Hydration**: drink catalog, water logging, caloric drink logging, daily/weekly summaries, delete.
+- **Movement**: activity catalog, log, daily summary, update, delete.
+- **Nutrition**: bulk nutrition lookup and activity presence.
 - **Notifications**: FCM token management, deduplication (notification_sent_log), preferences.
 - **Referrals**: validate, apply, my-code, stats, payout.
+- **Promo Codes / Codes**: validate/redeem promo codes and validate purchase codes.
 - **Cheat Days**: list, mark, delete.
 - **Feature Flags**: CRUD for feature toggles.
 - **Webhooks**: RevenueCat subscription sync.
@@ -65,9 +69,9 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 - Cooking time constraints (weekday 30min, weekend 60min).
 - Min 3 days before meal repetition, max 2 same-cuisine per week.
 
-### 5. Vector Search & Food Discovery
-- Pinecone Inference API with llama-text-embed-v2 (1024-dim embeddings).
-- Semantic ingredient search with 0.35 similarity threshold.
+### 5. Food Discovery & Vector-Backed Image Cache
+- PostgreSQL/pgvector-backed local runtime for vector-capable storage.
+- Meal image cache uses SigLIP embeddings and configurable cosine thresholds for image reuse.
 - Nutrition scaling by portion with unit conversion (g, kg, oz, lb, ml, cup, etc.).
 - Aggregated nutrition calculation across multiple ingredients.
 
@@ -88,9 +92,8 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 ## 3. Technical Stack
 - **Framework**: FastAPI 0.115+ (Python 3.11+)
-- **Database**: PostgreSQL (Neon) with SQLAlchemy 2.0 async runtime, 13+ core tables
+- **Database**: PostgreSQL (Neon) with SQLAlchemy 2.0 async runtime, asyncpg, Alembic, and pgvector-enabled local compose
 - **Cache**: Redis 7.0 for selective optional caching and AI-cost optimization; required state must be modeled separately
-- **Vector DB**: Pinecone Inference API (1024-dim, llama-text-embed-v2)
 - **AI Services**: Google Gemini 2.5 Flash (multi-model for rate distribution)
 - **Storage**: Cloudinary (image storage with folder organization)
 - **Image Search**: Unsplash + Pexels adapters (meal discovery)
@@ -104,7 +107,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 ## 4. Non-Functional Requirements
 - **Reliability**: 99.9% uptime with graceful degradation for external services.
-- **Test Coverage**: 70%+ overall (681+ tests), 100% critical paths.
+- **Test Coverage**: 70%+ overall target, 100% critical paths, 80%+ for new features.
 - **Maintainability**: <200 LOC per file, 4-Layer Clean Architecture with strict separation.
 - **Security**: Firebase JWT verification, RevenueCat webhook auth, soft deletes, input sanitization.
 - **Performance**: Request-scoped DB sessions, Redis caching with TTL, eager loading for queries.
@@ -117,12 +120,14 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 0.6.4 | Jun 17, 2026 | Documentation refresh aligned active docs to live code: 620 source files, 83 endpoint decorators, PostgreSQL/Neon async runtime, pgvector-enabled local compose, Redis optional cache posture, hydration/movement/nutrition/referral/promo endpoint inventory, and updated test scale. |
+| 0.6.3 | Jun 13, 2026 | Single-owner logger and provider-neutral observability connector. Sentry direct imports isolated, cron/background boundaries own swallowed exception capture, safe scalar context allowlists documented. |
 | 0.6.2 | May 15, 2026 | Configurable referral commissions (`REFERRAL_COMMISSIONS` env var, per-currency JSON). Custom unit-to-grams fix in nutrition calculation. BMR floor raised to 85% of standard daily; cutting deficit 500→300 kcal; clinical minimums 1200F/1500M. Email Universal Links (apple-app-site-association, /app-download). AsyncUnitOfWork concurrency guard (asyncio.Lock). Variable-length referral codes (3–15 chars). |
 | 0.6.0 | Mar 14, 2026 | Nutrition accuracy (5-phase implementation): fiber-aware calories, food density conversion, macro validation, food reference evolution, meal decomposition. Custom macro targets per profile. Date of birth tracking. Adjusted daily target from weekly budget in suggestions. 3 new services, 3 new migrations (034-037), 28+ modified/new files. |
-| 0.5.0 | Feb 3, 2026 | Updated metrics across all layers: API (76 files, 8,605 LOC), App (140 files, 6,229 LOC), Domain (133 files, 14,556 LOC), Infra (80 files, 8,895 LOC). Total: 430 files, ~38K LOC. Fixed metric inconsistencies from previous documentation. |
+| 0.5.0 | Feb 3, 2026 | Historical documentation metric refresh for the then-current layer layout. Superseded by the June 2026 live-code snapshot above. |
 | 0.4.9 | Jan 19, 2026 | Documentation refresh with updated dates. Verified CQRS patterns, domain services, and API endpoints against actual codebase. Weight-based macro calculation confirmed in TDEE service. |
 | 0.4.7 | Jan 16, 2026 | Documentation refresh with scout-verified statistics (408 files, ~37K LOC). |
 | 0.4.6 | Jan 9, 2026 | Phase 02: Language prompt integration (LANGUAGE_NAMES, language instructions, updated prompts). Phase 01: Meal suggestions multilingual support (7 languages, ISO 639-1 codes). |
-| 0.4.5 | Jan 7, 2026 | Phase 05 Pinecone Migration (1024-dim). Documentation split for modularity. |
+| 0.4.5 | Jan 7, 2026 | Legacy vector-search migration work. Documentation split for modularity. |
 | 0.4.4 | Jan 4, 2026 | Phase 03 Cleanup: Unified fitness goal enums to 3 canonical values. |
 | 0.4.0 | Jan 3, 2026 | Phase 06: Session-based suggestions with 4h TTL. |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,13 +1,18 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.3
-**Last Updated:** June 13, 2026
-**Status:** Production-ready. 430 source files, ~38K LOC across 4 layers (API: 76, App: 140, Domain: 133, Infra: 80). 681+ tests, 70%+ coverage.
+**Version:** 0.6.4
+**Last Updated:** June 17, 2026
+**Status:** Production-ready. 620 Python files and ~52.6K LOC in `src/` (API: 89, App: 208, Domain: 160, Infra: 154). 291 Python test files with 1,600+ collected tests.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
 
 ---
 
 ## Completed Phases
+
+### June 2026: Codebase Documentation Refresh
+- [x] Updated README, project instructions, codebase summary, architecture, API, database, external-service, standards, testing, CQRS, overview, roadmap, and troubleshooting docs against the live source tree.
+- [x] Replaced stale database-engine, legacy vector-service, route-count, layer-count, test-count, Redis-pool, migration-startup, and CORS risk claims in current docs.
+- [x] Documented current hydration, movement, nutrition, referral, promo-code, upload-token, scan-by-url, and health endpoint surfaces.
 
 ### June 2026: Single-Owner Logger System
 - [x] Established log-or-raise rule: one root-cause `ERROR` per unexpected request failure; expected 4xx exceptions produce zero ERROR logs.
@@ -93,7 +98,7 @@
 - [x] Documentation updates: system-architecture, code-standards, project-overview, roadmap
 
 ### February 2026: Documentation Refresh v0.5.0
-- [x] Updated all documentation with latest scout-verified statistics (430 files, ~38K LOC).
+- [x] Updated all documentation with then-current scout-verified statistics.
 - [x] Accurate metrics: 30 commands, 31 queries, 19 events, 54 handlers, 50+ domain services.
 - [x] Fixed metric inconsistencies across all doc files.
 - [x] Updated layer statistics (76/140/133/80 files, ~8.6K/6.2K/14.6K/8.9K LOC).
@@ -110,7 +115,7 @@
 - [x] SuggestionOrchestrationService with 4h TTL (Redis).
 - [x] Portion multipliers (1-4x) and rejection feedback.
 - [x] Generation fallback mechanism.
-- [x] 681+ tests passing.
+- [x] Test suite passing at the time of delivery.
 
 ### Phase 02: Language Prompt Integration (Jan 2026)
 - [x] Language-aware prompt generation with injected instructions.
@@ -122,9 +127,9 @@
 - [x] English fallback for invalid language codes.
 - [x] TranslationService for post-generation translation.
 
-### Phase 05: Pinecone Inference Migration (Jan 2026)
+### Phase 05: Legacy Vector Search Migration (Jan 2026)
 - [x] Recreated indexes with 1024-dim vectors (llama-text-embed-v2).
-- [x] Migrated to serverless Pinecone Inference API.
+- [x] Migrated legacy semantic search infrastructure; current active docs describe PostgreSQL/pgvector-backed vector-capable storage.
 - [x] Updated unit/integration tests with 1024-dim mocks.
 - [x] Semantic ingredient search with 0.35 similarity threshold.
 
@@ -150,8 +155,8 @@
 
 ## Current Priorities (Q2 2026)
 1. **Performance**: Optimize suggestion generation (target <10s from ~45s) — in progress.
-2. **Security**: Restrict CORS in production (`allow_origins=["*"]` currently wide open), add PII redaction to request logging — open.
-3. **Rate Limiting**: Tune rate limits on `meal_suggestions` endpoints (discover, generate) — open.
+2. **Security**: Review deployed `ALLOWED_ORIGINS` values and continue log/request PII redaction audits — open.
+3. **Rate Limiting**: Tune rate limits on `meal_suggestions` endpoints (`discover`, `recipes`, `save`) — open.
 4. **Testing**: Increase coverage for meal discovery and notification dedup logic — open.
 5. **Premium Gating**: Apply `require_premium` dependency to premium-only routes — open.
 
@@ -176,7 +181,7 @@
 
 ### High Priority
 - [ ] Plan contract migration to remove or secure legacy JSON compatibility fields after production observation window.
-- [ ] Fix CORS wide open (allow_origins=["*"]) - security risk in production
+- [ ] Verify production `ALLOWED_ORIGINS` is restricted to known app/web origins.
 - [ ] Implement API versioning strategy beyond v1
 - [ ] Apply `require_premium` dependency to premium-only features
 - [ ] Refactor hardcoded values (MAX_FILE_SIZE, SLOW_REQUEST_THRESHOLD) to config

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,9 +1,9 @@
 # Backend System Architecture Overview
 
-**Last Updated:** June 13, 2026
+**Last Updated:** June 17, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
-**Codebase:** 430 files, ~38.5K LOC across 4 layers
+**Codebase:** 620 Python files, ~52.6K LOC in `src/`
 
 ---
 
@@ -11,22 +11,22 @@
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                      API Layer (76 files)                    │
+│                      API Layer (89 files)                    │
 │  HTTP Routing │ Pydantic Validation │ Auth │ Middleware      │
 └────────────────────────┬────────────────────────────────────┘
                          │ Commands/Queries
 ┌────────────────────────▼────────────────────────────────────┐
-│              Application Layer (140 files)                   │
+│              Application Layer (208 files)                   │
 │  CQRS Handlers │ Event Publishing │ App Services             │
 └────────────────────────┬────────────────────────────────────┘
                          │ Domain Services
 ┌────────────────────────▼────────────────────────────────────┐
-│                Domain Layer (133 files)                      │
+│                Domain Layer (160 files)                      │
 │  Business Logic │ Domain Models │ Port Interfaces            │
 └────────────────────────┬────────────────────────────────────┘
                          │ Port Implementations
 ┌────────────────────────▼────────────────────────────────────┐
-│            Infrastructure Layer (80 files)                   │
+│            Infrastructure Layer (154 files)                  │
 │  DB │ Cache │ External APIs │ Event Bus │ Config             │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -37,11 +37,11 @@
 
 | Layer | Files | LOC | Key Contents |
 |-------|-------|-----|-------------|
-| API | 76 | ~8,605 | 17 route modules, 34 Pydantic schemas, 8 mappers, 3 middleware |
-| App | 140 | ~6,229 | 30 commands, 31 queries, 19 events, 51+ handlers, 3 app services |
-| Domain | 133 | ~14,556 | 8 bounded contexts, 30+ entities, 50+ services, 17 port interfaces |
-| Infra | 80 | ~8,895 | 13+ DB tables, 10+ repos, Redis, PyMediator, external adapters, push payload builders |
-| **Total** | **430** | **~38,300** | |
+| API | 89 | ~10,361 | 26 router registrations, 83 endpoint decorators, schemas, middleware, dependencies |
+| App | 208 | ~10,984 | 51 command files, 50 query files, 15 event files, 87 handler files |
+| Domain | 160 | ~15,460 | Meal, nutrition, user, hydration, movement, notification, planning, referral-facing policies |
+| Infra | 154 | ~15,041 | PostgreSQL/pgvector, Redis, PyMediator, external adapters, observability, push/email services |
+| **Total** | **611** | **~51,846** | Layer directories only; `src/` also has bootstrap, cron, and observability modules |
 
 **Layer rule:** Domain has ZERO external dependencies. See `cqrs-guide.md` for handler patterns.
 
@@ -93,14 +93,15 @@ Architecture guardrails enforced by `tests/unit/architecture/test_logging_owners
 
 | Context | Key Entities |
 |---------|-------------|
-| Meal | Meal (state machine), MealImage, Ingredient |
+| Meal | Meal (state machine), MealImage, Ingredient, image cache projection |
 | Nutrition | Nutrition, FoodItem, Macros, Micros |
-| User | User, UserProfile, Activity, TdeeRequest |
-| Meal Planning | MealPlan, PlannedMeal, DayPlan, UserPreferences |
-| Conversation | Conversation, Message, ConversationState |
-| Notification | UserFcmToken, NotificationPreferences, PushNotification, NotificationSentLog |
+| User | User, UserProfile, Activity, TdeeRequest, weight history |
+| Hydration | Hydration entries, drink catalog, caloric drink logging |
+| Movement | Movement entries, activity catalog, daily movement summaries |
+| Meal Planning | Weekly budget, meal planning, meal suggestion, saved suggestion models |
+| Notification | UserFcmToken, NotificationPreferences, PushNotification, queued notification rows |
 | AI | GPTAnalysisResponse, GPTFoodItem, GPTResponseError |
-| Chat | Thread, Message, ThreadStatus, MessageRole |
+| Commerce | Subscription state, referral code application, promo code redemption |
 
 ---
 
@@ -150,11 +151,11 @@ Nutree mobile ──→ MealTrack (validate/apply code)
 
 ## Known Issues
 
-- CORS `allow_origins=["*"]` wide open in production (security risk)
 - Premium features not restricted on routes (`require_premium` dependency not applied)
 - No API versioning strategy beyond v1
 - `CloudinaryImageStore` instantiated directly in routes (not via DI)
 - Hardcoded constants (MAX_FILE_SIZE, SLOW_REQUEST_THRESHOLD) not in config
+- CORS is configured only when `ALLOWED_ORIGINS` is set; production origin values still need deployment review.
 - `AsyncUnitOfWork` uses `asyncio.Lock`; concurrent reuse within one instance will block (by design — use separate instances per handler, enforced by event bus handler cloning)
 - Database runtime is async-only: request paths, cron jobs, and handlers use `config_async.py`, `AsyncSession`, `AsyncUnitOfWork`, and async repositories. Alembic uses its separate migration engine.
 - Manual meal save (`POST /v1/meals/manual`) instruments `db_ms` and `cache_ms` in structured logs so DB commit and Redis cache invalidation latency are independently observable without logging food payload or auth data.

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -1,8 +1,8 @@
 # Backend Testing Standards
 
-**Last Updated:** April 17, 2026  
+**Last Updated:** June 17, 2026
 **Coverage Target:** 70%+ overall, 100% critical paths, 80%+ new features  
-**Total Tests:** 681+ tests in 92 test files
+**Suite Size:** 291 Python files in `tests/`; latest collection reaches 1,600+ tests
 
 ---
 
@@ -10,14 +10,18 @@
 
 ```
 tests/
+├── architecture/       # Import boundaries and async-runtime guardrails
 ├── unit/
-│   ├── domain/          # Domain services, entities
-│   ├── app/             # Handlers, commands, queries
-│   └── conftest.py      # Shared fixtures
-└── integration/
-    ├── api/             # Route endpoints
-    ├── infra/           # Repository, external services
-    └── conftest.py      # DB/event bus fixtures
+│   ├── api/            # Routes, dependencies, middleware, mappers
+│   ├── app/            # Handlers, commands, queries, services
+│   ├── domain/         # Domain services, entities, policies
+│   └── infra/          # Adapters, repositories, event bus, external services
+├── integration/
+│   ├── api/            # Route endpoints
+│   ├── infra/          # Repository, external services
+│   └── routes/         # Route-level integration coverage
+├── fixtures/           # Factories, fakes, DB fixtures
+└── migrations/         # Alembic migration validation
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Backend Troubleshooting Guide
 
-**Last Updated:** June 13, 2026
+**Last Updated:** June 17, 2026
 
 ---
 
@@ -24,18 +24,20 @@ python -c "from src.app.commands.meal import CreateMealCommand"
 
 ### Database Connection Errors
 
-**Problem:** `OperationalError: Can't connect to MySQL server`
+**Problem:** `OperationalError`, `ConnectionDoesNotExistError`, or failure to connect to PostgreSQL/Neon
 
 **Diagnosis:**
 ```bash
 echo $DATABASE_URL
-# Should be: mysql+pymysql://user:pass@host:3306/dbname
+echo $APP_DATABASE_URL
+# App runtime should use a PostgreSQL/Neon URL.
 ```
 
 **Solutions:**
-1. Verify `DATABASE_URL` format (user, pass, host, port, dbname)
-2. Verify MySQL is running and credentials are correct
-3. Check firewall/network access rules
+1. Prefer `APP_DATABASE_URL` for app runtime; keep `DATABASE_URL_DIRECT` for Alembic migration/admin use only.
+2. Verify `DB_CONNECTION_MODE=direct_pool` uses a direct Neon host, or `DB_CONNECTION_MODE=neon_pooler` uses a `-pooler` host.
+3. For local development, verify the `postgres` service from `docker-compose.yml` is running and healthy.
+4. Check firewall/network access rules and Neon connection limits.
 
 ---
 
@@ -205,8 +207,8 @@ curl -i -X OPTIONS "http://localhost:8000/v1/meals"
 ```
 
 **Solutions:**
-1. Development: `allow_origins=["*"]` (already set)
-2. Production: Restrict to known origins via environment config
+1. Set `ALLOWED_ORIGINS` to a comma-separated list, for example `http://localhost:3000,https://app.example.com`.
+2. Production: restrict `ALLOWED_ORIGINS` to known origins only.
 3. Verify preflight (OPTIONS) returns 200
 
 ---


### PR DESCRIPTION
## Summary
- Refresh backend README, project instructions, and evergreen docs against the live source tree.
- Update current metrics, API endpoint inventory, PostgreSQL/Neon runtime guidance, Redis defaults, migration flow, and testing scale.
- Remove stale current claims around MySQL, legacy vector-service wording, old route/layer/test counts, and CORS risk wording.

## Related issues
- None found via GitHub issue search for codebase docs/documentation drift.

## Test plan
- [x] `git diff --check`
- [x] top-level Markdown file-link check
- [x] stale-reference scan for removed MySQL/Pinecone/old-count/CORS-wide-open claims
- [ ] `ruff check src/` currently fails on pre-existing source lint issues unrelated to this docs-only branch