### PR TITLE
fix(my-plan): persist metrics updates

### DIFF
--- a/src/api/routes/v1/user_profiles.py
+++ b/src/api/routes/v1/user_profiles.py
@@ -176,6 +176,7 @@ async def update_user_metrics(
     Authentication required: User ID is automatically extracted from the Firebase token.
     """
     import logging
+
     logger = logging.getLogger(__name__)
     # Debug: log incoming request values
     logger.info(
@@ -183,14 +184,24 @@ async def update_user_metrics(
         f"target_weight_kg={request.target_weight_kg}, "
         f"weight_kg={request.weight_kg}"
     )
+    body_fat_provided = (
+        request.body_fat_percentage is not None or request.reset_body_fat
+    )
+
     # Update metrics (including optional fitness goal and target weight)
     command = UpdateUserMetricsCommand(
         user_id=user_id,
+        age=request.age,
+        height_cm=request.height_cm,
         weight_kg=request.weight_kg,
+        biological_sex=request.biological_sex,
         job_type=request.job_type,
         training_days_per_week=request.training_days_per_week,
         training_minutes_per_session=request.training_minutes_per_session,
-        body_fat_percent=request.body_fat_percent,
+        body_fat_percent=(
+            None if request.reset_body_fat else request.body_fat_percentage
+        ),
+        body_fat_percent_provided=body_fat_provided,
         fitness_goal=request.fitness_goal.value if request.fitness_goal else None,
         training_level=(
             request.training_level.value if request.training_level else None

--- a/src/api/schemas/request/user_profile_update_requests.py
+++ b/src/api/schemas/request/user_profile_update_requests.py
@@ -1,16 +1,16 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
-class GoalEnum(str, Enum):
+class GoalEnum(StrEnum):
     cut = "cut"
     bulk = "bulk"
     recomp = "recomp"
 
 
-class TrainingLevelEnum(str, Enum):
+class TrainingLevelEnum(StrEnum):
     """Enum for training experience levels."""
 
     beginner = "beginner"
@@ -18,7 +18,7 @@ class TrainingLevelEnum(str, Enum):
     advanced = "advanced"
 
 
-class JobTypeEnum(str, Enum):
+class JobTypeEnum(StrEnum):
     """Enum for job types based on daily movement requirements."""
 
     desk = "desk"
@@ -33,16 +33,33 @@ class UpdateFitnessGoalRequest(BaseModel):
 class UpdateMetricsRequest(BaseModel):
     """Unified update for weight, job type, training, body fat, fitness goal, and target weight."""
 
+    model_config = ConfigDict(extra="forbid")
+
+    age: int | None = Field(None, ge=13, le=120, description="User age")
+    height_cm: float | None = Field(None, ge=100, le=272, description="Height in cm")
     weight_kg: float | None = Field(None, description="Weight in kg", gt=0)
+    biological_sex: str | None = Field(
+        None, description="Biological sex (male, female)"
+    )
     job_type: str | None = Field(None, description="Job type (desk, on_feet, physical)")
+    weekly_weight_change_kg: float | None = Field(
+        None, description="Planned weekly weight change in kg"
+    )
     training_days_per_week: int | None = Field(
         None, ge=0, le=7, description="Training days per week"
     )
     training_minutes_per_session: int | None = Field(
         None, ge=15, le=180, description="Minutes per training session"
     )
-    body_fat_percent: float | None = Field(
-        None, description="Body fat percentage", ge=0, le=70
+    body_fat_percentage: float | None = Field(
+        None,
+        validation_alias=AliasChoices("body_fat_percentage", "body_fat_percent"),
+        description="Body fat percentage",
+        ge=0,
+        le=70,
+    )
+    reset_body_fat: bool = Field(
+        False, description="Clear saved body fat percentage when true"
     )
     fitness_goal: GoalEnum | None = Field(
         None, description="Fitness goal (cut, bulk, recomp)"
@@ -60,8 +77,11 @@ class UpdateMetricsRequest(BaseModel):
         None, description="Timestamp when goal journey started"
     )
     daily_water_goal_ml: int | None = Field(
-        None, gt=0, description="Custom daily water goal in ml (null = use weight-based formula)"
+        None,
+        gt=0,
+        description="Custom daily water goal in ml (null = use weight-based formula)",
     )
     reset_water_goal: bool = Field(
-        False, description="Reset daily water goal to weight-based calculation (35 ml/kg)"
+        False,
+        description="Reset daily water goal to weight-based calculation (35 ml/kg)",
     )

--- a/src/app/commands/user/update_user_metrics_command.py
+++ b/src/app/commands/user/update_user_metrics_command.py
@@ -4,7 +4,6 @@ Command to update user metrics (weight, job type, training, body fat).
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 
 @dataclass
@@ -12,15 +11,19 @@ class UpdateUserMetricsCommand:
     """Update user metrics (including fitness goal and target weight) and trigger TDEE recalculation."""
 
     user_id: str
-    weight_kg: Optional[float] = None
-    job_type: Optional[str] = None
-    training_days_per_week: Optional[int] = None
-    training_minutes_per_session: Optional[int] = None
-    body_fat_percent: Optional[float] = None
-    fitness_goal: Optional[str] = None
-    training_level: Optional[str] = None
-    target_weight_kg: Optional[float] = None
-    goal_start_weight_kg: Optional[float] = None
-    goal_started_at: Optional[datetime] = None
-    daily_water_goal_ml: Optional[int] = None
+    age: int | None = None
+    height_cm: float | None = None
+    weight_kg: float | None = None
+    biological_sex: str | None = None
+    job_type: str | None = None
+    training_days_per_week: int | None = None
+    training_minutes_per_session: int | None = None
+    body_fat_percent: float | None = None
+    body_fat_percent_provided: bool = False
+    fitness_goal: str | None = None
+    training_level: str | None = None
+    target_weight_kg: float | None = None
+    goal_start_weight_kg: float | None = None
+    goal_started_at: datetime | None = None
+    daily_water_goal_ml: int | None = None
     reset_water_goal: bool = False

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -17,32 +17,42 @@ logger = logging.getLogger(__name__)
 _VALID_JOB_TYPES = {e.value for e in JobType}
 _VALID_FITNESS_GOALS = {e.value for e in FitnessGoal}
 _VALID_TRAINING_LEVELS = {e.value for e in TrainingLevel}
+_VALID_BIOLOGICAL_SEXES = {"male", "female"}
 
 
 def _has_metric_update(command: UpdateUserMetricsCommand) -> bool:
-    return any(
-        value is not None
-        for value in [
-            command.weight_kg,
-            command.job_type,
-            command.training_days_per_week,
-            command.training_minutes_per_session,
-            command.body_fat_percent,
-            command.fitness_goal,
-            command.training_level,
-            command.target_weight_kg,
-            command.goal_start_weight_kg,
-            command.goal_started_at,
-            command.daily_water_goal_ml,
-        ]
-    ) or command.reset_water_goal
+    return (
+        any(
+            value is not None
+            for value in [
+                command.weight_kg,
+                command.height_cm,
+                command.age,
+                command.biological_sex,
+                command.job_type,
+                command.training_days_per_week,
+                command.training_minutes_per_session,
+                command.body_fat_percent,
+                command.fitness_goal,
+                command.training_level,
+                command.target_weight_kg,
+                command.goal_start_weight_kg,
+                command.goal_started_at,
+                command.daily_water_goal_ml,
+            ]
+        )
+        or command.body_fat_percent_provided
+        or command.reset_water_goal
+    )
 
 
 @handles(UpdateUserMetricsCommand)
 class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, None]):
     """Handle updating user metrics (weight, job type, training, body fat)."""
 
-    def __init__(self, uow: AsyncUnitOfWorkPort, cache_service: CachePort | None = None):
+    def __init__(
+        self, uow: AsyncUnitOfWorkPort, cache_service: CachePort | None = None
+    ):
         self.uow = uow
         self.cache_service = cache_service
 
@@ -60,10 +70,25 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 )
 
             # Update provided fields only
+            if command.age is not None:
+                if command.age < 13 or command.age > 120:
+                    raise ValidationException("Age must be between 13 and 120")
+                profile.age = command.age
+
+            if command.height_cm is not None:
+                if command.height_cm < 100 or command.height_cm > 272:
+                    raise ValidationException("Height must be between 100 and 272 cm")
+                profile.height_cm = command.height_cm
+
             if command.weight_kg is not None:
                 if command.weight_kg <= 0:
                     raise ValidationException("Weight must be greater than 0")
                 profile.weight_kg = command.weight_kg
+
+            if command.biological_sex is not None:
+                if command.biological_sex not in _VALID_BIOLOGICAL_SEXES:
+                    raise ValidationException("Biological sex must be male or female")
+                profile.gender = command.biological_sex
 
             if command.job_type is not None:
                 if command.job_type not in _VALID_JOB_TYPES:
@@ -94,8 +119,13 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                     command.training_minutes_per_session
                 )
 
-            if command.body_fat_percent is not None:
-                if command.body_fat_percent < 0 or command.body_fat_percent > 70:
+            if (
+                command.body_fat_percent is not None
+                or command.body_fat_percent_provided
+            ):
+                if command.body_fat_percent is not None and (
+                    command.body_fat_percent < 0 or command.body_fat_percent > 70
+                ):
                     raise ValidationException(
                         "Body fat percentage must be between 0 and 70"
                     )
@@ -192,7 +222,9 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         try:
             await self.cache_service.invalidate_pattern(macros_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate macros pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate macros pattern for user {user_id}: {e}"
+            )
 
         # Invalidate ALL weekly budgets for this user
         # TDEE changes affect weekly targets
@@ -200,16 +232,22 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         try:
             await self.cache_service.invalidate_pattern(weekly_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate weekly budget pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate weekly budget pattern for user {user_id}: {e}"
+            )
 
         hydration_pattern = f"user:{user_id}:hydration:*"
         try:
             await self.cache_service.invalidate_pattern(hydration_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate hydration pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate hydration pattern for user {user_id}: {e}"
+            )
 
         weekly_hydration_pattern = f"user:{user_id}:hydration_weekly:*"
         try:
             await self.cache_service.invalidate_pattern(weekly_hydration_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate weekly hydration pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate weekly hydration pattern for user {user_id}: {e}"
+            )

--- a/tests/integration/api/test_user_profiles_api.py
+++ b/tests/integration/api/test_user_profiles_api.py
@@ -151,11 +151,14 @@ class TestUserProfilesAPI:
 
         # Arrange: Update request
         payload = {
+            "age": 35,
+            "height_cm": 180.0,
             "weight_kg": 75.0,
+            "biological_sex": "female",
             "job_type": "on_feet",
             "training_days_per_week": 5,
             "training_minutes_per_session": 60,
-            "body_fat_percent": 15.0,
+            "body_fat_percentage": 15.0,
             "fitness_goal": "cut",
         }
 
@@ -170,3 +173,11 @@ class TestUserProfilesAPI:
         data = response.json()
         assert "tdee" in data
         assert "macros" in data
+
+        test_session.refresh(profile)
+        assert profile.age == 35
+        assert profile.height_cm == 180.0
+        assert profile.weight_kg == 75.0
+        assert profile.gender == "female"
+        assert profile.body_fat_percentage == 15.0
+        assert profile.fitness_goal == "cut"

--- a/tests/unit/api/test_routes_with_mocked_event_bus.py
+++ b/tests/unit/api/test_routes_with_mocked_event_bus.py
@@ -161,6 +161,116 @@ def test_user_profiles_get_tdee(monkeypatch, client: TestClient):
     assert r.json()["tdee"] == 2400.0
 
 
+def test_user_profiles_update_metrics_accepts_my_plan_payload(
+    monkeypatch, client: TestClient
+):
+    import src.api.main as main
+    from src.api.dependencies.event_bus import get_configured_event_bus
+    from src.app.commands.user.update_user_metrics_command import (
+        UpdateUserMetricsCommand,
+    )
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+        if isinstance(msg, UpdateUserMetricsCommand):
+            return None
+        return {
+            "bmr": 1700.0,
+            "tdee": 2400.0,
+            "profile_data": {"fitness_goal": "bulk"},
+            "macros": {
+                "calories": 2400.0,
+                "protein": 120.0,
+                "carbs": 250.0,
+                "fat": 70.0,
+            },
+            "activity_multiplier": 1.4,
+            "formula_used": "Mifflin-St Jeor",
+            "is_custom": False,
+        }
+
+    main.app.dependency_overrides[get_configured_event_bus] = lambda: _Bus(send)
+
+    r = client.post(
+        "/v1/user-profiles/metrics",
+        json={
+            "age": 25,
+            "height_cm": 177.0,
+            "weight_kg": 86.5,
+            "biological_sex": "male",
+            "weekly_weight_change_kg": None,
+            "job_type": "desk",
+            "training_days_per_week": 5,
+            "training_minutes_per_session": 52,
+            "body_fat_percentage": 20.0,
+            "fitness_goal": "bulk",
+            "training_level": "intermediate",
+            "target_weight_kg": None,
+            "goal_start_weight_kg": None,
+            "goal_started_at": None,
+        },
+    )
+
+    assert r.status_code == 200
+    command = next(msg for msg in sent if isinstance(msg, UpdateUserMetricsCommand))
+    assert command.age == 25
+    assert command.height_cm == 177.0
+    assert command.weight_kg == 86.5
+    assert command.biological_sex == "male"
+    assert command.body_fat_percent == 20.0
+    assert command.body_fat_percent_provided is True
+    assert command.training_level == "intermediate"
+
+
+def test_user_profiles_update_metrics_null_body_fat_does_not_clear_by_default(
+    monkeypatch, client: TestClient
+):
+    import src.api.main as main
+    from src.api.dependencies.event_bus import get_configured_event_bus
+    from src.app.commands.user.update_user_metrics_command import (
+        UpdateUserMetricsCommand,
+    )
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+        if isinstance(msg, UpdateUserMetricsCommand):
+            return None
+        return {
+            "bmr": 1700.0,
+            "tdee": 2400.0,
+            "profile_data": {"fitness_goal": "bulk"},
+            "macros": {
+                "calories": 2400.0,
+                "protein": 120.0,
+                "carbs": 250.0,
+                "fat": 70.0,
+            },
+            "activity_multiplier": 1.4,
+            "formula_used": "Mifflin-St Jeor",
+            "is_custom": False,
+        }
+
+    main.app.dependency_overrides[get_configured_event_bus] = lambda: _Bus(send)
+
+    r = client.post(
+        "/v1/user-profiles/metrics",
+        json={
+            "weight_kg": 86.5,
+            "fitness_goal": "bulk",
+            "body_fat_percentage": None,
+        },
+    )
+
+    assert r.status_code == 200
+    command = next(msg for msg in sent if isinstance(msg, UpdateUserMetricsCommand))
+    assert command.body_fat_percent is None
+    assert command.body_fat_percent_provided is False
+
+
 def test_meals_parse_text_happy_path(monkeypatch, client: TestClient):
     import src.api.main as main
     from src.api.dependencies.event_bus import get_configured_event_bus

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -52,7 +52,10 @@ class TestUpdateUserMetricsCommand:
         """Test creating command with all metrics."""
         command = UpdateUserMetricsCommand(
             user_id="test_user",
+            age=35,
+            height_cm=180.0,
             weight_kg=75.0,
+            biological_sex="female",
             job_type="desk",
             training_days_per_week=4,
             training_minutes_per_session=60,
@@ -62,7 +65,10 @@ class TestUpdateUserMetricsCommand:
         )
 
         assert command.user_id == "test_user"
+        assert command.age == 35
+        assert command.height_cm == 180.0
         assert command.weight_kg == 75.0
+        assert command.biological_sex == "female"
         assert command.job_type == "desk"
         assert command.training_days_per_week == 4
         assert command.training_minutes_per_session == 60
@@ -162,7 +168,10 @@ class TestUpdateUserMetricsCommandHandler:
         handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
         command = UpdateUserMetricsCommand(
             user_id="test_user",
+            age=35,
+            height_cm=180.0,
             weight_kg=72.5,
+            biological_sex="female",
             job_type="on_feet",
             training_days_per_week=5,
             training_minutes_per_session=60,
@@ -172,12 +181,32 @@ class TestUpdateUserMetricsCommandHandler:
 
         await handler.handle(command)
 
+        assert profile.age == 35
+        assert profile.height_cm == 180.0
         assert profile.weight_kg == 72.5
+        assert profile.gender == "female"
         assert profile.job_type == "on_feet"
         assert profile.training_days_per_week == 5
         assert profile.training_minutes_per_session == 60
         assert profile.body_fat_percentage == 15.0
         assert profile.fitness_goal == "cut"
+        assert profile.is_current is True
+
+    async def test_clear_body_fat_when_explicitly_requested(self):
+        """Test clearing body fat requires an explicit clear signal."""
+        profile = _make_profile(body_fat_percentage=20.0)
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(
+            user_id="test_user",
+            body_fat_percent=None,
+            body_fat_percent_provided=True,
+        )
+
+        await handler.handle(command)
+
+        assert profile.body_fat_percentage is None
         assert profile.is_current is True
 
     async def test_user_not_found(self):
@@ -216,6 +245,47 @@ class TestUpdateUserMetricsCommandHandler:
             await handler.handle(command)
 
         assert "Weight must be greater than 0" in str(exc_info.value)
+
+    async def test_invalid_age(self):
+        """Test validation for invalid age."""
+        profile = _make_profile()
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(user_id="test_user", age=12)
+
+        with pytest.raises(ValidationException) as exc_info:
+            await handler.handle(command)
+
+        assert "Age must be between 13 and 120" in str(exc_info.value)
+
+    async def test_invalid_height(self):
+        """Test validation for invalid height."""
+        profile = _make_profile()
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(user_id="test_user", height_cm=99.0)
+
+        with pytest.raises(ValidationException) as exc_info:
+            await handler.handle(command)
+
+        assert "Height must be between 100 and 272 cm" in str(exc_info.value)
+
+    async def test_invalid_biological_sex(self):
+        """Test validation for invalid biological sex."""
+        profile = _make_profile()
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(
+            user_id="test_user", biological_sex="unknown"
+        )
+
+        with pytest.raises(ValidationException) as exc_info:
+            await handler.handle(command)
+
+        assert "Biological sex must be male or female" in str(exc_info.value)
 
     async def test_invalid_body_fat(self):
         """Test validation for body fat out of range."""


### PR DESCRIPTION
## Summary
- Accept My Plan save fields in the metrics endpoint: age, height, biological sex, body fat, and training level.
- Persist those fields through the update metrics command handler so TDEE recalculates from saved profile data.
- Add route and command-handler regression tests for the mobile My Plan payload and null body-fat behavior.

## Related issues
- None found from GitHub issue search for \"My Plan metrics persistence\".

## Test plan
- [x] .venv/bin/python -m pytest tests/unit/domain/test_update_user_metrics.py tests/unit/api/test_routes_with_mocked_event_bus.py
- [x] .venv/bin/ruff check src/api/routes/v1/user_profiles.py src/api/schemas/request/user_profile_update_requests.py src/app/commands/user/update_user_metrics_command.py src/app/handlers/command_handlers/update_user_metrics_command_handler.py tests/unit/domain/test_update_user_metrics.py tests/unit/api/test_routes_with_mocked_event_bus.py
- [ ] Full backend test suite

## Notes
- Integration test fixture for MockImageStore is currently missing abstract upload-signature methods, so the focused integration node cannot run until that fixture is fixed.