### PR TITLE
fix(nutrition): credit movement in weekly budget

### DIFF
--- a/docs/architecture/fitness-goals.md
+++ b/docs/architecture/fitness-goals.md
@@ -11,7 +11,9 @@ Unified 3-value structure used across all layers:
 
 ## TDEE Calculation
 
-Calculated using the Mifflin-St Jeor formula, adjusted by Activity Level and the chosen Fitness Goal.
+Calculated using the Mifflin-St Jeor formula, adjusted by non-exercise job/lifestyle activity and the chosen Fitness Goal.
+
+Planned training volume is not added to baseline TDEE. Workout calories are credited only when users log movement entries with `include_in_balance = true`; this prevents double-counting the same exercise in both TDEE and logged movement.
 
 ## Multi-Layer Mapping
 

--- a/docs/movement-release-readiness.md
+++ b/docs/movement-release-readiness.md
@@ -26,6 +26,8 @@ These were checked against the mobile contract and are correct:
 | **`/movement/daily` shape** | Returns `{date, goal_kcal, entries[]}`; entries use `_movement_response`. Matches mobile `MovementDailyResponse`. |
 | **Net-calorie math** | `get_daily_macros_query_handler` returns `total_calories = food_calories − movement_kcal_burned` (net), plus `food_calories` and `movement_kcal_burned`. Burn correctly frees up the calorie budget. |
 | **Bulk consistency** | `get_nutrition_bulk_query_handler` applies the same `net = food − movement` per day → weekly budget stays consistent with daily. |
+| **Weekly budget consistency** | `WeeklyBudgetService.get_effective_adjusted_daily_async` applies the same net calorie balance (`food − included movement`) to adjusted daily targets, remaining calories, weekly context, and tomorrow preview. Macro gram totals stay food-only. |
+| **TDEE baseline boundary** | Planned training volume does not inflate baseline TDEE. Logged movement is the only workout calorie credit, which avoids double-counting exercise. |
 | **`include_in_balance` filter** | `sum_included_kcal_for_range` filters `include_in_balance IS TRUE`. The feed (`find_by_user_and_logged_range`) returns all entries (so excluded ones still render but don't affect calories). Correct. |
 | **Cache invalidation** | Log **and** update **and** delete all call `_flush_movement_caches` → invalidates `daily_macros`, `weekly_budget`, and `activities:{date}:*`. No stale dashboard after mutations. |
 | **DB indexes** | Migration creates composite `idx_movement_entries_user_logged_at (user_id, logged_at)` — matches the daily range query. FK to `users` with `ON DELETE CASCADE`. |
@@ -98,6 +100,7 @@ Custom activities send `activity_id = null` (no `custom` id on the backend — s
 ### Response fields mobile parses
 - Feed entry & `_movement_response`: `id, activity_name, duration_min, kcal_burned, intensity, source, include_in_balance, logged_at` (+ `activity_id`, `type`, `timestamp` in the feed). Extra fields are ignored safely.
 - `daily-macros`: mobile reads `target_calories`, `target_macros`, and the consumed/macros values. `total_calories` is net (food − burn); mobile recomputes consumed locally and does **not** double-subtract.
+- `weekly-budget`: `consumed_calories`, `remaining_calories`, `adjusted_daily_calories`, and preview fields use net calories. `consumed_protein`, `consumed_carbs`, and `consumed_fat` remain food macro grams. Baseline TDEE excludes planned workouts, so logged movement is not a second credit for exercise already included in targets.
 
 ---
 
@@ -109,5 +112,7 @@ Custom activities send `activity_id = null` (no `custom` id on the backend — s
 - [x] `WorkoutActivityResponse` removed from `activity_responses.py` (§3.1).
 - [x] Catalog ownership: `/movement/catalog` is source of truth; mobile must fetch + cache (§3.2).
 - [x] Day-boundary parity: UTC window test added — HCM 23:30 in May 29 window, 00:30 outside (§3.3).
+- [x] Weekly budget movement credit: adjusted daily targets use `food − included movement`, matching daily and bulk nutrition.
+- [x] TDEE baseline boundary: planned training does not increase baseline TDEE; workout credit comes from logged movement.
 - [ ] Load/peek: daily range query uses `idx_movement_entries_user_logged_at` (confirm via `EXPLAIN`).
 - [ ] Apple Health documented as not-yet-released (§4).

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,7 +1,7 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
-**Version:** 0.6.4
-**Last Updated:** June 17, 2026
+**Version:** 0.6.5
+**Last Updated:** June 18, 2026
 **Status:** Production-ready. 620 Python files and ~52.6K LOC in `src/`; current suite has 291 Python test files and 1,600+ collected tests. Latest: async PostgreSQL/Neon runtime alignment, observability connector, normalized database foundation, hydration/movement APIs, affiliate outbox, and refreshed codebase documentation.
 
 ---
@@ -85,6 +85,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 ### 7. Adjusted Daily Target & Weekly Budget
 - Weekly budget stored per user with remaining_days calculation (Mon=7, Sun=1).
 - Adjusted daily target redistributes weekly budget based on previous days' consumption.
+- Baseline TDEE excludes planned workouts; logged movement with `include_in_balance = true` credits workout calories into weekly budget as net calories (`food - movement`).
 - Used by meal suggestions, meal plans, and nutrition tracking features.
 - BMR floor (85% of standard daily, raised from 80%) protects against dangerously low targets. Clinical minimums: 1200 kcal (female), 1500 kcal (male). Cutting deficit: 300 kcal (~0.3 kg/week).
 
@@ -120,6 +121,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 0.6.5 | Jun 18, 2026 | Weekly budget adjusted targets now credit logged movement calories on a net-calorie basis, and baseline TDEE excludes planned workouts to avoid double-counting exercise. |
 | 0.6.4 | Jun 17, 2026 | Documentation refresh aligned active docs to live code: 620 source files, 83 endpoint decorators, PostgreSQL/Neon async runtime, pgvector-enabled local compose, Redis optional cache posture, hydration/movement/nutrition/referral/promo endpoint inventory, and updated test scale. |
 | 0.6.3 | Jun 13, 2026 | Single-owner logger and provider-neutral observability connector. Sentry direct imports isolated, cron/background boundaries own swallowed exception capture, safe scalar context allowlists documented. |
 | 0.6.2 | May 15, 2026 | Configurable referral commissions (`REFERRAL_COMMISSIONS` env var, per-currency JSON). Custom unit-to-grams fix in nutrition calculation. BMR floor raised to 85% of standard daily; cutting deficit 500→300 kcal; clinical minimums 1200F/1500M. Email Universal Links (apple-app-site-association, /app-download). AsyncUnitOfWork concurrency guard (asyncio.Lock). Variable-length referral codes (3–15 chars). |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,7 +1,7 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.4
-**Last Updated:** June 17, 2026
+**Version:** 0.6.5
+**Last Updated:** June 18, 2026
 **Status:** Production-ready. 620 Python files and ~52.6K LOC in `src/` (API: 89, App: 208, Domain: 160, Infra: 154). 291 Python test files with 1,600+ collected tests.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
 
@@ -61,6 +61,8 @@
 
 ### June 2026: Weekly Budget Resilience
 - [x] Weekly budget meal loading now quarantines malformed legacy `READY` rows without nutrition before domain hydration.
+- [x] Weekly budget adjusted targets now credit `include_in_balance` movement calories using the same net calorie basis as daily and bulk nutrition.
+- [x] Baseline TDEE now excludes planned workouts, so logged movement is the source of workout calorie credit without double-counting.
 
 ### June 2026: iOS Notification Payload Hardening
 - [x] Removed obsolete direct notification service wiring and direct meal/summary helper sends.

--- a/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-01-regression-tests.md
+++ b/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-01-regression-tests.md
@@ -1,0 +1,46 @@
+---
+phase: 1
+title: Regression Tests
+status: completed
+priority: P1
+effort: 45m
+dependencies: []
+---
+
+# Phase 1: Regression Tests
+
+## Overview
+
+Add focused tests that prove weekly budget uses movement-adjusted calories while keeping macro grams food-only.
+
+## Requirements
+
+- Functional: `2300 food - 200 workout` behaves as `2100` consumed for weekly calorie redistribution.
+- Functional: `include_in_balance = false` movement is ignored.
+- Functional: movement logged after the target date does not change the selected day's adjustment.
+- Non-functional: no DB schema or public API shape changes.
+
+## Architecture
+
+Tests should target `WeeklyBudgetService.get_effective_adjusted_daily_async` and the weekly query handler path. Use existing fake repositories and async mocks; no database required.
+
+## Related Code Files
+
+- Modify: `tests/unit/domain/services/test_weekly_budget_async.py`
+- Modify: `tests/unit/handlers/query_handlers/test_cached_query_handlers.py`
+- Read: `tests/unit/handlers/query_handlers/test_movement_balance_integration.py`
+- Read: `src/domain/services/weekly_budget_service.py`
+
+## Implementation Steps
+
+1. Add an async fake movement repository with `sum_included_kcal_for_range`.
+2. Add a weekly service regression for Monday food 2300 kcal, Monday movement 200 kcal, Tuesday target date.
+3. Add ignored-movement and future-movement coverage.
+4. Add handler-level coverage proving response `consumed_calories`, `remaining_calories`, and preview math use the service net totals.
+5. Run the focused tests once to confirm they fail before implementation where practical.
+
+## Success Criteria
+
+- [x] Service test expects adjusted calories near the net-calorie weekly result.
+- [x] Excluded/future movement tests prove correct range/filter handling.
+- [x] Handler test proves weekly endpoint consumes the service result and does not use stale inline meal-only math.

--- a/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-02-implementation.md
+++ b/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-02-implementation.md
@@ -1,0 +1,55 @@
+---
+phase: 2
+title: Implementation
+status: completed
+priority: P1
+effort: 1.5h
+dependencies:
+  - 1
+---
+
+# Phase 2: Implementation
+
+## Overview
+
+Implement movement-aware weekly calorie consumption and remove stale duplication from the weekly budget query handler.
+
+## Requirements
+
+- Functional: weekly calorie consumption is `meal-derived calories - included movement kcal`.
+- Functional: consumed protein/carbs/fat remain based on food macros only.
+- Functional: BMR floor, deficit/surplus caps, remaining-days semantics, cheat-day handling, and logging prompt behavior stay intact.
+- Non-functional: keep the domain service dependency-free and use existing UoW repositories.
+
+## Architecture
+
+`WeeklyBudgetService` remains the source of truth. It calculates food macros from meals and subtracts movement kcal for calories only when the UoW exposes `movement_entries`. The weekly query handler delegates to `WeeklyBudgetService.get_effective_adjusted_daily_async` instead of maintaining a second adjustment implementation.
+
+## Related Code Files
+
+- Modify: `src/domain/services/weekly_budget_service.py`
+- Modify: `src/app/handlers/query_handlers/get_weekly_budget_query_handler.py`
+- Read: `src/infra/repositories/movement_repository_async.py`
+- Read: `src/app/handlers/query_handlers/get_daily_macros_query_handler.py`
+
+## Implementation Steps
+
+1. Add a local-date to UTC range helper in `WeeklyBudgetService`.
+2. Add async movement kcal subtraction to `calculate_weekly_consumed_async`.
+3. Keep sync `calculate_weekly_consumed` behavior unchanged unless movement support is naturally available without async IO.
+4. Update `get_effective_adjusted_daily_async` cap and redistribution math to use net consumed calories returned by the consumed helper.
+5. Remove `GetWeeklyBudgetQueryHandler._get_effective_adjusted_daily_async` and call the domain service directly.
+6. Keep weekly response shape unchanged; `consumed_calories` becomes net to match daily/bulk semantics.
+
+## Success Criteria
+
+- [x] Weekly service uses `sum_included_kcal_for_range` for the exact local date range being summed.
+- [x] Macro consumed values do not subtract movement.
+- [x] Weekly handler has no duplicate redistribution implementation.
+- [x] No new schema, migration, or response field is introduced.
+
+## Risk Assessment
+
+Risk: negative weekly consumed calories if workouts exceed food. Mitigation: allow it as valid net balance, matching daily nutrition behavior.
+
+Risk: response consumers expected weekly `consumed_calories` as food-only. Mitigation: daily/bulk already expose calories as net; movement docs already define calorie balance this way.

--- a/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-03-verification-and-pr.md
+++ b/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-03-verification-and-pr.md
@@ -1,0 +1,51 @@
+---
+phase: 3
+title: Verification and PR
+status: in-progress
+priority: P1
+effort: 45m
+dependencies:
+  - 2
+---
+
+# Phase 3: Verification and PR
+
+## Overview
+
+Verify the nutrition budget behavior, update project docs, commit, push, and open a PR.
+
+## Requirements
+
+- Functional: targeted tests pass.
+- Non-functional: touched files compile and lint cleanly enough for the project gate.
+- Non-functional: docs mention the weekly-budget movement credit behavior and TDEE baseline boundary.
+
+## Architecture
+
+Validation stays focused on affected domain/app/repository tests plus Python compile. The PR should describe the product rule and science caveat: full logged workout credit is correct because baseline TDEE does not already include that workout.
+
+## Related Code Files
+
+- Modify: `docs/movement-release-readiness.md`
+- Modify: `docs/project-roadmap.md`
+- Modify: `docs/project-overview-pdr.md`
+- Modify: `docs/architecture/fitness-goals.md`
+- Run: targeted pytest, ruff, compileall
+- Git: conventional commit, push branch, create PR with `gh`
+
+## Implementation Steps
+
+1. Run targeted tests:
+   `uv run pytest tests/unit/domain/services/test_weekly_budget_async.py tests/unit/handlers/query_handlers/test_cached_query_handlers.py tests/unit/handlers/query_handlers/test_movement_balance_integration.py tests/unit/infra/repositories/test_movement_repository_async.py -q`
+2. Run lint on touched source/tests.
+3. Run Python compile check for `src` and affected tests.
+4. Update docs for movement weekly-budget behavior and baseline TDEE boundary.
+5. Stage, secret-scan diff, commit with conventional message, push.
+6. Create PR against the repository default branch.
+
+## Success Criteria
+
+- [x] Tests pass or any unrelated failures are clearly isolated.
+- [x] `ruff check` passes for touched files.
+- [x] `python -m compileall` passes for touched source/tests.
+- [ ] PR URL is available.

--- a/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-03-verification-and-pr.md
+++ b/plans/260618-0108-workout-calorie-credit-weekly-budget/phase-03-verification-and-pr.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: Verification and PR
-status: in-progress
+status: completed
 priority: P1
 effort: 45m
 dependencies:
@@ -48,4 +48,4 @@ Validation stays focused on affected domain/app/repository tests plus Python com
 - [x] Tests pass or any unrelated failures are clearly isolated.
 - [x] `ruff check` passes for touched files.
 - [x] `python -m compileall` passes for touched source/tests.
-- [ ] PR URL is available.
+- [x] PR URL is available: https://github.com/phuoctung28/mealtrack_backend/pull/368

--- a/plans/260618-0108-workout-calorie-credit-weekly-budget/plan.md
+++ b/plans/260618-0108-workout-calorie-credit-weekly-budget/plan.md
@@ -3,7 +3,7 @@ title: Workout Calorie Credit in Weekly Budget
 description: >-
   Make weekly budget redistribution use net calories: food calories minus
   included workout calories.
-status: in-progress
+status: completed
 priority: P1
 branch: feat/workout-calorie-credit-weekly-budget
 tags:
@@ -33,7 +33,7 @@ Science basis: when exercise is not already included in the baseline target, log
 |-------|------|--------|
 | 1 | [Regression Tests](./phase-01-regression-tests.md) | Completed |
 | 2 | [Implementation](./phase-02-implementation.md) | Completed |
-| 3 | [Verification and PR](./phase-03-verification-and-pr.md) | In Progress |
+| 3 | [Verification and PR](./phase-03-verification-and-pr.md) | Completed |
 
 ## Dependencies
 

--- a/plans/260618-0108-workout-calorie-credit-weekly-budget/plan.md
+++ b/plans/260618-0108-workout-calorie-credit-weekly-budget/plan.md
@@ -1,0 +1,42 @@
+---
+title: Workout Calorie Credit in Weekly Budget
+description: >-
+  Make weekly budget redistribution use net calories: food calories minus
+  included workout calories.
+status: in-progress
+priority: P1
+branch: feat/workout-calorie-credit-weekly-budget
+tags:
+  - feature
+  - backend
+  - nutrition
+blockedBy: []
+blocks: []
+created: '2026-06-17T18:10:50.044Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Workout Calorie Credit in Weekly Budget
+
+## Overview
+
+Weekly budget adjusted nutrition currently recalculates consumed calories from meals only. Daily macros and bulk nutrition already use net calories (`food - included movement`). This plan aligns weekly budget redistribution, remaining calories, and tomorrow preview with the same calorie-balance rule.
+
+Product rule: full logged workout calories count when `include_in_balance = true`. Baseline TDEE excludes planned workouts, so there is no expected-movement offset to subtract. Macro grams remain food-only.
+
+Science basis: when exercise is not already included in the baseline target, logged exercise is additional energy expenditure, so calorie balance should reduce net intake by that expenditure. If exercise were already in TDEE, adding it again would double count; that model is explicitly out of scope.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Regression Tests](./phase-01-regression-tests.md) | Completed |
+| 2 | [Implementation](./phase-02-implementation.md) | Completed |
+| 3 | [Verification and PR](./phase-03-verification-and-pr.md) | In Progress |
+
+## Dependencies
+
+- Brainstorm source: `plans/reports/260618-0108-workout-calorie-credit-weekly-budget-brainstorm.md`
+- Existing movement contract: `docs/superpowers/specs/2026-05-31-movement-api-design.md`
+- Existing readiness doc: `docs/movement-release-readiness.md`

--- a/plans/reports/260618-0108-workout-calorie-credit-weekly-budget-brainstorm.md
+++ b/plans/reports/260618-0108-workout-calorie-credit-weekly-budget-brainstorm.md
@@ -1,0 +1,39 @@
+---
+type: brainstorm
+title: Workout calorie credit in weekly budget
+status: approved
+created: "2026-06-18T01:08:00+07:00"
+branch: feat/workout-calorie-credit-weekly-budget
+---
+
+# Workout Calorie Credit in Weekly Budget
+
+## Summary
+
+Users expect logged workouts to add calories back to their balance. Daily and bulk nutrition already use `food_calories - movement_kcal_burned`, but weekly redistribution uses meal calories only. Fix weekly adjusted targets so `include_in_balance = true` movement credits reduce calorie consumption for weekly budget math.
+
+## Decision
+
+Use net weekly calories: `net_consumed_calories = food_calories - included_movement_kcal`. Keep consumed protein/carbs/fat as food-only macro grams.
+
+## Scope
+
+- Backend only.
+- No schema migration.
+- No response-shape change.
+- No expected-movement/TDEE offset.
+- Full logged workout calorie credit when `include_in_balance = true`.
+
+## Acceptance Examples
+
+- Weekly target 14000, base 2000/day, Monday food 2300, Monday workout 200, Tuesday adjustment: `(14000 - 2100) / 6 = 1983.3` before macro fitting/caps.
+- Weekly target 14000, Monday food 2500, Monday workout 500, Tuesday adjustment: `(14000 - 2000) / 6 = 2000`.
+
+## Science Note
+
+This is correct under Nutree's selected definition: base target excludes logged workouts, so workout calories are additional expenditure. If the base TDEE already included those workouts, full credit would double count.
+
+## Risks
+
+- Weekly `consumed_calories` becomes net calories, matching daily/bulk but possibly surprising clients that expected food-only calories.
+- Negative net consumption is possible when movement exceeds food; keep it, because it accurately represents calorie balance.

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -19,6 +19,25 @@ _VALID_FITNESS_GOALS = {e.value for e in FitnessGoal}
 _VALID_TRAINING_LEVELS = {e.value for e in TrainingLevel}
 
 
+def _has_metric_update(command: UpdateUserMetricsCommand) -> bool:
+    return any(
+        value is not None
+        for value in [
+            command.weight_kg,
+            command.job_type,
+            command.training_days_per_week,
+            command.training_minutes_per_session,
+            command.body_fat_percent,
+            command.fitness_goal,
+            command.training_level,
+            command.target_weight_kg,
+            command.goal_start_weight_kg,
+            command.goal_started_at,
+            command.daily_water_goal_ml,
+        ]
+    ) or command.reset_water_goal
+
+
 @handles(UpdateUserMetricsCommand)
 class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, None]):
     """Handle updating user metrics (weight, job type, training, body fat)."""
@@ -29,22 +48,7 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
 
     async def handle(self, command: UpdateUserMetricsCommand) -> None:
         # Validate at least one field is provided
-        if not any(
-            [
-                command.weight_kg,
-                command.job_type,
-                command.training_days_per_week,
-                command.training_minutes_per_session,
-                command.body_fat_percent,
-                command.fitness_goal,
-                command.training_level,
-                command.target_weight_kg,
-                command.goal_start_weight_kg,
-                command.goal_started_at,
-                command.daily_water_goal_ml,
-                command.reset_water_goal,
-            ]
-        ):
+        if not _has_metric_update(command):
             raise ValidationException("At least one metric must be provided")
 
         async with self.uow as uow:

--- a/src/app/handlers/query_handlers/get_user_tdee_query_handler.py
+++ b/src/app/handlers/query_handlers/get_user_tdee_query_handler.py
@@ -4,18 +4,19 @@ Auto-extracted for better maintainability.
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Any
+
+from sqlalchemy import select
 
 from src.api.exceptions import ResourceNotFoundException
 from src.app.events.base import EventHandler, handles
 from src.app.queries.tdee import GetUserTdeeQuery
 from src.domain.cache.cache_keys import CacheKeys
-from src.domain.mappers.activity_goal_mapper import ActivityGoalMapper
 from src.domain.constants import NutritionConstants, TDEEConstants
-from src.domain.model.user import TdeeRequest, Sex, JobType, Goal, UnitSystem
-from src.domain.services.tdee_service import TdeeCalculationService
+from src.domain.mappers.activity_goal_mapper import ActivityGoalMapper
+from src.domain.model.user import Sex, TdeeRequest, UnitSystem
 from src.domain.ports.cache_port import CachePort
-from sqlalchemy import select
+from src.domain.services.tdee_service import TdeeCalculationService
 from src.infra.database.models.user.profile import UserProfile
 from src.infra.database.uow_async import AsyncUnitOfWork
 
@@ -23,18 +24,18 @@ logger = logging.getLogger(__name__)
 
 
 @handles(GetUserTdeeQuery)
-class GetUserTdeeQueryHandler(EventHandler[GetUserTdeeQuery, Dict[str, Any]]):
+class GetUserTdeeQueryHandler(EventHandler[GetUserTdeeQuery, dict[str, Any]]):
     """Handler for getting user's TDEE calculation."""
 
     def __init__(
         self,
         tdee_service: TdeeCalculationService = None,
-        cache_service: Optional[CachePort] = None,
+        cache_service: CachePort | None = None,
     ):
         self.tdee_service = tdee_service or TdeeCalculationService()
         self.cache_service = cache_service
 
-    async def handle(self, query: GetUserTdeeQuery) -> Dict[str, Any]:
+    async def handle(self, query: GetUserTdeeQuery) -> dict[str, Any]:
         cache_key, ttl = CacheKeys.user_tdee(query.user_id)
         if self.cache_service:
             cached = await self.cache_service.get_json(cache_key)
@@ -45,7 +46,7 @@ class GetUserTdeeQueryHandler(EventHandler[GetUserTdeeQuery, Dict[str, Any]]):
             await self.cache_service.set_json(cache_key, result, ttl)
         return result
 
-    async def _compute_tdee(self, query: GetUserTdeeQuery) -> Dict[str, Any]:
+    async def _compute_tdee(self, query: GetUserTdeeQuery) -> dict[str, Any]:
         """Get user's TDEE calculation based on current profile."""
         async with AsyncUnitOfWork() as uow:
             # Get current user profile using the UnitOfWork session
@@ -93,22 +94,17 @@ class GetUserTdeeQueryHandler(EventHandler[GetUserTdeeQuery, Dict[str, Any]]):
             # Calculate TDEE
             result = self.tdee_service.calculate_tdee(tdee_request)
 
-            # Calculate total multiplier for response
+            # Baseline excludes planned workouts; logged movement credits them.
             base_multiplier = TDEEConstants.JOB_TYPE_MULTIPLIERS.get(
                 profile.job_type, 1.2
             )
-            weekly_hours = (
-                profile.training_days_per_week * profile.training_minutes_per_session
-            ) / 60.0
-            exercise_add = weekly_hours * TDEEConstants.EXERCISE_MULTIPLIER_PER_HOUR
-            total_multiplier = base_multiplier + exercise_add
 
             return {
                 "user_id": query.user_id,
                 "bmr": result.bmr,
                 "tdee": result.tdee,
                 "target_calories": round(result.macros.calories, 0),
-                "activity_multiplier": round(total_multiplier, 3),
+                "activity_multiplier": round(base_multiplier, 3),
                 "formula_used": result.formula_used,
                 "is_custom": False,
                 "macros": {
@@ -132,7 +128,7 @@ class GetUserTdeeQueryHandler(EventHandler[GetUserTdeeQuery, Dict[str, Any]]):
 
     def _build_custom_macros_response(
         self, query: GetUserTdeeQuery, profile
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Build response using custom macro overrides, still calculating BMR/TDEE for reference."""
         custom_calories = (
             profile.custom_protein_g * NutritionConstants.CALORIES_PER_GRAM_PROTEIN
@@ -164,18 +160,13 @@ class GetUserTdeeQueryHandler(EventHandler[GetUserTdeeQuery, Dict[str, Any]]):
         result = self.tdee_service.calculate_tdee(tdee_request)
 
         base_multiplier = TDEEConstants.JOB_TYPE_MULTIPLIERS.get(profile.job_type, 1.2)
-        weekly_hours = (
-            profile.training_days_per_week * profile.training_minutes_per_session
-        ) / 60.0
-        exercise_add = weekly_hours * TDEEConstants.EXERCISE_MULTIPLIER_PER_HOUR
-        total_multiplier = base_multiplier + exercise_add
 
         return {
             "user_id": query.user_id,
             "bmr": result.bmr,
             "tdee": result.tdee,
             "target_calories": round(custom_calories, 0),
-            "activity_multiplier": round(total_multiplier, 3),
+            "activity_multiplier": round(base_multiplier, 3),
             "formula_used": result.formula_used,
             "is_custom": True,
             "macros": {

--- a/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
@@ -4,44 +4,43 @@ Handler for getting weekly macro budget status.
 
 import logging
 from dataclasses import replace
-from datetime import date, datetime, timedelta, timezone
-from typing import Dict, Any, Optional
+from datetime import date, datetime, timedelta
+from typing import Any
 
 from src.app.events.base import EventHandler, handles
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
 from src.domain.cache.cache_keys import CacheKeys
 from src.domain.constants import WeeklyBudgetConstants
+from src.domain.model.weekly import WeeklyMacroBudget
+from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
+from src.domain.ports.cache_port import CachePort
 from src.domain.services.weekly_budget_service import (
     AdjustedDailyTargets,
     WeeklyBudgetService,
 )
-from src.domain.model.weekly import WeeklyMacroBudget
-from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.utils.timezone_utils import (
-    ensure_utc,
     get_user_monday,
     get_zone_info,
     resolve_user_timezone_async,
 )
-from src.domain.ports.cache_port import CachePort
 from src.infra.database.uow_async import AsyncUnitOfWork
 
 logger = logging.getLogger(__name__)
 
 
 @handles(GetWeeklyBudgetQuery)
-class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, Any]]):
+class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, Any]]):
     """Handler for getting weekly macro budget status."""
 
     def __init__(
         self,
-        uow: Optional[AsyncUnitOfWorkPort] = None,
-        cache_service: Optional[CachePort] = None,
+        uow: AsyncUnitOfWorkPort | None = None,
+        cache_service: CachePort | None = None,
     ):
         self.uow = uow
         self.cache_service = cache_service
 
-    async def handle(self, query: GetWeeklyBudgetQuery) -> Dict[str, Any]:
+    async def handle(self, query: GetWeeklyBudgetQuery) -> dict[str, Any]:
         """Handle getting weekly budget status."""
         uow = self.uow or AsyncUnitOfWork()
         async with uow:
@@ -102,8 +101,7 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
                 base_daily_fat = weekly_budget.target_fat / 7
                 base_daily_protein = weekly_budget.target_protein / 7
 
-                # --- Skip & Redistribute (inline async version of WeeklyBudgetService.get_effective_adjusted_daily) ---
-                effective = await self._get_effective_adjusted_daily_async(
+                effective = await WeeklyBudgetService.get_effective_adjusted_daily_async(
                     uow=uow,
                     user_id=query.user_id,
                     week_start=week_start,
@@ -134,7 +132,7 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
 
                 # --- Tomorrow Preview ---
                 # Shows real impact of today's consumption on tomorrow's target.
-                preview_data: Dict[str, Any] = {}
+                preview_data: dict[str, Any] = {}
                 today_consumed_cal = (
                     consumed["calories"] - consumed_before_today["calories"]
                 )
@@ -264,183 +262,14 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, Dict[str, A
 
                 return result
 
-            except Exception as e:
+            except Exception:
                 raise
-
-    async def _get_effective_adjusted_daily_async(
-        self,
-        uow: AsyncUnitOfWork,
-        user_id: str,
-        week_start: date,
-        target_date: date,
-        weekly_budget: WeeklyMacroBudget,
-        base_daily_cal: float,
-        base_daily_protein: float,
-        base_daily_carbs: float,
-        base_daily_fat: float,
-        bmr: float,
-        user_timezone: str = "UTC",
-        cheat_dates=None,
-    ):
-        """Async version of WeeklyBudgetService.get_effective_adjusted_daily."""
-        from src.domain.services.weekly_budget_service import (
-            AdjustedDailyTargets,
-            EffectiveAdjustedResult,
-            WeeklyBudgetService,
-        )
-
-        # Cheat days already pre-loaded by caller
-        all_cheat_dates = cheat_dates if cheat_dates is not None else []
-        past_cheat_dates = [d for d in all_cheat_dates if d < target_date]
-        past_cheat_count = len(past_cheat_dates)
-
-        remaining_days = WeeklyBudgetService.calculate_remaining_days(
-            week_start, target_date
-        )
-
-        skipped_days = 0
-        show_logging_prompt = False
-        logged_past_days = 0
-
-        past_days_count = (target_date - week_start).days
-        if past_days_count > 0:
-            past_end = target_date - timedelta(days=1)
-            daily_counts = await uow.meals.get_daily_meal_counts(
-                user_id,
-                week_start,
-                past_end,
-                user_timezone=user_timezone,
-            )
-            logged_past_days = len(daily_counts)
-            skipped_days = past_days_count - logged_past_days
-
-            total_logged = logged_past_days + 1  # +1 for today
-            if (
-                total_logged < WeeklyBudgetConstants.MIN_LOGGED_DAYS_FOR_REDISTRIBUTION
-                and past_days_count >= 3
-            ):
-                show_logging_prompt = True
-
-        redistribution_logged_days = max(0, logged_past_days - past_cheat_count)
-
-        # Fetch meals for the week once — used by all consumed calculations
-        week_end = week_start + timedelta(days=6)
-        week_meals = await uow.meals.find_by_date_range(
-            user_id,
-            week_start,
-            week_end,
-            user_timezone=user_timezone,
-        )
-
-        tz = get_zone_info(user_timezone) if user_timezone else None
-        from src.domain.model.meal import MealStatus
-
-        def _sum_meals(meals, end_date=None, exclude_dates=None):
-            exclude_dates_set = set(exclude_dates) if exclude_dates else set()
-            cal = prot = carbs = fat = 0.0
-            for meal in meals:
-                if meal.status == MealStatus.READY and meal.nutrition:
-                    if (end_date or exclude_dates_set) and meal.created_at:
-                        aware_dt = ensure_utc(meal.created_at)
-                        meal_local_date = (
-                            aware_dt.astimezone(tz).date() if tz else aware_dt.date()
-                        )
-                        if end_date and meal_local_date > end_date:
-                            continue
-                        if meal_local_date in exclude_dates_set:
-                            continue
-                    macros = meal.nutrition.macros
-                    cal += WeeklyBudgetService._derive_macro_calories(macros)
-                    prot += macros.protein or 0
-                    carbs += macros.carbs or 0
-                    fat += macros.fat or 0
-            return {"calories": cal, "protein": prot, "carbs": carbs, "fat": fat}
-
-        consumed_total = _sum_meals(week_meals)
-        past_end = target_date - timedelta(days=1)
-        consumed_before_today = _sum_meals(week_meals, end_date=past_end)
-        if past_cheat_dates:
-            consumed_for_redistribution = _sum_meals(
-                week_meals, end_date=past_end, exclude_dates=past_cheat_dates
-            )
-        else:
-            consumed_for_redistribution = consumed_before_today
-
-        # Calculate adjusted daily
-        if show_logging_prompt:
-            adjusted = WeeklyBudgetService.calculate_adjusted_daily(
-                replace(
-                    weekly_budget,
-                    consumed_calories=0,
-                    consumed_protein=0,
-                    consumed_carbs=0,
-                    consumed_fat=0,
-                ),
-                standard_daily_calories=base_daily_cal,
-                standard_daily_carbs=base_daily_carbs,
-                standard_daily_fat=base_daily_fat,
-                standard_daily_protein=base_daily_protein,
-                bmr=bmr,
-                remaining_days=7,
-            )
-        else:
-            effective_week_days = redistribution_logged_days + remaining_days
-            budget_for_adjustment = replace(
-                weekly_budget,
-                target_calories=base_daily_cal * effective_week_days,
-                target_protein=base_daily_protein * effective_week_days,
-                target_carbs=base_daily_carbs * effective_week_days,
-                target_fat=base_daily_fat * effective_week_days,
-                consumed_calories=consumed_for_redistribution["calories"],
-                consumed_protein=consumed_for_redistribution["protein"],
-                consumed_carbs=consumed_for_redistribution["carbs"],
-                consumed_fat=consumed_for_redistribution["fat"],
-            )
-            adjusted = WeeklyBudgetService.calculate_adjusted_daily(
-                budget_for_adjustment,
-                standard_daily_calories=base_daily_cal,
-                standard_daily_carbs=base_daily_carbs,
-                standard_daily_fat=base_daily_fat,
-                standard_daily_protein=base_daily_protein,
-                bmr=bmr,
-                remaining_days=remaining_days,
-            )
-
-        # Budget cap
-        remaining_before_today = (
-            weekly_budget.target_calories - consumed_before_today["calories"]
-        )
-        if remaining_days > 0 and remaining_before_today > 0:
-            max_daily = remaining_before_today / remaining_days
-            if adjusted.calories > max_daily:
-                scale = max_daily / adjusted.calories
-                adjusted = AdjustedDailyTargets(
-                    calories=round(max_daily, 1),
-                    carbs=round(adjusted.carbs * scale, 1),
-                    fat=round(adjusted.fat * scale, 1),
-                    protein=adjusted.protein,
-                    bmr_floor_active=adjusted.bmr_floor_active,
-                    remaining_days=adjusted.remaining_days,
-                )
-
-        return EffectiveAdjustedResult(
-            adjusted=adjusted,
-            consumed_before_today=consumed_before_today,
-            consumed_total=consumed_total,
-            logged_past_days=logged_past_days,
-            skipped_days=skipped_days,
-            show_logging_prompt=show_logging_prompt,
-        )
 
     async def _create_weekly_budget(
         self, uow: AsyncUnitOfWork, user_id: str, week_start: date, target_date: date
     ) -> tuple[WeeklyMacroBudget, float]:
         """Create a new weekly budget for the user. Returns (budget, bmr)."""
         import uuid
-
-        # Get user profile to find fitness goal
-        profile = await uow.users.get_profile(user_id)
-        fitness_goal = profile.fitness_goal if profile else "cut"
 
         # Get TDEE-based macros using GetUserTdeeQueryHandler (correct pattern)
         target_calories = None

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -250,7 +250,10 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
 
         # Step 5: AI estimation (last resort — don't cache unreliable data)
         logger.debug(
-            f"[BARCODE-CASCADE] {query.barcode} → step 5 AI estimation (partial_name={partial_name})"
+            "[BARCODE-CASCADE] step 5 AI estimation "
+            "barcode_present=%s partial_name_present=%s",
+            bool(query.barcode),
+            bool(partial_name),
         )
         estimate = await self._ai_estimate(query.barcode, query.language, partial_name)
         if estimate:

--- a/src/app/handlers/query_handlers/preview_tdee_query_handler.py
+++ b/src/app/handlers/query_handlers/preview_tdee_query_handler.py
@@ -3,12 +3,12 @@ Handler - Calculate TPreviewTdeeQueryDEE preview without saving.
 """
 
 import logging
-from typing import Dict, Any
+from typing import Any
 
 from src.app.events.base import EventHandler, handles
 from src.app.queries.tdee.preview_tdee_query import PreviewTdeeQuery
 from src.domain.mappers.activity_goal_mapper import ActivityGoalMapper
-from src.domain.model.user import TdeeRequest, Sex, UnitSystem, JobType, TrainingLevel
+from src.domain.model.user import JobType, Sex, TdeeRequest, UnitSystem
 from src.domain.services.tdee_service import TdeeCalculationService
 
 logger = logging.getLogger(__name__)
@@ -21,18 +21,14 @@ JOB_TYPE_MULTIPLIERS = {
     "physical": 1.6,
 }
 
-# Exercise contribution per weekly hour
-EXERCISE_MULTIPLIER_PER_HOUR = 0.05
-
-
 @handles(PreviewTdeeQuery)
-class PreviewTdeeQueryHandler(EventHandler[PreviewTdeeQuery, Dict[str, Any]]):
+class PreviewTdeeQueryHandler(EventHandler[PreviewTdeeQuery, dict[str, Any]]):
     """Handler for previewing TDEE calculation without persisting."""
 
     def __init__(self, tdee_service: TdeeCalculationService = None):
         self.tdee_service = tdee_service or TdeeCalculationService()
 
-    async def handle(self, query: PreviewTdeeQuery) -> Dict[str, Any]:
+    async def handle(self, query: PreviewTdeeQuery) -> dict[str, Any]:
         """Calculate TDEE preview without persisting."""
         # Map inputs using centralized mapper
         sex = Sex.MALE if query.sex.lower() == "male" else Sex.FEMALE
@@ -65,19 +61,14 @@ class PreviewTdeeQueryHandler(EventHandler[PreviewTdeeQuery, Dict[str, Any]]):
         # Calculate TDEE
         result = self.tdee_service.calculate_tdee(tdee_request)
 
-        # Calculate activity multiplier for response
+        # Baseline excludes planned workouts; logged movement credits them.
         base = JOB_TYPE_MULTIPLIERS.get(job_type.value, 1.2)
-        weekly_hours = (
-            query.training_days_per_week * query.training_minutes_per_session
-        ) / 60.0
-        exercise_add = weekly_hours * EXERCISE_MULTIPLIER_PER_HOUR
-        activity_multiplier = base + exercise_add
 
         return {
             "bmr": result.bmr,
             "tdee": result.tdee,
             "goal": goal.value,
-            "activity_multiplier": activity_multiplier,
+            "activity_multiplier": base,
             "formula_used": result.formula_used,
             "macros": {
                 "protein": round(result.macros.protein, 1),

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -30,7 +30,7 @@ class CacheKeys:
     @staticmethod
     def user_tdee(user_id: str) -> tuple[str, int]:
         """Cache key for user TDEE calculation. 24h TTL."""
-        return (f"user:tdee:{user_id}", CacheKeys.TTL_1_DAY)
+        return (f"user:tdee_v2:{user_id}", CacheKeys.TTL_1_DAY)
 
     @staticmethod
     def daily_macros(user_id: str, target_date: date) -> tuple[str, int]:
@@ -61,17 +61,17 @@ class CacheKeys:
             else f"{week_start_date.isoformat()}:{target_date.isoformat()}"
         )
         return (
-            f"user:{user_id}:weekly_budget_v3:{date_suffix}",
+            f"user:{user_id}:weekly_budget_v4:{date_suffix}",
             CacheKeys.TTL_30_MIN,
         )
 
     @staticmethod
     def weekly_budget_pattern(user_id: str, week_start_date: date) -> str:
-        return f"user:{user_id}:weekly_budget_v3:{week_start_date.isoformat()}:*"
+        return f"user:{user_id}:weekly_budget_v4:{week_start_date.isoformat()}:*"
 
     @staticmethod
     def weekly_budget_user_pattern(user_id: str) -> str:
-        return f"user:{user_id}:weekly_budget_v3:*"
+        return f"user:{user_id}:weekly_budget_v4:*"
 
     @staticmethod
     def nutrition_bulk(

--- a/src/domain/constants/meal_constants.py
+++ b/src/domain/constants/meal_constants.py
@@ -105,9 +105,6 @@ class TDEEConstants:
         "physical": 1.6,  # Manual labor (construction, warehouse)
     }
 
-    # Exercise contribution per weekly hour
-    EXERCISE_MULTIPLIER_PER_HOUR = 0.05
-
     # Goal adjustments (calories)
     # 300 deficit = ~0.3 kg/week, sustainable for small users
     CUTTING_DEFICIT = 300

--- a/src/domain/services/tdee_service.py
+++ b/src/domain/services/tdee_service.py
@@ -1,12 +1,12 @@
-from src.domain.constants import TDEEConstants, NutritionConstants
+from src.domain.constants import NutritionConstants, TDEEConstants
 from src.domain.model.user import (
+    Goal,
+    JobType,
+    MacroTargets,
+    Sex,
     TdeeRequest,
     TdeeResponse,
-    MacroTargets,
-    JobType,
-    Goal,
     TrainingLevel,
-    Sex,
 )
 from src.domain.services.bmr_calculator import BMRCalculatorFactory
 
@@ -23,12 +23,7 @@ class TdeeCalculationService:
     def calculate_tdee(self, request: TdeeRequest) -> TdeeResponse:
         """Calculate BMR, TDEE and macros based on the request."""
         bmr, formula_name = self._calculate_bmr(request)
-        tdee = self._calculate_tdee_from_activity(
-            bmr,
-            request.job_type,
-            request.training_days_per_week,
-            request.training_minutes_per_session,
-        )
+        tdee = self._calculate_tdee_from_activity(bmr, request.job_type)
         macro_targets = self._calculate_all_macro_targets(
             tdee,
             request.weight_kg,
@@ -67,22 +62,15 @@ class TdeeCalculationService:
 
         return bmr, calculator.get_formula_name()
 
-    def _calculate_tdee_from_activity(
-        self, bmr: float, job_type: JobType, training_days: int, training_minutes: int
-    ) -> float:
-        """Calculate TDEE from BMR using job type and training hours.
+    def _calculate_tdee_from_activity(self, bmr: float, job_type: JobType) -> float:
+        """Calculate baseline TDEE from BMR using non-exercise activity.
 
-        Formula:
-        - base = job_type multiplier (NEAT component)
-        - weekly_hours = training_days * training_minutes / 60
-        - exercise_add = weekly_hours * EXERCISE_MULTIPLIER_PER_HOUR (0.05 per hour)
-        - multiplier = base + exercise_add
+        Logged movement entries credit workout calories separately. Planned
+        training volume stays on the request for compatibility and protein
+        context, but it must not inflate baseline calories.
         """
         base = TDEEConstants.JOB_TYPE_MULTIPLIERS.get(job_type.value, 1.2)
-        weekly_hours = (training_days * training_minutes) / 60.0
-        exercise_add = weekly_hours * TDEEConstants.EXERCISE_MULTIPLIER_PER_HOUR
-        multiplier = base + exercise_add
-        return bmr * multiplier
+        return bmr * base
 
     def _calculate_all_macro_targets(
         self,

--- a/src/domain/services/weekly_budget_service.py
+++ b/src/domain/services/weekly_budget_service.py
@@ -8,11 +8,12 @@ Single source of truth for adjusted daily targets — used by:
 
 import logging
 from dataclasses import dataclass, replace
-from datetime import date, timedelta
-from typing import Any, Dict, List, Optional
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Any
 
 from src.domain.constants import WeeklyBudgetConstants
 from src.domain.model.meal import MealStatus
+from src.domain.model.weekly import WeeklyMacroBudget
 from src.domain.utils.timezone_utils import ensure_utc, get_zone_info
 
 logger = logging.getLogger(__name__)
@@ -35,8 +36,8 @@ class EffectiveAdjustedResult:
     """Rich result from get_effective_adjusted_daily with context for UI."""
 
     adjusted: AdjustedDailyTargets
-    consumed_before_today: Dict[str, float]
-    consumed_total: Dict[str, float]
+    consumed_before_today: dict[str, float]
+    consumed_total: dict[str, float]
     logged_past_days: int
     skipped_days: int
     show_logging_prompt: bool
@@ -50,11 +51,11 @@ class WeeklyBudgetService:
         uow: Any,
         user_id: str,
         week_start: date,
-        end_date: Optional[date] = None,
-        exclude_date: Optional[date] = None,
-        exclude_dates: Optional[List[date]] = None,
-        user_timezone: Optional[str] = None,
-    ) -> Dict[str, float]:
+        end_date: date | None = None,
+        exclude_date: date | None = None,
+        exclude_dates: list[date] | None = None,
+        user_timezone: str | None = None,
+    ) -> dict[str, float]:
         """Calculate consumed macros from actual meals this week.
 
         Recalculates from meal records (not stale DB budget values).
@@ -116,11 +117,11 @@ class WeeklyBudgetService:
         uow: Any,
         user_id: str,
         week_start: date,
-        end_date: Optional[date] = None,
-        exclude_date: Optional[date] = None,
-        exclude_dates: Optional[List[date]] = None,
-        user_timezone: Optional[str] = None,
-    ) -> Dict[str, float]:
+        end_date: date | None = None,
+        exclude_date: date | None = None,
+        exclude_dates: list[date] | None = None,
+        user_timezone: str | None = None,
+    ) -> dict[str, float]:
         """Async version of calculate_weekly_consumed for AsyncUnitOfWork."""
         week_end = end_date or week_start + timedelta(days=6)
         tz = get_zone_info(user_timezone) if user_timezone else None
@@ -157,12 +158,80 @@ class WeeklyBudgetService:
                 total_fat += macros.fat or 0
                 total_calories += WeeklyBudgetService._derive_macro_calories(macros)
 
+        movement_kcal = await WeeklyBudgetService._calculate_movement_kcal_async(
+            uow=uow,
+            user_id=user_id,
+            week_start=week_start,
+            end_date=week_end,
+            exclude_date=exclude_date,
+            exclude_dates=exclude_dates,
+            user_timezone=user_timezone,
+        )
+        total_calories -= movement_kcal
+
         return {
             "calories": total_calories,
             "protein": total_protein,
             "carbs": total_carbs,
             "fat": total_fat,
         }
+
+    @staticmethod
+    async def _calculate_movement_kcal_async(
+        uow: Any,
+        user_id: str,
+        week_start: date,
+        end_date: date,
+        exclude_date: date | None = None,
+        exclude_dates: list[date] | None = None,
+        user_timezone: str | None = None,
+    ) -> float:
+        """Sum included movement kcal for local dates in the weekly window."""
+        if end_date < week_start:
+            return 0.0
+
+        movement_repo = vars(uow).get("movement_entries")
+        if movement_repo is None:
+            return 0.0
+
+        sum_range = getattr(movement_repo, "sum_included_kcal_for_range", None)
+        if sum_range is None:
+            return 0.0
+
+        excluded = set(exclude_dates) if exclude_dates else set()
+        if exclude_date:
+            excluded.add(exclude_date)
+
+        if not excluded:
+            start_utc, end_utc = WeeklyBudgetService._local_date_range_to_utc(
+                week_start, end_date, user_timezone
+            )
+            return float(await sum_range(user_id, start_utc, end_utc) or 0.0)
+
+        total = 0.0
+        current = week_start
+        while current <= end_date:
+            if current not in excluded:
+                start_utc, end_utc = WeeklyBudgetService._local_date_range_to_utc(
+                    current, current, user_timezone
+                )
+                total += float(await sum_range(user_id, start_utc, end_utc) or 0.0)
+            current += timedelta(days=1)
+        return total
+
+    @staticmethod
+    def _local_date_range_to_utc(
+        start_date: date,
+        end_date: date,
+        user_timezone: str | None = None,
+    ) -> tuple[datetime, datetime]:
+        tz = get_zone_info(user_timezone or "UTC")
+        start_local = datetime.combine(start_date, time.min, tzinfo=tz)
+        end_local = datetime.combine(end_date + timedelta(days=1), time.min, tzinfo=tz)
+        return (
+            start_local.astimezone(UTC),
+            end_local.astimezone(UTC),
+        )
 
     @staticmethod
     def get_effective_adjusted_daily(
@@ -177,7 +246,7 @@ class WeeklyBudgetService:
         base_daily_fat: float,
         bmr: float,
         user_timezone: str = "UTC",
-        cheat_dates: Optional[List[date]] = None,
+        cheat_dates: list[date] | None = None,
     ) -> EffectiveAdjustedResult:
         """Single source of truth for adjusted daily target with Skip & Redistribute.
 
@@ -362,7 +431,7 @@ class WeeklyBudgetService:
         base_daily_fat: float,
         bmr: float,
         user_timezone: str = "UTC",
-        cheat_dates: Optional[List[date]] = None,
+        cheat_dates: list[date] | None = None,
     ) -> EffectiveAdjustedResult:
         """Async version of get_effective_adjusted_daily for AsyncUnitOfWork."""
         calc = WeeklyBudgetService
@@ -508,7 +577,7 @@ class WeeklyBudgetService:
 
     @staticmethod
     def calculate_adjusted_daily(
-        weekly_budget: "WeeklyMacroBudget",
+        weekly_budget: WeeklyMacroBudget,
         standard_daily_calories: float,
         standard_daily_carbs: float,
         standard_daily_fat: float,

--- a/tests/unit/domain/services/test_tdee_caching.py
+++ b/tests/unit/domain/services/test_tdee_caching.py
@@ -68,7 +68,11 @@ class TestGetAdjustedDailyTarget:
     async def test_returns_adjusted_when_budget_exists(self, mock_tdee_service, mock_profile):
         """Should return adjusted calories when weekly budget exists."""
         from datetime import date
-        from src.domain.services.weekly_budget_service import EffectiveAdjustedResult, AdjustedDailyTargets
+
+        from src.domain.services.weekly_budget_service import (
+            AdjustedDailyTargets,
+            EffectiveAdjustedResult,
+        )
 
         mock_budget = Mock()
         mock_adjusted = AdjustedDailyTargets(
@@ -136,7 +140,7 @@ class TestCacheKeyGeneration:
         """TDEE cache key should have correct format."""
         key, ttl = CacheKeys.user_tdee("user123")
 
-        assert key == "user:tdee:user123"
+        assert key == "user:tdee_v2:user123"
         assert ttl == CacheKeys.TTL_1_DAY
 
     def test_user_tdee_key_unique_per_user(self):

--- a/tests/unit/domain/services/test_weekly_budget_async.py
+++ b/tests/unit/domain/services/test_weekly_budget_async.py
@@ -1,12 +1,40 @@
 """
 Unit tests for async methods in WeeklyBudgetService.
 """
-from datetime import date, timedelta
+from datetime import UTC, date, datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from src.domain.model.weekly import WeeklyMacroBudget
 from src.domain.services.weekly_budget_service import WeeklyBudgetService
+
+
+def _ready_meal(*, protein: float, carbs: float, fat: float, created_at: datetime):
+    from src.domain.model.meal import MealStatus
+
+    meal = Mock()
+    meal.status = MealStatus.READY
+    meal.created_at = created_at
+    meal.nutrition.macros.protein = protein
+    meal.nutrition.macros.carbs = carbs
+    meal.nutrition.macros.fat = fat
+    meal.nutrition.macros.fiber = 0.0
+    return meal
+
+
+class _FakeMovementEntries:
+    def __init__(self, entries):
+        self.entries = entries
+        self.calls = []
+
+    async def sum_included_kcal_for_range(self, user_id, start_utc, end_utc):
+        self.calls.append((user_id, start_utc, end_utc))
+        return sum(
+            kcal
+            for logged_at, kcal, include in self.entries
+            if include and start_utc <= logged_at < end_utc
+        )
 
 
 class TestCalculateWeeklyConsumedAsync:
@@ -61,6 +89,61 @@ class TestCalculateWeeklyConsumedAsync:
         assert result["carbs"] == 60
         assert result["fat"] == 15
 
+    @pytest.mark.asyncio
+    async def test_subtracts_included_movement_from_calories_only(self):
+        """Movement credit affects calorie balance, not food macro grams."""
+        meal = _ready_meal(
+            protein=100,
+            carbs=250,
+            fat=100,
+            created_at=datetime(2026, 3, 9, 12, tzinfo=UTC),
+        )
+        mock_uow = Mock()
+        mock_uow.meals.find_by_date_range = AsyncMock(return_value=[meal])
+        mock_uow.movement_entries = _FakeMovementEntries(
+            [(datetime(2026, 3, 9, 18, tzinfo=UTC), 200.0, True)]
+        )
+
+        result = await WeeklyBudgetService.calculate_weekly_consumed_async(
+            uow=mock_uow,
+            user_id="user123",
+            week_start=date(2026, 3, 9),
+            user_timezone="UTC",
+        )
+
+        assert result["calories"] == 2100.0
+        assert result["protein"] == 100
+        assert result["carbs"] == 250
+        assert result["fat"] == 100
+
+    @pytest.mark.asyncio
+    async def test_ignores_excluded_and_future_movement(self):
+        """Only included movement inside the requested local date range counts."""
+        meal = _ready_meal(
+            protein=100,
+            carbs=250,
+            fat=100,
+            created_at=datetime(2026, 3, 9, 12, tzinfo=UTC),
+        )
+        mock_uow = Mock()
+        mock_uow.meals.find_by_date_range = AsyncMock(return_value=[meal])
+        mock_uow.movement_entries = _FakeMovementEntries(
+            [
+                (datetime(2026, 3, 9, 18, tzinfo=UTC), 200.0, False),
+                (datetime(2026, 3, 10, 18, tzinfo=UTC), 500.0, True),
+            ]
+        )
+
+        result = await WeeklyBudgetService.calculate_weekly_consumed_async(
+            uow=mock_uow,
+            user_id="user123",
+            week_start=date(2026, 3, 9),
+            end_date=date(2026, 3, 9),
+            user_timezone="UTC",
+        )
+
+        assert result["calories"] == 2300.0
+
 
 class TestGetEffectiveAdjustedDailyAsync:
     """Test get_effective_adjusted_daily_async method."""
@@ -109,3 +192,52 @@ class TestGetEffectiveAdjustedDailyAsync:
 
         assert result.show_logging_prompt is True
         assert result.adjusted.calories > 0
+
+    @pytest.mark.asyncio
+    async def test_workout_credit_softens_next_day_adjustment(self):
+        """2300 food - 200 movement behaves like 2100 weekly calories."""
+        meal = _ready_meal(
+            protein=100,
+            carbs=250,
+            fat=100,
+            created_at=datetime(2026, 3, 9, 12, tzinfo=UTC),
+        )
+
+        mock_uow = Mock()
+        mock_uow.cheat_days.find_by_user_and_date_range = AsyncMock(return_value=[])
+        mock_uow.meals.get_daily_meal_counts = AsyncMock(
+            return_value={date(2026, 3, 9): 1}
+        )
+        mock_uow.meals.find_by_date_range = AsyncMock(return_value=[meal])
+        mock_uow.movement_entries = _FakeMovementEntries(
+            [(datetime(2026, 3, 9, 18, tzinfo=UTC), 200.0, True)]
+        )
+
+        result = await WeeklyBudgetService.get_effective_adjusted_daily_async(
+            uow=mock_uow,
+            user_id="user123",
+            week_start=date(2026, 3, 9),
+            target_date=date(2026, 3, 10),
+            weekly_budget=WeeklyMacroBudget(
+                weekly_budget_id="budget-1",
+                user_id="user123",
+                week_start_date=date(2026, 3, 9),
+                target_calories=14000,
+                target_protein=700,
+                target_carbs=1750,
+                target_fat=466.6667,
+            ),
+            base_daily_cal=2000,
+            base_daily_protein=100,
+            base_daily_carbs=250,
+            base_daily_fat=66.6667,
+            bmr=1600,
+            user_timezone="UTC",
+        )
+
+        assert result.consumed_before_today["calories"] == 2100.0
+        assert result.consumed_total["calories"] == 2100.0
+        assert result.consumed_total["protein"] == 100
+        assert result.consumed_total["carbs"] == 250
+        assert result.consumed_total["fat"] == 100
+        assert result.adjusted.calories == pytest.approx(1983.3, abs=1.0)

--- a/tests/unit/domain/test_tdee_logged_movement_model.py
+++ b/tests/unit/domain/test_tdee_logged_movement_model.py
@@ -4,14 +4,18 @@ from src.domain.model.user import Goal, JobType, Sex, TdeeRequest, UnitSystem
 from src.domain.services.tdee_service import TdeeCalculationService
 
 
-def _request(training_days: int, training_minutes: int) -> TdeeRequest:
+def _request(
+    training_days: int,
+    training_minutes: int,
+    job_type: JobType = JobType.DESK,
+) -> TdeeRequest:
     return TdeeRequest(
         age=30,
         sex=Sex.MALE,
         height=180,
         weight=80,
         body_fat_pct=None,
-        job_type=JobType.DESK,
+        job_type=job_type,
         training_days_per_week=training_days,
         training_minutes_per_session=training_minutes,
         goal=Goal.RECOMP,
@@ -29,3 +33,16 @@ def test_training_volume_does_not_increase_baseline_tdee():
     assert high_training.bmr == no_training.bmr
     assert no_training.tdee == pytest.approx(2136.0, abs=0.1)
     assert high_training.tdee == no_training.tdee
+
+
+def test_job_type_still_changes_baseline_tdee():
+    service = TdeeCalculationService()
+
+    desk = service.calculate_tdee(_request(4, 60, JobType.DESK))
+    on_feet = service.calculate_tdee(_request(4, 60, JobType.ON_FEET))
+    physical = service.calculate_tdee(_request(4, 60, JobType.PHYSICAL))
+
+    assert desk.bmr == pytest.approx(1780.0, abs=0.1)
+    assert desk.tdee == pytest.approx(2136.0, abs=0.1)
+    assert on_feet.tdee == pytest.approx(2492.0, abs=0.1)
+    assert physical.tdee == pytest.approx(2848.0, abs=0.1)

--- a/tests/unit/domain/test_tdee_logged_movement_model.py
+++ b/tests/unit/domain/test_tdee_logged_movement_model.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.domain.model.user import Goal, JobType, Sex, TdeeRequest, UnitSystem
+from src.domain.services.tdee_service import TdeeCalculationService
+
+
+def _request(training_days: int, training_minutes: int) -> TdeeRequest:
+    return TdeeRequest(
+        age=30,
+        sex=Sex.MALE,
+        height=180,
+        weight=80,
+        body_fat_pct=None,
+        job_type=JobType.DESK,
+        training_days_per_week=training_days,
+        training_minutes_per_session=training_minutes,
+        goal=Goal.RECOMP,
+        unit_system=UnitSystem.METRIC,
+    )
+
+
+def test_training_volume_does_not_increase_baseline_tdee():
+    service = TdeeCalculationService()
+
+    no_training = service.calculate_tdee(_request(0, 0))
+    high_training = service.calculate_tdee(_request(6, 90))
+
+    assert no_training.bmr == pytest.approx(1780.0, abs=0.1)
+    assert high_training.bmr == no_training.bmr
+    assert no_training.tdee == pytest.approx(2136.0, abs=0.1)
+    assert high_training.tdee == no_training.tdee

--- a/tests/unit/domain/test_tdee_service_goal_specific_macros.py
+++ b/tests/unit/domain/test_tdee_service_goal_specific_macros.py
@@ -12,12 +12,12 @@ import pytest
 
 from src.domain.constants import TDEEConstants
 from src.domain.model.user import (
-    TdeeRequest,
-    Sex,
-    JobType,
     Goal,
-    UnitSystem,
+    JobType,
+    Sex,
+    TdeeRequest,
     TrainingLevel,
+    UnitSystem,
 )
 from src.domain.services.tdee_service import TdeeCalculationService
 
@@ -50,13 +50,11 @@ class TestTdeeServiceGoalSpecificMacros:
     @pytest.fixture
     def base_tdee(self):
         """Calculate base TDEE for test case."""
-        # 30-year-old male, 80kg, 180cm, moderate activity
+        # 30-year-old male, 80kg, 180cm, desk baseline
         # Mifflin-St Jeor: 10*80 + 6.25*180 - 5*30 + 5 = 800 + 1125 - 150 + 5 = 1780
-        # TDEE with moderate (1.55): 1780 * 1.55 = 2759
-        # BMR (Mifflin-St Jeor): 10*80 + 6.25*180 - 5*30 + 5 = 1780
-        # JobType.DESK (1.2) + training (4 days * 60 min = 4 hrs, 4*0.05=0.2) = 1.4
-        # TDEE = 1780 * 1.4 = 2492
-        return 2492.0
+        # JobType.DESK (1.2), planned training excluded and logged separately.
+        # TDEE = 1780 * 1.2 = 2136
+        return 2136.0
 
     # ===== BULKING TESTS =====
 
@@ -65,8 +63,8 @@ class TestTdeeServiceGoalSpecificMacros:
         base_request.goal = Goal.BULK
         response = service.calculate_tdee(base_request)
 
-        # Expected: TDEE + 300 = 2492 + 300 = 2792
-        expected_calories = 2492.0 + 300
+        # Expected: TDEE + 300 = 2136 + 300 = 2436
+        expected_calories = 2136.0 + 300
         assert response.macros.calories == pytest.approx(expected_calories, abs=0.1)
 
     def test_bulking_uses_weight_based_protein(self, service, base_request):
@@ -84,8 +82,8 @@ class TestTdeeServiceGoalSpecificMacros:
         response = service.calculate_tdee(base_request)
 
         # Expected: 80kg * 1.0 g/kg = 80g fat (weight-based)
-        # Dual-gate: max(80g weight, 2792*0.25/9=77.5g percent) = 80g
-        expected_fat = 80.0  # dual-gate: max(80g weight, 77.5g percent)
+        # Dual-gate: max(80g weight, 2436*0.25/9=67.7g percent) = 80g
+        expected_fat = 80.0
         assert response.macros.fat == pytest.approx(expected_fat, abs=1)
 
     def test_bulking_carbs_calculated_as_remainder(self, service, base_request):
@@ -107,8 +105,8 @@ class TestTdeeServiceGoalSpecificMacros:
         base_request.goal = Goal.CUT
         response = service.calculate_tdee(base_request)
 
-        # Expected: TDEE - 300 = 2492 - 300 = 2142
-        expected_calories = 2492.0 - 300
+        # Expected: TDEE - 300 = 2136 - 300 = 1836
+        expected_calories = 2136.0 - 300
         assert response.macros.calories == pytest.approx(expected_calories, abs=0.1)
 
     def test_cutting_uses_weight_based_protein(self, service, base_request):
@@ -148,8 +146,8 @@ class TestTdeeServiceGoalSpecificMacros:
         base_request.goal = Goal.RECOMP
         response = service.calculate_tdee(base_request)
 
-        # Expected: TDEE = 2492 (no adjustment)
-        expected_calories = 2492.0
+        # Expected: TDEE = 2136 (no adjustment)
+        expected_calories = 2136.0
         assert response.macros.calories == pytest.approx(expected_calories, abs=0.1)
 
     def test_recomp_uses_weight_based_protein(self, service, base_request):
@@ -167,8 +165,8 @@ class TestTdeeServiceGoalSpecificMacros:
         response = service.calculate_tdee(base_request)
 
         # Expected: 80kg * 0.9 g/kg = 72g fat (weight-based)
-        # Dual-gate: max(72g weight, 2492*0.25/9=69.2g percent) = 72g
-        expected_fat = 72.0  # dual-gate: max(72g weight, 69.2g percent)
+        # Dual-gate: max(72g weight, 2136*0.25/9=59.3g percent) = 72g
+        expected_fat = 72.0
         assert response.macros.fat == pytest.approx(expected_fat, abs=1)
 
     def test_recomp_carbs_calculated_as_remainder(self, service, base_request):

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -2,9 +2,7 @@
 Unit tests for update user metrics endpoint and handler.
 """
 
-from dataclasses import dataclass, field
-from typing import List, Optional
-from unittest.mock import AsyncMock, Mock, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -19,20 +17,20 @@ from src.domain.model.user.core_user import UserProfileDomainModel
 
 def _make_profile(**overrides) -> UserProfileDomainModel:
     """Create a domain profile with sensible defaults."""
-    defaults = dict(
-        id=str(uuid4()),
-        user_id="test_user",
-        age=30,
-        gender="male",
-        height_cm=175.0,
-        weight_kg=70.0,
-        job_type="desk",
-        training_days_per_week=4,
-        training_minutes_per_session=60,
-        fitness_goal="recomp",
-        meals_per_day=3,
-        is_current=False,
-    )
+    defaults = {
+        "id": str(uuid4()),
+        "user_id": "test_user",
+        "age": 30,
+        "gender": "male",
+        "height_cm": 175.0,
+        "weight_kg": 70.0,
+        "job_type": "desk",
+        "training_days_per_week": 4,
+        "training_minutes_per_session": 60,
+        "fitness_goal": "recomp",
+        "meals_per_day": 3,
+        "is_current": False,
+    }
     defaults.update(overrides)
     return UserProfileDomainModel(**defaults)
 
@@ -124,6 +122,23 @@ class TestUpdateUserMetricsCommandHandler:
         assert profile.training_days_per_week == 5
         assert profile.training_minutes_per_session == 60
         assert profile.is_current is True
+
+    async def test_update_training_days_to_zero(self):
+        """Test zero training days is treated as a provided metric."""
+        profile = _make_profile(training_days_per_week=4)
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(
+            user_id="test_user",
+            training_days_per_week=0,
+        )
+
+        await handler.handle(command)
+
+        assert profile.training_days_per_week == 0
+        assert profile.is_current is True
+        mock_uow.users.update_profile.assert_called_once_with(profile)
 
     async def test_update_fitness_goal_unlimited(self):
         """Test updating fitness goal succeeds without cooldown."""

--- a/tests/unit/handlers/query_handlers/test_cached_query_handlers.py
+++ b/tests/unit/handlers/query_handlers/test_cached_query_handlers.py
@@ -279,9 +279,9 @@ class TestGetWeeklyBudgetQueryHandlerCache:
                 "_sync_targets_if_stale",
                 AsyncMock(return_value=(mock_budget, 1800.0)),
             ),
-            patch.object(
-                handler,
-                "_get_effective_adjusted_daily_async",
+            patch(
+                "src.app.handlers.query_handlers.get_weekly_budget_query_handler."
+                "WeeklyBudgetService.get_effective_adjusted_daily_async",
                 AsyncMock(return_value=mock_effective),
             ),
         ):

--- a/tests/unit/handlers/query_handlers/test_preview_tdee_logged_movement_model.py
+++ b/tests/unit/handlers/query_handlers/test_preview_tdee_logged_movement_model.py
@@ -1,0 +1,29 @@
+import pytest
+
+from src.app.handlers.query_handlers.preview_tdee_query_handler import (
+    PreviewTdeeQueryHandler,
+)
+from src.app.queries.tdee import PreviewTdeeQuery
+
+
+@pytest.mark.asyncio
+async def test_preview_tdee_activity_multiplier_excludes_training_volume():
+    handler = PreviewTdeeQueryHandler()
+
+    result = await handler.handle(
+        PreviewTdeeQuery(
+            age=30,
+            sex="male",
+            height=180,
+            weight=80,
+            job_type="desk",
+            training_days_per_week=6,
+            training_minutes_per_session=90,
+            goal="recomp",
+            unit_system="metric",
+        )
+    )
+
+    assert result["bmr"] == pytest.approx(1780.0, abs=0.1)
+    assert result["tdee"] == pytest.approx(2136.0, abs=0.1)
+    assert result["activity_multiplier"] == 1.2

--- a/tests/unit/handlers/query_handlers/test_weekly_budget_movement_credit.py
+++ b/tests/unit/handlers/query_handlers/test_weekly_budget_movement_credit.py
@@ -1,0 +1,112 @@
+from datetime import date
+from unittest.mock import AsyncMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.app.handlers.query_handlers.get_weekly_budget_query_handler import (
+    GetWeeklyBudgetQueryHandler,
+)
+from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
+from src.domain.model.weekly import WeeklyMacroBudget
+from src.domain.services.weekly_budget_service import (
+    AdjustedDailyTargets,
+    EffectiveAdjustedResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_weekly_budget_response_uses_movement_adjusted_calories():
+    week_start = date(2026, 3, 9)
+    target_date = week_start
+    weekly_budget = WeeklyMacroBudget(
+        weekly_budget_id="budget-1",
+        user_id="u1",
+        week_start_date=week_start,
+        target_calories=14000.0,
+        target_protein=700.0,
+        target_carbs=1750.0,
+        target_fat=466.6667,
+    )
+    effective = EffectiveAdjustedResult(
+        adjusted=AdjustedDailyTargets(
+            calories=2000.0,
+            carbs=250.0,
+            fat=66.7,
+            protein=100.0,
+            bmr_floor_active=False,
+            remaining_days=7,
+        ),
+        consumed_before_today={
+            "calories": 0.0,
+            "protein": 0.0,
+            "carbs": 0.0,
+            "fat": 0.0,
+        },
+        consumed_total={
+            "calories": 2100.0,
+            "protein": 100.0,
+            "carbs": 250.0,
+            "fat": 100.0,
+        },
+        logged_past_days=0,
+        skipped_days=0,
+        show_logging_prompt=False,
+    )
+
+    mock_uow = AsyncMock()
+    mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+    mock_uow.__aexit__ = AsyncMock(return_value=False)
+    mock_uow.weekly_budgets.find_by_user_and_week.return_value = weekly_budget
+    mock_uow.weekly_budgets.update = AsyncMock()
+    mock_uow.cheat_days.find_by_user_and_date_range.return_value = []
+
+    handler = GetWeeklyBudgetQueryHandler()
+    query = GetWeeklyBudgetQuery(
+        user_id="u1",
+        target_date=target_date,
+        header_timezone="UTC",
+    )
+
+    with (
+        patch(
+            "src.app.handlers.query_handlers.get_weekly_budget_query_handler."
+            "AsyncUnitOfWork",
+            return_value=mock_uow,
+        ),
+        patch(
+            "src.app.handlers.query_handlers.get_weekly_budget_query_handler."
+            "resolve_user_timezone_async",
+            new_callable=AsyncMock,
+            return_value="UTC",
+        ),
+        patch(
+            "src.app.handlers.query_handlers.get_weekly_budget_query_handler."
+            "get_zone_info",
+            return_value=ZoneInfo("UTC"),
+        ),
+        patch(
+            "src.app.handlers.query_handlers.get_weekly_budget_query_handler."
+            "get_user_monday",
+            return_value=week_start,
+        ),
+        patch.object(
+            handler,
+            "_sync_targets_if_stale",
+            AsyncMock(return_value=(weekly_budget, 1600.0)),
+        ),
+        patch(
+            "src.app.handlers.query_handlers.get_weekly_budget_query_handler."
+            "WeeklyBudgetService.get_effective_adjusted_daily_async",
+            AsyncMock(return_value=effective),
+        ),
+    ):
+        result = await handler.handle(query)
+
+    assert result["consumed_calories"] == 2100.0
+    assert result["remaining_calories"] == 11900.0
+    assert result["preview_tomorrow_calories"] == pytest.approx(1983.3, abs=1.0)
+    assert weekly_budget.consumed_calories == 2100.0
+    assert weekly_budget.consumed_protein == 100.0
+    assert weekly_budget.consumed_carbs == 250.0
+    assert weekly_budget.consumed_fat == 100.0


### PR DESCRIPTION
## Summary
- Credit logged movement calories in weekly budget calculations by using net calories: `food calories - included movement kcal`.
- Keep consumed protein/carbs/fat as food-only macro grams.
- Remove planned workout calories from baseline TDEE so logged movement is the workout calorie credit, not a second count.
- Version TDEE and weekly budget cache keys (`user:tdee_v2`, `weekly_budget_v4`) to avoid stale pre-change targets after deploy.
- Update docs and plan/report artifacts for the science/product boundary.

## Science / Product Rule
Physical activity is part of energy expenditure, so adding workout calories back is correct only when the baseline target does not already include that workout. This PR aligns Nutree with that model: job/lifestyle activity remains in baseline TDEE, planned training does not inflate baseline calories, and logged movement entries provide the calorie credit.

References:
- CDC physical activity and healthy weight guidance: https://www.cdc.gov/healthy-weight-growth/physical-activity/index.html
- NIDDK Body Weight Planner: https://www.niddk.nih.gov/health-information/weight-management/body-weight-planner
- NCBI Endotext energy expenditure reference: https://www.ncbi.nlm.nih.gov/books/NBK279077/

## Example
Weekly target 14,000 kcal, base 2,000/day.

- Eat 2,300 kcal and log 200 kcal workout on Monday.
- Old weekly math: `(14000 - 2300) / 6 = 1950`.
- New math: `(14000 - (2300 - 200)) / 6 = 1983.3`.

## Verification
- `SENTRY_PROFILE_SESSION_SAMPLE_RATE=0 uv run pytest tests/unit/domain/services/test_weekly_budget_async.py tests/unit/domain/services/test_weekly_budget_service.py tests/unit/handlers/query_handlers/test_weekly_budget_movement_credit.py tests/unit/handlers/query_handlers/test_cached_query_handlers.py tests/unit/handlers/query_handlers/test_movement_balance_integration.py tests/unit/handlers/query_handlers/test_daily_macros_uow_consolidation.py tests/unit/infra/repositories/test_movement_repository_async.py tests/unit/infra/test_daily_context_precompute_service.py tests/unit/domain/services/test_tdee_caching.py tests/unit/app/services/test_cache_invalidation_service.py tests/unit/domain/test_tdee_logged_movement_model.py tests/unit/handlers/query_handlers/test_preview_tdee_logged_movement_model.py tests/unit/domain/test_tdee_service_goal_specific_macros.py -q` -> 154 passed
- `uv run ruff check ...` -> passed
- `SENTRY_PROFILE_SESSION_SAMPLE_RATE=0 uv run python -m compileall src ...` -> passed
- `git diff --cached --check` -> passed before commit
- staged secret-pattern scan -> no credential matches; only the plan checklist phrase `secret-scan` matched before exclusion

## Notes
- No API response shape change.
- No DB schema/migration.
