### PR TITLE
feat(progress): add journey progress endpoint

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -168,6 +168,14 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 
 ---
 
+## Progress
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/progress/journey` | Action-based journey progress snapshot for the dashboard card |
+
+---
+
 ## Notifications
 
 | Method | Endpoint | Purpose |

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,8 +1,8 @@
 # Backend Codebase Summary
 
-**Generated:** June 13, 2026
-**Status:** Production-ready (430 files, ~38.5K LOC, 681+ tests, 70%+ coverage)
-**Language:** Python 3.13 | **Framework:** FastAPI 0.115+ + SQLAlchemy 2.0
+**Generated:** June 22, 2026
+**Status:** Production-ready snapshot of the live backend codebase
+**Runtime:** FastAPI 0.115+ on Python 3.11+ with async SQLAlchemy 2.0
 
 ---
 
@@ -10,28 +10,52 @@
 
 | Metric | Value |
 |--------|-------|
-| Total Source Files | 430 Python files |
-| API Layer | 76 files, ~8,605 LOC |
-| Application Layer | 140 files, ~6,229 LOC |
-| Domain Layer | 133 files, ~14,556 LOC |
-| Infrastructure Layer | 80 files, ~8,895 LOC |
-| Total LOC (src/) | ~38,300 LOC |
-| Test Files | 92 files |
-| Total Test Cases | 681+ tests |
-| Test Coverage | 70%+ maintained |
-| API Endpoints | 60+ REST endpoints across 17 route modules |
-| CQRS Commands | 30 commands across 11 domains |
-| CQRS Queries | 31 query definitions |
-| Domain Events | 19 event definitions |
-| Handlers | 51 handlers with @handles decorator (28+ cmd, 24+ query, 1 event) |
-| Application Services | 3 (MessageOrchestrationService, AIResponseCoordinator, ChatNotificationService) |
-| Domain Services | 50+ service files |
-| Bounded Contexts | 8 contexts (Meal, Nutrition, User, Planning, Conversation, Notification, AI, Chat) |
-| Analysis Strategies | 6 strategies (basic, portion, ingredient, weight, user-context, combined) |
-| Database Tables | 13+ (core + notification_sent_log for dedup) |
-| Repositories | 10+ with smart sync and eager loading |
-| Port Interfaces | 17 port interfaces for dependency inversion |
-| External Integrations | 9 (Gemini, Pinecone, Firebase, Cloudinary, RevenueCat, PostHog, Redis, MySQL, Sentry) |
+| Source files | 620 Python files in `src/` |
+| Source LOC | ~52.6K LOC in `src/` |
+| Test files | 291 Python files in `tests/` |
+| Collected tests | 1,600+ collected tests |
+| API routers | 26 router registrations in `src/api/main.py` |
+| API endpoints | 83 endpoint decorators under `src/api/routes/` |
+| CQRS command files | 51 |
+| CQRS query files | 50 |
+| CQRS event files | 15 |
+| CQRS handler files | 87 |
+| Domain service files | 50 |
+| Port files | 26 |
+| Database model files | 47 |
+| ORM table declarations | 36 |
+
+---
+
+## Layer Snapshot
+
+| Layer | Files | LOC | Notes |
+|-------|-------|-----|-------|
+| API | 89 | ~10.4K | Routes, middleware, schemas, dependency wiring, and API mappers |
+| Application | 208 | ~11.0K | Commands, queries, handlers, and orchestration services |
+| Domain | 160 | ~15.5K | Entities, services, ports, policies, and bounded contexts |
+| Infrastructure | 154 | ~15.0K | Database, cache, adapters, observability, and service integrations |
+
+---
+
+## Live API Surface
+
+The current HTTP surface includes:
+
+- Meal logging and analysis: image upload, upload-token, scan-by-url, manual meals, parse-text, streak, weekly budget, and daily macros.
+- User and profile management: Firebase sync, onboarding completion, metrics, TDEE, language, timezone, and account deletion.
+- Discovery and planning: meal suggestions discover, recipes, and save.
+- Nutrition and activity tracking: nutrition bulk/presence, activities daily/bulk, hydration, movement, and the journey progress snapshot.
+- Support routes: foods, ingredients, notifications, feature flags, saved suggestions, cheat days, referrals, promo codes, unified code validation, monitoring, health, app download, and well-known links.
+
+---
+
+## Core Runtime Notes
+
+- Runtime DB access uses PostgreSQL/Neon via `src/infra/database/config_async.py` and `asyncpg`.
+- Redis is optional and used for cache-aside and AI-context caching, not as the source of truth.
+- Database migrations are Alembic-managed and run before app startup through the entrypoint/pre-deploy flow.
+- The event bus is a singleton PyMediator registry wired from `src/api/dependencies/event_bus.py`.
 
 ---
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -17,6 +17,11 @@
 - [x] Upgraded pytest tooling to 9.x to clear the test dependency audit finding.
 - [x] Verified `requirements.txt` and `requirements-test.txt` with `pip-audit`; ML-only `torch` remains isolated in `requirements-ml.txt` pending an upstream CVE fix.
 
+### June 2026: Journey Progress Card
+- [x] Added canonical `GET /v1/progress/journey` for the dashboard progress card.
+- [x] Strict active-period filtering keeps only `period_start <= action_time < period_end`; existing users without `goal_started_at` fall back to the stable 2026-06-21 feature start in their local timezone.
+- [x] Onboarding and target-weight updates now set the journey baseline fields that anchor the active period.
+
 ### June 2026: Single-Owner Logger System
 - [x] Established log-or-raise rule: one root-cause `ERROR` per unexpected request failure; expected 4xx exceptions produce zero ERROR logs.
 - [x] `src/api/exception_handlers.py` — new central exception boundary with `register_exception_handlers(app)`; owns single ERROR for unexpected exceptions.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,6 +1,6 @@
 # Backend System Architecture Overview
 
-**Last Updated:** June 17, 2026
+**Last Updated:** June 22, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
 **Codebase:** 620 Python files, ~52.6K LOC in `src/`
@@ -39,7 +39,7 @@
 |-------|-------|-----|-------------|
 | API | 89 | ~10,361 | 26 router registrations, 83 endpoint decorators, schemas, middleware, dependencies |
 | App | 208 | ~10,984 | 51 command files, 50 query files, 15 event files, 87 handler files |
-| Domain | 160 | ~15,460 | Meal, nutrition, user, hydration, movement, notification, planning, referral-facing policies |
+| Domain | 160 | ~15,460 | Meal, nutrition, user, hydration, movement, progress, notification, planning, referral-facing policies |
 | Infra | 154 | ~15,041 | PostgreSQL/pgvector, Redis, PyMediator, external adapters, observability, push/email services |
 | **Total** | **611** | **~51,846** | Layer directories only; `src/` also has bootstrap, cron, and observability modules |
 
@@ -98,6 +98,7 @@ Architecture guardrails enforced by `tests/unit/architecture/test_logging_owners
 | User | User, UserProfile, Activity, TdeeRequest, weight history |
 | Hydration | Hydration entries, drink catalog, caloric drink logging |
 | Movement | Movement entries, activity catalog, daily movement summaries |
+| Progress | Journey progress snapshot, active-period filtering, action scoring |
 | Meal Planning | Weekly budget, meal planning, meal suggestion, saved suggestion models |
 | Notification | UserFcmToken, NotificationPreferences, PushNotification, queued notification rows |
 | AI | GPTAnalysisResponse, GPTFoodItem, GPTResponseError |

--- a/plans/260621-2340-journey-progress-card/phase-01-backend-contract.md
+++ b/plans/260621-2340-journey-progress-card/phase-01-backend-contract.md
@@ -1,0 +1,51 @@
+---
+phase: 1
+title: Backend Contract
+status: completed
+priority: P1
+effort: 2h
+dependencies: []
+---
+
+# Phase 1: Backend Contract
+
+## Overview
+
+Add the API contract for `GET /v1/progress/journey`, register the route, and expose typed response schemas. Keep the contract small and dashboard-focused.
+
+## Requirements
+
+- Functional: authenticated users can fetch the active journey progress snapshot.
+- Functional: response includes period bounds, percent fields, score breakdown, and optional latest action.
+- Non-functional: no schema migration and no mobile visual redesign in this phase.
+
+## Architecture
+
+FastAPI route sends a CQRS query through the configured event bus. The response model lives in progress schemas and maps directly to the existing mobile `GoalMomentumSnapshot` shape.
+
+## Related Code Files
+
+- Create: `src/api/routes/v1/progress.py`
+- Create: `src/app/queries/progress/get_journey_progress_query.py`
+- Modify: `src/app/queries/progress/__init__.py`
+- Modify: `src/api/schemas/progress_schemas.py`
+- Modify: `src/api/main.py`
+- Modify: `src/api/dependencies/event_bus.py`
+
+## Implementation Steps
+
+1. Add `JourneyProgressResponse`, `JourneyProgressBreakdown`, and `JourneyProgressAction` schemas.
+2. Add `GetJourneyProgressQuery(user_id, header_timezone)`.
+3. Add `/v1/progress/journey` route using auth and `X-Timezone`.
+4. Register the route in `src/api/main.py`.
+5. Register the query handler placeholder after Phase 2 adds it.
+
+## Success Criteria
+
+- [ ] Endpoint contract compiles.
+- [ ] Response field names are snake_case for backend and generate clean mobile JSON keys.
+- [ ] Route requires authenticated user id.
+
+## Risk Assessment
+
+Risk: response contract grows into analytics payload. Mitigation: only include fields the current card consumes.

--- a/plans/260621-2340-journey-progress-card/phase-02-backend-calculation.md
+++ b/plans/260621-2340-journey-progress-card/phase-02-backend-calculation.md
@@ -1,0 +1,59 @@
+---
+phase: 2
+title: Backend Calculation
+status: completed
+priority: P1
+effort: 5h
+dependencies:
+  - 1
+---
+
+# Phase 2: Backend Calculation
+
+## Overview
+
+Implement the canonical calculation for action-based journey progress. The strict period filter is the core feature: count only `period_start <= action_time < period_end`.
+
+## Requirements
+
+- Functional: existing users use the later of `goal_started_at` and the stable 2026-06-21 feature start in their timezone, so old logs are excluded.
+- Functional: new onboarding with `target_weight_kg` sets `goal_start_weight_kg` and `goal_started_at`.
+- Functional: scoring mirrors current mobile weights: calories 30%, protein 15%, meal count 20%, hydration 15%, movement 20%.
+- Functional: today's progress is capped at `100 / timelineDays`; logged actions get the visible floor.
+- Non-functional: use indexed range reads and avoid per-day query loops.
+
+## Architecture
+
+`GetJourneyProgressQueryHandler` resolves timezone/profile, derives the active period, gathers meals/hydration/movement/weight logs within the strict UTC window, and returns a precomputed snapshot. Existing repositories should get focused range helpers where needed.
+
+## Related Code Files
+
+- Create: `src/app/handlers/query_handlers/get_journey_progress_query_handler.py`
+- Modify: `src/app/handlers/query_handlers/__init__.py`
+- Modify: `src/infra/repositories/meal_repository_async.py`
+- Modify: `src/infra/repositories/hydration_repository_async.py`
+- Modify: `src/infra/repositories/movement_repository_async.py`
+- Modify: `src/infra/repositories/weight_repository_async.py`
+- Modify: `src/app/handlers/command_handlers/save_user_onboarding_command_handler.py`
+- Add/modify tests under `tests/unit/handlers/query_handlers/` and `tests/unit/handlers/command_handlers/`
+
+## Implementation Steps
+
+1. Add small repository helpers for action summary ranges if existing methods are insufficient.
+2. Derive timeline days from fitness goal and weight delta using existing mobile constants.
+3. Compute daily scores for days from period start through `as_of`, capped by daily budget and total 100%.
+4. Select latest action from included meal, hydration, movement, and weight logs.
+5. Set onboarding goal baseline fields only when a target weight exists and baseline is absent.
+6. Add unit tests for strict lower/upper boundaries, no historical backfill, scoring, and onboarding baseline.
+
+## Success Criteria
+
+- [ ] Logs before `period_start` do not affect percent or latest action.
+- [ ] Logs exactly at `period_start` count.
+- [ ] Logs at `period_end` do not count.
+- [ ] Existing users without a start date receive a current-period start.
+- [ ] New onboarding stores start weight and start timestamp when target weight exists.
+
+## Risk Assessment
+
+Risk: timezone errors shift actions across period boundary. Mitigation: convert local period bounds to UTC once and pass UTC windows to repositories.

--- a/plans/260621-2340-journey-progress-card/phase-03-mobile-integration.md
+++ b/plans/260621-2340-journey-progress-card/phase-03-mobile-integration.md
@@ -1,0 +1,56 @@
+---
+phase: 3
+title: Mobile Integration
+status: completed
+priority: P1
+effort: 4h
+dependencies:
+  - 1
+  - 2
+---
+
+# Phase 3: Mobile Integration
+
+## Overview
+
+Wire mobile to the backend snapshot while preserving the existing dashboard card surface. The app maps the API response into `GoalMomentumSnapshot` and falls back to current weight-progress behavior if the endpoint fails.
+
+## Requirements
+
+- Functional: dashboard ribbon progress percent comes from backend journey snapshot.
+- Functional: API failure does not hide or break the card.
+- Functional: meal, hydration, and movement mutations invalidate the journey snapshot.
+- Non-functional: no local SharedPreferences action-progress source of truth.
+
+## Architecture
+
+Add Freezed API models to `progress_models.dart`, a Retrofit method to `ApiService`, a provider in `progress_providers.dart`, and update `goal_momentum_snapshot_provider.dart` to adapt backend response into the existing domain entity.
+
+## Related Code Files
+
+- Modify: `/Users/tonytran/Projects/nutree-universe/worktrees/mobile-journey-progress-card/lib/core/network/api_service.dart`
+- Modify: `/Users/tonytran/Projects/nutree-universe/worktrees/mobile-journey-progress-card/lib/features/progress/data/models/progress_models.dart`
+- Modify: `/Users/tonytran/Projects/nutree-universe/worktrees/mobile-journey-progress-card/lib/features/progress/application/providers/progress_providers.dart`
+- Modify: `/Users/tonytran/Projects/nutree-universe/worktrees/mobile-journey-progress-card/lib/features/progress/application/providers/goal_momentum_snapshot_provider.dart`
+- Modify: hydration/movement log providers and dashboard host invalidation paths as needed.
+
+## Implementation Steps
+
+1. Add `JourneyProgressResponse`, breakdown, and latest-action Freezed models.
+2. Add `ApiService.getJourneyProgress()`.
+3. Add provider that fetches `/progress/journey`.
+4. Map backend action source strings to `GoalMomentumActionSource`.
+5. Update current snapshot provider to use backend response with weight fallback.
+6. Invalidate journey provider after meal save, hydration log/delete, and movement log/update/delete.
+7. Regenerate Dart code.
+
+## Success Criteria
+
+- [ ] Existing `WaveRibbonCard` receives backend progress via `GoalMomentumSnapshot`.
+- [ ] Provider test proves backend percent wins over weight percent.
+- [ ] Provider test proves fallback remains weight progress if API throws.
+- [ ] Generated Retrofit/Freezed files are updated.
+
+## Risk Assessment
+
+Risk: stale percent after logging actions. Mitigation: explicit provider invalidation at all mutation paths that can create/delete counted actions.

--- a/plans/260621-2340-journey-progress-card/phase-04-verification-and-pr.md
+++ b/plans/260621-2340-journey-progress-card/phase-04-verification-and-pr.md
@@ -1,10 +1,13 @@
 ---
 phase: 4
-title: "Verification and PR"
-status: pending
+title: Verification and PR
+status: completed
 priority: P1
-effort: "3h"
-dependencies: [1, 2, 3]
+effort: 3h
+dependencies:
+  - 1
+  - 2
+  - 3
 ---
 
 # Phase 4: Verification and PR

--- a/plans/260621-2340-journey-progress-card/phase-04-verification-and-pr.md
+++ b/plans/260621-2340-journey-progress-card/phase-04-verification-and-pr.md
@@ -1,0 +1,50 @@
+---
+phase: 4
+title: "Verification and PR"
+status: pending
+priority: P1
+effort: "3h"
+dependencies: [1, 2, 3]
+---
+
+# Phase 4: Verification and PR
+
+## Overview
+
+Verify backend and mobile changes, update docs where needed, commit each child repo, push, and create PRs.
+
+## Requirements
+
+- Functional: focused tests pass in both worktrees.
+- Non-functional: generated code is current, no syntax/type errors, no secret leakage in staged diffs.
+
+## Architecture
+
+Backend and mobile are separate repos/worktrees on the same branch name. Each should get its own commit and PR. The dirty parent checkout remains untouched.
+
+## Related Code Files
+
+- Backend tests: focused pytest files added/changed in this plan.
+- Mobile tests: progress provider test plus generated files.
+- Docs: `docs/project-changelog.md` in each child repo if present and warranted.
+
+## Implementation Steps
+
+1. Run backend focused pytest for journey handler/onboarding.
+2. Run backend compile/import checks if focused pytest does not cover route import.
+3. Run mobile code generation.
+4. Run focused Flutter tests for progress provider/card.
+5. Run `flutter analyze` or a focused analyzer target if full analyze is too noisy.
+6. Update plan status and docs/changelog when implementation is verified.
+7. Stage, secret-scan, commit, push, and create PRs for backend and mobile.
+
+## Success Criteria
+
+- [ ] Backend focused tests pass.
+- [ ] Mobile focused tests pass.
+- [ ] Codegen outputs are committed.
+- [ ] Two PR URLs are created or a blocker is reported with exact command output.
+
+## Risk Assessment
+
+Risk: full mobile analysis may expose unrelated existing issues. Mitigation: run focused tests and report any unrelated analyzer noise without hiding it.

--- a/plans/260621-2340-journey-progress-card/plan.md
+++ b/plans/260621-2340-journey-progress-card/plan.md
@@ -1,0 +1,43 @@
+---
+title: Journey Progress Card
+description: >-
+  Server-derived action-progress snapshot for the dashboard goal journey card
+  with strict active-period boundaries.
+status: pending
+priority: P2
+branch: feat/journey-progress-card
+tags:
+  - progress
+  - backend
+  - mobile
+  - dashboard
+blockedBy: []
+blocks: []
+created: '2026-06-21T16:41:14.580Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Journey Progress Card
+
+## Overview
+
+Build a canonical backend journey-progress snapshot and wire the mobile dashboard progress card to it. The backend owns period selection and strict action filtering so new users and existing users follow the same rule: only actions in the current active period count.
+
+Brainstorm source: `plans/reports/260621-2340-journey-progress-card-brainstorm.md`
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Backend Contract](./phase-01-backend-contract.md) | Completed |
+| 2 | [Backend Calculation](./phase-02-backend-calculation.md) | Completed |
+| 3 | [Mobile Integration](./phase-03-mobile-integration.md) | Completed |
+| 4 | [Verification and PR](./phase-04-verification-and-pr.md) | Pending |
+
+## Dependencies
+
+- Backend worktree: `/Users/tonytran/Projects/nutree-universe/worktrees/backend-journey-progress-card`
+- Mobile worktree: `/Users/tonytran/Projects/nutree-universe/worktrees/mobile-journey-progress-card`
+- Relevant completed plan: `plans/260618-0108-workout-calorie-credit-weekly-budget/plan.md`
+- Unrelated pending plan: `plans/260612-1046-service-initiated-bandwidth-reduction/plan.md`

--- a/plans/260621-2340-journey-progress-card/plan.md
+++ b/plans/260621-2340-journey-progress-card/plan.md
@@ -3,7 +3,7 @@ title: Journey Progress Card
 description: >-
   Server-derived action-progress snapshot for the dashboard goal journey card
   with strict active-period boundaries.
-status: pending
+status: completed
 priority: P2
 branch: feat/journey-progress-card
 tags:
@@ -33,7 +33,7 @@ Brainstorm source: `plans/reports/260621-2340-journey-progress-card-brainstorm.m
 | 1 | [Backend Contract](./phase-01-backend-contract.md) | Completed |
 | 2 | [Backend Calculation](./phase-02-backend-calculation.md) | Completed |
 | 3 | [Mobile Integration](./phase-03-mobile-integration.md) | Completed |
-| 4 | [Verification and PR](./phase-04-verification-and-pr.md) | Pending |
+| 4 | [Verification and PR](./phase-04-verification-and-pr.md) | Completed |
 
 ## Dependencies
 

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -2,17 +2,16 @@
 Event bus dependency for FastAPI with proper type registrations.
 """
 
-from typing import Optional
-
+from src.app.commands.cheat_day import MarkCheatDayCommand, UnmarkCheatDayCommand
 from src.app.commands.ingredient import RecognizeIngredientCommand
 
 # Import all commands
 from src.app.commands.meal import (
-    ScanByUrlCommand,
-    UploadMealImageImmediatelyCommand,
-    EditMealCommand,
     AddCustomIngredientCommand,
     DeleteMealCommand,
+    EditMealCommand,
+    ScanByUrlCommand,
+    UploadMealImageImmediatelyCommand,
 )
 from src.app.commands.meal.create_manual_meal_command import CreateManualMealCommand
 from src.app.commands.meal.parse_meal_text_command import ParseMealTextCommand
@@ -21,15 +20,24 @@ from src.app.commands.meal_suggestion import (
     GenerateMealRecipesCommand,
     SaveMealSuggestionCommand,
 )
+from src.app.commands.movement import (
+    DeleteMovementEntryCommand,
+    LogMovementCommand,
+    UpdateMovementEntryCommand,
+)
 from src.app.commands.notification import (
-    RegisterFcmTokenCommand,
     DeleteFcmTokenCommand,
+    RegisterFcmTokenCommand,
     UpdateNotificationPreferencesCommand,
 )
+from src.app.commands.saved_suggestion import (
+    DeleteSavedSuggestionCommand,
+    SaveSuggestionCommand,
+)
 from src.app.commands.user import (
-    SaveUserOnboardingCommand,
     CompleteOnboardingCommand,
     DeleteUserCommand,
+    SaveUserOnboardingCommand,
     UpdateCustomMacrosCommand,
     UpdateLanguageCommand,
     UpdateTimezoneCommand,
@@ -39,144 +47,132 @@ from src.app.commands.user.sync_user_command import (
     UpdateUserLastAccessedCommand,
 )
 from src.app.commands.user.update_user_metrics_command import UpdateUserMetricsCommand
-# Import all command handlers from module
-from src.app.handlers.command_handlers import (
-    EditMealCommandHandler,
-    AddCustomIngredientCommandHandler,
-    DeleteMealCommandHandler,
-    SaveUserOnboardingCommandHandler,
-    SyncUserCommandHandler,
-    UpdateUserLastAccessedCommandHandler,
-    CompleteOnboardingCommandHandler,
-    DeleteUserCommandHandler,
-    CreateManualMealCommandHandler,
-    UpdateUserMetricsCommandHandler,
-    ScanByUrlCommandHandler,
-    UpdateCustomMacrosCommandHandler,
-    UploadMealImageImmediatelyHandler,
-    DiscoverMealsCommandHandler,
-    GenerateMealRecipesCommandHandler,
-    SaveMealSuggestionCommandHandler,
-    ParseMealTextHandler,
-)
-
-# Ingredient handlers
-from src.app.handlers.command_handlers import (
-    RecognizeIngredientCommandHandler,
-)
-from src.app.handlers.command_handlers import (
-    RegisterFcmTokenCommandHandler,
-    DeleteFcmTokenCommandHandler,
-    UpdateLanguageCommandHandler,
-    UpdateNotificationPreferencesCommandHandler,
-    UpdateTimezoneCommandHandler,
-)
-
-# Saved suggestion handlers
-from src.app.handlers.command_handlers import (
-    SaveSuggestionCommandHandler,
-    DeleteSavedSuggestionCommandHandler,
-)
-from src.app.commands.saved_suggestion import (
-    SaveSuggestionCommand,
-    DeleteSavedSuggestionCommand,
-)
-from src.app.queries.saved_suggestion import GetSavedSuggestionsQuery
-from src.app.handlers.query_handlers import GetSavedSuggestionsQueryHandler
-from src.app.commands.cheat_day import MarkCheatDayCommand, UnmarkCheatDayCommand
-from src.app.queries.cheat_day import GetCheatDaysQuery
 from src.app.commands.weight import (
     AddWeightEntryCommand,
     DeleteWeightEntryCommand,
     SyncWeightEntriesCommand,
 )
-from src.app.queries.weight import GetWeightEntriesQuery
+
+# Import all command handlers from module
+# Ingredient handlers
+# Saved suggestion handlers
+from src.app.handlers.command_handlers import (
+    AddCustomIngredientCommandHandler,
+    CompleteOnboardingCommandHandler,
+    CreateManualMealCommandHandler,
+    DeleteFcmTokenCommandHandler,
+    DeleteMealCommandHandler,
+    DeleteMovementEntryCommandHandler,
+    DeleteSavedSuggestionCommandHandler,
+    DeleteUserCommandHandler,
+    DiscoverMealsCommandHandler,
+    EditMealCommandHandler,
+    GenerateMealRecipesCommandHandler,
+    LogMovementCommandHandler,
+    ParseMealTextHandler,
+    RecognizeIngredientCommandHandler,
+    RegisterFcmTokenCommandHandler,
+    SaveMealSuggestionCommandHandler,
+    SaveSuggestionCommandHandler,
+    SaveUserOnboardingCommandHandler,
+    ScanByUrlCommandHandler,
+    SyncUserCommandHandler,
+    UpdateCustomMacrosCommandHandler,
+    UpdateLanguageCommandHandler,
+    UpdateMovementEntryCommandHandler,
+    UpdateNotificationPreferencesCommandHandler,
+    UpdateTimezoneCommandHandler,
+    UpdateUserLastAccessedCommandHandler,
+    UpdateUserMetricsCommandHandler,
+    UploadMealImageImmediatelyHandler,
+)
 from src.app.handlers.command_handlers.add_weight_entry_command_handler import (
     AddWeightEntryCommandHandler,
 )
 from src.app.handlers.command_handlers.delete_weight_entry_command_handler import (
     DeleteWeightEntryCommandHandler,
 )
-from src.app.handlers.command_handlers.sync_weight_entries_command_handler import (
-    SyncWeightEntriesCommandHandler,
-)
-from src.app.handlers.query_handlers.get_weight_entries_query_handler import (
-    GetWeightEntriesQueryHandler,
-)
 from src.app.handlers.command_handlers.mark_cheat_day_command_handler import (
     MarkCheatDayCommandHandler,
+)
+from src.app.handlers.command_handlers.sync_weight_entries_command_handler import (
+    SyncWeightEntriesCommandHandler,
 )
 from src.app.handlers.command_handlers.unmark_cheat_day_command_handler import (
     UnmarkCheatDayCommandHandler,
 )
-from src.app.handlers.query_handlers.get_cheat_days_query_handler import (
-    GetCheatDaysQueryHandler,
-)
-
-from src.app.handlers.query_handlers import (
-    GetNotificationPreferencesQueryHandler,
-)
 
 # Import all query handlers from module
 from src.app.handlers.query_handlers import (
+    GetBulkActivitiesQueryHandler,
+    GetDailyActivitiesQueryHandler,
+    GetDailyBreakdownQueryHandler,
+    GetDailyMacrosQueryHandler,
+    GetDailyMovementQueryHandler,
+    GetFoodDetailsQueryHandler,
+    GetJourneyProgressQueryHandler,
+    GetMealByIdQueryHandler,
+    GetMealsByDateQueryHandler,
+    GetMovementCatalogQueryHandler,
+    GetNotificationPreferencesQueryHandler,
+    GetSavedSuggestionsQueryHandler,
+    GetStreakQueryHandler,
+    GetUserByFirebaseUidQueryHandler,
+    GetUserMetricsQueryHandler,
+    GetUserOnboardingStatusQueryHandler,
+    GetUserProfileQueryHandler,
     GetUserTdeeQueryHandler,
+    GetWeeklyBudgetQueryHandler,
+    LookupBarcodeQueryHandler,
     PreviewTdeeQueryHandler,
     SearchFoodsQueryHandler,
-    GetFoodDetailsQueryHandler,
-    LookupBarcodeQueryHandler,
-    GetMealByIdQueryHandler,
-    GetDailyMacrosQueryHandler,
-    GetWeeklyBudgetQueryHandler,
-    GetUserProfileQueryHandler,
-    GetUserByFirebaseUidQueryHandler,
-    GetUserOnboardingStatusQueryHandler,
-    GetDailyActivitiesQueryHandler,
-    GetBulkActivitiesQueryHandler,
-    GetMovementCatalogQueryHandler,
-    GetMealsByDateQueryHandler,
-    GetUserMetricsQueryHandler,
-    GetStreakQueryHandler,
-    GetDailyBreakdownQueryHandler,
-)
-from src.app.handlers.query_handlers.get_nutrition_bulk_query_handler import (
-    GetNutritionBulkQueryHandler,
 )
 from src.app.handlers.query_handlers.get_activities_presence_query_handler import (
     GetActivitiesPresenceQueryHandler,
 )
-from src.app.queries.activity import GetDailyActivitiesQuery, GetBulkActivitiesQuery
+from src.app.handlers.query_handlers.get_cheat_days_query_handler import (
+    GetCheatDaysQueryHandler,
+)
+from src.app.handlers.query_handlers.get_nutrition_bulk_query_handler import (
+    GetNutritionBulkQueryHandler,
+)
+from src.app.handlers.query_handlers.get_weight_entries_query_handler import (
+    GetWeightEntriesQueryHandler,
+)
+from src.app.queries.activity import GetBulkActivitiesQuery, GetDailyActivitiesQuery
+from src.app.queries.cheat_day import GetCheatDaysQuery
 from src.app.queries.food.get_food_details_query import GetFoodDetailsQuery
 from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 from src.app.queries.food.search_foods_query import SearchFoodsQuery
-from src.app.queries.movement import GetMovementCatalogQuery, GetDailyMovementQuery
-from src.app.commands.movement import LogMovementCommand, DeleteMovementEntryCommand, UpdateMovementEntryCommand
-from src.app.handlers.command_handlers import LogMovementCommandHandler, DeleteMovementEntryCommandHandler, UpdateMovementEntryCommandHandler
-from src.app.handlers.query_handlers import GetDailyMovementQueryHandler
+from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
 
 # Import all queries
 from src.app.queries.meal import (
-    GetMealByIdQuery,
+    GetDailyBreakdownQuery,
     GetDailyMacrosQuery,
+    GetMealByIdQuery,
     GetMealsByDateQuery,
     GetStreakQuery,
-    GetDailyBreakdownQuery,
 )
-from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
+from src.app.queries.movement import GetDailyMovementQuery, GetMovementCatalogQuery
 from src.app.queries.notification import GetNotificationPreferencesQuery
-from src.app.queries.nutrition import GetNutritionBulkQuery, GetActivitiesPresenceQuery
+from src.app.queries.nutrition import GetActivitiesPresenceQuery, GetNutritionBulkQuery
+from src.app.queries.progress import GetJourneyProgressQuery
+from src.app.queries.saved_suggestion import GetSavedSuggestionsQuery
 from src.app.queries.tdee import GetUserTdeeQuery, PreviewTdeeQuery
-from src.app.queries.user import GetUserProfileQuery, GetUserMetricsQuery
+from src.app.queries.user import GetUserMetricsQuery, GetUserProfileQuery
 from src.app.queries.user.get_user_by_firebase_uid_query import (
     GetUserByFirebaseUidQuery,
 )
 from src.app.queries.user.get_user_onboarding_status_query import (
     GetUserOnboardingStatusQuery,
 )
-from src.infra.event_bus import PyMediatorEventBus, EventBus
+from src.app.queries.weight import GetWeightEntriesQuery
+from src.infra.event_bus import EventBus, PyMediatorEventBus
 
 # Singleton event buses
-_food_search_event_bus: Optional[EventBus] = None
-_configured_event_bus: Optional[EventBus] = None
+_food_search_event_bus: EventBus | None = None
+_configured_event_bus: EventBus | None = None
 
 
 def get_food_search_event_bus() -> EventBus:
@@ -194,19 +190,18 @@ def get_food_search_event_bus() -> EventBus:
         return _food_search_event_bus
 
     from src.api.base_dependencies import (
+        get_deepl_text_translation_service,
+        get_fat_secret_service_instance,
         get_food_cache_service,
         get_food_data_service,
         get_food_mapping_service,
         get_open_food_facts_service_instance,
-        get_fat_secret_service_instance,
-        get_deepl_text_translation_service,
-    )
-
-    from src.infra.adapters.brave_search_nutrition_service import (
-        get_brave_search_nutrition_service,
     )
     from src.domain.services.meal_suggestion.macro_validation_service import (
         MacroValidationService,
+    )
+    from src.infra.adapters.brave_search_nutrition_service import (
+        get_brave_search_nutrition_service,
     )
     from src.infra.database.uow_async import AsyncUnitOfWork
 
@@ -283,18 +278,18 @@ def get_configured_event_bus() -> EventBus:
 
     # Get singleton services (these are safe to reuse)
     from src.api.base_dependencies import (
-        get_image_store,
-        get_vision_service,
-        get_gpt_parser,
+        get_cache_service,
+        get_daily_context_precompute_service,
+        get_deepl_meal_translation_service,
+        get_deepl_text_translation_service,
+        get_fat_secret_service_instance,
         get_food_cache_service,
         get_food_data_service,
         get_food_mapping_service,
-        get_fat_secret_service_instance,
-        get_cache_service,
+        get_gpt_parser,
+        get_image_store,
         get_suggestion_orchestration_service,
-        get_deepl_meal_translation_service,
-        get_deepl_text_translation_service,
-        get_daily_context_precompute_service,
+        get_vision_service,
     )
 
     image_store = get_image_store()
@@ -307,8 +302,8 @@ def get_configured_event_bus() -> EventBus:
     cache_service = get_cache_service()
     suggestion_service = get_suggestion_orchestration_service()
 
-    from src.infra.database.uow_async import AsyncUnitOfWork
     from src.app.services.cache_invalidation_service import CacheInvalidationService
+    from src.infra.database.uow_async import AsyncUnitOfWork
 
     # Synchronous invalidation service — handlers await this before returning,
     # eliminating the fire-and-forget race condition.
@@ -459,15 +454,21 @@ def get_configured_event_bus() -> EventBus:
     )
     event_bus.register_handler(
         LogMovementCommand,
-        LogMovementCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service),
+        LogMovementCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
     )
     event_bus.register_handler(
         DeleteMovementEntryCommand,
-        DeleteMovementEntryCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service),
+        DeleteMovementEntryCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
     )
     event_bus.register_handler(
         UpdateMovementEntryCommand,
-        UpdateMovementEntryCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service),
+        UpdateMovementEntryCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
     )
 
     event_bus.register_handler(GetMealsByDateQuery, GetMealsByDateQueryHandler())
@@ -483,7 +484,9 @@ def get_configured_event_bus() -> EventBus:
     )
     event_bus.register_handler(
         SaveMealSuggestionCommand,
-        SaveMealSuggestionCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service),
+        SaveMealSuggestionCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
     )
 
     # Register user handlers
@@ -580,19 +583,60 @@ def get_configured_event_bus() -> EventBus:
         SyncWeightEntriesCommand, SyncWeightEntriesCommandHandler()
     )
     event_bus.register_handler(GetWeightEntriesQuery, GetWeightEntriesQueryHandler())
+    event_bus.register_handler(
+        GetJourneyProgressQuery,
+        GetJourneyProgressQueryHandler(cache_service=cache_service),
+    )
 
     # Register hydration handlers
-    from src.app.commands.hydration import LogHydrationCommand, LogCaloricDrinkCommand, DeleteHydrationEntryCommand
-    from src.app.queries.hydration import GetDailyHydrationQuery, GetDrinkCatalogQuery, GetWeeklyHydrationQuery
-    from src.app.handlers.command_handlers import LogHydrationCommandHandler, LogCaloricDrinkCommandHandler, DeleteHydrationEntryCommandHandler
-    from src.app.handlers.query_handlers import GetDailyHydrationQueryHandler, GetDrinkCatalogQueryHandler, GetWeeklyHydrationQueryHandler
+    from src.app.commands.hydration import (
+        DeleteHydrationEntryCommand,
+        LogCaloricDrinkCommand,
+        LogHydrationCommand,
+    )
+    from src.app.handlers.command_handlers import (
+        DeleteHydrationEntryCommandHandler,
+        LogCaloricDrinkCommandHandler,
+        LogHydrationCommandHandler,
+    )
+    from src.app.handlers.query_handlers import (
+        GetDailyHydrationQueryHandler,
+        GetDrinkCatalogQueryHandler,
+        GetWeeklyHydrationQueryHandler,
+    )
+    from src.app.queries.hydration import (
+        GetDailyHydrationQuery,
+        GetDrinkCatalogQuery,
+        GetWeeklyHydrationQuery,
+    )
 
-    event_bus.register_handler(LogHydrationCommand, LogHydrationCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service))
-    event_bus.register_handler(LogCaloricDrinkCommand, LogCaloricDrinkCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service))
-    event_bus.register_handler(DeleteHydrationEntryCommand, DeleteHydrationEntryCommandHandler(uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service))
-    event_bus.register_handler(GetDailyHydrationQuery, GetDailyHydrationQueryHandler(cache_service=cache_service))
+    event_bus.register_handler(
+        LogHydrationCommand,
+        LogHydrationCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
+    )
+    event_bus.register_handler(
+        LogCaloricDrinkCommand,
+        LogCaloricDrinkCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
+    )
+    event_bus.register_handler(
+        DeleteHydrationEntryCommand,
+        DeleteHydrationEntryCommandHandler(
+            uow=AsyncUnitOfWork(), cache_invalidation=cache_invalidation_service
+        ),
+    )
+    event_bus.register_handler(
+        GetDailyHydrationQuery,
+        GetDailyHydrationQueryHandler(cache_service=cache_service),
+    )
     event_bus.register_handler(GetDrinkCatalogQuery, GetDrinkCatalogQueryHandler())
-    event_bus.register_handler(GetWeeklyHydrationQuery, GetWeeklyHydrationQueryHandler(cache_service=cache_service))
+    event_bus.register_handler(
+        GetWeeklyHydrationQuery,
+        GetWeeklyHydrationQueryHandler(cache_service=cache_service),
+    )
 
     # Register saved suggestion handlers
     event_bus.register_handler(

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -35,12 +35,12 @@ from src.api.base_dependencies import (
     initialize_cache_layer,
     shutdown_cache_layer,
 )
-from src.api.exception_handlers import register_exception_handlers
 from src.api.dependencies.task_manager import (
     clear_task_manager,
     create_task_manager,
     set_task_manager,
 )
+from src.api.exception_handlers import register_exception_handlers
 from src.api.middleware.accept_language import AcceptLanguageMiddleware
 from src.api.middleware.dev_auth_bypass import add_dev_auth_bypass
 from src.api.middleware.rate_limit import limiter
@@ -63,6 +63,7 @@ from src.api.routes.v1.monitoring import router as monitoring_router
 from src.api.routes.v1.movement import router as movement_router
 from src.api.routes.v1.notifications import router as notifications_router
 from src.api.routes.v1.nutrition import router as nutrition_router
+from src.api.routes.v1.progress import router as progress_router
 from src.api.routes.v1.promo_codes import router as promo_codes_router
 from src.api.routes.v1.referrals import router as referrals_router
 from src.api.routes.v1.saved_suggestions import router as saved_suggestions_router
@@ -353,6 +354,7 @@ app.include_router(referrals_router)
 app.include_router(promo_codes_router)
 app.include_router(codes_router)
 app.include_router(nutrition_router)
+app.include_router(progress_router)
 app.include_router(weight_entries_router)
 app.include_router(movement_router)
 app.include_router(well_known_router)

--- a/src/api/routes/v1/progress.py
+++ b/src/api/routes/v1/progress.py
@@ -1,0 +1,25 @@
+"""Progress API endpoints."""
+
+from fastapi import APIRouter, Depends, Request
+
+from src.api.dependencies.auth import get_current_user_id
+from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.schemas.progress_schemas import JourneyProgressResponse
+from src.app.queries.progress import GetJourneyProgressQuery
+from src.infra.event_bus import EventBus
+
+router = APIRouter(prefix="/v1/progress", tags=["Progress"])
+
+
+@router.get("/journey", response_model=JourneyProgressResponse)
+async def get_journey_progress(
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """Get the current action-based journey progress snapshot."""
+    query = GetJourneyProgressQuery(
+        user_id=user_id,
+        header_timezone=request.headers.get("X-Timezone"),
+    )
+    return await event_bus.send(query)

--- a/src/api/schemas/progress_schemas.py
+++ b/src/api/schemas/progress_schemas.py
@@ -4,8 +4,6 @@ Pydantic response schemas for progress screen endpoints.
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import BaseModel
 
 
@@ -14,7 +12,7 @@ class StreakResponse(BaseModel):
 
     current_streak: int
     best_streak: int
-    last_logged_date: Optional[str] = None  # YYYY-MM-DD, None if never logged
+    last_logged_date: str | None = None  # YYYY-MM-DD, None if never logged
     scan_count: int = 0  # total meals created via scanner
 
 
@@ -36,5 +34,40 @@ class DailyBreakdownEntry(BaseModel):
 class DailyBreakdownResponse(BaseModel):
     """Response for GET /v1/meals/weekly/daily-breakdown."""
 
-    days: List[DailyBreakdownEntry]
+    days: list[DailyBreakdownEntry]
     week_start: str  # YYYY-MM-DD (Monday)
+
+
+class JourneyProgressAction(BaseModel):
+    """Latest counted action inside the active journey period."""
+
+    source: str
+    label: str
+    logged_at: str
+
+
+class JourneyProgressBreakdown(BaseModel):
+    """Current-day action score contribution."""
+
+    calories_points: float = 0.0
+    logging_points: float = 0.0
+    protein_points: float = 0.0
+    hydration_points: float = 0.0
+    activity_points: float = 0.0
+
+
+class JourneyProgressResponse(BaseModel):
+    """Response for GET /v1/progress/journey."""
+
+    period_start: str
+    period_end: str
+    as_of: str
+    progress_percent: float
+    confirmed_progress_percent: float
+    provisional_progress_percent: float
+    timeline_days: int
+    daily_progress_budget_percent: float
+    score: int = 0
+    breakdown: JourneyProgressBreakdown
+    latest_action: JourneyProgressAction | None = None
+    is_week_over_budget: bool = False

--- a/src/app/handlers/command_handlers/save_user_onboarding_command_handler.py
+++ b/src/app/handlers/command_handlers/save_user_onboarding_command_handler.py
@@ -13,6 +13,7 @@ from src.domain.cache.cache_keys import CacheKeys
 from src.domain.model.user import UserProfileDomainModel
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.cache_port import CachePort
+from src.domain.utils.timezone_utils import utc_now
 from src.infra.database.uow_async import AsyncUnitOfWork
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class SaveUserOnboardingCommandHandler(EventHandler[SaveUserOnboardingCommand, N
                 profile = await uow.users.get_profile(UUID(command.user_id))
 
                 if not profile:
+                    goal_started_at = utc_now() if command.target_weight_kg else None
                     # Create new profile
                     profile = UserProfileDomainModel(
                         user_id=UUID(command.user_id),
@@ -68,6 +70,10 @@ class SaveUserOnboardingCommandHandler(EventHandler[SaveUserOnboardingCommand, N
                         body_fat_percentage=command.body_fat_percentage,
                         date_of_birth=command.date_of_birth,
                         target_weight_kg=command.target_weight_kg,
+                        goal_start_weight_kg=(
+                            command.weight_kg if command.target_weight_kg else None
+                        ),
+                        goal_started_at=goal_started_at,
                         job_type=command.job_type,
                         training_days_per_week=command.training_days_per_week,
                         training_minutes_per_session=command.training_minutes_per_session,
@@ -81,6 +87,7 @@ class SaveUserOnboardingCommandHandler(EventHandler[SaveUserOnboardingCommand, N
                         training_types=command.training_types,
                     )
                 else:
+                    previous_target = profile.target_weight_kg
                     # Update existing profile
                     profile.age = command.age
                     profile.gender = command.gender
@@ -101,6 +108,12 @@ class SaveUserOnboardingCommandHandler(EventHandler[SaveUserOnboardingCommand, N
                     profile.training_level = command.training_level
                     profile.date_of_birth = command.date_of_birth
                     profile.target_weight_kg = command.target_weight_kg
+                    if command.target_weight_kg and (
+                        profile.goal_started_at is None
+                        or previous_target != command.target_weight_kg
+                    ):
+                        profile.goal_start_weight_kg = command.weight_kg
+                        profile.goal_started_at = utc_now()
                     # Write-once — don't overwrite if already set
                     if command.referral_sources and not profile.referral_sources:
                         profile.referral_sources = command.referral_sources
@@ -123,7 +136,7 @@ class SaveUserOnboardingCommandHandler(EventHandler[SaveUserOnboardingCommand, N
                 await uow.commit()
                 await self._invalidate_user_profile(command.user_id)
 
-            except Exception as e:
+            except Exception:
                 await uow.rollback()
                 raise
 

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -11,6 +11,7 @@ from src.domain.cache.cache_keys import CacheKeys
 from src.domain.model.common.enums import FitnessGoal, JobType, TrainingLevel
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.cache_port import CachePort
+from src.domain.utils.timezone_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -20,29 +21,34 @@ _VALID_TRAINING_LEVELS = {e.value for e in TrainingLevel}
 
 
 def _has_metric_update(command: UpdateUserMetricsCommand) -> bool:
-    return any(
-        value is not None
-        for value in [
-            command.weight_kg,
-            command.job_type,
-            command.training_days_per_week,
-            command.training_minutes_per_session,
-            command.body_fat_percent,
-            command.fitness_goal,
-            command.training_level,
-            command.target_weight_kg,
-            command.goal_start_weight_kg,
-            command.goal_started_at,
-            command.daily_water_goal_ml,
-        ]
-    ) or command.reset_water_goal
+    return (
+        any(
+            value is not None
+            for value in [
+                command.weight_kg,
+                command.job_type,
+                command.training_days_per_week,
+                command.training_minutes_per_session,
+                command.body_fat_percent,
+                command.fitness_goal,
+                command.training_level,
+                command.target_weight_kg,
+                command.goal_start_weight_kg,
+                command.goal_started_at,
+                command.daily_water_goal_ml,
+            ]
+        )
+        or command.reset_water_goal
+    )
 
 
 @handles(UpdateUserMetricsCommand)
 class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, None]):
     """Handle updating user metrics (weight, job type, training, body fat)."""
 
-    def __init__(self, uow: AsyncUnitOfWorkPort, cache_service: CachePort | None = None):
+    def __init__(
+        self, uow: AsyncUnitOfWorkPort, cache_service: CachePort | None = None
+    ):
         self.uow = uow
         self.cache_service = cache_service
 
@@ -127,9 +133,17 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 profile.training_level = command.training_level
 
             # Handle target weight update
+            target_weight_changed = False
+            should_auto_start_goal = False
             if command.target_weight_kg is not None:
                 if command.target_weight_kg <= 0:
                     raise ValidationException("Target weight must be greater than 0")
+                target_weight_changed = (
+                    profile.target_weight_kg != command.target_weight_kg
+                )
+                should_auto_start_goal = (
+                    target_weight_changed or profile.goal_started_at is None
+                )
                 logger.info(
                     f"Updating target_weight_kg for user {command.user_id}: "
                     f"{profile.target_weight_kg} -> {command.target_weight_kg}"
@@ -147,6 +161,8 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                     f"{profile.goal_start_weight_kg} -> {command.goal_start_weight_kg}"
                 )
                 profile.goal_start_weight_kg = command.goal_start_weight_kg
+            elif should_auto_start_goal:
+                profile.goal_start_weight_kg = profile.weight_kg
 
             if command.goal_started_at is not None:
                 logger.info(
@@ -154,6 +170,8 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                     f"{profile.goal_started_at} -> {command.goal_started_at}"
                 )
                 profile.goal_started_at = command.goal_started_at
+            elif should_auto_start_goal:
+                profile.goal_started_at = utc_now()
 
             if command.reset_water_goal:
                 profile.daily_water_goal_ml = None
@@ -192,7 +210,9 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         try:
             await self.cache_service.invalidate_pattern(macros_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate macros pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate macros pattern for user {user_id}: {e}"
+            )
 
         # Invalidate ALL weekly budgets for this user
         # TDEE changes affect weekly targets
@@ -200,16 +220,22 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
         try:
             await self.cache_service.invalidate_pattern(weekly_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate weekly budget pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate weekly budget pattern for user {user_id}: {e}"
+            )
 
         hydration_pattern = f"user:{user_id}:hydration:*"
         try:
             await self.cache_service.invalidate_pattern(hydration_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate hydration pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate hydration pattern for user {user_id}: {e}"
+            )
 
         weekly_hydration_pattern = f"user:{user_id}:hydration_weekly:*"
         try:
             await self.cache_service.invalidate_pattern(weekly_hydration_pattern)
         except Exception as e:
-            logger.warning(f"Failed to invalidate weekly hydration pattern for user {user_id}: {e}")
+            logger.warning(
+                f"Failed to invalidate weekly hydration pattern for user {user_id}: {e}"
+            )

--- a/src/app/handlers/query_handlers/__init__.py
+++ b/src/app/handlers/query_handlers/__init__.py
@@ -4,24 +4,29 @@ Each handler is in its own file for better maintainability.
 """
 
 # Activity handlers
-from .get_daily_activities_query_handler import GetDailyActivitiesQueryHandler
 from .get_bulk_activities_query_handler import GetBulkActivitiesQueryHandler
+from .get_daily_activities_query_handler import GetDailyActivitiesQueryHandler
 from .get_daily_breakdown_query_handler import GetDailyBreakdownQueryHandler
+
+# Hydration handlers
+from .get_daily_hydration_query_handler import GetDailyHydrationQueryHandler
 from .get_daily_macros_query_handler import GetDailyMacrosQueryHandler
-from .get_movement_catalog_query_handler import GetMovementCatalogQueryHandler
 from .get_daily_movement_query_handler import GetDailyMovementQueryHandler
-from .get_streak_query_handler import GetStreakQueryHandler
+from .get_drink_catalog_query_handler import GetDrinkCatalogQueryHandler
 from .get_food_details_query_handler import GetFoodDetailsQueryHandler
+from .get_journey_progress_query_handler import GetJourneyProgressQueryHandler
 
 # Meal handlers
 from .get_meal_by_id_query_handler import GetMealByIdQueryHandler
-
 from .get_meals_by_date_query_handler import GetMealsByDateQueryHandler
+from .get_movement_catalog_query_handler import GetMovementCatalogQueryHandler
 
 # Notification handlers
 from .get_notification_preferences_query_handler import (
     GetNotificationPreferencesQueryHandler,
 )
+from .get_saved_suggestions_query_handler import GetSavedSuggestionsQueryHandler
+from .get_streak_query_handler import GetStreakQueryHandler
 from .get_user_by_firebase_uid_query_handler import GetUserByFirebaseUidQueryHandler
 from .get_user_metrics_query_handler import GetUserMetricsQueryHandler
 from .get_user_onboarding_status_query_handler import (
@@ -33,18 +38,13 @@ from .get_user_profile_query_handler import GetUserProfileQueryHandler
 
 # TDEE handlers
 from .get_user_tdee_query_handler import GetUserTdeeQueryHandler
-from .preview_tdee_query_handler import PreviewTdeeQueryHandler
+from .get_weekly_budget_query_handler import GetWeeklyBudgetQueryHandler
+from .get_weekly_hydration_query_handler import GetWeeklyHydrationQueryHandler
 
 # Food handlers
 from .lookup_barcode_query_handler import LookupBarcodeQueryHandler
+from .preview_tdee_query_handler import PreviewTdeeQueryHandler
 from .search_foods_query_handler import SearchFoodsQueryHandler
-from .get_saved_suggestions_query_handler import GetSavedSuggestionsQueryHandler
-from .get_weekly_budget_query_handler import GetWeeklyBudgetQueryHandler
-
-# Hydration handlers
-from .get_daily_hydration_query_handler import GetDailyHydrationQueryHandler
-from .get_drink_catalog_query_handler import GetDrinkCatalogQueryHandler
-from .get_weekly_hydration_query_handler import GetWeeklyHydrationQueryHandler
 
 __all__ = [
     # TDEE
@@ -81,4 +81,5 @@ __all__ = [
     "GetDailyHydrationQueryHandler",
     "GetDrinkCatalogQueryHandler",
     "GetWeeklyHydrationQueryHandler",
+    "GetJourneyProgressQueryHandler",
 ]

--- a/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
+++ b/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
@@ -1,0 +1,170 @@
+"""Handler for active journey progress snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from typing import Any
+from uuid import UUID
+
+from src.api.exceptions import ResourceNotFoundException
+from src.app.events.base import EventHandler, handles
+from src.app.queries.progress import GetJourneyProgressQuery
+from src.app.queries.tdee import GetUserTdeeQuery
+from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
+from src.domain.ports.cache_port import CachePort
+from src.domain.services.journey_progress_rules import (
+    estimate_timeline_days,
+    journey_period_start,
+)
+from src.domain.services.journey_progress_service import (
+    JourneyAction,
+    calculate_journey_progress,
+)
+from src.domain.utils.timezone_utils import (
+    ensure_utc,
+    get_zone_info,
+    resolve_user_timezone_async,
+    utc_now,
+)
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+TargetLoader = Callable[[str], Awaitable[tuple[float, float]]]
+
+
+@handles(GetJourneyProgressQuery)
+class GetJourneyProgressQueryHandler(
+    EventHandler[GetJourneyProgressQuery, dict[str, Any]]
+):
+    """Build the server-derived action progress for the active journey period."""
+
+    def __init__(
+        self,
+        uow: AsyncUnitOfWorkPort | None = None,
+        cache_service: CachePort | None = None,
+        now_fn: Callable[[], Any] = utc_now,
+        target_loader: TargetLoader | None = None,
+    ):
+        self.uow = uow
+        self.cache_service = cache_service
+        self.now_fn = now_fn
+        self.target_loader = target_loader
+
+    async def handle(self, query: GetJourneyProgressQuery) -> dict[str, Any]:
+        now = ensure_utc(self.now_fn())
+        uow = self.uow or AsyncUnitOfWork()
+
+        async with uow:
+            user_tz_str = await resolve_user_timezone_async(
+                query.user_id, uow, query.header_timezone
+            )
+            user_tz = get_zone_info(user_tz_str)
+            profile = await uow.users.get_profile(UUID(query.user_id))
+            if profile is None:
+                raise ResourceNotFoundException("Current user profile not found")
+
+            start_weight = profile.goal_start_weight_kg or profile.weight_kg
+            timeline_days = estimate_timeline_days(
+                goal=profile.fitness_goal,
+                start_weight_kg=start_weight,
+                target_weight_kg=profile.target_weight_kg,
+                challenge_duration=profile.challenge_duration,
+            )
+            period_start = journey_period_start(
+                goal_started_at=profile.goal_started_at,
+                user_tz=user_tz,
+            )
+            period_end = period_start + timedelta(days=timeline_days)
+            actions = await self._load_actions(
+                uow,
+                query.user_id,
+                period_start,
+                min(now, period_end),
+            )
+            water_goal_ml = profile.daily_water_goal_ml or 2000
+
+        target_calories, target_protein_g = await self._load_targets(query.user_id)
+        return calculate_journey_progress(
+            actions=actions,
+            period_start=period_start,
+            timeline_days=timeline_days,
+            user_tz=user_tz,
+            as_of=now,
+            target_calories=target_calories,
+            target_protein_g=target_protein_g,
+            water_goal_ml=water_goal_ml,
+        )
+
+    async def _load_actions(
+        self,
+        uow,
+        user_id: str,
+        start_utc,
+        end_utc,
+    ) -> list[JourneyAction]:
+        if end_utc <= start_utc:
+            return []
+
+        actions: list[JourneyAction] = []
+        for row in await uow.meals.fetch_journey_progress_meals(
+            user_id, start_utc, end_utc
+        ):
+            actions.append(
+                JourneyAction(
+                    source="meal",
+                    label=row["label"],
+                    logged_at=row["logged_at"],
+                    calories=row["calories"],
+                    protein_g=row["protein_g"],
+                )
+            )
+        for row in await uow.hydration_entries.fetch_journey_progress_hydration(
+            user_id, start_utc, end_utc
+        ):
+            actions.append(
+                JourneyAction(
+                    source="hydration",
+                    label=row["label"],
+                    logged_at=row["logged_at"],
+                    hydration_ml=row["hydration_ml"],
+                    calories=row.get("calories", 0.0),
+                    protein_g=row.get("protein_g", 0.0),
+                )
+            )
+        for row in await uow.movement_entries.fetch_journey_progress_movements(
+            user_id, start_utc, end_utc
+        ):
+            actions.append(
+                JourneyAction(
+                    source="activity",
+                    label=row["label"],
+                    logged_at=row["logged_at"],
+                )
+            )
+        for entry in await uow.weight_entries.find_by_recorded_range(
+            user_id, start_utc, end_utc
+        ):
+            actions.append(
+                JourneyAction(
+                    source="weight",
+                    label="Weight log",
+                    logged_at=entry.recorded_at,
+                )
+            )
+        return actions
+
+    async def _load_targets(self, user_id: str) -> tuple[float, float]:
+        if self.target_loader is not None:
+            return await self.target_loader(user_id)
+
+        from src.app.handlers.query_handlers.get_user_tdee_query_handler import (
+            GetUserTdeeQueryHandler,
+        )
+
+        result = await GetUserTdeeQueryHandler(cache_service=self.cache_service).handle(
+            GetUserTdeeQuery(user_id=user_id)
+        )
+        macros = result.get("macros") or {}
+        return float(result.get("target_calories") or 0), float(
+            macros.get("protein") or 0
+        )

--- a/src/app/queries/progress/__init__.py
+++ b/src/app/queries/progress/__init__.py
@@ -1,0 +1,5 @@
+"""Progress queries."""
+
+from .get_journey_progress_query import GetJourneyProgressQuery
+
+__all__ = ["GetJourneyProgressQuery"]

--- a/src/app/queries/progress/get_journey_progress_query.py
+++ b/src/app/queries/progress/get_journey_progress_query.py
@@ -1,0 +1,11 @@
+"""Query for the active journey progress snapshot."""
+
+from dataclasses import dataclass
+
+from src.app.events.base import Query
+
+
+@dataclass
+class GetJourneyProgressQuery(Query):
+    user_id: str
+    header_timezone: str | None = None

--- a/src/domain/ports/meal_repository_port.py
+++ b/src/domain/ports/meal_repository_port.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 
 from src.domain.model.meal import Meal, MealStatus
@@ -124,3 +124,12 @@ class MealRepositoryPort(ABC):
     ) -> dict[date, int]:
         """Return {date: meal_count} for each day in range with at least 1 meal."""
         return {}
+
+    async def fetch_journey_progress_meals(
+        self,
+        user_id: str,
+        start_utc: datetime,
+        end_utc: datetime,
+    ) -> list[dict]:
+        """Return meal action rows in a strict UTC range for journey progress."""
+        return []

--- a/src/domain/services/journey_progress_rules.py
+++ b/src/domain/services/journey_progress_rules.py
@@ -1,0 +1,61 @@
+"""Period and timeline rules for journey progress."""
+
+from datetime import UTC, date, datetime, time
+from math import ceil
+from zoneinfo import ZoneInfo
+
+from src.domain.utils.timezone_utils import ensure_utc
+
+FEATURE_START_DATE = date(2026, 6, 21)
+RECOMP_TIMELINE_DAYS = 84
+MINIMUM_TIMELINE_DAYS = 7
+MAXIMUM_TIMELINE_DAYS = 730
+CUT_PACE_KG_PER_WEEK = 0.5
+BULK_PACE_KG_PER_WEEK = 0.25
+
+
+def journey_period_start(
+    *,
+    goal_started_at: datetime | None,
+    user_tz: ZoneInfo,
+) -> datetime:
+    local_start = datetime.combine(FEATURE_START_DATE, time.min, tzinfo=user_tz)
+    feature_start = local_start.astimezone(UTC)
+    if goal_started_at is not None:
+        return max(ensure_utc(goal_started_at), feature_start)
+
+    return feature_start
+
+
+def estimate_timeline_days(
+    *,
+    goal: str | None,
+    start_weight_kg: float | None,
+    target_weight_kg: float | None,
+    challenge_duration: str | None = None,
+) -> int:
+    challenge_days = _challenge_days(challenge_duration)
+    if challenge_days is not None:
+        return challenge_days
+    if goal == "recomp":
+        return RECOMP_TIMELINE_DAYS
+    if start_weight_kg is None or target_weight_kg is None:
+        return RECOMP_TIMELINE_DAYS
+
+    delta_kg = abs(start_weight_kg - target_weight_kg)
+    if delta_kg < 0.1:
+        return MINIMUM_TIMELINE_DAYS
+
+    pace = BULK_PACE_KG_PER_WEEK if goal == "bulk" else CUT_PACE_KG_PER_WEEK
+    days = ceil((delta_kg / pace) * 7)
+    return max(MINIMUM_TIMELINE_DAYS, min(MAXIMUM_TIMELINE_DAYS, days))
+
+
+def _challenge_days(value: str | None) -> int | None:
+    if not value or not value.endswith("_days"):
+        return None
+    try:
+        days = int(value.removesuffix("_days"))
+    except ValueError:
+        return None
+    return max(MINIMUM_TIMELINE_DAYS, min(MAXIMUM_TIMELINE_DAYS, days))

--- a/src/domain/services/journey_progress_service.py
+++ b/src/domain/services/journey_progress_service.py
@@ -1,0 +1,167 @@
+"""Journey progress period and scoring helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from src.domain.utils.timezone_utils import ensure_utc
+
+COMPLETE_MEAL_COUNT = 3
+MINIMUM_LOGGED_ACTION_PERCENT = 0.1
+EMPTY_BREAKDOWN = {
+    "calories_points": 0.0,
+    "logging_points": 0.0,
+    "protein_points": 0.0,
+    "hydration_points": 0.0,
+    "activity_points": 0.0,
+}
+
+
+@dataclass(frozen=True)
+class JourneyAction:
+    source: str
+    label: str
+    logged_at: datetime
+    calories: float = 0.0
+    protein_g: float = 0.0
+    hydration_ml: int = 0
+
+
+@dataclass
+class DayTotals:
+    calories: float = 0.0
+    protein_g: float = 0.0
+    meal_count: int = 0
+    hydration_ml: int = 0
+    movement_count: int = 0
+    action_count: int = 0
+
+
+def calculate_journey_progress(
+    *,
+    actions: list[JourneyAction],
+    period_start: datetime,
+    timeline_days: int,
+    user_tz: ZoneInfo,
+    as_of: datetime,
+    target_calories: float,
+    target_protein_g: float,
+    water_goal_ml: int,
+) -> dict:
+    period_end = period_start + timedelta(days=timeline_days)
+    effective_end = min(as_of, period_end)
+    included = [
+        action
+        for action in actions
+        if period_start <= ensure_utc(action.logged_at) < effective_end
+    ]
+    daily_budget = 100 / timeline_days
+    buckets = _bucket_actions(included, user_tz)
+    as_of_local_date = as_of.astimezone(user_tz).date()
+
+    confirmed = 0.0
+    provisional = 0.0
+    breakdown = EMPTY_BREAKDOWN.copy()
+    for day, totals in buckets.items():
+        points = _score_day(
+            totals,
+            target_calories=target_calories,
+            target_protein_g=target_protein_g,
+            water_goal_ml=water_goal_ml,
+        )
+        percent = _day_percent(points, totals.action_count, daily_budget)
+        if day == as_of_local_date and as_of < period_end:
+            provisional += percent
+            breakdown = points
+        else:
+            confirmed += percent
+
+    display = min(100.0, confirmed + provisional)
+    latest = max(
+        included, key=lambda action: ensure_utc(action.logged_at), default=None
+    )
+    return {
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "as_of": as_of.isoformat(),
+        "progress_percent": round(display, 3),
+        "confirmed_progress_percent": round(min(100.0, confirmed), 3),
+        "provisional_progress_percent": round(
+            min(100.0, max(0.0, display - confirmed)), 3
+        ),
+        "timeline_days": timeline_days,
+        "daily_progress_budget_percent": round(daily_budget, 3),
+        "score": round(sum(breakdown.values())),
+        "breakdown": {key: round(value, 3) for key, value in breakdown.items()},
+        "latest_action": _action_dict(latest),
+        "is_week_over_budget": False,
+    }
+
+
+def _bucket_actions(
+    actions: list[JourneyAction], user_tz: ZoneInfo
+) -> dict[date, DayTotals]:
+    buckets: dict[date, DayTotals] = {}
+    for action in actions:
+        day = ensure_utc(action.logged_at).astimezone(user_tz).date()
+        totals = buckets.setdefault(day, DayTotals())
+        totals.action_count += 1
+        if action.source == "meal":
+            totals.meal_count += 1
+        elif action.source == "hydration":
+            totals.hydration_ml += action.hydration_ml
+        elif action.source == "activity":
+            totals.movement_count += 1
+        totals.calories += action.calories
+        totals.protein_g += action.protein_g
+    return buckets
+
+
+def _score_day(
+    totals: DayTotals,
+    *,
+    target_calories: float,
+    target_protein_g: float,
+    water_goal_ml: int,
+) -> dict[str, float]:
+    return {
+        "calories_points": _calorie_adherence(target_calories, totals.calories) * 30,
+        "logging_points": min(1.0, totals.meal_count / COMPLETE_MEAL_COUNT) * 20,
+        "protein_points": _target_progress(target_protein_g, totals.protein_g) * 15,
+        "hydration_points": _target_progress(water_goal_ml, totals.hydration_ml) * 15,
+        "activity_points": min(1.0, totals.movement_count) * 20,
+    }
+
+
+def _day_percent(
+    points: dict[str, float], action_count: int, daily_budget: float
+) -> float:
+    if action_count <= 0:
+        return 0.0
+    scored = daily_budget * (sum(points.values()) / 100)
+    floor = min(daily_budget, action_count * MINIMUM_LOGGED_ACTION_PERCENT)
+    return min(daily_budget, max(floor, scored))
+
+
+def _calorie_adherence(target: float, consumed: float) -> float:
+    if target <= 0 or consumed <= 0:
+        return 0.0
+    return max(0.0, min(1.0, 1 - abs(1 - consumed / target)))
+
+
+def _target_progress(target: float, consumed: float) -> float:
+    if target <= 0 or consumed <= 0:
+        return 0.0
+    return max(0.0, min(1.0, consumed / target))
+
+
+def _action_dict(action: JourneyAction | None) -> dict | None:
+    if action is None:
+        return None
+    return {
+        "source": action.source,
+        "label": action.label,
+        "logged_at": ensure_utc(action.logged_at).isoformat(),
+    }

--- a/src/infra/repositories/hydration_repository_async.py
+++ b/src/infra/repositories/hydration_repository_async.py
@@ -181,6 +181,46 @@ class AsyncHydrationRepository:
             totals[day_val] = int(total)
         return totals
 
+    async def fetch_journey_progress_hydration(
+        self,
+        user_id: str,
+        start_utc: datetime,
+        end_utc: datetime,
+    ) -> list[dict]:
+        result = await self.session.execute(
+            select(
+                HydrationEntryORM.logged_at,
+                HydrationEntryORM.drink_name_snapshot,
+                HydrationEntryORM.credited_ml,
+                HydrationEntryORM.protein_g,
+                HydrationEntryORM.carbs_g,
+                HydrationEntryORM.fat_g,
+                HydrationEntryORM.fiber_g,
+            )
+            .where(
+                HydrationEntryORM.user_id == user_id,
+                HydrationEntryORM.logged_at >= start_utc,
+                HydrationEntryORM.logged_at < end_utc,
+            )
+            .order_by(HydrationEntryORM.logged_at.asc())
+        )
+        return [
+            {
+                "logged_at": logged_at,
+                "label": label or "Hydration",
+                "hydration_ml": int(credited_ml or 0),
+                "calories": round(
+                    float(protein_g or 0.0) * 4
+                    + max(0.0, float(carbs_g or 0.0) - float(fiber_g or 0.0)) * 4
+                    + float(fiber_g or 0.0) * 2
+                    + float(fat_g or 0.0) * 9,
+                    1,
+                ),
+                "protein_g": float(protein_g or 0.0),
+            }
+            for logged_at, label, credited_ml, protein_g, carbs_g, fat_g, fiber_g in result.all()
+        ]
+
     async def delete_by_id_or_legacy_meal_id(self, user_id: str, entry_id: str) -> bool:
         result = await self.session.execute(
             delete(HydrationEntryORM).where(

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -432,6 +432,50 @@ class AsyncMealRepository(MealRepositoryPort):
             out[day_val] = count
         return out
 
+    async def fetch_journey_progress_meals(
+        self,
+        user_id: str,
+        start_utc: datetime,
+        end_utc: datetime,
+    ) -> list[dict]:
+        result = await self.session.execute(
+            select(
+                MealORM.created_at,
+                MealORM.dish_name,
+                NutritionORM.protein,
+                NutritionORM.carbs,
+                NutritionORM.fat,
+                NutritionORM.fiber,
+            )
+            .join(NutritionORM, NutritionORM.meal_id == MealORM.meal_id, isouter=True)
+            .where(
+                MealORM.user_id == user_id,
+                MealORM.created_at >= start_utc,
+                MealORM.created_at < end_utc,
+                or_(MealORM.meal_type.is_(None), MealORM.meal_type != "hydration"),
+                _domain_hydratable_active_meal_filter(),
+            )
+            .order_by(MealORM.created_at.asc())
+        )
+        rows = []
+        for logged_at, label, protein, carbs, fat, fiber in result.all():
+            protein = float(protein or 0.0)
+            carbs = float(carbs or 0.0)
+            fat = float(fat or 0.0)
+            fiber = float(fiber or 0.0)
+            net_carbs = max(0.0, carbs - fiber)
+            rows.append(
+                {
+                    "logged_at": logged_at,
+                    "label": label or "Meal",
+                    "calories": round(
+                        protein * 4 + net_carbs * 4 + fiber * 2 + fat * 9, 1
+                    ),
+                    "protein_g": protein,
+                }
+            )
+        return rows
+
     async def get_dates_with_meals(
         self, user_id: str, user_timezone: str | None = None
     ) -> list[date]:

--- a/src/infra/repositories/movement_repository_async.py
+++ b/src/infra/repositories/movement_repository_async.py
@@ -89,6 +89,29 @@ class AsyncMovementRepository:
         )
         return [(row.logged_at, float(row.kcal_burned)) for row in result.all()]
 
+    async def fetch_journey_progress_movements(
+        self,
+        user_id: str,
+        start_utc: datetime,
+        end_utc: datetime,
+    ) -> list[dict]:
+        result = await self.session.execute(
+            select(MovementEntryORM.logged_at, MovementEntryORM.activity_name)
+            .where(
+                MovementEntryORM.user_id == user_id,
+                MovementEntryORM.logged_at >= start_utc,
+                MovementEntryORM.logged_at < end_utc,
+            )
+            .order_by(MovementEntryORM.logged_at.asc())
+        )
+        return [
+            {
+                "logged_at": logged_at,
+                "label": activity_name or "Activity",
+            }
+            for logged_at, activity_name in result.all()
+        ]
+
     async def update(
         self,
         user_id: str,

--- a/src/infra/repositories/weight_repository_async.py
+++ b/src/infra/repositories/weight_repository_async.py
@@ -1,17 +1,16 @@
 """Async weight entry repository."""
 
 import logging
-from typing import List, Optional
 
-from sqlalchemy import select, delete
+from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.domain.model.weight import WeightEntry
 from src.infra.database.models.weight_entry import WeightEntryORM
 from src.infra.mappers.weight_entry_mapper import (
-    weight_entry_orm_to_domain,
     weight_entry_domain_to_orm,
+    weight_entry_orm_to_domain,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ class AsyncWeightRepository:
         await self.session.refresh(db)
         return weight_entry_orm_to_domain(db)
 
-    async def find_by_id(self, user_id: str, entry_id: str) -> Optional[WeightEntry]:
+    async def find_by_id(self, user_id: str, entry_id: str) -> WeightEntry | None:
         """Find entry by ID for a specific user."""
         result = await self.session.execute(
             select(WeightEntryORM).where(
@@ -44,7 +43,7 @@ class AsyncWeightRepository:
 
     async def find_by_user(
         self, user_id: str, limit: int = 100, offset: int = 0
-    ) -> List[WeightEntry]:
+    ) -> list[WeightEntry]:
         """Get weight entries for a user, ordered by recorded_at desc."""
         result = await self.session.execute(
             select(WeightEntryORM)
@@ -52,6 +51,24 @@ class AsyncWeightRepository:
             .order_by(WeightEntryORM.recorded_at.desc())
             .limit(limit)
             .offset(offset)
+        )
+        return [weight_entry_orm_to_domain(r) for r in result.scalars().all()]
+
+    async def find_by_recorded_range(
+        self,
+        user_id: str,
+        start_utc,
+        end_utc,
+    ) -> list[WeightEntry]:
+        """Get weight entries in a strict recorded_at UTC range."""
+        result = await self.session.execute(
+            select(WeightEntryORM)
+            .where(
+                WeightEntryORM.user_id == user_id,
+                WeightEntryORM.recorded_at >= start_utc,
+                WeightEntryORM.recorded_at < end_utc,
+            )
+            .order_by(WeightEntryORM.recorded_at.asc())
         )
         return [weight_entry_orm_to_domain(r) for r in result.scalars().all()]
 
@@ -65,7 +82,7 @@ class AsyncWeightRepository:
         )
         return result.rowcount > 0
 
-    async def bulk_upsert(self, user_id: str, entries: List[WeightEntry]) -> int:
+    async def bulk_upsert(self, user_id: str, entries: list[WeightEntry]) -> int:
         """Bulk upsert entries. Returns count of affected rows."""
         if not entries:
             return 0

--- a/tests/unit/domain/services/test_journey_progress_service.py
+++ b/tests/unit/domain/services/test_journey_progress_service.py
@@ -1,0 +1,143 @@
+from datetime import UTC, datetime
+
+from src.domain.services.journey_progress_rules import (
+    estimate_timeline_days,
+    journey_period_start,
+)
+from src.domain.services.journey_progress_service import (
+    JourneyAction,
+    calculate_journey_progress,
+)
+from src.domain.utils.timezone_utils import get_zone_info
+
+
+def test_existing_user_period_start_uses_feature_start_in_user_timezone():
+    start = journey_period_start(
+        goal_started_at=None,
+        user_tz=get_zone_info("Asia/Ho_Chi_Minh"),
+    )
+
+    assert start == datetime(2026, 6, 20, 17, 0, tzinfo=UTC)
+
+
+def test_existing_user_old_goal_start_is_clamped_to_feature_start():
+    start = journey_period_start(
+        goal_started_at=datetime(2026, 5, 1, 12, tzinfo=UTC),
+        user_tz=get_zone_info("Asia/Ho_Chi_Minh"),
+    )
+
+    assert start == datetime(2026, 6, 20, 17, 0, tzinfo=UTC)
+
+
+def test_new_goal_start_after_feature_start_is_used():
+    goal_started_at = datetime(2026, 6, 22, 12, tzinfo=UTC)
+    start = journey_period_start(
+        goal_started_at=goal_started_at,
+        user_tz=get_zone_info("Asia/Ho_Chi_Minh"),
+    )
+
+    assert start == goal_started_at
+
+
+def test_challenge_duration_overrides_weight_pace_timeline():
+    assert (
+        estimate_timeline_days(
+            goal="cut",
+            start_weight_kg=80,
+            target_weight_kg=75,
+            challenge_duration="30_days",
+        )
+        == 30
+    )
+
+
+def test_journey_progress_counts_only_actions_inside_strict_period():
+    period_start = datetime(2026, 6, 21, tzinfo=UTC)
+    period_end = datetime(2026, 7, 21, tzinfo=UTC)
+
+    result = calculate_journey_progress(
+        actions=[
+            JourneyAction(
+                source="meal",
+                label="Old meal",
+                logged_at=datetime(2026, 6, 20, 23, 59, tzinfo=UTC),
+                calories=400,
+                protein_g=20,
+            ),
+            JourneyAction(
+                source="meal",
+                label="Start meal",
+                logged_at=period_start,
+                calories=400,
+                protein_g=20,
+            ),
+            JourneyAction(
+                source="hydration",
+                label="End water",
+                logged_at=period_end,
+                hydration_ml=500,
+            ),
+        ],
+        period_start=period_start,
+        timeline_days=30,
+        user_tz=get_zone_info("UTC"),
+        as_of=period_end,
+        target_calories=400,
+        target_protein_g=20,
+        water_goal_ml=2000,
+    )
+
+    assert result["progress_percent"] > 0
+    assert result["latest_action"]["label"] == "Start meal"
+    assert result["latest_action"]["source"] == "meal"
+
+
+def test_caloric_hydration_contributes_macro_points_without_meal_count():
+    result = calculate_journey_progress(
+        actions=[
+            JourneyAction(
+                source="hydration",
+                label="Juice",
+                logged_at=datetime(2026, 6, 21, 12, tzinfo=UTC),
+                calories=400,
+                protein_g=20,
+                hydration_ml=300,
+            )
+        ],
+        period_start=datetime(2026, 6, 21, tzinfo=UTC),
+        timeline_days=30,
+        user_tz=get_zone_info("UTC"),
+        as_of=datetime(2026, 6, 21, 13, tzinfo=UTC),
+        target_calories=400,
+        target_protein_g=20,
+        water_goal_ml=600,
+    )
+
+    assert result["breakdown"]["calories_points"] == 30
+    assert result["breakdown"]["protein_points"] == 15
+    assert result["breakdown"]["hydration_points"] == 7.5
+    assert result["breakdown"]["logging_points"] == 0
+
+
+def test_journey_progress_does_not_backfill_before_current_period():
+    result = calculate_journey_progress(
+        actions=[
+            JourneyAction(
+                source="meal",
+                label="Historical meal",
+                logged_at=datetime(2026, 6, 1, 12, tzinfo=UTC),
+                calories=2000,
+                protein_g=150,
+            )
+        ],
+        period_start=datetime(2026, 6, 21, tzinfo=UTC),
+        timeline_days=30,
+        user_tz=get_zone_info("UTC"),
+        as_of=datetime(2026, 6, 22, tzinfo=UTC),
+        target_calories=2000,
+        target_protein_g=150,
+        water_goal_ml=2000,
+    )
+
+    assert result["progress_percent"] == 0
+    assert result["latest_action"] is None

--- a/tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+
+from src.app.commands.user import SaveUserOnboardingCommand
+from src.app.handlers.command_handlers.save_user_onboarding_command_handler import (
+    SaveUserOnboardingCommandHandler,
+)
+
+
+class _FakeUsers:
+    def __init__(self):
+        self.saved_profile = None
+
+    async def find_by_id(self, user_id):
+        return object()
+
+    async def get_profile(self, user_id):
+        return None
+
+    async def update_profile(self, profile):
+        self.saved_profile = profile
+
+
+class _FakeUow:
+    def __init__(self):
+        self.users = _FakeUsers()
+        self.committed = False
+        self.rolled_back = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        self.rolled_back = True
+
+
+@pytest.mark.asyncio
+async def test_onboarding_sets_goal_journey_baseline(monkeypatch):
+    fixed_now = datetime(2026, 6, 21, 1, 2, 3, tzinfo=UTC)
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.save_user_onboarding_command_handler.utc_now",
+        lambda: fixed_now,
+    )
+    uow = _FakeUow()
+    handler = SaveUserOnboardingCommandHandler(uow=uow)
+    user_id = str(UUID("11111111-1111-1111-1111-111111111111"))
+
+    await handler.handle(
+        SaveUserOnboardingCommand(
+            user_id=user_id,
+            age=30,
+            gender="male",
+            height_cm=180,
+            weight_kg=80,
+            target_weight_kg=75,
+            job_type="desk",
+            training_days_per_week=3,
+            training_minutes_per_session=45,
+            fitness_goal="cut",
+        )
+    )
+
+    assert uow.committed is True
+    assert uow.users.saved_profile.goal_start_weight_kg == 80
+    assert uow.users.saved_profile.goal_started_at == fixed_now

--- a/tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py
@@ -1,0 +1,95 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from src.app.handlers.query_handlers.get_journey_progress_query_handler import (
+    GetJourneyProgressQueryHandler,
+)
+from src.app.queries.progress import GetJourneyProgressQuery
+
+
+class _FakeUsers:
+    async def find_by_id(self, user_id):
+        return SimpleNamespace(timezone="Asia/Ho_Chi_Minh")
+
+    async def get_profile(self, user_id):
+        return SimpleNamespace(
+            fitness_goal="cut",
+            weight_kg=80.0,
+            target_weight_kg=75.0,
+            goal_start_weight_kg=None,
+            goal_started_at=None,
+            challenge_duration="30_days",
+            daily_water_goal_ml=2000,
+        )
+
+
+class _FakeMeals:
+    def __init__(self):
+        self.args = None
+
+    async def fetch_journey_progress_meals(self, user_id, start_utc, end_utc):
+        self.args = (user_id, start_utc, end_utc)
+        return [
+            {
+                "logged_at": start_utc,
+                "label": "Launch meal",
+                "calories": 400.0,
+                "protein_g": 20.0,
+            }
+        ]
+
+
+class _EmptyRepo:
+    async def fetch_journey_progress_hydration(self, *args):
+        return []
+
+    async def fetch_journey_progress_movements(self, *args):
+        return []
+
+    async def find_by_recorded_range(self, *args):
+        return []
+
+
+class _FakeUow:
+    def __init__(self):
+        self.users = _FakeUsers()
+        self.meals = _FakeMeals()
+        self.hydration_entries = _EmptyRepo()
+        self.movement_entries = _EmptyRepo()
+        self.weight_entries = _EmptyRepo()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_handler_uses_stable_existing_user_period_start():
+    uow = _FakeUow()
+    user_id = str(UUID("11111111-1111-1111-1111-111111111111"))
+    now = datetime(2026, 6, 22, 12, tzinfo=UTC)
+    handler = GetJourneyProgressQueryHandler(
+        uow=uow,
+        now_fn=lambda: now,
+        target_loader=lambda _: _targets(),
+    )
+
+    result = await handler.handle(GetJourneyProgressQuery(user_id=user_id))
+
+    assert result["period_start"] == "2026-06-20T17:00:00+00:00"
+    assert result["timeline_days"] == 30
+    assert result["latest_action"]["label"] == "Launch meal"
+    assert uow.meals.args == (
+        user_id,
+        datetime(2026, 6, 20, 17, tzinfo=UTC),
+        now,
+    )
+
+
+async def _targets():
+    return 400.0, 20.0


### PR DESCRIPTION
## Summary
- Add `GET /v1/progress/journey` as the backend-owned action journey snapshot.
- Count only actions inside the active period and clamp existing users to the feature start period.
- Add meal, hydration, movement, and weight action sources plus focused unit coverage.

## Test plan
- [x] `SENTRY_PROFILE_SESSION_SAMPLE_RATE=0 uv run --python 3.13 pytest tests/unit/domain/services/test_journey_progress_service.py tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py -q`
- [x] `uv run --python 3.13 ruff check ...focused journey progress files...`
- [x] `uv run --python 3.13 black --check ...focused journey progress files...`
- [x] `git diff --check origin/delivery...HEAD`
- [x] credential-pattern scan on PR diff