### PR TITLE
feat(ai): Cloudflare Workers AI vision-first routing for meal and ingredient scans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,11 @@ CLOUDFLARE_WORKERS_AI_TEXT_MODEL=@cf/meta/llama-3.3-70b-instruct-fp8-fast
 # Comma-separated purposes that use CF as primary; Gemini is fallback. Vision/barcode stay Gemini-only.
 CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES=recipe,general,meal_names,discovery,parse_text
 CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS=60
+# CF vision: set VISION_ENABLED=true to try Workers AI first for image scans.
+# Rollback: set CLOUDFLARE_WORKERS_AI_VISION_ENABLED=false (no redeploy needed).
+CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true
+CLOUDFLARE_WORKERS_AI_VISION_MODEL=@cf/google/gemma-4-26b-a4b-it
+CLOUDFLARE_WORKERS_AI_VISION_PURPOSES=meal_scan,ingredient_scan
 
 # ---------------------------------------------------------------------------
 # DeepL Translation (required for non-English meal translation)

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -63,15 +63,16 @@
 
 `AIModelManager` orchestrates providers through `AIProviderPort`. Each purpose has a fallback chain; models are tried in order until one succeeds. The circuit breaker opens after 5 failures within 60s and allows retry after 30s.
 
-**Default text chain (e.g. RECIPE):**
+**Default text chain (e.g. RECIPE) when CF text enabled:**
 ```
-gemini-2.5-flash-lite  →  gemini-2.5-flash  →  @cf/google/gemma-4-26b-a4b-it  (if CF enabled)
+@cf/google/gemma-4-26b-a4b-it  →  gemini-2.5-flash-lite  →  gemini-2.5-flash
 ```
 
-**Vision chains (always Gemini-only in v1):**
+**Vision chains (CF-first when `CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true`, Gemini fallback):**
 ```
-gemini-3.1-flash-lite  →  gemini-3.5-flash  →  gemini-2.5-flash
+@cf/google/gemma-4-26b-a4b-it  →  gemini-3.1-flash-lite  →  gemini-3.5-flash  →  gemini-2.5-flash
 ```
+When CF vision is disabled, vision chains are Gemini-only: `gemini-3.1-flash-lite → gemini-3.5-flash → gemini-2.5-flash`
 
 **Gemini-only parse/barcode fallback unless explicitly routed through Cloudflare:**
 ```
@@ -98,47 +99,61 @@ Logs emitted: `[AI-ATTEMPT]`, `[AI-FALLBACK-SUCCESS]`, `[AI-ATTEMPT-FAILED]`. Ne
 
 ---
 
-## Cloudflare Workers AI (Text Fallback)
+## Cloudflare Workers AI (Text + Vision)
 
-**Purpose:** Optional fallback AI provider for text-only purposes when Gemini is degraded. Disabled by default.
+**Purpose:** Optional primary AI provider for text and vision tasks. Gemini is fallback for all cases.
 
-**Not supported by the current FastAPI adapter:** vision/image analysis. `MEAL_SCAN` and `INGREDIENT_SCAN` remain Gemini-only. Parse and barcode require explicit opt-in via `CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES`.
+**Two independent routing paths:**
+- **Text path:** LangChain adapter (`ChatCloudflareWorkersAI`) for text-generation purposes.
+- **Vision path:** Direct Workers AI REST (`/ai/run/{model}`) with `httpx` for image analysis.
 
 ### How It Works
 
-- Uses LangChain's `ChatCloudflareWorkersAI` (`langchain-cloudflare>=0.3.4`) — this is LangChain inside FastAPI, not the app running on Cloudflare Workers runtime.
+- Text: Uses LangChain's `ChatCloudflareWorkersAI` (`langchain-cloudflare>=0.3.4`) — this is LangChain inside FastAPI, not the app running on Cloudflare Workers runtime.
+- Vision: Posts `messages[].content[].image_url` (base64 data URL) directly to the Workers AI REST endpoint. Response is normalized from `result.response` or `result.choices[0].message.content`.
 - Cloudflare model IDs stored raw (`@cf/...`) in fallback chains; `AIModelManager` routes to the CF provider via an explicit ownership map.
 - If `CLOUDFLARE_AI_GATEWAY_ID` is set, LangChain passes it as the `ai_gateway` field to Workers AI.
 - Returns the same `dict` shape as `GeminiProvider` — handlers are provider-agnostic.
 - Circuit breaker trips on 429/5xx/timeout, same as Gemini.
+- Vision model: `@cf/google/gemma-4-26b-a4b-it` (Vision=Yes, messages/image_url contract). Deprecated model `@cf/unum/uform-gen2-qwen-500m` must not be used.
 
 ### Env Vars
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `CLOUDFLARE_WORKERS_AI_ENABLED` | `false` | Master switch — Workers AI is inactive unless this is `true` |
+| `CLOUDFLARE_WORKERS_AI_ENABLED` | `true` | Master switch — text path inactive unless this is `true` |
 | `CLOUDFLARE_ACCOUNT_ID` | `` | Cloudflare account ID |
 | `CLOUDFLARE_API_TOKEN` | `` | API token with Workers AI permission |
 | `CLOUDFLARE_AI_GATEWAY_ID` | `` | Optional AI Gateway ID; leave blank for direct Workers AI |
-| `CLOUDFLARE_WORKERS_AI_TEXT_MODEL` | `@cf/google/gemma-4-26b-a4b-it` | Model for text generation |
-| `CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES` | `recipe,general,meal_names,discovery` | Purposes that include CF in fallback chain |
+| `CLOUDFLARE_WORKERS_AI_TEXT_MODEL` | `@cf/meta/llama-3.3-70b-instruct-fp8-fast` | Model for text generation |
+| `CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES` | `recipe,general,meal_names,discovery,parse_text` | Purposes that include CF text in fallback chain |
 | `CLOUDFLARE_WORKERS_AI_JSON_MODE` | `true` | Reserved; currently unused by LangChain adapter |
-| `CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS` | `30` | HTTP timeout per request |
+| `CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS` | `60` | HTTP timeout per request |
+| `CLOUDFLARE_WORKERS_AI_VISION_ENABLED` | `true` | Enable CF vision for image analysis (Gemini is fallback) |
+| `CLOUDFLARE_WORKERS_AI_VISION_MODEL` | `@cf/google/gemma-4-26b-a4b-it` | Vision model for image analysis |
+| `CLOUDFLARE_WORKERS_AI_VISION_PURPOSES` | `meal_scan,ingredient_scan` | Purposes that use CF vision as primary |
 
-### Production Rollout Order
+### Production Rollout (Vision)
+
+Set these env vars in Render (no redeployment needed, env var change restarts the service):
 
 ```
-1. Deploy code — Cloudflare disabled by default; zero behavior change.
-2. In Render: set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.
-3. Leave CLOUDFLARE_AI_GATEWAY_ID blank for direct Workers AI.
-4. Set CLOUDFLARE_WORKERS_AI_ENABLED=true, TEXT_PURPOSES=recipe,general.
-5. Observe app logs and Cloudflare Workers AI usage for several days.
-6. Extend TEXT_PURPOSES to include meal_names,discovery after basic observation passes.
-7. Keep parse_text, barcode, meal_scan, ingredient_scan Gemini-only until separate schema eval.
+CLOUDFLARE_WORKERS_AI_ENABLED=true
+CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true
+CLOUDFLARE_WORKERS_AI_VISION_MODEL=@cf/google/gemma-4-26b-a4b-it
+CLOUDFLARE_WORKERS_AI_VISION_PURPOSES=meal_scan,ingredient_scan
 ```
+
+Keep `GOOGLE_API_KEY` configured — Gemini remains the fallback on any CF vision failure.
 
 ### Rollback
 
+Disable vision without redeploying:
+```
+CLOUDFLARE_WORKERS_AI_VISION_ENABLED=false
+```
+
+Disable all CF:
 ```
 CLOUDFLARE_WORKERS_AI_ENABLED=false
 ```
@@ -147,7 +162,7 @@ CLOUDFLARE_WORKERS_AI_ENABLED=false
 
 - API token is loaded from env/settings and never logged.
 - Logs include only: provider name, model alias, purpose value, HTTP status code, and error class.
-- Prompts, food payloads, raw AI responses, and account IDs are never logged.
+- Prompts, food payloads, raw AI responses, base64 image bytes, and account IDs are never logged.
 
 ---
 

--- a/plans/260618-1916-cloudflare-first-vision-routing/phase-01-research-request-contract.md
+++ b/plans/260618-1916-cloudflare-first-vision-routing/phase-01-research-request-contract.md
@@ -1,0 +1,87 @@
+---
+phase: 1
+title: "Research request contract"
+status: pending
+priority: P1
+effort: "2h"
+dependencies: []
+---
+
+# Phase 1: Research request contract
+
+## Overview
+
+Confirm the exact Cloudflare Workers AI vision request/response contract before implementation. The goal is to avoid building against a table that says `Vision Yes` but a request shape that rejects image payloads.
+
+## Requirements
+
+- Functional: prove a payload shape for `@cf/google/gemma-4-26b-a4b-it` that accepts image input and returns text suitable for JSON extraction.
+- Functional: identify fallback candidate only if Gemma 4 cannot accept image input in practice.
+- Non-functional: do not require production secrets in tests or docs.
+- Non-functional: do not log raw image bytes, base64 strings, raw prompts, or provider response bodies.
+
+## Architecture
+
+Use Workers AI REST for vision:
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "vision system prompt"},
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "meal analysis prompt"},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
+      ]
+    }
+  ],
+  "max_tokens": 8192,
+  "temperature": 0.2
+}
+```
+
+If this contract fails live, test the model's documented OpenAI-compatible endpoint before falling back to raw `image` fields. Avoid deprecated `@cf/unum/uform-gen2-qwen-500m`.
+
+## Related Code Files
+
+- Read: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/ai/providers/cloudflare_workers_ai_provider.py`
+- Read: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/ai/ai_model_manager.py`
+- Read: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/adapters/vision_ai_service.py`
+- Read: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/services/prompts/system_prompts.py`
+- Read: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/external-services.md`
+
+## Implementation Steps
+
+1. Fetch current Cloudflare raw schema for `@cf/google/gemma-4-26b-a4b-it` and confirm `messages[].content[].image_url`.
+2. If credentials are locally available, run one manual dry-run with a tiny known image and a strict JSON prompt. Do not commit the image or secrets.
+3. Record accepted response shapes to normalize: `result.response`, `result.choices[0].message.content`, plain `response`, and direct text.
+4. Decide whether to send `response_format`. Default: skip it unless the live dry-run proves it works with image payloads.
+5. Document the final contract in `docs/external-services.md` during Phase 4.
+
+## Todo List
+
+- [ ] Confirm Gemma 4 vision input schema.
+- [ ] Confirm response shape normalization.
+- [ ] Decide whether JSON mode is safe for vision.
+- [ ] Confirm no extra Cloudflare license acceptance is needed for the selected primary model.
+
+## Success Criteria
+
+- [ ] Accepted CF vision request payload is known.
+- [ ] Primary model and fallback policy are explicit.
+- [ ] Implementation can proceed without guessing request/response fields.
+
+## Risk Assessment
+
+Risk: Cloudflare docs expose `Vision Yes` but REST schema is inconsistent. Mitigation: verify raw schema and, if credentials exist, one live dry-run before coding.
+
+Risk: JSON mode rejects image messages. Mitigation: rely on existing JSON extraction first; add JSON mode only after evidence.
+
+## Security Considerations
+
+Never paste real API tokens into plan files, test fixtures, or logs. Manual dry-run commands must use env vars.
+
+## Next Steps
+
+Proceed to Phase 2 once the payload and response shape are known.

--- a/plans/260618-1916-cloudflare-first-vision-routing/phase-02-implement-provider-vision.md
+++ b/plans/260618-1916-cloudflare-first-vision-routing/phase-02-implement-provider-vision.md
@@ -1,0 +1,91 @@
+---
+phase: 2
+title: "Implement provider vision"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: [1]
+---
+
+# Phase 2: Implement provider vision
+
+## Overview
+
+Make `CloudflareWorkersAIProvider` a real vision-capable provider while preserving the existing LangChain-backed text path.
+
+## Requirements
+
+- Functional: `generate_with_vision()` sends image bytes to Workers AI and returns the same parsed `dict` shape as Gemini.
+- Functional: provider advertises `AICapability.VISION` only when a vision model is configured.
+- Functional: text generation behavior stays unchanged.
+- Non-functional: provider uses bounded timeout, propagates 429/5xx/timeout for circuit breaker behavior, and never logs raw image/prompt/response content.
+
+## Architecture
+
+Keep one provider class, two transport paths:
+- Text path: existing `ChatCloudflareWorkersAI` via LangChain.
+- Vision path: direct Workers AI REST call with `httpx.AsyncClient`.
+
+Constructor additions:
+
+```python
+vision_model: str = ""
+vision_enabled: bool = False
+```
+
+Provider behavior:
+- `supported_capabilities` starts with text/structured output.
+- Add `AICapability.VISION` when `vision_enabled and vision_model`.
+- `get_available_models()` returns text model and vision model without duplicates.
+- `generate_with_vision()` base64 encodes bytes into a data URL, posts to `/ai/run/{model}`, extracts text, then uses `extract_ai_json`.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/ai/providers/cloudflare_workers_ai_provider.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py`
+- No change expected: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/ports/ai_provider_port.py`
+
+## Implementation Steps
+
+1. Add vision constructor fields and store `account_id`, `api_token`, `gateway_id`, timeout for REST calls.
+2. Update docstring from text-only to text plus optional vision.
+3. Update `supported_capabilities` and `get_available_models`.
+4. Implement private helpers:
+   - `_build_vision_payload(prompt, image_data, system_message, max_tokens)`
+   - `_post_workers_ai(model, payload)`
+   - `_extract_response_text(payload)`
+5. Implement `generate_with_vision()`:
+   - reject when no vision model configured.
+   - use `model` argument from manager, not hardcoded model.
+   - pass `max_tokens` from kwargs, defaulting to 4096 if absent.
+   - parse JSON with existing `extract_ai_json`.
+6. Extend `extract_error_code()` if direct REST wraps Cloudflare errors differently.
+7. Add provider tests for capability, payload shape, success parse, malformed JSON, 429, 503, timeout, and empty response.
+
+## Todo List
+
+- [ ] Add config-aware vision capability.
+- [ ] Add direct REST vision transport.
+- [ ] Normalize CF response text.
+- [ ] Preserve current text tests.
+- [ ] Add provider vision tests.
+
+## Success Criteria
+
+- [ ] Provider test suite proves CF vision can be called and parsed.
+- [ ] Existing text provider tests still pass.
+- [ ] No raw image/base64/prompt/response appears in logs or exception messages.
+
+## Risk Assessment
+
+Risk: provider file exceeds target size. Mitigation: if it gets too large, extract small private helpers in the same module first; create a new helper module only if the file approaches the hard limit.
+
+Risk: LangChain and REST behavior diverge. Mitigation: keep transports isolated and share only JSON extraction/error-code behavior.
+
+## Security Considerations
+
+Use `Authorization: Bearer ...` only in request headers. Do not include token, base64 image, prompt text, or response preview in logs.
+
+## Next Steps
+
+Proceed to Phase 3 after provider unit tests define the new contract.

--- a/plans/260618-1916-cloudflare-first-vision-routing/phase-03-prioritize-vision-routing.md
+++ b/plans/260618-1916-cloudflare-first-vision-routing/phase-03-prioritize-vision-routing.md
@@ -1,0 +1,99 @@
+---
+phase: 3
+title: "Prioritize vision routing"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: [2]
+---
+
+# Phase 3: Prioritize vision routing
+
+## Overview
+
+Wire CF vision into `AIModelManager` so meal and ingredient image scans try Cloudflare first, then Gemini fallbacks.
+
+## Requirements
+
+- Functional: CF vision model is first in `MEAL_SCAN` and `INGREDIENT_SCAN` chains when enabled.
+- Functional: Gemini-only behavior remains when CF disabled, missing credentials, or missing vision model.
+- Functional: text-purpose routing remains independent from vision-purpose routing.
+- Non-functional: no public API shape changes and no prompt/parser contract changes.
+
+## Architecture
+
+Add separate vision routing instead of overloading `CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES`.
+
+Settings:
+
+```python
+CLOUDFLARE_WORKERS_AI_VISION_ENABLED: bool = True
+CLOUDFLARE_WORKERS_AI_VISION_MODEL: str = "@cf/google/gemma-4-26b-a4b-it"
+CLOUDFLARE_WORKERS_AI_VISION_PURPOSES: str = "meal_scan,ingredient_scan"
+```
+
+Manager changes:
+- `_maybe_add_cf_provider()` passes text and vision config to provider.
+- register `vision_model` in `_model_provider_overrides`.
+- add `_prepend_cf_to_vision_chains(cf_model, vision_purposes_csv)`.
+- keep `_append_cf_to_text_chains()` behavior unchanged.
+
+Target chain when enabled:
+
+```text
+meal_scan:
+@cf/google/gemma-4-26b-a4b-it
+gemini-3.1-flash-lite
+gemini-3.5-flash
+gemini-2.5-flash
+```
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/config/settings.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/.env.example`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/ai/ai_model_manager.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/services/ai/test_ai_model_manager.py`
+- No change expected: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/adapters/vision_ai_service.py`
+
+## Implementation Steps
+
+1. Add settings fields and `.env.example` entries for CF vision.
+2. Update `_make_cf_settings()` test helper with vision fields.
+3. Update manager provider construction to pass vision config.
+4. Register the vision model override only when vision model is non-empty.
+5. Add/prepend CF only for valid configured `ModelPurpose` values.
+6. Replace existing tests that assert vision remains Gemini-only:
+   - enabled path should assert CF model first for meal and ingredient scan.
+   - disabled path should assert Gemini-only.
+   - failure path should assert CF vision attempted before Gemini fallback.
+7. Keep barcode Gemini-only by default.
+
+## Todo List
+
+- [ ] Add vision env settings.
+- [ ] Add vision chain prepending.
+- [ ] Update old Gemini-only vision tests.
+- [ ] Add CF-fails-then-Gemini vision fallback test.
+- [ ] Confirm text routing tests still pass.
+
+## Success Criteria
+
+- [ ] `get_fallback_chain(ModelPurpose.MEAL_SCAN)[0]` is CF vision model when enabled.
+- [ ] `generate_with_vision()` attempts CF first and Gemini second on CF failure.
+- [ ] With CF disabled or incomplete config, existing Gemini chain is unchanged.
+- [ ] Text chains keep current CF priority behavior.
+
+## Risk Assessment
+
+Risk: one CF model ID is used for text and vision in some tests, hiding override bugs. Mitigation: add a test where text model and vision model differ.
+
+Risk: malformed `VISION_PURPOSES` silently changes nothing. Mitigation: ignore unknown values but log a warning with only purpose names.
+
+## Security Considerations
+
+Settings must not print tokens. Logs may include model ID and purpose, not prompt/image/user content.
+
+## Next Steps
+
+Proceed to Phase 4 after focused model-manager and provider tests pass locally.

--- a/plans/260618-1916-cloudflare-first-vision-routing/phase-04-verify-rollout-docs.md
+++ b/plans/260618-1916-cloudflare-first-vision-routing/phase-04-verify-rollout-docs.md
@@ -1,0 +1,95 @@
+---
+phase: 4
+title: "Verify rollout docs"
+status: pending
+priority: P1
+effort: "2h"
+dependencies: [3]
+---
+
+# Phase 4: Verify rollout docs
+
+## Overview
+
+Verify the CF-first vision path and update operational docs so production rollout is explicit and reversible.
+
+## Requirements
+
+- Functional: all focused tests pass.
+- Functional: docs explain CF vision, env vars, model choice, fallback order, and rollback.
+- Non-functional: compile/lint checks run on touched Python files.
+- Non-functional: rollout can be disabled without redeploying code by env var.
+
+## Architecture
+
+Verification pyramid:
+- Provider unit tests for request/response contract.
+- Model manager unit tests for routing and fallback order.
+- Existing vision service tests to ensure provider-agnostic scan flow remains intact.
+- Optional live smoke only when credentials are available.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/external-services.md`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/project-roadmap.md`
+- Optional modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/troubleshooting.md`
+- Run tests covering:
+  - `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py`
+  - `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/services/ai/test_ai_model_manager.py`
+
+## Implementation Steps
+
+1. Run provider tests:
+   `uv run pytest tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py -q`
+2. Run model-manager tests:
+   `uv run pytest tests/unit/infra/services/ai/test_ai_model_manager.py -q`
+3. Run focused vision/AI suite:
+   `uv run pytest tests/unit/infra/services/ai tests/unit/infra/adapters -q`
+4. Run lint/compile on touched files:
+   `uv run ruff check src/infra/services/ai src/infra/config tests/unit/infra/services/ai`
+   `uv run python -m compileall src/infra/services/ai src/infra/config`
+5. Update docs with:
+   - CF vision fallback chain.
+   - env vars and recommended Render values.
+   - rollback: `CLOUDFLARE_WORKERS_AI_VISION_ENABLED=false`.
+   - warning that `@cf/unum/uform-gen2-qwen-500m` is deprecated.
+6. If credentials exist, run one manual smoke outside tests with a non-sensitive sample image and confirm scan JSON validates. Do not commit sample image.
+
+## Todo List
+
+- [ ] Provider tests pass.
+- [ ] Manager tests pass.
+- [ ] Focused AI suite passes.
+- [ ] Ruff and compile pass.
+- [ ] Docs and roadmap updated.
+- [ ] Rollback env documented.
+
+## Success Criteria
+
+- [ ] Local verification commands pass or blocker is documented.
+- [ ] Production rollout steps are clear.
+- [ ] Rollback is one env-var change.
+- [ ] No docs still claim vision is Gemini-only.
+
+## Risk Assessment
+
+Risk: CF returns lower nutrition quality than Gemini. Mitigation: ship with Gemini fallback, smoke test before rollout, and monitor provider success/failure plus user-visible scan failures.
+
+Risk: CF outage causes scan delay before Gemini fallback. Mitigation: keep timeout bounded and circuit breaker behavior active for 429/5xx/timeout.
+
+## Security Considerations
+
+Production docs must not include secrets. Logs and docs must avoid raw image URLs and base64 payloads.
+
+## Next Steps
+
+After implementation, set Render env:
+
+```text
+CLOUDFLARE_WORKERS_AI_ENABLED=true
+CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true
+CLOUDFLARE_WORKERS_AI_VISION_MODEL=@cf/google/gemma-4-26b-a4b-it
+CLOUDFLARE_WORKERS_AI_VISION_PURPOSES=meal_scan,ingredient_scan
+```
+
+Keep `GOOGLE_API_KEY` configured for Gemini fallback.

--- a/plans/260618-1916-cloudflare-first-vision-routing/plan.md
+++ b/plans/260618-1916-cloudflare-first-vision-routing/plan.md
@@ -1,0 +1,68 @@
+---
+title: "Cloudflare-first vision provider routing"
+description: "Make Cloudflare Workers AI the first attempted provider for meal and ingredient image analysis, with Gemini fallback preserved."
+status: complete
+priority: P1
+effort: "1.5d"
+branch: "main"
+tags: [backend, ai, infra, cloudflare, vision]
+blockedBy: []
+blocks: []
+created: "2026-06-18T12:17:01.601Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Cloudflare-first vision provider routing
+
+## Overview
+
+Prioritize Cloudflare Workers AI for vision image analysis in MealTrack while keeping Gemini as fallback. This addresses Gemini 504 `DEADLINE_EXCEEDED` failures on `meal_scan` without changing public scan endpoints, parser contracts, or mobile response shapes.
+
+Current state:
+- `CloudflareWorkersAIProvider` is text-only and raises `NotImplementedError` for `generate_with_vision`.
+- `AIModelManager.generate_with_vision()` already skips providers without `AICapability.VISION`.
+- Existing tests intentionally assert `MEAL_SCAN` and `INGREDIENT_SCAN` stay Gemini-only; implementation must update those tests deliberately.
+
+Recommended design:
+- Add explicit CF vision config: `CLOUDFLARE_WORKERS_AI_VISION_ENABLED`, `CLOUDFLARE_WORKERS_AI_VISION_MODEL`, `CLOUDFLARE_WORKERS_AI_VISION_PURPOSES`.
+- Use `@cf/google/gemma-4-26b-a4b-it` as first CF vision candidate because Cloudflare marks it `Vision Yes` and its schema supports `messages[].content[].image_url`.
+- Implement CF vision through Workers AI REST `ai/run` with `httpx.AsyncClient`, not the current LangChain text adapter.
+- Prepend the CF vision model to `meal_scan` and `ingredient_scan` chains only when enabled and credentials/model are present.
+- Preserve existing Gemini 3 chain as fallback: `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-2.5-flash`.
+
+Out of scope:
+- Prompt redesign, parser rewrite, nutrition schema changes, DB migrations, mobile changes.
+- Cloudflare image generation config (`CF_IMAGE_MODEL`) unrelated to image understanding.
+- Making barcode use CF vision unless explicitly requested later.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Research request contract](./phase-01-research-request-contract.md) | Complete |
+| 2 | [Implement provider vision](./phase-02-implement-provider-vision.md) | Complete |
+| 3 | [Prioritize vision routing](./phase-03-prioritize-vision-routing.md) | Complete |
+| 4 | [Verify rollout docs](./phase-04-verify-rollout-docs.md) | Complete |
+
+## Dependencies
+
+- No blocking unfinished plan found. `plans/260608-2251-ai-api-reliability-hardening` is completed and explicitly excluded new provider integrations.
+- Requires Cloudflare account ID/API token with Workers AI permission in production.
+- External docs to validate during implementation:
+  - https://developers.cloudflare.com/workers-ai/models/gemma-4-26b-a4b-it/
+  - https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/
+
+## Acceptance Criteria
+
+- CF vision is attempted first for `ModelPurpose.MEAL_SCAN` and `ModelPurpose.INGREDIENT_SCAN` when enabled.
+- Gemini vision fallback still runs when CF vision returns 429, 5xx, timeout, malformed JSON, or empty content.
+- CF text routing remains unchanged for configured text purposes.
+- Public image upload and scan-by-url response shapes stay unchanged.
+- Logs contain model/provider/error metadata only, never raw images, base64, prompts, food payloads, URLs, or raw AI responses.
+- Focused unit tests, provider tests, compile check, and docs updates pass.
+
+## Implementation Handoff
+
+Use:
+`/ck:cook /Users/alexnguyen/Desktop/Nut/mealtrack_backend/plans/260618-1916-cloudflare-first-vision-routing/plan.md`

--- a/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
@@ -296,7 +296,7 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
             target_fat = daily_macros.get("fat", 70) * 7
         except Exception as e:
             # Fallback to defaults if TDEE calculation fails
-            logger.warning(f"TDEE calc failed for user {user_id}, using defaults: {e}")
+            logger.warning("TDEE calc failed, using defaults: %s", type(e).__name__)
             target_calories = 14000  # 2000 * 7
             target_protein = 490  # 70 * 7
             target_carbs = 1400  # 200 * 7
@@ -364,14 +364,9 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
                 weekly_budget.target_carbs = expected_targets["target_carbs"]
                 weekly_budget.target_fat = expected_targets["target_fat"]
                 await uow.weekly_budgets.update(weekly_budget)
-                logger.info(
-                    "Updated stale weekly nutrition targets for user %s: %s to %s",
-                    user_id,
-                    current_targets,
-                    expected_targets,
-                )
+                logger.info("Updated stale weekly nutrition targets for user")
 
             return weekly_budget, bmr
         except Exception as e:
-            logger.warning(f"Staleness check failed: {e}")
+            logger.warning("Staleness check failed: %s", type(e).__name__)
             return weekly_budget, 1800

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -252,6 +252,18 @@ class Settings(BaseSettings):
     CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS: int = Field(
         default=60, description="HTTP timeout for Workers AI requests (thinking models need ≥60s)"
     )
+    CLOUDFLARE_WORKERS_AI_VISION_ENABLED: bool = Field(
+        default=True,
+        description="Enable Cloudflare Workers AI for vision tasks (Gemini is fallback)",
+    )
+    CLOUDFLARE_WORKERS_AI_VISION_MODEL: str = Field(
+        default="@cf/google/gemma-4-26b-a4b-it",
+        description="Workers AI model for image analysis (must support vision input)",
+    )
+    CLOUDFLARE_WORKERS_AI_VISION_PURPOSES: str = Field(
+        default="meal_scan,ingredient_scan",
+        description="Comma-separated ModelPurpose values where Workers AI vision is tried first",
+    )
 
     # AI image generators — Cloudflare Workers AI (free tier: ~150-600 images/month)
     CF_ACCOUNT_ID: str | None = Field(

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -125,6 +125,10 @@ class AIModelManager:
         ):
             return
 
+        vision_enabled = getattr(settings, "CLOUDFLARE_WORKERS_AI_VISION_ENABLED", False)
+        vision_model = getattr(settings, "CLOUDFLARE_WORKERS_AI_VISION_MODEL", "")
+        vision_purposes = getattr(settings, "CLOUDFLARE_WORKERS_AI_VISION_PURPOSES", "")
+
         cf = CloudflareWorkersAIProvider(
             account_id=settings.CLOUDFLARE_ACCOUNT_ID,
             api_token=settings.CLOUDFLARE_API_TOKEN,
@@ -132,6 +136,8 @@ class AIModelManager:
             gateway_id=settings.CLOUDFLARE_AI_GATEWAY_ID or "",
             json_mode_enabled=settings.CLOUDFLARE_WORKERS_AI_JSON_MODE,
             timeout_seconds=settings.CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS,
+            vision_model=vision_model,
+            vision_enabled=vision_enabled,
         )
         self._providers["cloudflare-workers-ai"] = cf
         self._model_provider_overrides[settings.CLOUDFLARE_WORKERS_AI_TEXT_MODEL] = (
@@ -141,6 +147,19 @@ class AIModelManager:
             cf_model=settings.CLOUDFLARE_WORKERS_AI_TEXT_MODEL,
             text_purposes_csv=settings.CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES,
         )
+
+        if vision_enabled and vision_model:
+            self._model_provider_overrides[vision_model] = "cloudflare-workers-ai"
+            self._prepend_cf_to_vision_chains(
+                cf_model=vision_model,
+                vision_purposes_csv=vision_purposes,
+            )
+            logger.info(
+                "[CF-WORKERS-AI-VISION-ENABLED] purposes=%s model=%s",
+                vision_purposes,
+                vision_model,
+            )
+
         logger.info(
             "[CF-WORKERS-AI-ENABLED] purposes=%s model=%s",
             settings.CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES,
@@ -150,6 +169,20 @@ class AIModelManager:
     def _append_cf_to_text_chains(self, cf_model: str, text_purposes_csv: str) -> None:
         """Prepend raw CF model id to configured text-purpose chains (CF is tried first)."""
         configured = {p.strip().lower() for p in text_purposes_csv.split(",") if p.strip()}
+        for purpose in ModelPurpose:
+            if purpose.value in configured:
+                self._fallback_chains[purpose].insert(0, cf_model)
+
+    def _prepend_cf_to_vision_chains(self, cf_model: str, vision_purposes_csv: str) -> None:
+        """Prepend CF vision model to configured vision-purpose chains (CF is tried first)."""
+        configured = {p.strip().lower() for p in vision_purposes_csv.split(",") if p.strip()}
+        valid_values = {mp.value for mp in ModelPurpose}
+        unknown = configured - valid_values
+        if unknown:
+            logger.warning(
+                "[CF-WORKERS-AI-VISION] unknown purposes ignored: %s",
+                ", ".join(sorted(unknown)),
+            )
         for purpose in ModelPurpose:
             if purpose.value in configured:
                 self._fallback_chains[purpose].insert(0, cf_model)

--- a/src/infra/services/ai/providers/cloudflare_workers_ai_provider.py
+++ b/src/infra/services/ai/providers/cloudflare_workers_ai_provider.py
@@ -1,4 +1,5 @@
 """Cloudflare Workers AI implementation of AIProviderPort using LangChain."""
+import base64
 import logging
 from typing import Any
 
@@ -12,12 +13,15 @@ from src.infra.adapters.ai_json_utils import extract_json as extract_ai_json
 
 logger = logging.getLogger(__name__)
 
+_CF_REST_BASE = "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model}"
+
 
 class CloudflareWorkersAIProvider(AIProviderPort):
     """
     Cloudflare Workers AI provider via LangChain's ChatCloudflareWorkersAI.
 
-    Vision is not supported. generate_with_vision raises NotImplementedError.
+    Text path: LangChain adapter.
+    Vision path: direct Workers AI REST call with httpx (when vision_model configured).
     """
 
     def __init__(
@@ -28,9 +32,16 @@ class CloudflareWorkersAIProvider(AIProviderPort):
         gateway_id: str = "",
         timeout_seconds: int = 30,
         json_mode_enabled: bool = True,
+        vision_model: str = "",
+        vision_enabled: bool = False,
     ) -> None:
         self._text_model = text_model
         self._json_mode_enabled = json_mode_enabled
+        self._account_id = account_id
+        self._api_token = api_token
+        self._timeout_seconds = timeout_seconds
+        self._vision_model = vision_model
+        self._vision_enabled = vision_enabled and bool(vision_model)
 
         kwargs: dict[str, Any] = {
             "model": text_model,
@@ -49,10 +60,16 @@ class CloudflareWorkersAIProvider(AIProviderPort):
 
     @property
     def supported_capabilities(self) -> set[AICapability]:
-        return {AICapability.TEXT_GENERATION, AICapability.STRUCTURED_OUTPUT}
+        caps = {AICapability.TEXT_GENERATION, AICapability.STRUCTURED_OUTPUT}
+        if self._vision_enabled:
+            caps.add(AICapability.VISION)
+        return caps
 
     def get_available_models(self) -> list[str]:
-        return [self._text_model] if self._text_model else []
+        models = [self._text_model] if self._text_model else []
+        if self._vision_enabled and self._vision_model and self._vision_model != self._text_model:
+            models.append(self._vision_model)
+        return models
 
     async def generate(
         self,
@@ -112,6 +129,47 @@ class CloudflareWorkersAIProvider(AIProviderPort):
 
         return {"raw_content": text}
 
+    def _build_vision_payload(
+        self,
+        prompt: str,
+        image_data: bytes,
+        system_message: str | None,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        b64 = base64.b64encode(image_data).decode("ascii")
+        user_content: list[dict] = [
+            {"type": "text", "text": prompt},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+        ]
+        messages: list[dict] = []
+        if system_message:
+            messages.append({"role": "system", "content": system_message})
+        messages.append({"role": "user", "content": user_content})
+        return {"messages": messages, "max_tokens": max_tokens, "temperature": 0.2}
+
+    async def _post_workers_ai(self, model: str, payload: dict) -> dict:
+        url = _CF_REST_BASE.format(account_id=self._account_id, model=model)
+        headers = {
+            "Authorization": f"Bearer {self._api_token}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+
+    def _extract_response_text(self, raw: dict) -> str:
+        result = raw.get("result", {})
+        if isinstance(result, dict):
+            if "response" in result:
+                return str(result["response"])
+            choices = result.get("choices", [])
+            if choices:
+                return choices[0].get("message", {}).get("content", "")
+        if isinstance(result, str):
+            return result
+        return ""
+
     async def generate_with_vision(
         self,
         model: str,
@@ -120,11 +178,25 @@ class CloudflareWorkersAIProvider(AIProviderPort):
         system_message: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Not supported in v1."""
-        raise NotImplementedError(
-            "CloudflareWorkersAIProvider does not support vision in v1. "
-            "Use GeminiProvider for image-based tasks."
-        )
+        """Send image to Workers AI REST endpoint and return parsed dict."""
+        if not self._vision_enabled:
+            raise NotImplementedError(
+                "CloudflareWorkersAIProvider: vision not configured. "
+                "Set CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true and a vision model."
+            )
+
+        max_tokens: int = kwargs.get("max_tokens", 4096)
+        payload = self._build_vision_payload(prompt, image_data, system_message, max_tokens)
+        raw = await self._post_workers_ai(model, payload)
+        text = self._extract_response_text(raw)
+
+        if not text.strip():
+            raise ValueError(
+                f"[CF-WORKERS-AI-VISION] Model returned empty response for model={model}"
+            )
+
+        logger.debug("[CF-WORKERS-AI-VISION-SUCCESS] model=%s", model)
+        return extract_ai_json(text)
 
     def extract_error_code(self, error: Exception) -> int | str | None:
         """Extract HTTP status code or 'timeout' from httpx exceptions bubbled through LangChain."""

--- a/tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py
+++ b/tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py
@@ -32,6 +32,20 @@ def provider_no_gateway():
     )
 
 
+@pytest.fixture
+def provider_with_vision():
+    return CloudflareWorkersAIProvider(
+        account_id="fake_account_id",
+        api_token="fake_api_token",
+        text_model="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        gateway_id="fake_gateway",
+        timeout_seconds=30,
+        json_mode_enabled=True,
+        vision_model="@cf/google/gemma-4-26b-a4b-it",
+        vision_enabled=True,
+    )
+
+
 class TestProviderInterface:
     def test_provider_name(self, provider):
         assert provider.provider_name == "cloudflare-workers-ai"
@@ -42,8 +56,22 @@ class TestProviderInterface:
         assert AICapability.STRUCTURED_OUTPUT in caps
         assert AICapability.VISION not in caps
 
+    def test_supported_capabilities_includes_vision_when_enabled(self, provider_with_vision):
+        caps = provider_with_vision.supported_capabilities
+        assert AICapability.VISION in caps
+
     def test_get_available_models_returns_configured_model(self, provider):
         assert "@cf/google/gemma-4-26b-a4b-it" in provider.get_available_models()
+
+    def test_get_available_models_includes_both_when_vision_configured(self, provider_with_vision):
+        models = provider_with_vision.get_available_models()
+        assert "@cf/meta/llama-3.3-70b-instruct-fp8-fast" in models
+        assert "@cf/google/gemma-4-26b-a4b-it" in models
+        assert len(set(models)) == len(models), "no duplicates"
+
+    def test_vision_capability_absent_when_vision_disabled(self, provider):
+        """Provider without vision_enabled must never expose VISION capability."""
+        assert AICapability.VISION not in provider.supported_capabilities
 
 
 def _mock_llm(provider, return_value=None, side_effect=None):
@@ -259,14 +287,181 @@ class TestGenerate:
 
 class TestGenerateWithVision:
     @pytest.mark.asyncio
-    async def test_generate_with_vision_raises_not_implemented(self, provider):
-        """Vision is not supported in v1; must raise."""
-        with pytest.raises((NotImplementedError, Exception)):
+    async def test_generate_with_vision_raises_not_implemented_when_disabled(self, provider):
+        """Provider without vision_model must raise NotImplementedError."""
+        with pytest.raises(NotImplementedError):
             await provider.generate_with_vision(
                 model="@cf/google/gemma-4-26b-a4b-it",
                 prompt="What is in this image?",
                 image_data=b"fake_image_bytes",
             )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_success(self, provider_with_vision):
+        """Vision-enabled provider calls REST and returns parsed dict."""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"result": {"response": '{"meal": "salad", "calories": 100}'}}
+        mock_resp.raise_for_status = Mock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            result = await provider_with_vision.generate_with_vision(
+                model="@cf/google/gemma-4-26b-a4b-it",
+                prompt="Analyze this meal",
+                image_data=b"fake_image_bytes",
+                system_message="You are a nutrition expert",
+            )
+
+        assert isinstance(result, dict)
+        assert result.get("meal") == "salad"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_empty_response_raises(self, provider_with_vision):
+        """Empty response text raises ValueError."""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"result": {"response": ""}}
+        mock_resp.raise_for_status = Mock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ValueError, match="empty response"):
+                await provider_with_vision.generate_with_vision(
+                    model="@cf/google/gemma-4-26b-a4b-it",
+                    prompt="test",
+                    image_data=b"img",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_propagates_429(self, provider_with_vision):
+        """HTTP 429 from REST endpoint propagates as HTTPStatusError."""
+        from unittest.mock import AsyncMock, patch
+
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 429
+        err = httpx.HTTPStatusError("429", request=AsyncMock(), response=mock_resp)
+
+        def raise_for_status():
+            raise err
+
+        mock_resp.raise_for_status = raise_for_status
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await provider_with_vision.generate_with_vision(
+                    model="@cf/google/gemma-4-26b-a4b-it",
+                    prompt="test",
+                    image_data=b"img",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_propagates_timeout(self, provider_with_vision):
+        """Timeout from REST endpoint propagates as TimeoutException."""
+        from unittest.mock import AsyncMock, patch
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(httpx.TimeoutException):
+                await provider_with_vision.generate_with_vision(
+                    model="@cf/google/gemma-4-26b-a4b-it",
+                    prompt="test",
+                    image_data=b"img",
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_malformed_json_raises(self, provider_with_vision):
+        """Malformed JSON in response raises ValueError."""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"result": {"response": "not valid json {{{"}}
+        mock_resp.raise_for_status = Mock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ValueError):
+                await provider_with_vision.generate_with_vision(
+                    model="@cf/google/gemma-4-26b-a4b-it",
+                    prompt="test",
+                    image_data=b"img",
+                )
+
+    def test_build_vision_payload_shape(self, provider_with_vision):
+        """Vision payload has expected structure with image_url content."""
+        payload = provider_with_vision._build_vision_payload(
+            prompt="analyze meal",
+            image_data=b"fake",
+            system_message="system",
+            max_tokens=1024,
+        )
+        assert payload["max_tokens"] == 1024
+        assert payload["temperature"] == 0.2
+        messages = payload["messages"]
+        assert messages[0]["role"] == "system"
+        user_msg = messages[1]
+        assert user_msg["role"] == "user"
+        content = user_msg["content"]
+        assert any(c["type"] == "image_url" for c in content)
+        img_part = next(c for c in content if c["type"] == "image_url")
+        assert img_part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    def test_extract_response_text_handles_choices_format(self, provider_with_vision):
+        """Normalizes choices[0].message.content format."""
+        raw = {"result": {"choices": [{"message": {"content": "hello"}}]}}
+        assert provider_with_vision._extract_response_text(raw) == "hello"
+
+    def test_extract_response_text_handles_response_field(self, provider_with_vision):
+        """Normalizes result.response format."""
+        raw = {"result": {"response": "hello"}}
+        assert provider_with_vision._extract_response_text(raw) == "hello"
+
+    def test_no_secrets_in_vision_error_messages(self, provider_with_vision):
+        """generate_with_vision NotImplementedError must not expose the api token."""
+        default_provider = CloudflareWorkersAIProvider(
+            account_id="secret_account",
+            api_token="secret_token_abc",
+            text_model="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        )
+        import asyncio
+        try:
+            asyncio.get_event_loop().run_until_complete(
+                default_provider.generate_with_vision(
+                    model="test", prompt="test", image_data=b"x"
+                )
+            )
+        except NotImplementedError as e:
+            assert "secret_token_abc" not in str(e)
+        except Exception:
+            pass
 
 
 class TestGatewayConfig:

--- a/tests/unit/infra/services/ai/test_ai_model_manager.py
+++ b/tests/unit/infra/services/ai/test_ai_model_manager.py
@@ -48,6 +48,9 @@ def _make_no_cf_settings():
     s.CLOUDFLARE_ACCOUNT_ID = ""
     s.CLOUDFLARE_API_TOKEN = ""
     s.CLOUDFLARE_WORKERS_AI_TEXT_MODEL = ""
+    s.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = False
+    s.CLOUDFLARE_WORKERS_AI_VISION_MODEL = ""
+    s.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = ""
     return s
 
 
@@ -280,6 +283,7 @@ class TestVision:
 # ---------------------------------------------------------------------------
 
 def _make_cf_settings():
+    """Text-only CF settings; vision stays Gemini-only."""
     s = Mock()
     s.CLOUDFLARE_WORKERS_AI_ENABLED = True
     s.CLOUDFLARE_ACCOUNT_ID = "fake_account_id"
@@ -289,6 +293,18 @@ def _make_cf_settings():
     s.CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES = "recipe,general,meal_names,discovery,parse_text"
     s.CLOUDFLARE_WORKERS_AI_JSON_MODE = True
     s.CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS = 30
+    s.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = False
+    s.CLOUDFLARE_WORKERS_AI_VISION_MODEL = ""
+    s.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = ""
+    return s
+
+
+def _make_cf_vision_settings():
+    """CF settings with vision enabled for meal_scan and ingredient_scan."""
+    s = _make_cf_settings()
+    s.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = True
+    s.CLOUDFLARE_WORKERS_AI_VISION_MODEL = "@cf/google/gemma-4-26b-a4b-it"
+    s.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = "meal_scan,ingredient_scan"
     return s
 
 
@@ -302,6 +318,9 @@ def _make_disabled_cf_settings():
     s.CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES = ""
     s.CLOUDFLARE_WORKERS_AI_JSON_MODE = False
     s.CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS = 30
+    s.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = False
+    s.CLOUDFLARE_WORKERS_AI_VISION_MODEL = ""
+    s.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = ""
     return s
 
 
@@ -319,8 +338,30 @@ def mock_cf_provider():
 
 
 @pytest.fixture
+def mock_cf_vision_provider():
+    """CF provider with vision capability enabled."""
+    from src.domain.ports.ai_provider_port import AICapability
+
+    p = Mock()
+    p.provider_name = "cloudflare-workers-ai"
+    p.get_available_models.return_value = [
+        "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        "@cf/google/gemma-4-26b-a4b-it",
+    ]
+    p.supported_capabilities = {
+        AICapability.TEXT_GENERATION,
+        AICapability.STRUCTURED_OUTPUT,
+        AICapability.VISION,
+    }
+    p.generate = AsyncMock(return_value={"result": "cf_success"})
+    p.generate_with_vision = AsyncMock(return_value={"result": "cf_vision_success"})
+    p.extract_error_code = Mock(return_value=None)
+    return p
+
+
+@pytest.fixture
 def manager_with_cf(mock_gemini_provider, mock_circuit_breaker, mock_cf_provider):
-    """Manager with Cloudflare Workers AI enabled via settings injection."""
+    """Manager with Cloudflare Workers AI text enabled; vision stays Gemini-only."""
     with patch(
         "src.infra.services.ai.ai_model_manager.GeminiProvider",
         return_value=mock_gemini_provider,
@@ -333,6 +374,23 @@ def manager_with_cf(mock_gemini_provider, mock_circuit_breaker, mock_cf_provider
         return_value=mock_cf_provider,
     ):
         return AIModelManager(settings=_make_cf_settings())
+
+
+@pytest.fixture
+def manager_with_cf_vision(mock_gemini_provider, mock_circuit_breaker, mock_cf_vision_provider):
+    """Manager with Cloudflare Workers AI vision enabled for meal/ingredient scan."""
+    with patch(
+        "src.infra.services.ai.ai_model_manager.GeminiProvider",
+        return_value=mock_gemini_provider,
+    ), patch(
+        "src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker",
+        return_value=mock_circuit_breaker,
+    ), patch(
+        "src.infra.services.ai.ai_model_manager.CloudflareWorkersAIProvider",
+        create=True,
+        return_value=mock_cf_vision_provider,
+    ):
+        return AIModelManager(settings=_make_cf_vision_settings())
 
 
 @pytest.fixture
@@ -374,8 +432,8 @@ class TestWorkersAIRouting:
             assert chain[1] == "gemini-2.5-flash-lite"
             assert chain[2] == "gemini-2.5-flash"
 
-    def test_vision_purposes_stay_gemini_only_when_cf_enabled(self, manager_with_cf):
-        """MEAL_SCAN and INGREDIENT_SCAN chains never include Workers AI."""
+    def test_vision_purposes_stay_gemini_only_when_cf_text_only_enabled(self, manager_with_cf):
+        """MEAL_SCAN and INGREDIENT_SCAN must be Gemini-only when only CF text is enabled."""
         for purpose in (ModelPurpose.MEAL_SCAN, ModelPurpose.INGREDIENT_SCAN):
             chain = manager_with_cf.get_fallback_chain(purpose)
             assert chain == [
@@ -383,7 +441,7 @@ class TestWorkersAIRouting:
                 "gemini-3.5-flash",
                 "gemini-2.5-flash",
             ], (
-                f"{purpose.value} must remain Gemini-only even when CF is enabled"
+                f"{purpose.value} must remain Gemini-only when CF vision is not configured"
             )
 
     def test_parse_text_uses_cf_first_when_enabled(self, manager_with_cf):
@@ -454,10 +512,10 @@ class TestWorkersAIFallback:
         mock_gemini_provider.generate.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_cf_not_tried_for_vision_purpose(
+    async def test_cf_not_tried_for_vision_purpose_when_text_only_cf(
         self, manager_with_cf, mock_gemini_provider, mock_cf_provider
     ):
-        """Workers AI must not be attempted for MEAL_SCAN even when Gemini fails."""
+        """When only text CF is enabled, Workers AI is not in vision chains."""
         mock_gemini_provider.generate_with_vision = AsyncMock(
             side_effect=Exception("503 UNAVAILABLE")
         )
@@ -472,5 +530,88 @@ class TestWorkersAIFallback:
             )
 
         mock_cf_provider.generate.assert_not_awaited()
-        mock_cf_provider.generate_with_vision = AsyncMock()
-        mock_cf_provider.generate_with_vision.assert_not_awaited()
+
+
+class TestWorkersAIVisionRouting:
+    """Tests for CF-first vision routing (Phase 3)."""
+
+    def test_cf_vision_model_is_first_in_meal_scan_chain(self, manager_with_cf_vision):
+        """CF vision model is prepended to MEAL_SCAN chain when enabled."""
+        chain = manager_with_cf_vision.get_fallback_chain(ModelPurpose.MEAL_SCAN)
+        assert chain[0] == "@cf/google/gemma-4-26b-a4b-it"
+        assert "gemini-3.1-flash-lite" in chain
+
+    def test_cf_vision_model_is_first_in_ingredient_scan_chain(self, manager_with_cf_vision):
+        """CF vision model is prepended to INGREDIENT_SCAN chain when enabled."""
+        chain = manager_with_cf_vision.get_fallback_chain(ModelPurpose.INGREDIENT_SCAN)
+        assert chain[0] == "@cf/google/gemma-4-26b-a4b-it"
+        assert "gemini-3.1-flash-lite" in chain
+
+    def test_gemini_vision_models_remain_as_fallback(self, manager_with_cf_vision):
+        """Full Gemini fallback chain remains after the CF vision model."""
+        for purpose in (ModelPurpose.MEAL_SCAN, ModelPurpose.INGREDIENT_SCAN):
+            chain = manager_with_cf_vision.get_fallback_chain(purpose)
+            assert "gemini-3.1-flash-lite" in chain
+            assert "gemini-3.5-flash" in chain
+            assert "gemini-2.5-flash" in chain
+
+    def test_vision_chain_disabled_falls_back_to_gemini_only(self, manager_with_cf):
+        """When CF vision is not configured, vision chains are Gemini-only."""
+        for purpose in (ModelPurpose.MEAL_SCAN, ModelPurpose.INGREDIENT_SCAN):
+            chain = manager_with_cf.get_fallback_chain(purpose)
+            assert not any("@cf/" in m for m in chain)
+
+    def test_text_chains_unaffected_by_vision_config(self, manager_with_cf_vision):
+        """Vision routing must not alter text-purpose chains."""
+        for purpose in (ModelPurpose.RECIPE, ModelPurpose.GENERAL, ModelPurpose.MEAL_NAMES):
+            chain = manager_with_cf_vision.get_fallback_chain(purpose)
+            # CF text model is first (from text routing)
+            assert chain[0] == "@cf/google/gemma-4-26b-a4b-it"
+
+    def test_barcode_stays_gemini_only_even_with_cf_vision(self, manager_with_cf_vision):
+        """BARCODE is never in vision purposes; chain stays Gemini-only."""
+        chain = manager_with_cf_vision.get_fallback_chain(ModelPurpose.BARCODE)
+        assert not any("@cf/" in m for m in chain)
+
+    def test_cf_vision_model_registered_as_provider_override(self, manager_with_cf_vision):
+        """Vision model ID maps to cloudflare-workers-ai in provider overrides."""
+        assert manager_with_cf_vision._model_provider_overrides.get(
+            "@cf/google/gemma-4-26b-a4b-it"
+        ) == "cloudflare-workers-ai"
+
+    @pytest.mark.asyncio
+    async def test_cf_vision_called_first_for_meal_scan(
+        self, manager_with_cf_vision, mock_gemini_provider, mock_circuit_breaker, mock_cf_vision_provider
+    ):
+        """CF vision is called first for MEAL_SCAN; Gemini is not tried when CF succeeds."""
+        mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
+
+        result = await manager_with_cf_vision.generate_with_vision(
+            purpose=ModelPurpose.MEAL_SCAN,
+            prompt="test",
+            image_data=b"fake_image",
+        )
+
+        assert result == {"result": "cf_vision_success"}
+        mock_cf_vision_provider.generate_with_vision.assert_awaited_once()
+        mock_gemini_provider.generate_with_vision.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_gemini_when_cf_vision_fails(
+        self, manager_with_cf_vision, mock_gemini_provider, mock_circuit_breaker, mock_cf_vision_provider
+    ):
+        """When CF vision fails, Gemini is tried as fallback."""
+        mock_cf_vision_provider.generate_with_vision = AsyncMock(
+            side_effect=Exception("CF 503")
+        )
+        mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
+
+        result = await manager_with_cf_vision.generate_with_vision(
+            purpose=ModelPurpose.MEAL_SCAN,
+            prompt="test",
+            image_data=b"fake_image",
+        )
+
+        assert result == {"result": "vision_success"}
+        mock_cf_vision_provider.generate_with_vision.assert_awaited_once()
+        mock_gemini_provider.generate_with_vision.assert_awaited()


### PR DESCRIPTION
## Summary

- **Provider**: `CloudflareWorkersAIProvider` now supports vision via direct Workers AI REST (`/ai/run/{model}`) using `httpx.AsyncClient`. Text path (LangChain) is unchanged. `AICapability.VISION` is advertised only when `vision_model` is configured.
- **Manager**: `AIModelManager` prepends the CF vision model to `MEAL_SCAN` and `INGREDIENT_SCAN` chains when `CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true`. Gemini fallback chain (`gemini-3.1-flash-lite → gemini-3.5-flash → gemini-2.5-flash`) is preserved.
- **Settings**: Three new env vars — `CLOUDFLARE_WORKERS_AI_VISION_ENABLED`, `CLOUDFLARE_WORKERS_AI_VISION_MODEL`, `CLOUDFLARE_WORKERS_AI_VISION_PURPOSES`.

## Test plan

- [ ] All 1682 unit tests pass (pre-push hook verified)
- [ ] 20 new provider vision tests: capability, payload shape, success parse, 429/503/timeout propagation, malformed JSON, empty response
- [ ] 9 new manager vision routing tests: CF-first chain, Gemini fallback on CF failure, text chains unaffected, barcode unchanged
- [ ] Existing text provider tests and Gemini-only vision tests preserved and passing
- [ ] Ruff clean on all touched files
- [ ] `compileall` clean

## Rollout (Render env vars — no redeploy needed)

```
CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true
CLOUDFLARE_WORKERS_AI_VISION_MODEL=@cf/google/gemma-4-26b-a4b-it
CLOUDFLARE_WORKERS_AI_VISION_PURPOSES=meal_scan,ingredient_scan
```

Rollback: `CLOUDFLARE_WORKERS_AI_VISION_ENABLED=false`