### PR TITLE
feat(ai): remove Gemini fallback from vision scan chains

### DIFF
--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -33,18 +33,10 @@ class ModelPurpose(Enum):
 
 FALLBACK_CHAINS: dict[ModelPurpose, list[str]] = {
     # ==========================================================================
-    # VISION TASKS: Gemini 3.1 Flash-Lite first → stronger Gemini fallbacks
+    # VISION TASKS: CF Workers AI only — no Gemini fallback for vision
     # ==========================================================================
-    ModelPurpose.MEAL_SCAN: [
-        "gemini-3.1-flash-lite",
-        "gemini-3.5-flash",
-        "gemini-2.5-flash",
-    ],
-    ModelPurpose.INGREDIENT_SCAN: [
-        "gemini-3.1-flash-lite",
-        "gemini-3.5-flash",
-        "gemini-2.5-flash",
-    ],
+    ModelPurpose.MEAL_SCAN: [],
+    ModelPurpose.INGREDIENT_SCAN: [],
     # ==========================================================================
     # SHORT STRUCTURED TEXT: Gemini Flash-Lite first → Flash fallback
     # ==========================================================================

--- a/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
+++ b/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
@@ -79,6 +79,10 @@ def _build_manager(mock_circuit_breaker, mock_gemini_provider, extra_providers=N
     mgr._providers = {"gemini": mock_gemini_provider}
     mgr._model_provider_overrides = {}
 
+    # Set an explicit chain so routing tests can advance through providers,
+    # independent of the production FALLBACK_CHAINS (which has no Gemini for vision).
+    mgr._fallback_chains[ModelPurpose.MEAL_SCAN] = ["gemini-2.5-flash"]
+
     if extra_providers:
         mgr._providers.update(extra_providers)
 


### PR DESCRIPTION
## Summary

- `MEAL_SCAN` and `INGREDIENT_SCAN` fallback chains now contain no Gemini models
- When CF Workers AI vision fails, the scan returns `AIUnavailableError` immediately instead of falling back to Gemini
- All text-path chains (RECIPE, GENERAL, PARSE_TEXT, etc.) are unchanged — Gemini still handles text

## Before / After

**Before:** `@cf/google/gemma-4-26b-a4b-it → gemini-3.1-flash-lite → gemini-3.5-flash → gemini-2.5-flash`

**After:** `@cf/google/gemma-4-26b-a4b-it` (CF Workers AI only, no Gemini safety net)

## Test plan

- [ ] 151 AI unit tests pass
- [ ] `test_ai_vision_failure_routing.py` updated — test helper now builds an explicit chain for routing behavior tests, independent of production chain contents