### PR TITLE
feat(progress): seed journey progress for existing users

### DIFF
--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -21,6 +21,7 @@
 - [x] Added canonical `GET /v1/progress/journey` for the dashboard progress card.
 - [x] Strict active-period filtering keeps only `period_start <= action_time < period_end`; existing users without `goal_started_at` fall back to the stable 2026-06-21 feature start in their local timezone.
 - [x] Onboarding and target-weight updates now set the journey baseline fields that anchor the active period.
+- [x] Existing-user migration can now seed journey progress from pre-release action logs with a bounded `journey_progress_seed_percent`, while post-release actions continue filling the remaining progress.
 
 ### June 2026: Single-Owner Logger System
 - [x] Established log-or-raise rule: one root-cause `ERROR` per unexpected request failure; expected 4xx exceptions produce zero ERROR logs.

--- a/migrations/versions/20260624000001_add_journey_progress_seed.py
+++ b/migrations/versions/20260624000001_add_journey_progress_seed.py
@@ -1,0 +1,42 @@
+"""Add journey progress seed to user profiles.
+
+Revision ID: 20260624000001
+Revises: 20260620000001
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260624000001"
+down_revision = "20260620000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_profiles",
+        sa.Column(
+            "journey_progress_seed_percent",
+            sa.Float(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.alter_column(
+        "user_profiles", "journey_progress_seed_percent", server_default=None
+    )
+    op.create_check_constraint(
+        "check_journey_progress_seed_percent_range",
+        "user_profiles",
+        "journey_progress_seed_percent >= 0 AND journey_progress_seed_percent <= 100",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "check_journey_progress_seed_percent_range",
+        "user_profiles",
+        type_="check",
+    )
+    op.drop_column("user_profiles", "journey_progress_seed_percent")

--- a/scripts/backfill_journey_progress_seed.py
+++ b/scripts/backfill_journey_progress_seed.py
@@ -1,0 +1,154 @@
+"""Backfill journey progress seeds from pre-release action logs.
+
+Usage:
+  python scripts/backfill_journey_progress_seed.py --dry-run
+  python scripts/backfill_journey_progress_seed.py --cap-percent 70
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import UTC, datetime, time, timedelta
+
+from sqlalchemy import select
+
+from src.app.handlers.query_handlers.get_user_tdee_query_handler import (
+    GetUserTdeeQueryHandler,
+)
+from src.app.queries.tdee import GetUserTdeeQuery
+from src.domain.services.journey_progress_rules import (
+    FEATURE_START_DATE,
+    estimate_timeline_days,
+)
+from src.domain.services.journey_progress_service import calculate_journey_progress
+from src.domain.utils.timezone_utils import ensure_utc, get_zone_info
+from src.infra.database.models.user.profile import UserProfile
+from src.infra.database.models.user.user import User
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+
+def _feature_start_utc(timezone: str) -> datetime:
+    user_tz = get_zone_info(timezone)
+    return datetime.combine(FEATURE_START_DATE, time.min, tzinfo=user_tz).astimezone(
+        UTC
+    )
+
+
+async def _load_targets(user_id: str) -> tuple[float, float]:
+    result = await GetUserTdeeQueryHandler().handle(GetUserTdeeQuery(user_id=user_id))
+    macros = result.get("macros") or {}
+    return float(result.get("target_calories") or 0), float(macros.get("protein") or 0)
+
+
+async def backfill(
+    *,
+    cap_percent: float,
+    lookback_days: int,
+    dry_run: bool,
+    limit: int | None,
+) -> int:
+    updated = 0
+    async with AsyncUnitOfWork() as uow:
+        stmt = (
+            select(UserProfile, User)
+            .join(User, User.id == UserProfile.user_id)
+            .where(
+                User.is_active.is_(True),
+                UserProfile.is_current.is_(True),
+                UserProfile.journey_progress_seed_percent == 0,
+            )
+            .order_by(UserProfile.created_at.asc())
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        rows = (await uow.session.execute(stmt)).all()
+        for profile, user in rows:
+            user_tz = get_zone_info(user.timezone)
+            feature_start = _feature_start_utc(user.timezone)
+            raw_start = profile.goal_started_at or profile.created_at
+            if raw_start is None:
+                raw_start = feature_start - timedelta(days=lookback_days)
+
+            history_start = max(
+                ensure_utc(raw_start),
+                feature_start - timedelta(days=lookback_days),
+            )
+            if history_start >= feature_start:
+                continue
+
+            start_weight = profile.goal_start_weight_kg or profile.weight_kg
+            timeline_days = estimate_timeline_days(
+                goal=profile.fitness_goal,
+                start_weight_kg=start_weight,
+                target_weight_kg=profile.target_weight_kg,
+                challenge_duration=profile.challenge_duration,
+            )
+            actions = await _load_actions(
+                uow, str(profile.user_id), history_start, feature_start
+            )
+            if not actions:
+                continue
+
+            target_calories, target_protein_g = await _load_targets(
+                str(profile.user_id)
+            )
+            result = calculate_journey_progress(
+                actions=actions,
+                period_start=history_start,
+                timeline_days=timeline_days,
+                user_tz=user_tz,
+                as_of=feature_start,
+                target_calories=target_calories,
+                target_protein_g=target_protein_g,
+                water_goal_ml=profile.daily_water_goal_ml or 2000,
+            )
+            seed = min(cap_percent, result["progress_percent"])
+            if seed <= 0:
+                continue
+
+            updated += 1
+            print(f"{profile.user_id}: seed={seed:.3f}% actions={len(actions)}")
+            if not dry_run:
+                profile.journey_progress_seed_percent = seed
+
+    return updated
+
+
+async def _load_actions(uow, user_id: str, start_utc: datetime, end_utc: datetime):
+    from src.app.handlers.query_handlers.get_journey_progress_query_handler import (
+        GetJourneyProgressQueryHandler,
+    )
+
+    handler = GetJourneyProgressQueryHandler(uow=uow)
+    return await handler._load_actions(uow, user_id, start_utc, end_utc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cap-percent", type=float, default=70.0)
+    parser.add_argument("--lookback-days", type=int, default=90)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args()
+
+    if args.cap_percent < 0 or args.cap_percent > 100:
+        raise SystemExit("--cap-percent must be between 0 and 100")
+    if args.lookback_days <= 0:
+        raise SystemExit("--lookback-days must be greater than 0")
+
+    count = asyncio.run(
+        backfill(
+            cap_percent=args.cap_percent,
+            lookback_days=args.lookback_days,
+            dry_run=args.dry_run,
+            limit=args.limit,
+        )
+    )
+    action = "would update" if args.dry_run else "updated"
+    print(f"{action} {count} profile(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/schemas/progress_schemas.py
+++ b/src/api/schemas/progress_schemas.py
@@ -63,6 +63,8 @@ class JourneyProgressResponse(BaseModel):
     period_end: str
     as_of: str
     progress_percent: float
+    current_period_progress_percent: float = 0.0
+    journey_progress_seed_percent: float = 0.0
     confirmed_progress_percent: float
     provisional_progress_percent: float
     timeline_days: int

--- a/src/api/schemas/response/user_responses.py
+++ b/src/api/schemas/response/user_responses.py
@@ -132,6 +132,9 @@ class UserMetricsResponse(BaseModel):
     goal_started_at: Optional[datetime] = Field(
         None, description="Timestamp when goal journey started"
     )
+    journey_progress_seed_percent: float = Field(
+        0.0, description="Starting journey percent granted from historical actions"
+    )
     updated_at: datetime = Field(..., description="Last update timestamp")
 
 

--- a/src/app/handlers/command_handlers/save_user_onboarding_command_handler.py
+++ b/src/app/handlers/command_handlers/save_user_onboarding_command_handler.py
@@ -114,6 +114,7 @@ class SaveUserOnboardingCommandHandler(EventHandler[SaveUserOnboardingCommand, N
                     ):
                         profile.goal_start_weight_kg = command.weight_kg
                         profile.goal_started_at = utc_now()
+                        profile.journey_progress_seed_percent = 0.0
                     # Write-once — don't overwrite if already set
                     if command.referral_sources and not profile.referral_sources:
                         profile.referral_sources = command.referral_sources

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -198,6 +198,13 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
             elif should_auto_start_goal:
                 profile.goal_started_at = utc_now()
 
+            if (
+                should_auto_start_goal
+                or command.goal_start_weight_kg is not None
+                or command.goal_started_at is not None
+            ):
+                profile.journey_progress_seed_percent = 0.0
+
             if command.reset_water_goal:
                 profile.daily_water_goal_ml = None
             elif command.daily_water_goal_ml is not None:

--- a/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
+++ b/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
@@ -92,6 +92,9 @@ class GetJourneyProgressQueryHandler(
             target_calories=target_calories,
             target_protein_g=target_protein_g,
             water_goal_ml=water_goal_ml,
+            journey_progress_seed_percent=getattr(
+                profile, "journey_progress_seed_percent", 0.0
+            ),
         )
 
     async def _load_actions(

--- a/src/app/handlers/query_handlers/get_user_metrics_query_handler.py
+++ b/src/app/handlers/query_handlers/get_user_metrics_query_handler.py
@@ -69,5 +69,8 @@ class GetUserMetricsQueryHandler(EventHandler[GetUserMetricsQuery, Dict[str, Any
                 "target_weight_kg": profile.target_weight_kg,
                 "goal_start_weight_kg": profile.goal_start_weight_kg,
                 "goal_started_at": profile.goal_started_at,
+                "journey_progress_seed_percent": getattr(
+                    profile, "journey_progress_seed_percent", 0.0
+                ),
                 "updated_at": profile.updated_at,
             }

--- a/src/domain/model/user/core_user.py
+++ b/src/domain/model/user/core_user.py
@@ -47,6 +47,7 @@ class UserProfileDomainModel(BaseDomainModel):
     custom_fat_g: Optional[float] = None
     goal_start_weight_kg: Optional[float] = None
     goal_started_at: Optional[datetime] = None
+    journey_progress_seed_percent: float = 0.0
     daily_water_goal_ml: Optional[int] = None
 
 

--- a/src/domain/services/journey_progress_service.py
+++ b/src/domain/services/journey_progress_service.py
@@ -49,6 +49,7 @@ def calculate_journey_progress(
     target_calories: float,
     target_protein_g: float,
     water_goal_ml: int,
+    journey_progress_seed_percent: float = 0.0,
 ) -> dict:
     period_end = period_start + timedelta(days=timeline_days)
     effective_end = min(as_of, period_end)
@@ -78,7 +79,9 @@ def calculate_journey_progress(
         else:
             confirmed += percent
 
-    display = min(100.0, confirmed + provisional)
+    current_period_progress = min(100.0, confirmed + provisional)
+    seed = _clamp_percent(journey_progress_seed_percent)
+    display = seed + ((100.0 - seed) * current_period_progress / 100.0)
     latest = max(
         included, key=lambda action: ensure_utc(action.logged_at), default=None
     )
@@ -87,9 +90,13 @@ def calculate_journey_progress(
         "period_end": period_end.isoformat(),
         "as_of": as_of.isoformat(),
         "progress_percent": round(display, 3),
-        "confirmed_progress_percent": round(min(100.0, confirmed), 3),
+        "current_period_progress_percent": round(current_period_progress, 3),
+        "journey_progress_seed_percent": round(seed, 3),
+        "confirmed_progress_percent": round(
+            _apply_seed(seed, min(100.0, confirmed)), 3
+        ),
         "provisional_progress_percent": round(
-            min(100.0, max(0.0, display - confirmed)), 3
+            max(0.0, display - _apply_seed(seed, min(100.0, confirmed))), 3
         ),
         "timeline_days": timeline_days,
         "daily_progress_budget_percent": round(daily_budget, 3),
@@ -143,6 +150,16 @@ def _day_percent(
     scored = daily_budget * (sum(points.values()) / 100)
     floor = min(daily_budget, action_count * MINIMUM_LOGGED_ACTION_PERCENT)
     return min(daily_budget, max(floor, scored))
+
+
+def _apply_seed(seed: float, progress_percent: float) -> float:
+    return seed + ((100.0 - seed) * _clamp_percent(progress_percent) / 100.0)
+
+
+def _clamp_percent(value: float | None) -> float:
+    if value is None:
+        return 0.0
+    return max(0.0, min(100.0, float(value)))
 
 
 def _calorie_adherence(target: float, consumed: float) -> float:

--- a/src/infra/database/models/user/profile.py
+++ b/src/infra/database/models/user/profile.py
@@ -66,6 +66,7 @@ class UserProfile(Base, BaseMixin):
     # Goal progress tracking — tracks when user started current goal journey
     goal_start_weight_kg = Column(Float, nullable=True, default=None)
     goal_started_at = Column(DateTime(timezone=True), nullable=True, default=None)
+    journey_progress_seed_percent = Column(Float, nullable=False, default=0.0)
     daily_water_goal_ml = Column(Integer, nullable=True, default=None)
 
     @property
@@ -105,6 +106,10 @@ class UserProfile(Base, BaseMixin):
         CheckConstraint(
             "daily_water_goal_ml IS NULL OR daily_water_goal_ml > 0",
             name="check_water_goal_positive",
+        ),
+        CheckConstraint(
+            "journey_progress_seed_percent >= 0 AND journey_progress_seed_percent <= 100",
+            name="check_journey_progress_seed_percent_range",
         ),
     )
 

--- a/src/infra/mappers/user_mapper.py
+++ b/src/infra/mappers/user_mapper.py
@@ -181,6 +181,9 @@ class UserProfileMapper:
             custom_fat_g=profile_entity.custom_fat_g,
             goal_start_weight_kg=profile_entity.goal_start_weight_kg,
             goal_started_at=profile_entity.goal_started_at,
+            journey_progress_seed_percent=float(
+                profile_entity.journey_progress_seed_percent or 0.0
+            ),
             daily_water_goal_ml=profile_entity.daily_water_goal_ml,
             created_at=profile_entity.created_at,
             updated_at=profile_entity.updated_at,
@@ -219,6 +222,7 @@ class UserProfileMapper:
             custom_fat_g=profile_domain.custom_fat_g,
             goal_start_weight_kg=profile_domain.goal_start_weight_kg,
             goal_started_at=profile_domain.goal_started_at,
+            journey_progress_seed_percent=profile_domain.journey_progress_seed_percent,
             daily_water_goal_ml=profile_domain.daily_water_goal_ml,
         )
         profile.preference_entries = build_profile_preference_entries(profile_domain)

--- a/tests/unit/domain/services/test_journey_progress_service.py
+++ b/tests/unit/domain/services/test_journey_progress_service.py
@@ -141,3 +141,73 @@ def test_journey_progress_does_not_backfill_before_current_period():
 
     assert result["progress_percent"] == 0
     assert result["latest_action"] is None
+
+
+def test_journey_progress_seed_scales_current_period_into_remaining_percent():
+    result = calculate_journey_progress(
+        actions=[
+            JourneyAction(
+                source="meal",
+                label="Breakfast",
+                logged_at=datetime(2026, 6, 21, 12, tzinfo=UTC),
+                calories=400,
+                protein_g=20,
+            ),
+            JourneyAction(
+                source="meal",
+                label="Lunch",
+                logged_at=datetime(2026, 6, 21, 13, tzinfo=UTC),
+                calories=400,
+                protein_g=20,
+            ),
+            JourneyAction(
+                source="meal",
+                label="Dinner",
+                logged_at=datetime(2026, 6, 21, 18, tzinfo=UTC),
+                calories=400,
+                protein_g=20,
+            ),
+            JourneyAction(
+                source="hydration",
+                label="Water",
+                logged_at=datetime(2026, 6, 21, 19, tzinfo=UTC),
+                hydration_ml=2000,
+            ),
+            JourneyAction(
+                source="activity",
+                label="Walk",
+                logged_at=datetime(2026, 6, 21, 20, tzinfo=UTC),
+            ),
+        ],
+        period_start=datetime(2026, 6, 21, tzinfo=UTC),
+        timeline_days=10,
+        user_tz=get_zone_info("UTC"),
+        as_of=datetime(2026, 6, 22, tzinfo=UTC),
+        target_calories=1200,
+        target_protein_g=60,
+        water_goal_ml=2000,
+        journey_progress_seed_percent=50,
+    )
+
+    assert result["current_period_progress_percent"] == 10
+    assert result["journey_progress_seed_percent"] == 50
+    assert result["progress_percent"] == 55
+    assert result["confirmed_progress_percent"] == 55
+    assert result["provisional_progress_percent"] == 0
+
+
+def test_journey_progress_seed_is_clamped_to_valid_percent_range():
+    result = calculate_journey_progress(
+        actions=[],
+        period_start=datetime(2026, 6, 21, tzinfo=UTC),
+        timeline_days=10,
+        user_tz=get_zone_info("UTC"),
+        as_of=datetime(2026, 6, 22, tzinfo=UTC),
+        target_calories=400,
+        target_protein_g=20,
+        water_goal_ml=2000,
+        journey_progress_seed_percent=150,
+    )
+
+    assert result["journey_progress_seed_percent"] == 100
+    assert result["progress_percent"] == 100

--- a/tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py
@@ -4,8 +4,12 @@ from uuid import UUID
 import pytest
 
 from src.app.commands.user import SaveUserOnboardingCommand
+from src.app.commands.user.update_user_metrics_command import UpdateUserMetricsCommand
 from src.app.handlers.command_handlers.save_user_onboarding_command_handler import (
     SaveUserOnboardingCommandHandler,
+)
+from src.app.handlers.command_handlers.update_user_metrics_command_handler import (
+    UpdateUserMetricsCommandHandler,
 )
 
 
@@ -42,6 +46,29 @@ class _FakeUow:
         self.rolled_back = True
 
 
+class _FakeMetricUsers:
+    def __init__(self, profile):
+        self.profile = profile
+        self.saved_profile = None
+
+    async def get_profile(self, user_id):
+        return self.profile
+
+    async def update_profile(self, profile):
+        self.saved_profile = profile
+
+
+class _FakeMetricUow:
+    def __init__(self, profile):
+        self.users = _FakeMetricUsers(profile)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
 @pytest.mark.asyncio
 async def test_onboarding_sets_goal_journey_baseline(monkeypatch):
     fixed_now = datetime(2026, 6, 21, 1, 2, 3, tzinfo=UTC)
@@ -71,3 +98,39 @@ async def test_onboarding_sets_goal_journey_baseline(monkeypatch):
     assert uow.committed is True
     assert uow.users.saved_profile.goal_start_weight_kg == 80
     assert uow.users.saved_profile.goal_started_at == fixed_now
+
+
+@pytest.mark.asyncio
+async def test_target_weight_change_resets_journey_seed(monkeypatch):
+    fixed_now = datetime(2026, 6, 24, 1, 2, 3, tzinfo=UTC)
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.update_user_metrics_command_handler.utc_now",
+        lambda: fixed_now,
+    )
+
+    profile = type(
+        "Profile",
+        (),
+        {
+            "target_weight_kg": 75.0,
+            "goal_started_at": datetime(2026, 6, 1, tzinfo=UTC),
+            "goal_start_weight_kg": 80.0,
+            "journey_progress_seed_percent": 50.0,
+            "weight_kg": 78.0,
+            "is_current": True,
+        },
+    )()
+    uow = _FakeMetricUow(profile)
+    handler = UpdateUserMetricsCommandHandler(uow=uow)
+
+    await handler.handle(
+        UpdateUserMetricsCommand(
+            user_id=str(UUID("11111111-1111-1111-1111-111111111111")),
+            target_weight_kg=72.0,
+        )
+    )
+
+    assert uow.users.saved_profile.target_weight_kg == 72.0
+    assert uow.users.saved_profile.goal_start_weight_kg == 78.0
+    assert uow.users.saved_profile.goal_started_at == fixed_now
+    assert uow.users.saved_profile.journey_progress_seed_percent == 0.0

--- a/tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py
@@ -21,6 +21,7 @@ class _FakeUsers:
             target_weight_kg=75.0,
             goal_start_weight_kg=None,
             goal_started_at=None,
+            journey_progress_seed_percent=25.0,
             challenge_duration="30_days",
             daily_water_goal_ml=2000,
         )
@@ -83,6 +84,8 @@ async def test_handler_uses_stable_existing_user_period_start():
 
     assert result["period_start"] == "2026-06-20T17:00:00+00:00"
     assert result["timeline_days"] == 30
+    assert result["journey_progress_seed_percent"] == 25.0
+    assert result["progress_percent"] > result["current_period_progress_percent"]
     assert result["latest_action"]["label"] == "Launch meal"
     assert uow.meals.args == (
         user_id,


### PR DESCRIPTION
## Summary
- add journey progress seed storage on user profiles
- scale journey display progress from historical seed plus current-period progress
- add dry-run backfill script for existing users and reset seed when goal journey changes

## Verification
- python -m pytest tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py tests/unit/domain/services/test_journey_progress_service.py tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py
- python -m pytest tests/unit/api/test_routes_with_mocked_event_bus.py
- python -m compileall src/domain/services/journey_progress_service.py src/app/handlers/query_handlers/get_journey_progress_query_handler.py src/app/handlers/command_handlers/update_user_metrics_command_handler.py src/app/handlers/command_handlers/save_user_onboarding_command_handler.py src/domain/model/user/core_user.py src/infra/database/models/user/profile.py src/infra/mappers/user_mapper.py src/api/schemas/response/user_responses.py src/api/schemas/progress_schemas.py src/app/handlers/query_handlers/get_user_metrics_query_handler.py scripts/backfill_journey_progress_seed.py tests/unit/domain/services/test_journey_progress_service.py tests/unit/handlers/query_handlers/test_journey_progress_query_handler.py tests/unit/handlers/command_handlers/test_goal_journey_baseline_handlers.py migrations/versions/20260624000001_add_journey_progress_seed.py