### PR TITLE
fix(ai): restore structured vision reliability

### DIFF
--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -416,4 +416,44 @@ Permanent failures (5 attempts exhausted) capture a Sentry error. Cron: `src/cro
 
 ---
 
+## AI Observability (Sentry + PostHog)
+
+### Operational metrics (Sentry)
+Primary dashboard for incident response and alerting.
+
+Metrics emitted via `src.observability`:
+- `ai.vision.request.count` — total image analysis requests (tags: status, ai_purpose)
+- `ai.vision.request.duration_ms` — end-to-end duration (distribution)
+- `ai.vision.provider.attempt.count` — per-provider attempt count
+- `ai.vision.provider.failure.count` — transient provider failures
+- `ai.vision.fallback.count` — provider fallbacks triggered
+- `ai.vision.parse_failure.count` — JSON parse failures
+- `ai.vision.schema_validation_failure.count` — schema validation failures
+- `ai.vision.request.failure.count` — all providers exhausted
+
+Recommended Sentry dashboard panels:
+- Success rate = `request.count{status=success}` / `request.count`
+- 503 rate = `request.failure.count` / `request.count`
+- p95 duration = `request.duration_ms` distribution p95
+- Parse/schema failure rate per provider
+
+Alert thresholds (starting points, tune after baseline):
+- 503 rate > 5% over 5 min → P1 alert
+- Parse/schema failure count > 10/min → investigate provider
+- p95 duration > 20s → latency regression
+
+### Cloudflare canary rollout gates
+Before making Cloudflare vision primary:
+1. Enable via env: `CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true`
+2. Monitor `schema_validation_failure.count{ai_provider=cloudflare-workers-ai}` vs Gemini baseline
+3. Compare `request.duration_ms` p95 vs Gemini
+4. Rollback: set `CLOUDFLARE_WORKERS_AI_VISION_ENABLED=false` — zero-downtime via env
+
+### LLM traces (PostHog)
+PostHog AI observability is wired via `src/api/main.py` LangChain OpenTelemetry integration.
+Use for: model latency trends, token costs, product funnel correlation.
+Do NOT use PostHog for operational failure alerts — use Sentry metrics.
+
+---
+
 See related: `system-architecture.md`, `database-guide.md`, `cqrs-guide.md`

--- a/plans/260623-0954-langchain-structured-vision-output/phase-01-schema-contract.md
+++ b/plans/260623-0954-langchain-structured-vision-output/phase-01-schema-contract.md
@@ -1,0 +1,94 @@
+---
+phase: 1
+title: "Schema Contract"
+status: pending
+priority: P1
+effort: "0.5 day"
+dependencies: []
+---
+
+# Phase 1: Schema Contract
+
+## Overview
+
+Lock the exact structured response contract before touching provider or retry code. Current `VisionAnalyzeResponse` validates foods/macros, but it omits `emoji`, `total_calories`, and per-food `calories` that the prompt asks for. That mismatch makes provider-native structured output harder and leaves raw-parser failures looking like model failures.
+
+## Context Links
+
+- `src/domain/parsers/vision_response_models.py`
+- `src/domain/services/prompts/system_prompts.py`
+- `src/domain/parsers/gpt_response_parser.py`
+- `tests/unit/domain/parsers/test_vision_response_models.py`
+- LangChain Google GenAI structured output docs
+- Gemini structured output docs
+
+## Key Insights
+
+- The model prompt requires `dish_name`, `emoji`, `foods`, `total_calories`, and `confidence`.
+- Existing schema only covers `dish_name`, `foods`, and `confidence`.
+- Backend calories remain source of truth. AI-provided calories can be accepted as optional evidence, but backend macro-derived calories remain the persisted/displayed truth.
+- `gpt_response_parser.py` currently consumes `structured_data`; provider output should normalize into that existing shape instead of changing the API route contract.
+
+## Requirements
+
+- Functional: schema must represent the full current prompt response shape.
+- Functional: zero or invalid quantity foods stay handled by existing validation policy.
+- Functional: normalized provider output must still feed the existing `parse_foods_from_response()` path.
+- Non-functional: schema must be Pydantic v2 compatible and usable by LangChain `with_structured_output`.
+- Non-functional: no API response shape change.
+
+## Architecture
+
+The schema lives in the domain parser layer because it describes the provider-independent AI contract. Infrastructure providers can import it for validation, but domain must not import LangChain or provider packages.
+
+## Related Code Files
+
+- Modify: `src/domain/parsers/vision_response_models.py`
+- Modify: `tests/unit/domain/parsers/test_vision_response_models.py`
+- Read: `src/domain/parsers/gpt_response_parser.py`
+- Read: `src/domain/services/prompts/system_prompts.py`
+
+## Implementation Steps
+
+### Tests Before
+
+1. Add schema tests for a complete meal scan payload with `emoji`, `total_calories`, per-food `calories`, and nested macros.
+2. Add a compatibility test for older payloads if current parser paths still tolerate missing optional fields.
+3. Add a zero-quantity food test to prove existing sanitizer remains intact.
+
+### Refactor
+
+1. Extend `FoodItemResponse` with optional or required `calories` based on downstream parser expectations.
+2. Extend `VisionAnalyzeResponse` with `emoji` and `total_calories`.
+3. Add a small normalization helper or method only if it keeps provider code from duplicating schema-to-dict behavior.
+4. Add field descriptions that help provider-native schema generation.
+5. Keep constraints realistic: `confidence` between 0 and 1 if adding bounds does not break current fixtures.
+6. Keep AI calories optional or advisory if required fields would break current fallback providers.
+
+### Tests After
+
+1. Run domain parser tests.
+2. Run focused GPT parser tests if they consume these fields.
+3. Confirm `model_json_schema()` is serializable.
+
+## Todo List
+
+- [ ] Decide required vs optional for `emoji`, `total_calories`, and item `calories` based on parser compatibility.
+- [ ] Add complete-response schema tests.
+- [ ] Update schema.
+- [ ] Verify serialization.
+
+## Success Criteria
+
+- [ ] `VisionAnalyzeResponse.model_json_schema()` includes every prompt-required field.
+- [ ] Provider-normalized output can still be wrapped as `{"structured_data": ...}` for existing parser/service code.
+- [ ] Existing valid vision payload tests still pass.
+- [ ] No provider or API files changed in this phase.
+
+## Risk Assessment
+
+Risk: making fields required can break fallback responses from older providers. Mitigation: start with optional fields if current downstream parsers tolerate absent values, then tighten only after regression data.
+
+## Security Considerations
+
+No new user input or secret handling. Do not add raw image, prompt, or raw AI response logging in tests or schema errors.

--- a/plans/260623-0954-langchain-structured-vision-output/phase-02-structured-provider-output.md
+++ b/plans/260623-0954-langchain-structured-vision-output/phase-02-structured-provider-output.md
@@ -1,0 +1,130 @@
+---
+phase: 2
+title: "Structured Provider Output"
+status: pending
+priority: P1
+effort: "1 day"
+dependencies: [1]
+---
+
+# Phase 2: Structured Provider Output
+
+## Overview
+
+Make provider calls schema-valid by default. Gemini vision should use LangChain/Gemini structured output before raw parsing. Cloudflare vision should be evaluated through the existing direct Workers AI REST path, not `langchain-cloudflare`, because the LangChain Cloudflare integration reports structured output support but no image input support.
+
+## Context Links
+
+- `src/infra/services/ai/providers/gemini_provider.py`
+- `src/infra/services/ai/gemini_model_manager.py`
+- `src/infra/services/ai/providers/cloudflare_workers_ai_provider.py`
+- `src/infra/adapters/vision_ai_service.py`
+- `src/infra/services/ai/ai_model_manager.py`
+- `tests/unit/infra/services/ai/providers/test_gemini_provider.py`
+- `tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py`
+- `tests/unit/infra/adapters/test_vision_ai_service.py`
+- LangChain `ChatGoogleGenerativeAI.with_structured_output(..., method="json_schema")`
+- Cloudflare Workers AI JSON mode docs
+
+## Key Insights
+
+- `GeminiProvider.generate()` already has a text structured-output path when `schema` is passed.
+- `GeminiProvider.generate_with_vision()` currently calls `llm.invoke(messages)` and parses raw text.
+- LangChain Google GenAI docs list both structured output and image input support. Docs recommend `method="json_schema"` because it uses Gemini native structured output.
+- Current code has a direct Cloudflare vision path with REST/image support. Do not undo it, but do require schema/JSON contract proof before Cloudflare is primary.
+- `langchain-cloudflare` is not the right image path unless its feature matrix changes; direct REST remains the Cloudflare path for this repo.
+
+## Requirements
+
+- Functional: meal image scans use structured output first.
+- Functional: image input format remains compatible with current LangChain message shape.
+- Functional: Cloudflare vision either returns schema-valid JSON or is treated as failed/degraded and falls through according to provider policy.
+- Functional: fallback chain behavior in `AIModelManager.generate_with_vision()` stays unchanged.
+- Non-functional: no new provider abstraction unless unavoidable.
+- Non-functional: no raw AI response logging.
+
+## Architecture
+
+Keep structured output and provider-specific contract handling inside providers. `VisionAIService` continues to call `AIModelManager.generate_with_vision()` and receives a dict. `AIModelManager` remains provider-agnostic, but it can classify a provider result as failed if validation fails.
+
+Proposed provider flow:
+
+```python
+llm = get_model_for_purpose(...)
+structured = llm.with_structured_output(
+    VisionAnalyzeResponse.model_json_schema(),
+    method="json_schema",
+)
+parsed = structured.invoke(messages)
+return normalize_to_dict(parsed)
+```
+
+If LangChain returns `parsed=None`, raises unsupported multimodal structured output, or returns a raw `AIMessage`, fall back to current `llm.invoke()` plus parser.
+
+Cloudflare provider flow:
+
+1. Send direct Workers AI vision request with explicit JSON/schema instructions.
+2. Use Cloudflare JSON mode only if the target model/API accepts it in real tests.
+3. Validate returned JSON with `VisionAnalyzeResponse`.
+4. On schema/parser failure, return a classified provider error for fallback instead of pretending success.
+
+## Related Code Files
+
+- Modify: `src/infra/services/ai/providers/gemini_provider.py`
+- Modify: `src/infra/services/ai/providers/cloudflare_workers_ai_provider.py`
+- Modify: `tests/unit/infra/services/ai/providers/test_gemini_provider.py`
+- Modify: `tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py`
+- Modify: `tests/unit/infra/adapters/test_vision_ai_service.py`
+- Read: `src/infra/services/ai/gemini_model_manager.py`
+- Read: `src/infra/services/ai/ai_model_manager.py`
+
+## Implementation Steps
+
+### Tests Before
+
+1. Add provider test: `generate_with_vision()` calls `with_structured_output(..., method="json_schema")` and returns parsed dict.
+2. Add provider test: Pydantic object result is converted with `model_dump()`.
+3. Add provider test: dict result is returned as dict.
+4. Add fallback test: structured output raises or returns no parsed value, raw content parser is used.
+5. Add Cloudflare test: valid JSON/schema returns normalized dict.
+6. Add Cloudflare test: non-JSON/object-literal/prose response is classified as schema or parse failure.
+7. Add manager test: `ModelPurpose.MEAL_SCAN` fallback chain behavior unchanged except failed validation can advance to the next provider.
+
+### Refactor
+
+1. Import `VisionAnalyzeResponse` into `GeminiProvider`.
+2. Extract helper to normalize LangChain structured output return shapes:
+   - Pydantic model
+   - dict
+   - `{"parsed": ...}` when `include_raw=True`
+3. Update `generate_with_vision()` to try structured output before raw parse.
+4. Keep `max_tokens`, `purpose_hint`, and message construction unchanged.
+5. Avoid cache changes; vision path does not currently use Gemini context cache.
+6. In Cloudflare provider, validate parsed response against `VisionAnalyzeResponse` before returning.
+7. Keep parser fallback shared through `ai_json_utils.extract_json()`; do not duplicate raw parser logic in providers.
+
+### Tests After
+
+1. Run provider tests.
+2. Run vision adapter tests.
+3. Run AI model manager tests for fallback chain.
+
+## Success Criteria
+
+- [ ] `generate_with_vision()` no longer relies on raw text parsing for the normal success path.
+- [ ] Cloudflare vision cannot return malformed text as successful provider output.
+- [ ] Fallback parser path is still covered by tests.
+- [ ] Existing `VisionAIService` API stays unchanged.
+- [ ] `uv run pytest tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/infra/services/ai/test_ai_model_manager.py -q` passes.
+
+## Risk Assessment
+
+Risk: LangChain structured output may not work with image messages for a specific installed version even if docs list both features. Mitigation: implement fallback and test both structured success and structured failure.
+
+Risk: `SystemMessage` handling with multimodal Gemini can be provider-sensitive. Current manager sets `convert_system_message_to_human=True`; keep current message structure unless tests prove it fails.
+
+Risk: Cloudflare JSON mode support may differ by model. Mitigation: make JSON mode/model support a live dry-run gate and keep prompt-only JSON plus validation as fallback.
+
+## Security Considerations
+
+No raw base64 images, image URLs, provider payloads, or prompt bodies in logs. Structured-output failures should log only provider, model, purpose, stage, and exception class.

--- a/plans/260623-0954-langchain-structured-vision-output/phase-03-retry-budget-and-failure-classification.md
+++ b/plans/260623-0954-langchain-structured-vision-output/phase-03-retry-budget-and-failure-classification.md
@@ -1,0 +1,110 @@
+---
+phase: 3
+title: "Retry Budget and Failure Classification"
+status: pending
+priority: P1
+effort: "1 day"
+dependencies: [2]
+---
+
+# Phase 3: Retry Budget and Failure Classification
+
+## Overview
+
+Replace blind whole-chain retries with failure-kind aware retry and fallback behavior. The current analyzer can retry the entire vision path, while `AIModelManager` also walks a provider chain. That can turn malformed JSON or schema drift into 30-38s user-visible failures.
+
+## Context Links
+
+- `src/infra/adapters/ai_json_utils.py`
+- `tests/unit/infra/adapters/test_ai_json_logging.py`
+- `src/infra/services/ai/ai_model_manager.py`
+- `src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py`
+- `src/domain/services/meal_analysis/fast_path_policy.py`
+- `src/infra/services/ai/gemini_model_manager.py`
+- `src/infra/config/settings.py`
+- `docs/code-standards.md`
+
+## Key Insights
+
+- Production logs show long 503s around 31-38s and occasional 200s around 24s.
+- `MEAL_ANALYZE_MAX_ATTEMPTS` retries the whole image analysis flow by default.
+- Provider fallback already tries multiple models. Outer retry should not repeat every provider for non-transient parse/schema failures.
+- Circuit breaker may not trip on parse failures when provider `extract_error_code()` returns no tripping code.
+
+## Requirements
+
+- Functional: classify failures as transient provider, timeout, rate limit, schema validation, JSON parse, no-food/low-confidence, or unknown.
+- Functional: retry transient/provider failures when budget remains.
+- Functional: do not retry the full chain for deterministic schema/parse failures from the same provider/model.
+- Functional: fallback to the next provider/model on schema/parse failure when another candidate remains.
+- Non-functional: enforce a bounded request wall-time target for image analysis.
+- Non-functional: preserve existing public API error semantics unless a current status mapping is clearly wrong.
+
+## Architecture
+
+Add a small failure classification boundary in infrastructure/application code, not domain entities. Provider adapters raise or return classified failures. `AIModelManager` uses classification to decide provider fallback and circuit-breaker recording. The upload handler uses classification and remaining time budget to decide whether an outer retry is worthwhile.
+
+Suggested behavior:
+
+| Failure kind | Same provider retry | Next provider fallback | Outer retry |
+|--------------|---------------------|------------------------|-------------|
+| timeout | no, unless budget remains | yes | maybe |
+| 429/5xx | no immediate same-model retry | yes | maybe |
+| schema validation | no | yes | no |
+| JSON parse | no | yes | no |
+| no food detected | no | no | no |
+| unknown | no | yes if available | no by default |
+
+## Related Code Files
+
+- Modify: `src/infra/services/ai/ai_model_manager.py`
+- Modify: `src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py`
+- Modify: `src/infra/services/ai/providers/gemini_provider.py`
+- Modify: `src/infra/services/ai/providers/cloudflare_workers_ai_provider.py`
+- Modify: `src/infra/adapters/ai_json_utils.py`
+- Modify: `tests/unit/infra/services/ai/test_ai_model_manager.py`
+- Modify: `tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py`
+
+## Implementation Steps
+
+### Tests Before
+
+1. Add manager test: schema/parse failure on Cloudflare falls through to Gemini without retrying Cloudflare.
+2. Add manager test: timeout/rate-limit failure records circuit breaker signal and falls through.
+3. Add handler test: parse/schema failure does not run the whole chain twice.
+4. Add handler test: transient timeout can retry only when remaining request budget is enough.
+5. Add handler test: final user-facing error maps to existing 503/analysis-unavailable path.
+
+### Refactor
+
+1. Define or reuse a small classified AI exception/result type with `kind`, `provider`, `model`, and safe `error_code`.
+2. Map provider exceptions and parser/schema exceptions to the classification.
+3. Update `AIModelManager.generate_with_vision()` to use classification for fallback and circuit-breaker decisions.
+4. Update upload handler outer retry to check classification and remaining wall-time budget.
+5. Keep `ai_json_utils.extract_json()` as the only raw text parser.
+6. Avoid adding sleeps/backoff that push image scans past current user tolerance.
+
+### Tests After
+
+1. Run model-manager tests.
+2. Run upload handler tests.
+3. Run provider tests.
+4. Run parser logging tests.
+
+## Success Criteria
+
+- [ ] Parse/schema failures do not trigger full-chain outer retry.
+- [ ] Transient failures can still fall back or retry within a clear budget.
+- [ ] Circuit-breaker metrics/failures include parse/schema failures when they affect provider reliability.
+- [ ] Long 503 behavior has a concrete maximum attempt/time budget.
+- [ ] Focused tests pass.
+
+## Risk Assessment
+
+Risk: reducing retries lowers occasional recovery rate. Mitigation: only remove retries for deterministic parse/schema/no-food failures; transient failures still use fallback/retry budget.
+
+Risk: too many new exception types. Mitigation: keep classification small and local to AI infrastructure/application handling.
+
+## Security Considerations
+
+Never log raw AI content, image bytes, base64, signed URLs, prompt text, Firebase claims, or user food descriptions.

--- a/plans/260623-0954-langchain-structured-vision-output/phase-04-ai-observability-dashboard-and-rollout.md
+++ b/plans/260623-0954-langchain-structured-vision-output/phase-04-ai-observability-dashboard-and-rollout.md
@@ -1,0 +1,132 @@
+---
+phase: 4
+title: "AI Observability Dashboard and Rollout"
+status: pending
+priority: P1
+effort: "1 day"
+dependencies: [2, 3]
+---
+
+# Phase 4: AI Observability Dashboard and Rollout
+
+## Overview
+
+Make image-analysis reliability visible in production. Use the existing `src.observability` facade and Sentry connector for operational logs, metrics, alerts, and dashboards. Keep PostHog for existing OpenTelemetry/LangChain AI analytics and product funnels.
+
+## Context Links
+
+- `src/observability.py`
+- `src/observability_connectors.py`
+- `src/infra/monitoring/sentry.py`
+- `src/infra/adapters/posthog_adapter.py`
+- `src/api/main.py`
+- `src/infra/services/ai/ai_model_manager.py`
+- `docs/external-services.md`
+- Sentry Python metrics/logs docs
+- PostHog AI observability docs
+
+## Key Insights
+
+- The repo already has Sentry logs/metrics support through `src.observability`; do not bypass it with direct SDK calls scattered across providers.
+- `observability_connectors.py` safe attribute allowlist lacks several AI-specific low-cardinality keys.
+- `src/api/main.py` already instruments LangChain with PostHog OpenTelemetry when `POSTHOG_API_KEY` is set.
+- The missing piece is operational AI reliability metrics by provider/model/failure kind and a rollout dashboard.
+
+## Requirements
+
+- Functional: emit metrics for request count, success/failure, provider attempt, provider latency, retry, fallback, parse failure, schema validation failure, timeout, and circuit open.
+- Functional: emit safe structured logs that can answer which provider/model/stage failed for a request.
+- Functional: document a Sentry dashboard/alert checklist and PostHog secondary analysis use.
+- Functional: define Cloudflare canary rollout gates based on schema-valid success rate and p95 duration.
+- Non-functional: all attributes must be low-cardinality and privacy-safe.
+- Non-functional: no raw model response, prompt, image URL, image bytes/base64, or user food text in logs/metrics.
+
+## Architecture
+
+Instrumentation locations:
+
+1. Upload handler: request-level duration, final status, attempt count.
+2. `AIModelManager`: provider attempt, fallback, circuit state, classified failure kind.
+3. Providers: provider latency, schema success/failure, parser fallback use.
+4. `ai_json_utils`: parse-failure counters with content-length bucket only.
+
+Dashboard source decision:
+
+- Primary: Sentry logs/metrics for incident response, alerts, and operational dashboard.
+- Secondary: PostHog AI observability for LangChain traces, model/cost trends, and product funnel correlation.
+
+## Related Code Files
+
+- Modify: `src/observability_connectors.py`
+- Modify: `src/infra/services/ai/ai_model_manager.py`
+- Modify: `src/infra/services/ai/providers/gemini_provider.py`
+- Modify: `src/infra/services/ai/providers/cloudflare_workers_ai_provider.py`
+- Modify: `src/infra/adapters/ai_json_utils.py`
+- Modify: `src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py`
+- Modify: `docs/external-services.md`
+- Modify: focused observability/provider tests
+
+## Implementation Steps
+
+### Tests Before
+
+1. Add tests that provider attempts emit metric/log calls with safe fields.
+2. Add tests that parse/schema failures emit counters without raw content.
+3. Add tests that allowlisted AI attributes survive sanitization and high-cardinality fields are dropped.
+4. Add tests that upload handler emits request-level duration/final status.
+
+### Metrics
+
+Emit these through `src.observability`:
+
+- `ai.vision.request.count`
+- `ai.vision.request.duration_ms`
+- `ai.vision.provider.attempt.count`
+- `ai.vision.provider.latency_ms`
+- `ai.vision.retry.count`
+- `ai.vision.fallback.count`
+- `ai.vision.parse_failure.count`
+- `ai.vision.schema_validation_failure.count`
+- `ai.vision.timeout.count`
+- `ai.vision.circuit_open.count`
+
+### Refactor
+
+1. Extend safe attribute allowlist with low-cardinality AI keys: `ai_provider`, `ai_model`, `ai_purpose`, `ai_stage`, `failure_kind`, `error_code`, `attempt_index`, `fallback_from`, `fallback_to`, `content_len_bucket`.
+2. Add metrics/log events at the four instrumentation locations.
+3. Bucket content lengths instead of emitting exact raw response size if cardinality becomes noisy.
+4. Add docs section with Sentry dashboard panels and alert thresholds.
+5. Add Cloudflare rollout gates:
+   - canary enabled by env only
+   - schema-valid success rate at or above Gemini baseline
+   - p95 request duration below agreed threshold
+   - parse/schema failure rate below alert threshold
+   - one-command rollback to Gemini-first/provider-disabled config
+
+### Tests After
+
+1. Run observability connector tests.
+2. Run AI model manager tests.
+3. Run provider tests.
+4. Run parser logging tests.
+5. Run docs/lint checks if docs changed.
+
+## Success Criteria
+
+- [ ] Sentry dashboard can show image-analysis success rate, 503 rate, p95/p99 duration, provider success rate, parse/schema failures, retries, fallbacks, and circuit opens.
+- [ ] PostHog remains wired for LLM traces/product correlation without replacing Sentry operational metrics.
+- [ ] All emitted attributes are allowlisted and privacy-safe.
+- [ ] Cloudflare primary routing requires canary evidence, not just model availability.
+- [ ] Docs explain where to look during a production image-analysis incident.
+
+## Risk Assessment
+
+Risk: dashboard metrics are too noisy or too expensive. Mitigation: emit counters/distributions at stage boundaries, not every internal helper; keep tag set small.
+
+Risk: exact model IDs create moderate cardinality. Mitigation: model set is controlled by config; keep raw response IDs/request IDs out of metric tags.
+
+Risk: PostHog and Sentry numbers disagree. Mitigation: define Sentry as source of truth for operational failure rate and PostHog as trace/product analysis.
+
+## Security Considerations
+
+Do not log raw AI content, image bytes/base64, signed URLs, prompts, Firebase claims, or food descriptions. Avoid user ID tags unless existing request context already hashes/sanitizes them.

--- a/plans/260623-0954-langchain-structured-vision-output/plan.md
+++ b/plans/260623-0954-langchain-structured-vision-output/plan.md
@@ -1,0 +1,68 @@
+---
+title: "Structured Vision Reliability, Retry Budgets, and AI Observability"
+description: "Rework meal image analysis around schema-valid provider success, bounded retry policy, Cloudflare/Gemini rollout gates, and Sentry/PostHog AI metrics."
+status: done
+priority: P1
+effort: "2-3 days"
+branch: "main"
+tags: [backend, ai, langchain, cloudflare, vision, reliability, observability]
+blockedBy: []
+blocks: []
+created: "2026-06-23T02:54:55.741Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Structured Vision Reliability, Retry Budgets, and AI Observability
+
+## Overview
+
+Make meal image analysis reliable enough for production traffic. Current logs show repeated `[JSON-EXTRACT-FAILED]` and 30-38s `503` responses because the normal success path still depends on raw model text, the outer meal analyzer can retry the whole provider chain, and observability does not cleanly answer which provider, model, retry, or validation stage failed.
+
+This plan changes the success contract: a provider call is successful only when output validates against the meal-vision schema and is normalized for the existing parser/service path. Raw JSON extraction becomes a last-resort fallback. Retry behavior becomes failure-kind aware and time-budgeted. Operational metrics go through the existing `src.observability` facade into Sentry logs/metrics; PostHog remains useful for existing LangChain/LLM traces and product analytics, not the primary alerting surface.
+
+Acceptance criteria:
+- Schema covers the prompt-required image response shape and preserves backend-derived calories as source of truth.
+- Gemini vision uses LangChain/Gemini structured output before raw parsing.
+- Cloudflare vision uses direct Workers AI REST only behind a contract/canary gate; do not rely on `langchain-cloudflare` for image input.
+- Retry policy separates transient provider failures, timeout, schema validation failure, parser failure, and no-food analysis.
+- Image analysis has Sentry-safe metrics/logs for request, provider attempt, latency, fallback, retry, timeout, parse failure, and validation failure.
+- Focused parser, provider, model-manager, vision-service, and route smoke tests pass with `uv run`.
+
+Mode: TDD-style hard plan. Reason: critical AI user flow, existing tests, provider behavior risk.
+
+Hard-mode decisions:
+- Sentry is the operational dashboard/alerting path because the repo already has `src.observability`, Sentry logs, and Sentry metrics wiring. Do not add a new dashboard dependency.
+- PostHog is kept for existing OpenTelemetry/LangChain AI analytics and product funnels. It can help with model latency/cost trends, but it should not own user-impacting error alerts.
+- Cloudflare-first production routing is allowed only after schema-valid canary data. Until then, prefer Gemini structured output as the reliability baseline and use Cloudflare as gated/canary or fallback per env policy.
+- Do not log raw model responses, prompts, image bytes/base64, image URLs, or user food descriptions.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Schema Contract](./phase-01-schema-contract.md) | Done |
+| 2 | [Structured Provider Output](./phase-02-structured-provider-output.md) | Done |
+| 3 | [Retry Budget and Failure Classification](./phase-03-retry-budget-and-failure-classification.md) | Done |
+| 4 | [AI Observability Dashboard and Rollout](./phase-04-ai-observability-dashboard-and-rollout.md) | Done |
+
+## Dependencies
+
+- No direct dependency on pending `260612-1046-service-initiated-bandwidth-reduction`; this plan touches AI provider parsing, not Cloudinary upload flow.
+- Must preserve current uncommitted parser-fallback work in `src/infra/adapters/ai_json_utils.py` and `tests/unit/infra/adapters/test_ai_json_logging.py`.
+- Must preserve current `AIProviderPort` and clean architecture direction: domain schema is provider-independent; infra owns LangChain, Cloudflare REST, Sentry, and PostHog.
+- External references:
+  - LangChain structured output: https://docs.langchain.com/oss/python/langchain/structured-output
+  - LangChain Google GenAI structured output: https://docs.langchain.com/oss/python/integrations/chat/google_generative_ai
+  - LangChain Cloudflare feature matrix: https://docs.langchain.com/oss/python/integrations/chat/cloudflare_workersai
+  - Cloudflare Workers AI JSON mode: https://developers.cloudflare.com/workers-ai/features/json-mode/
+  - Gemini structured output: https://ai.google.dev/gemini-api/docs/structured-output
+  - Sentry Python metrics: https://docs.sentry.io/platforms/python/metrics/
+  - PostHog AI observability: https://posthog.com/docs/ai-observability/installation/langgraph
+
+## Red-Team Review
+
+- Risk: schema-only output still returns plausible but wrong nutrition. Mitigation: schema validates shape only; existing downstream nutrition/macros validation and derived-calorie rules remain required.
+- Risk: retries improve success rate but worsen p95 latency. Mitigation: retry only transient/provider errors and enforce request-level wall-time budget.
+- Risk: Sentry metrics become high-cardinality or privacy-sensitive. Mitigation: add only allowlisted low-cardinality tags and content-length buckets, never raw content.
+- Risk: Cloudflare model is cheaper/faster but less schema-reliable. Mitigation: canary by env, compare schema-valid success rate and p95 before making it primary.

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -36,6 +36,8 @@ from src.domain.utils.timezone_utils import (
     utc_now,
 )
 from src.infra.config.settings import get_settings
+from src.domain.exceptions.ai_exceptions import AIVisionError, AIVisionFailureKind
+from src.observability import distribution_metric, increment_metric
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +105,18 @@ class UploadMealImageImmediatelyHandler(
                 return await self.vision_service.analyze(command.file_contents)
             except Exception as e:
                 last_error = e
+                # Deterministic failures (schema/parse/no-food) cannot be fixed by retrying
+                # the same provider chain — skip outer retry and surface immediately
+                if isinstance(e, AIVisionError) and e.kind in (
+                    AIVisionFailureKind.schema_validation,
+                    AIVisionFailureKind.json_parse,
+                    AIVisionFailureKind.no_food,
+                ):
+                    logger.warning(
+                        "[PHASE-1-NO-RETRY] meal=%s kind=%s attempt=%d/%d",
+                        meal_id, e.kind.value, attempt, max_attempts,
+                    )
+                    raise
                 logger.warning(
                     f"[PHASE-1-RETRY] meal={meal_id} | "
                     f"attempt={attempt}/{max_attempts} failed: {e}"
@@ -156,9 +170,23 @@ class UploadMealImageImmediatelyHandler(
             analysis_result = await self._run_vision_analysis(command, image_id)
         except Exception:
             # Image uploaded but analysis failed - acceptable orphan in Cloudinary
+            increment_metric(
+                "ai.vision.request.count",
+                attributes={"status": "failure", "ai_purpose": "meal_scan"},
+            )
             raise
 
         analysis_elapsed = time.time() - analysis_start
+        increment_metric(
+            "ai.vision.request.count",
+            attributes={"status": "success", "ai_purpose": "meal_scan"},
+        )
+        distribution_metric(
+            "ai.vision.request.duration_ms",
+            analysis_elapsed * 1000,
+            unit="millisecond",
+            attributes={"ai_purpose": "meal_scan", "status": "success"},
+        )
         logger.info(
             f"[ANALYSIS-COMPLETE] image_id={image_id} | elapsed={analysis_elapsed:.2f}s"
         )

--- a/src/domain/exceptions/ai_exceptions.py
+++ b/src/domain/exceptions/ai_exceptions.py
@@ -1,6 +1,39 @@
 """AI-related exception classes for resilience layer."""
 
+from enum import Enum
 from typing import Any
+
+
+class AIVisionFailureKind(Enum):
+    """Classified failure reason for a vision provider call."""
+
+    transient = "transient"
+    timeout = "timeout"
+    rate_limit = "rate_limit"
+    schema_validation = "schema_validation"
+    json_parse = "json_parse"
+    no_food = "no_food"
+    unknown = "unknown"
+
+
+class AIVisionError(Exception):
+    """Raised by vision providers with a classified failure kind.
+
+    Schema/parse kinds must NOT trip the circuit breaker — they are deterministic
+    failures that retrying on the same model cannot fix.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        kind: AIVisionFailureKind,
+        provider: str = "",
+        model: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.provider = provider
+        self.model = model
 
 
 class AIError(Exception):

--- a/src/domain/parsers/vision_response_models.py
+++ b/src/domain/parsers/vision_response_models.py
@@ -22,6 +22,9 @@ class FoodItemResponse(BaseModel):
     )
     unit: str = Field(..., description="Unit of measurement")
     macros: MacrosResponse = Field(..., description="Macronutrient breakdown")
+    calories: float | None = Field(
+        None, ge=0, description="Calories for this food item (advisory; backend derives from macros)"
+    )
 
 
 class VisionAnalyzeResponse(BaseModel):
@@ -32,6 +35,10 @@ class VisionAnalyzeResponse(BaseModel):
     """
 
     dish_name: str | None = Field(None, description="Dish name")
+    emoji: str | None = Field(None, description="Dish emoji identifier")
+    total_calories: float | None = Field(
+        None, ge=0, description="Total calories for the meal (advisory; backend re-derives from macros)"
+    )
     is_food: bool = Field(True, description="Whether the image contains edible food")
     foods: list[FoodItemResponse] | None = Field(
         None, max_length=8, description="List of foods"

--- a/src/infra/ai/json_extract.py
+++ b/src/infra/ai/json_extract.py
@@ -97,6 +97,11 @@ def extract_json(content: str) -> dict[str, Any]:
     logger.error(
         "[JSON-EXTRACT-FAILED] all attempts failed content_len=%d", len(content)
     )
+    from src.observability import increment_metric  # noqa: PLC0415
+    increment_metric(
+        "ai.vision.parse_failure.count",
+        attributes={"content_len_bucket": _content_len_bucket(len(content))},
+    )
     raise ValueError(
         "Could not extract valid JSON from AI response. "
         "Please try again or use a clearer image."
@@ -106,6 +111,17 @@ def extract_json(content: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Internal helpers (not part of public API)
 # ---------------------------------------------------------------------------
+
+
+def _content_len_bucket(n: int) -> str:
+    """Map content byte length to a low-cardinality bucket label for metrics."""
+    if n < 100:
+        return "0-100"
+    if n < 500:
+        return "100-500"
+    if n < 2000:
+        return "500-2000"
+    return "2000+"
 
 
 def _clean_json(content: str) -> str:

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -7,12 +7,13 @@ from typing import Any, Optional
 
 from src.domain.exceptions.ai_exceptions import AIUnavailableError
 from src.domain.ports.ai_provider_port import AICapability
+from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 from src.infra.services.ai.provider_circuit_breaker import ProviderCircuitBreaker
 from src.infra.services.ai.providers.cloudflare_workers_ai_provider import (
     CloudflareWorkersAIProvider,
 )
 from src.infra.services.ai.providers.gemini_provider import GeminiProvider
-from src.observability import log_event
+from src.observability import distribution_metric, increment_metric, log_event
 
 logger = logging.getLogger(__name__)
 
@@ -343,6 +344,14 @@ class AIModelManager:
                 continue
 
             attempted.append(model)
+            increment_metric(
+                "ai.vision.provider.attempt.count",
+                attributes={
+                    "ai_provider": provider.provider_name,
+                    "ai_model": model,
+                    "ai_purpose": purpose.value,
+                },
+            )
 
             try:
                 result = await provider.generate_with_vision(
@@ -355,15 +364,81 @@ class AIModelManager:
                 )
 
                 self._circuit_breaker.record_success(model)
+
+                if len(attempted) >= 2:
+                    # This model is not the first in the chain — a fallback occurred
+                    increment_metric(
+                        "ai.vision.fallback.count",
+                        attributes={
+                            "ai_purpose": purpose.value,
+                            "fallback_from": attempted[-2],
+                            "fallback_to": model,
+                        },
+                    )
+
                 return result
 
             except Exception as e:
                 last_error = str(e)
-                error_code = provider.extract_error_code(e)
 
+                if isinstance(e, AIVisionError) and e.kind in (
+                    AIVisionFailureKind.schema_validation,
+                    AIVisionFailureKind.json_parse,
+                ):
+                    # Deterministic failure — schema/parse errors won't fix with same model;
+                    # skip circuit breaker recording and advance to next provider
+                    logger.warning(
+                        "[AI-VISION-SCHEMA-FAIL] purpose=%s model=%s kind=%s",
+                        purpose.value, model, e.kind.value,
+                    )
+                    metric_name = (
+                        "ai.vision.schema_validation_failure.count"
+                        if e.kind == AIVisionFailureKind.schema_validation
+                        else "ai.vision.parse_failure.count"
+                    )
+                    increment_metric(
+                        metric_name,
+                        attributes={
+                            "ai_provider": e.provider,
+                            "ai_model": model,
+                            "ai_purpose": purpose.value,
+                            "failure_kind": e.kind.value,
+                        },
+                    )
+                    log_event(
+                        "warning",
+                        "ai.vision.classified_failure",
+                        attributes={
+                            "ai_provider": e.provider,
+                            "ai_model": model,
+                            "ai_purpose": purpose.value,
+                            "ai_stage": "provider_call",
+                            "failure_kind": e.kind.value,
+                        },
+                    )
+                    continue
+
+                # Transient/unknown — use circuit breaker as before
+                error_code = provider.extract_error_code(e)
                 if self._circuit_breaker.should_trip(error_code):
                     self._circuit_breaker.record_failure(model)
+                increment_metric(
+                    "ai.vision.provider.failure.count",
+                    attributes={
+                        "ai_provider": provider.provider_name,
+                        "ai_model": model,
+                        "ai_purpose": purpose.value,
+                    },
+                )
+                logger.warning(
+                    "[AI-ATTEMPT-FAILED] purpose=%s model=%s error=%s",
+                    purpose.value, model, last_error[:100],
+                )
 
+        increment_metric(
+            "ai.vision.request.failure.count",
+            attributes={"ai_purpose": purpose.value, "attempt_count": len(attempted)},
+        )
         log_event("warning", "ai.provider.failure", attributes={"component": "ai_model_manager", "attempt_count": len(attempted)})
         raise AIUnavailableError(
             f"All vision models failed for {purpose.value}",

--- a/src/infra/services/ai/ai_vision_errors.py
+++ b/src/infra/services/ai/ai_vision_errors.py
@@ -1,0 +1,10 @@
+"""
+Vision error types for the infra AI layer.
+
+Shim: canonical definitions live in the domain layer so the app layer can import
+them without crossing the app→infra boundary.
+"""
+
+from src.domain.exceptions.ai_exceptions import AIVisionError, AIVisionFailureKind
+
+__all__ = ["AIVisionError", "AIVisionFailureKind"]

--- a/src/infra/services/ai/providers/cloudflare_workers_ai_provider.py
+++ b/src/infra/services/ai/providers/cloudflare_workers_ai_provider.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from src.domain.ports.ai_provider_port import AICapability, AIProviderPort
 from src.infra.adapters.ai_json_utils import extract_json as extract_ai_json
+from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +179,10 @@ class CloudflareWorkersAIProvider(AIProviderPort):
         system_message: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Send image to Workers AI REST endpoint and return parsed dict."""
+        """Send image to Workers AI REST endpoint and return schema-validated dict."""
+        from pydantic import ValidationError as PydanticValidationError
+        from src.domain.parsers.vision_response_models import VisionAnalyzeResponse
+
         if not self._vision_enabled:
             raise NotImplementedError(
                 "CloudflareWorkersAIProvider: vision not configured. "
@@ -196,7 +200,28 @@ class CloudflareWorkersAIProvider(AIProviderPort):
             )
 
         logger.debug("[CF-WORKERS-AI-VISION-SUCCESS] model=%s", model)
-        return extract_ai_json(text)
+
+        try:
+            parsed = extract_ai_json(text)
+        except ValueError as exc:
+            raise AIVisionError(
+                f"[CF-WORKERS-AI-VISION-PARSE-FAIL] provider=cloudflare-workers-ai model={model}",
+                kind=AIVisionFailureKind.json_parse,
+                provider="cloudflare-workers-ai",
+                model=model,
+            ) from exc
+
+        # Validate against schema — return normalized dict or raise classified error
+        try:
+            validated = VisionAnalyzeResponse.model_validate(parsed)
+            return validated.model_dump()
+        except PydanticValidationError as exc:
+            raise AIVisionError(
+                f"[CF-WORKERS-AI-VISION-SCHEMA-FAIL] provider=cloudflare-workers-ai model={model}",
+                kind=AIVisionFailureKind.schema_validation,
+                provider="cloudflare-workers-ai",
+                model=model,
+            ) from exc
 
     def extract_error_code(self, error: Exception) -> int | str | None:
         """Extract HTTP status code or 'timeout' from httpx exceptions bubbled through LangChain."""

--- a/src/infra/services/ai/providers/gemini_provider.py
+++ b/src/infra/services/ai/providers/gemini_provider.py
@@ -10,6 +10,7 @@ from src.domain.ports.ai_provider_port import AICapability, AIProviderPort
 from src.infra.adapters.ai_json_utils import (
     extract_json as extract_ai_json,
 )
+from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 from src.infra.services.ai.gemini_model_config import GeminiModelPurpose
 from src.infra.services.ai.gemini_model_manager import GeminiModelManager
 
@@ -128,11 +129,12 @@ class GeminiProvider(AIProviderPort):
         prompt: str,
         image_data: bytes,
         system_message: str | None = None,
-        purpose_hint: str | None = None,   # NEW
+        purpose_hint: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Generate with image input."""
+        """Generate with image input, using structured output first."""
         import base64
+        from src.domain.parsers.vision_response_models import VisionAnalyzeResponse
 
         if purpose_hint is not None:
             purpose = _PURPOSE_HINT_MAP.get(purpose_hint, GeminiModelPurpose.GENERAL)
@@ -151,7 +153,6 @@ class GeminiProvider(AIProviderPort):
         messages = []
         if system_message:
             messages.append(SystemMessage(content=system_message))
-
         messages.append(
             HumanMessage(
                 content=[
@@ -161,8 +162,34 @@ class GeminiProvider(AIProviderPort):
             )
         )
 
+        # Try structured output first
+        try:
+            structured_llm = llm.with_structured_output(
+                VisionAnalyzeResponse.model_json_schema(),
+                method="json_schema",
+                include_raw=True,
+            )
+            result = await asyncio.to_thread(structured_llm.invoke, messages)
+            parsed = result.get("parsed") if isinstance(result, dict) else result
+            if parsed is not None:
+                if hasattr(parsed, "model_dump"):
+                    return parsed.model_dump()
+                if isinstance(parsed, dict):
+                    return parsed
+        except Exception:
+            logger.debug("[GEMINI-VISION-STRUCTURED-FALLBACK] model=%s", model)
+
+        # Fallback to raw text parse
         response = await asyncio.to_thread(llm.invoke, messages)
-        return self._extract_json(response.content)
+        try:
+            return self._extract_json(response.content)
+        except ValueError as exc:
+            raise AIVisionError(
+                f"[GEMINI-VISION-PARSE-FAIL] provider=gemini model={model}",
+                kind=AIVisionFailureKind.json_parse,
+                provider="gemini",
+                model=model,
+            ) from exc
 
     def extract_error_code(self, error: Exception) -> int | str | None:
         """Extract status code or error type from exception."""

--- a/src/observability_connectors.py
+++ b/src/observability_connectors.py
@@ -27,6 +27,17 @@ SAFE_CONTEXT_KEYS = frozenset(
         "result",
         "phase",
         "provider",
+        # AI observability — low-cardinality provider/model routing attributes
+        "ai_provider",       # e.g. "gemini", "cloudflare-workers-ai"
+        "ai_model",          # e.g. "gemini-3.1-flash-lite"
+        "ai_purpose",        # e.g. "meal_scan"
+        "ai_stage",          # e.g. "structured_output", "raw_parse", "schema_validation"
+        "failure_kind",      # AIVisionFailureKind.value
+        "attempt_index",     # int: which attempt in the chain
+        "fallback_from",     # model that failed before fallback
+        "fallback_to",       # model now being tried
+        "content_len_bucket",  # e.g. "0-100", "100-500", "500-2000", "2000+"
+        "error_code",        # numeric/string error code (context only, not a tag)
     }
 )
 
@@ -45,6 +56,14 @@ SAFE_TAG_KEYS = frozenset(
         "status",
         "result",
         "provider",
+        # AI observability — suitable as low-cardinality provider tags
+        "ai_provider",
+        "ai_model",
+        "ai_purpose",
+        "ai_stage",
+        "failure_kind",
+        "fallback_from",
+        "fallback_to",
     }
 )
 

--- a/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
+++ b/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
@@ -1,0 +1,131 @@
+"""Tests for UploadMealImageImmediatelyHandler — focusing on retry/fallback routing."""
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
+
+
+def _make_command():
+    from src.app.commands.meal import UploadMealImageImmediatelyCommand
+
+    cmd = Mock(spec=UploadMealImageImmediatelyCommand)
+    cmd.file_contents = b"fake_image_bytes"
+    cmd.content_type = "image/jpeg"
+    cmd.user_id = "user-123"
+    cmd.user_description = None
+    cmd.target_date = None
+    cmd.language = None
+    return cmd
+
+
+def _make_fast_path_policy(max_attempts: int = 3):
+    policy = Mock()
+    policy.max_attempts = max_attempts
+    return policy
+
+
+def _make_handler(vision_analyze_mock, max_attempts: int = 3):
+    """Build a handler wired with a mocked vision service."""
+    from src.app.handlers.command_handlers.upload_meal_image_immediately_command_handler import (
+        UploadMealImageImmediatelyHandler,
+    )
+
+    vision_service = Mock()
+    vision_service.analyze = vision_analyze_mock
+
+    handler = UploadMealImageImmediatelyHandler(
+        uow=Mock(),
+        event_bus=Mock(),
+        image_store=Mock(),
+        vision_service=vision_service,
+        gpt_parser=Mock(),
+        meal_translation_service=None,
+        fast_path_policy=_make_fast_path_policy(max_attempts),
+        cache_invalidation=None,
+    )
+    return handler
+
+
+class TestVisionRetryRouting:
+    """Phase 3: upload handler skips outer retry for deterministic vision failures."""
+
+    @pytest.mark.asyncio
+    async def test_vision_schema_fail_does_not_outer_retry(self):
+        """Schema validation failure is raised immediately — analyze called exactly once."""
+        schema_error = AIVisionError(
+            "[CF-WORKERS-AI-VISION-SCHEMA-FAIL] provider=cloudflare-workers-ai model=test",
+            kind=AIVisionFailureKind.schema_validation,
+            provider="cloudflare-workers-ai",
+            model="test",
+        )
+        analyze_mock = AsyncMock(side_effect=schema_error)
+        handler = _make_handler(analyze_mock, max_attempts=3)
+
+        with pytest.raises(AIVisionError) as exc_info:
+            await handler._run_vision_analysis(_make_command(), meal_id="meal-abc")
+
+        assert exc_info.value.kind == AIVisionFailureKind.schema_validation
+        # Only called once — no outer retry attempted
+        analyze_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_vision_json_parse_fail_does_not_outer_retry(self):
+        """JSON parse failure is raised immediately — analyze called exactly once."""
+        parse_error = AIVisionError(
+            "[CF-WORKERS-AI-VISION-PARSE-FAIL] provider=cloudflare-workers-ai model=test",
+            kind=AIVisionFailureKind.json_parse,
+            provider="cloudflare-workers-ai",
+            model="test",
+        )
+        analyze_mock = AsyncMock(side_effect=parse_error)
+        handler = _make_handler(analyze_mock, max_attempts=3)
+
+        with pytest.raises(AIVisionError) as exc_info:
+            await handler._run_vision_analysis(_make_command(), meal_id="meal-abc")
+
+        assert exc_info.value.kind == AIVisionFailureKind.json_parse
+        analyze_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_vision_no_food_fail_does_not_outer_retry(self):
+        """no_food failure is raised immediately — analyze called exactly once."""
+        no_food_error = AIVisionError(
+            "No food detected",
+            kind=AIVisionFailureKind.no_food,
+            provider="gemini",
+            model="gemini-3.1-flash-lite",
+        )
+        analyze_mock = AsyncMock(side_effect=no_food_error)
+        handler = _make_handler(analyze_mock, max_attempts=3)
+
+        with pytest.raises(AIVisionError) as exc_info:
+            await handler._run_vision_analysis(_make_command(), meal_id="meal-abc")
+
+        assert exc_info.value.kind == AIVisionFailureKind.no_food
+        analyze_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_vision_transient_fail_triggers_outer_retry(self):
+        """Plain Exception (transient) causes outer retry — analyze called twice when first fails."""
+        analysis_result = {"food_items": [{"name": "apple"}]}
+        analyze_mock = AsyncMock(
+            side_effect=[Exception("503 Service Unavailable"), analysis_result]
+        )
+        handler = _make_handler(analyze_mock, max_attempts=3)
+
+        result = await handler._run_vision_analysis(_make_command(), meal_id="meal-abc")
+
+        assert result == analysis_result
+        assert analyze_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_vision_transient_fail_exhausts_max_attempts_and_raises(self):
+        """Transient failure on all attempts raises the last exception after max_attempts."""
+        analyze_mock = AsyncMock(side_effect=Exception("persistent 503"))
+        handler = _make_handler(analyze_mock, max_attempts=2)
+
+        with pytest.raises(Exception, match="persistent 503"):
+            await handler._run_vision_analysis(_make_command(), meal_id="meal-abc")
+
+        assert analyze_mock.await_count == 2

--- a/tests/unit/domain/parsers/test_vision_response_models.py
+++ b/tests/unit/domain/parsers/test_vision_response_models.py
@@ -286,3 +286,70 @@ def test_all_zero_quantity_foods_fails_validation():
 
     with pytest.raises(ValidationError):
         VisionAnalyzeResponse.model_validate(payload)
+
+
+def test_full_prompt_response_with_emoji_and_calories():
+    """Complete response including all prompt-required fields."""
+    payload = {
+        "dish_name": "Pho Bo",
+        "emoji": "🍜",
+        "total_calories": 520,
+        "foods": [
+            {
+                "name": "Rice noodles",
+                "quantity": 200,
+                "unit": "g",
+                "calories": 210,
+                "macros": {"protein": 4, "carbs": 48, "fat": 1},
+            },
+            {
+                "name": "Beef slices",
+                "quantity": 100,
+                "unit": "g",
+                "calories": 200,
+                "macros": {"protein": 26, "carbs": 0, "fat": 10},
+            },
+        ],
+        "confidence": 0.88,
+    }
+    result = VisionAnalyzeResponse.model_validate(payload)
+    assert result.emoji == "🍜"
+    assert result.total_calories == pytest.approx(520)
+    assert result.foods[0].calories == pytest.approx(210)
+    assert result.foods[1].calories == pytest.approx(200)
+
+
+def test_legacy_payload_without_emoji_or_total_calories():
+    """Existing responses without new optional fields must still validate."""
+    payload = {
+        "dish_name": "Rice",
+        "foods": [{"name": "Rice", "quantity": 100, "unit": "g", "macros": {"protein": 3, "carbs": 28, "fat": 0}}],
+        "confidence": 0.9,
+    }
+    result = VisionAnalyzeResponse.model_validate(payload)
+    assert result.emoji is None
+    assert result.total_calories is None
+    assert result.foods[0].calories is None
+
+
+def test_schema_is_json_serializable():
+    """model_json_schema() must return a dict with all prompt-required fields."""
+    schema = VisionAnalyzeResponse.model_json_schema()
+    assert isinstance(schema, dict)
+    assert "dish_name" in schema.get("properties", {})
+    assert "emoji" in schema.get("properties", {})
+    assert "total_calories" in schema.get("properties", {})
+    assert "confidence" in schema.get("properties", {})
+
+
+def test_food_item_calories_is_optional():
+    """calories field on FoodItemResponse is optional."""
+    payload = {
+        "name": "Apple",
+        "quantity": 150,
+        "unit": "g",
+        "macros": {"protein": 0, "carbs": 20, "fat": 0},
+    }
+    from src.domain.parsers.vision_response_models import FoodItemResponse
+    item = FoodItemResponse.model_validate(payload)
+    assert item.calories is None

--- a/tests/unit/infra/adapters/test_ai_json_logging.py
+++ b/tests/unit/infra/adapters/test_ai_json_logging.py
@@ -1,4 +1,6 @@
-"""Regression tests for AI JSON parser log redaction."""
+"""Regression tests for AI JSON parser log redaction and observability metrics."""
+
+from unittest.mock import patch
 
 import pytest
 
@@ -6,6 +8,7 @@ from src.app.handlers.command_handlers.meal_text_parsing_utils import (
     extract_json_from_response,
 )
 from src.infra.adapters.ai_json_utils import extract_json
+from src.observability_connectors import SAFE_CONTEXT_KEYS, SAFE_TAG_KEYS
 
 
 def test_shared_ai_json_extractor_does_not_log_raw_response(caplog):
@@ -28,3 +31,38 @@ def test_meal_text_json_extractor_does_not_log_raw_response(caplog):
     assert raw_response not in caplog.text
     assert "user@example.com" not in caplog.text
     assert "length=" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Observability allowlist tests
+# ---------------------------------------------------------------------------
+
+
+def test_ai_safe_context_keys_include_ai_fields():
+    """AI observability keys must be in SAFE_CONTEXT_KEYS so they pass the filter."""
+    required = {"ai_provider", "ai_model", "ai_purpose", "failure_kind"}
+    assert required <= SAFE_CONTEXT_KEYS, (
+        f"Missing from SAFE_CONTEXT_KEYS: {required - SAFE_CONTEXT_KEYS}"
+    )
+
+
+def test_ai_safe_tag_keys_include_ai_fields():
+    """AI observability keys must be in SAFE_TAG_KEYS so they can be used as provider tags."""
+    required = {"ai_provider", "ai_model", "ai_purpose", "failure_kind"}
+    assert required <= SAFE_TAG_KEYS, (
+        f"Missing from SAFE_TAG_KEYS: {required - SAFE_TAG_KEYS}"
+    )
+
+
+def test_parse_failure_emits_metric():
+    """extract_json() must emit ai.vision.parse_failure.count when all parse attempts fail."""
+    invalid_content = "this is not json at all !!!"
+
+    with patch("src.observability.increment_metric") as mock_metric:
+        with pytest.raises(ValueError):
+            extract_json(invalid_content)
+
+    emitted_names = [call.args[0] for call in mock_metric.call_args_list]
+    assert "ai.vision.parse_failure.count" in emitted_names, (
+        f"Expected 'ai.vision.parse_failure.count' in emitted metrics, got: {emitted_names}"
+    )

--- a/tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py
+++ b/tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py
@@ -298,11 +298,16 @@ class TestGenerateWithVision:
 
     @pytest.mark.asyncio
     async def test_generate_with_vision_success(self, provider_with_vision):
-        """Vision-enabled provider calls REST and returns parsed dict."""
+        """Vision-enabled provider calls REST and returns schema-validated dict."""
         from unittest.mock import AsyncMock, Mock, patch
 
+        valid_json = (
+            '{"dish_name": "Salad", "confidence": 0.9, "foods": ['
+            '{"name": "Lettuce", "quantity": 100, "unit": "g",'
+            ' "macros": {"protein": 1.0, "carbs": 2.0, "fat": 0.2}}]}'
+        )
         mock_resp = Mock()
-        mock_resp.json.return_value = {"result": {"response": '{"meal": "salad", "calories": 100}'}}
+        mock_resp.json.return_value = {"result": {"response": valid_json}}
         mock_resp.raise_for_status = Mock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -320,7 +325,7 @@ class TestGenerateWithVision:
             )
 
         assert isinstance(result, dict)
-        assert result.get("meal") == "salad"
+        assert result.get("dish_name") == "Salad"
 
     @pytest.mark.asyncio
     async def test_generate_with_vision_empty_response_raises(self, provider_with_vision):
@@ -394,8 +399,10 @@ class TestGenerateWithVision:
 
     @pytest.mark.asyncio
     async def test_generate_with_vision_malformed_json_raises(self, provider_with_vision):
-        """Malformed JSON in response raises ValueError."""
+        """Malformed JSON in response raises AIVisionError with json_parse kind."""
         from unittest.mock import AsyncMock, Mock, patch
+
+        from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 
         mock_resp = Mock()
         mock_resp.json.return_value = {"result": {"response": "not valid json {{{"}}
@@ -408,12 +415,14 @@ class TestGenerateWithVision:
             mock_client.post = AsyncMock(return_value=mock_resp)
             mock_client_cls.return_value = mock_client
 
-            with pytest.raises(ValueError):
+            with pytest.raises(AIVisionError) as exc_info:
                 await provider_with_vision.generate_with_vision(
                     model="@cf/google/gemma-4-26b-a4b-it",
                     prompt="test",
                     image_data=b"img",
                 )
+            assert exc_info.value.kind == AIVisionFailureKind.json_parse
+            assert exc_info.value.provider == "cloudflare-workers-ai"
 
     def test_build_vision_payload_shape(self, provider_with_vision):
         """Vision payload has expected structure with image_url content."""
@@ -443,6 +452,60 @@ class TestGenerateWithVision:
         """Normalizes result.response format."""
         raw = {"result": {"response": "hello"}}
         assert provider_with_vision._extract_response_text(raw) == "hello"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_returns_schema_valid_dict(self, provider_with_vision):
+        """Valid JSON response is validated against VisionAnalyzeResponse and returned as dict."""
+        from unittest.mock import AsyncMock, patch
+
+        valid_json = (
+            '{"dish_name": "Salad", "confidence": 0.95, "foods": ['
+            '{"name": "Lettuce", "quantity": 100, "unit": "g",'
+            ' "macros": {"protein": 1.0, "carbs": 2.0, "fat": 0.2}}]}'
+        )
+
+        with patch.object(
+            provider_with_vision,
+            "_post_workers_ai",
+            new=AsyncMock(return_value={"result": {"response": valid_json}}),
+        ):
+            result = await provider_with_vision.generate_with_vision(
+                model="@cf/google/gemma-4-26b-a4b-it",
+                prompt="analyze",
+                image_data=b"fake",
+            )
+
+        assert isinstance(result, dict)
+        assert result["dish_name"] == "Salad"
+        assert result["confidence"] == 0.95
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_raises_on_schema_failure(self, provider_with_vision):
+        """Response that fails VisionAnalyzeResponse validation raises AIVisionError with schema_validation kind."""
+        from unittest.mock import AsyncMock, patch
+
+        from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
+
+        # macros is required per schema — missing it triggers PydanticValidationError
+        invalid_json = (
+            '{"dish_name": "Salad", "confidence": 0.9, "foods": ['
+            '{"name": "Lettuce", "quantity": 100, "unit": "g"}]}'
+        )
+
+        with patch.object(
+            provider_with_vision,
+            "_post_workers_ai",
+            new=AsyncMock(return_value={"result": {"response": invalid_json}}),
+        ):
+            with pytest.raises(AIVisionError) as exc_info:
+                await provider_with_vision.generate_with_vision(
+                    model="@cf/google/gemma-4-26b-a4b-it",
+                    prompt="analyze",
+                    image_data=b"fake",
+                )
+            assert exc_info.value.kind == AIVisionFailureKind.schema_validation
+            assert "SCHEMA-FAIL" in str(exc_info.value)
+            assert exc_info.value.provider == "cloudflare-workers-ai"
 
     def test_no_secrets_in_vision_error_messages(self, provider_with_vision):
         """generate_with_vision NotImplementedError must not expose the api token."""

--- a/tests/unit/infra/services/ai/providers/test_gemini_provider.py
+++ b/tests/unit/infra/services/ai/providers/test_gemini_provider.py
@@ -136,6 +136,7 @@ class TestGenerateWithVision:
     ):
         mock_llm = Mock()
         mock_llm.invoke = Mock(return_value=Mock(content='{"result": "ok"}'))
+        mock_llm.with_structured_output = Mock(side_effect=NotImplementedError)
         mock_model_manager.get_model_for_purpose.return_value = mock_llm
 
         await provider.generate_with_vision(
@@ -148,6 +149,73 @@ class TestGenerateWithVision:
 
         call_kwargs = mock_model_manager.get_model_for_purpose.call_args[1]
         assert call_kwargs["model_name"] == "gemini-3.1-flash-lite"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_uses_structured_output_first(
+        self, provider, mock_model_manager
+    ):
+        from src.domain.parsers.vision_response_models import VisionAnalyzeResponse
+
+        parsed_instance = VisionAnalyzeResponse(dish_name="Bowl", foods=[], confidence=0.9)
+        structured_chain = Mock()
+        structured_chain.invoke = Mock(return_value={"parsed": parsed_instance})
+
+        mock_llm = Mock()
+        mock_llm.with_structured_output = Mock(return_value=structured_chain)
+        mock_model_manager.get_model_for_purpose.return_value = mock_llm
+
+        result = await provider.generate_with_vision(
+            model="gemini-2.5-flash",
+            prompt="analyze this",
+            image_data=b"fake-image",
+        )
+
+        assert isinstance(result, dict)
+        assert result["dish_name"] == "Bowl"
+        # raw llm.invoke should NOT have been called
+        mock_llm.invoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_falls_back_to_raw_parse(
+        self, provider, mock_model_manager
+    ):
+        mock_llm = Mock()
+        mock_llm.with_structured_output = Mock(side_effect=NotImplementedError("unsupported"))
+        mock_llm.invoke = Mock(return_value=Mock(content='{"dish_name": "Rice", "confidence": 0.8}'))
+        mock_model_manager.get_model_for_purpose.return_value = mock_llm
+
+        result = await provider.generate_with_vision(
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            image_data=b"fake-image",
+        )
+
+        mock_llm.invoke.assert_called_once()
+        assert isinstance(result, dict)
+        assert result["dish_name"] == "Rice"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_vision_handles_none_parsed(
+        self, provider, mock_model_manager
+    ):
+        structured_chain = Mock()
+        structured_chain.invoke = Mock(return_value={"parsed": None})
+
+        mock_llm = Mock()
+        mock_llm.with_structured_output = Mock(return_value=structured_chain)
+        mock_llm.invoke = Mock(return_value=Mock(content='{"dish_name": "Soup", "confidence": 0.7}'))
+        mock_model_manager.get_model_for_purpose.return_value = mock_llm
+
+        result = await provider.generate_with_vision(
+            model="gemini-2.5-flash",
+            prompt="analyze",
+            image_data=b"fake-image",
+        )
+
+        # parsed=None triggers fallback to llm.invoke
+        mock_llm.invoke.assert_called_once()
+        assert isinstance(result, dict)
+        assert result["dish_name"] == "Soup"
 
 
 class TestErrorExtraction:

--- a/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
+++ b/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
@@ -1,0 +1,183 @@
+"""Tests for AIModelManager vision failure-kind routing.
+
+Phase 3: verifies that schema/parse failures advance to next provider without
+tripping the circuit breaker, while transient failures DO trip it.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.infra.services.ai.ai_model_manager import AIModelManager, ModelPurpose
+from src.domain.exceptions.ai_exceptions import AIVisionError, AIVisionFailureKind
+from src.domain.ports.ai_provider_port import AICapability
+
+
+def _fake_settings(cf_enabled=False):
+    s = Mock()
+    s.CLOUDFLARE_WORKERS_AI_ENABLED = cf_enabled
+    s.CLOUDFLARE_ACCOUNT_ID = ""
+    s.CLOUDFLARE_API_TOKEN = ""
+    s.CLOUDFLARE_WORKERS_AI_TEXT_MODEL = ""
+    s.CLOUDFLARE_WORKERS_AI_TEXT_PURPOSES = ""
+    s.CLOUDFLARE_WORKERS_AI_JSON_MODE = False
+    s.CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS = 30
+    s.CLOUDFLARE_AI_GATEWAY_ID = ""
+    s.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = False
+    s.CLOUDFLARE_WORKERS_AI_VISION_MODEL = ""
+    s.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = ""
+    return s
+
+
+@pytest.fixture(autouse=True)
+def reset_manager():
+    AIModelManager.reset_instance()
+    yield
+    AIModelManager.reset_instance()
+
+
+@pytest.fixture
+def mock_circuit_breaker():
+    breaker = Mock()
+    breaker.filter_available = Mock(side_effect=lambda models: models)
+    breaker.record_failure = Mock()
+    breaker.record_success = Mock()
+    breaker.should_trip = Mock(return_value=True)
+    return breaker
+
+
+@pytest.fixture
+def mock_gemini_provider():
+    provider = Mock()
+    provider.provider_name = "gemini"
+    provider.supported_capabilities = {AICapability.VISION, AICapability.TEXT_GENERATION}
+    provider.generate_with_vision = AsyncMock(return_value={"result": "vision_success"})
+    provider.extract_error_code = Mock(return_value=503)
+    return provider
+
+
+@pytest.fixture
+def mock_cf_vision_provider():
+    provider = Mock()
+    provider.provider_name = "cloudflare-workers-ai"
+    provider.supported_capabilities = {AICapability.VISION}
+    provider.generate_with_vision = AsyncMock(return_value={"result": "cf_vision_success"})
+    provider.extract_error_code = Mock(return_value=503)
+    return provider
+
+
+def _build_manager(mock_circuit_breaker, mock_gemini_provider, extra_providers=None, cf_vision_model=None):
+    """Construct AIModelManager with injected mocks bypassing real provider init."""
+    with patch("src.infra.services.ai.ai_model_manager.GeminiProvider", return_value=mock_gemini_provider):
+        with patch("src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker", return_value=mock_circuit_breaker):
+            mgr = AIModelManager(settings=_fake_settings())
+
+    # Replace internals with mocks
+    mgr._gemini = mock_gemini_provider
+    mgr._circuit_breaker = mock_circuit_breaker
+    mgr._providers = {"gemini": mock_gemini_provider}
+    mgr._model_provider_overrides = {}
+
+    if extra_providers:
+        mgr._providers.update(extra_providers)
+
+    if cf_vision_model:
+        model_name, provider = cf_vision_model
+        mgr._model_provider_overrides[model_name] = "cloudflare-workers-ai"
+        mgr._fallback_chains[ModelPurpose.MEAL_SCAN].insert(0, model_name)
+
+    return mgr
+
+
+@pytest.fixture
+def manager(mock_circuit_breaker, mock_gemini_provider):
+    return _build_manager(mock_circuit_breaker, mock_gemini_provider)
+
+
+@pytest.fixture
+def manager_with_cf_vision(mock_circuit_breaker, mock_gemini_provider, mock_cf_vision_provider):
+    return _build_manager(
+        mock_circuit_breaker,
+        mock_gemini_provider,
+        extra_providers={"cloudflare-workers-ai": mock_cf_vision_provider},
+        cf_vision_model=("cf-vision-model", mock_cf_vision_provider),
+    )
+
+
+class TestVisionFailureKindRouting:
+    @pytest.mark.asyncio
+    async def test_schema_fail_advances_without_circuit_break(
+        self, manager_with_cf_vision, mock_gemini_provider, mock_circuit_breaker, mock_cf_vision_provider
+    ):
+        """Schema validation failure must advance to next provider without tripping circuit breaker."""
+        mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
+        mock_cf_vision_provider.generate_with_vision = AsyncMock(
+            side_effect=AIVisionError(
+                "[CF-WORKERS-AI-VISION-SCHEMA-FAIL] provider=cloudflare-workers-ai model=test-model",
+                kind=AIVisionFailureKind.schema_validation,
+                provider="cloudflare-workers-ai",
+                model="test-model",
+            )
+        )
+        mock_gemini_provider.generate_with_vision = AsyncMock(
+            return_value={"result": "gemini_vision_success"}
+        )
+
+        result = await manager_with_cf_vision.generate_with_vision(
+            purpose=ModelPurpose.MEAL_SCAN,
+            prompt="analyze food",
+            image_data=b"fake_image",
+        )
+
+        assert result == {"result": "gemini_vision_success"}
+        mock_gemini_provider.generate_with_vision.assert_awaited()
+        mock_circuit_breaker.record_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_json_parse_fail_advances_without_circuit_break(
+        self, manager_with_cf_vision, mock_gemini_provider, mock_circuit_breaker, mock_cf_vision_provider
+    ):
+        """JSON parse failure must advance to next provider without tripping circuit breaker."""
+        mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
+        mock_cf_vision_provider.generate_with_vision = AsyncMock(
+            side_effect=AIVisionError(
+                "[CF-WORKERS-AI-VISION-PARSE-FAIL]",
+                kind=AIVisionFailureKind.json_parse,
+                provider="cloudflare-workers-ai",
+                model="test-model",
+            )
+        )
+        mock_gemini_provider.generate_with_vision = AsyncMock(
+            return_value={"result": "gemini_fallback"}
+        )
+
+        result = await manager_with_cf_vision.generate_with_vision(
+            purpose=ModelPurpose.MEAL_SCAN,
+            prompt="analyze food",
+            image_data=b"fake_image",
+        )
+
+        assert result == {"result": "gemini_fallback"}
+        mock_circuit_breaker.record_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transient_fail_records_circuit_breaker(
+        self, manager, mock_gemini_provider, mock_circuit_breaker
+    ):
+        """Transient (non-AIVisionError) failures must record failure in circuit breaker."""
+        mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
+        mock_gemini_provider.generate_with_vision = AsyncMock(
+            side_effect=Exception("503 Service Unavailable")
+        )
+        mock_gemini_provider.extract_error_code = Mock(return_value=503)
+        mock_circuit_breaker.should_trip = Mock(return_value=True)
+
+        with pytest.raises(AIUnavailableError):
+            await manager.generate_with_vision(
+                purpose=ModelPurpose.MEAL_SCAN,
+                prompt="analyze food",
+                image_data=b"fake_image",
+            )
+
+        mock_circuit_breaker.record_failure.assert_called()


### PR DESCRIPTION
## Summary
- Restores the structured vision output and failure-classification work from PR #381 onto the current delivery head.
- Keeps Gemini vision on structured output before raw parsing and validates Cloudflare vision responses before provider success.
- Prevents schema/json_parse/no_food failures from retrying the entire meal image analysis chain.

## Root cause
Production logs with `[JSON-EXTRACT-FAILED] all parsing attempts failed | content_len=...` match the older `origin/main` parser. PR #381 briefly merged into delivery and built a SIT image at 2026-06-23T04:42:48Z, but current `origin/delivery` no longer contains that merge commit after later delivery updates.

## Verification
- `uv run pytest tests/unit/infra/adapters/test_ai_json_logging.py tests/unit/infra/services/ai/test_ai_vision_failure_routing.py tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py tests/unit/infra/services/ai/providers/test_gemini_provider.py tests/unit/infra/services/ai/providers/test_cloudflare_workers_ai_provider.py tests/unit/domain/parsers/test_vision_response_models.py tests/unit/domain/test_update_user_metrics.py -q` -> 109 passed
- `uv run lint-imports` -> 4 contracts kept, 0 broken
- `uv run pytest tests/unit -q` -> 1776 passed, 3 skipped
- pre-push hook reran unit tests -> 1776 passed, 3 skipped
