### PR TITLE
docs: refresh backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ A sophisticated FastAPI-based microservice for meal tracking and nutritional ana
 ## Quick Links
 
 - **[Project Overview & PDR](./docs/project-overview-pdr.md)** - Vision, goals, and requirements.
-- **[System Architecture](./docs/architecture/index.md)** - Multi-layer architecture and data flow.
-- **[Code Standards](./docs/standards/index.md)** - Development guidelines and patterns.
+- **[System Architecture](./docs/system-architecture.md)** - Multi-layer architecture and data flow.
+- **[Code Standards](./docs/code-standards.md)** - Development guidelines and patterns.
 - **[Codebase Summary](./docs/codebase-summary.md)** - Directory structure and file organization.
 - **[Project Roadmap](./docs/project-roadmap.md)** - Future plans and completed features.
 
 ## 🚀 Features
 
-- **AI-Powered Meal Analysis**: Vision-based food recognition with 6 analysis strategies (basic, portion-aware, ingredient-aware, weight-aware, user-context-aware, combined).
-- **12 REST Route Modules**: 50+ endpoints covering meals, users, profiles, chat, notifications, meal plans, suggestions, activities, ingredients, webhooks.
-- **CQRS Architecture**: 29 commands, 23 queries, 10+ domain events with PyMediator event bus (singleton pattern).
+- **AI-Powered Meal Analysis**: Vision-based food recognition with 6 analysis strategies and provider fallback routing.
+- **26 Endpoint Route Modules**: 85 endpoint decorators covering meals, users, profiles, chat, notifications, meal plans, suggestions, activities, ingredients, webhooks, and support routes.
+- **CQRS Architecture**: Commands, queries, events, and handlers wired through a PyMediator singleton event bus.
 - **Intelligent Planning**: AI-generated weekly plans with dietary preferences, cooking time constraints, and ingredient-based generation.
 - **Vector Search**: Pinecone semantic search with 1024-dim embeddings (llama-text-embed-v2).
 - **Real-time Chat**: WebSocket + REST endpoints with streaming AI responses via MessageOrchestrationService.
@@ -23,12 +23,12 @@ A sophisticated FastAPI-based microservice for meal tracking and nutritional ana
 
 ## 🛠 Technology Stack
 
-- **Core**: FastAPI 0.115+ (Python 3.13.2), SQLAlchemy 2.0 async runtime (`AsyncSession`, `AsyncUnitOfWork`).
+- **Core**: FastAPI 0.136.3 (Python 3.13.2), SQLAlchemy 2.0 async runtime (`AsyncSession`, `AsyncUnitOfWork`).
 - **Database**: PostgreSQL (Neon) with SQLAlchemy 2.0, Redis 7.0 for selective optional caching; required state documented separately.
-- **AI**: OpenAI via LangChain for image scanning, Cloudflare Workers AI first for text tasks, Cloudflare embeddings, Pinecone Inference API (1024-dim).
+- **AI**: OpenAI via LangChain/Responses API as the default text and vision provider, with optional Cloudflare Workers AI routing for configured text purposes and vision fallback; Pinecone Inference API for embeddings.
 - **Infrastructure**: Firebase (JWT Auth + FCM), Cloudinary (image storage), RevenueCat (subscriptions).
 - **Event Bus**: PyMediator with singleton registry for CQRS.
-- **Testing**: pytest (1,499+ tests), ruff (linting), mypy (type checking).
+- **Testing**: pytest (unit-biased default config), ruff (linting), mypy (type checking).
 
 ### OpenAI Prompt Caching
 
@@ -42,10 +42,10 @@ A sophisticated FastAPI-based microservice for meal tracking and nutritional ana
 
 Follows a **4-Layer Clean Architecture** with **CQRS** and **Event-Driven Design**:
 
-1. **API Layer** (74 files, ~8,241 LOC): HTTP routing, Pydantic validation, 8 mappers, 3-layer middleware.
-2. **Application Layer** (136 files, ~5,968 LOC): CQRS - 29 commands, 23 queries, 10+ events, 40+ handlers.
-3. **Domain Layer** (130 files, ~14,079 LOC): 50+ domain services, 8 bounded contexts, 17 port interfaces, 6 analysis strategies.
-4. **Infrastructure Layer** (77 files, ~8,671 LOC): 11 database models, 10+ repositories, external service adapters, Redis cache, PyMediator event bus with singleton registry.
+1. **API Layer** (91 files, 10,624 LOC): 26 endpoint route modules, 85 endpoint decorators, schemas, middleware, dependencies, and API mappers.
+2. **Application Layer** (207 files, 11,192 LOC): CQRS command/query/event handlers and orchestration services.
+3. **Domain Layer** (166 files, 16,283 LOC): entities, services, ports, policies, and bounded contexts.
+4. **Infrastructure Layer** (154 files, 15,134 LOC): database models, repositories, external adapters, cache, observability, and event bus implementation.
 
 ## 🚦 Getting Started
 
@@ -65,4 +65,4 @@ uvicorn src.api.main:app --reload
 ```
 
 - **Swagger Docs**: http://localhost:8000/docs
-- **Tests**: `pytest --cov=src`
+- **Tests**: `pytest` for the default non-integration suite; CI runs `pytest tests/unit --cov=src --cov-fail-under=65`

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,10 +1,11 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** June 17, 2026
+**Last Updated:** June 27, 2026
 **Base URL:** `http://localhost:8000` (dev) or deployed host
 **API Docs:** `/docs` (Swagger UI)
 **Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
 Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
+**Surface:** 28 route files, 27 router registrations, 26 endpoint-bearing route modules, and 85 endpoint decorators.
 
 ---
 
@@ -37,6 +38,7 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | POST | `/v1/meals/scan-by-url` | Analyze meal from an existing image URL |
 | POST | `/v1/meals/manual` | Create meal from USDA foods |
 | POST | `/v1/meals/parse-text` | Parse meal from text description |
+| POST | `/v1/meals/parse-text/guest-trial` | One-shot guest text parse trial |
 | GET | `/v1/meals/streak` | Get meal logging streak |
 | GET | `/v1/meals/weekly/daily-breakdown` | Weekly daily nutrition breakdown |
 | GET | `/v1/meals/weekly/budget` | Weekly calorie budget |

--- a/docs/beverage-scan.md
+++ b/docs/beverage-scan.md
@@ -16,7 +16,7 @@ Mobile → POST /v1/meals/image/analyze or /v1/meals/scan-by-url
          ↓
 UploadMealImageImmediatelyHandler or ScanByUrlCommandHandler
   1. Get image bytes (multipart upload or Cloudinary URL download)
-  2. GeminiService.vision(MEAL_SCAN, image_bytes, VISION_ANALYSIS prompt)
+  2. VisionAIService routes MEAL_SCAN through the configured provider stack
   3. VisionAIService._to_legacy_vision_payload() → includes beverage_metadata
   4. bev_meta = structured_data.get("beverage_metadata")
   5. if bev_meta.is_packaged_beverage → hydration-only scan path
@@ -36,7 +36,7 @@ compatibility row in `meals`.
 
 ## BeverageMetadata Contract
 
-Gemini returns this when `is_packaged_beverage=true`:
+The vision provider returns this when `is_packaged_beverage=true`:
 
 ```json
 {
@@ -72,7 +72,7 @@ hydration_weight = compute_hydration_weight(label_source, sugar_per_100ml)
 
 ## Volume Heuristics
 
-If Gemini cannot read the label volume, the prompt instructs it to estimate:
+If the vision provider cannot read the label volume, the prompt instructs it to estimate:
 
 | Container | Default ml |
 |-----------|-----------|
@@ -106,9 +106,9 @@ new_entries = [e for e in hydration_entries if e.legacy_meal_id not in meal_id_s
 
 ## Observability
 
-GeminiService emits per-call structured logs:
+The AI provider stack emits per-call structured logs:
 ```
-[AI-CALL] method=vision purpose=MEAL_SCAN model=gemini-2.5-flash-lite latency_ms=1240 retry_count=0 fallback_used=False
+[AI-ATTEMPT] purpose=meal_scan model=gpt-5.4-mini-2026-03-17
 ```
 
 Beverages with estimated nutrition log a WARNING:

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,7 +1,7 @@
 # Backend Code Standards — Python Style & Conventions
 
-**Last Updated:** June 17, 2026
-**Scope:** All code in `src/` (620 Python files, ~52.6K LOC)
+**Last Updated:** June 27, 2026
+**Scope:** All code in `src/` (627 Python files, 53,972 LOC)
 **Applies To:** Typing, naming, imports, code organization, error handling
 
 ---
@@ -217,6 +217,7 @@ environment, not alias lists or raw provider identifiers.
 - [ ] No `dynamic` types (always explicit)
 - [ ] Logs follow severity and privacy rules
 - [ ] Run before commit: `black src/ tests/ && ruff check src/ && mypy src/`
+- [ ] Run `lint-imports` when changing layer boundaries or imports between `src/api`, `src/app`, `src/domain`, and `src/infra`
 
 ---
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,8 +1,8 @@
 # Backend Codebase Summary
 
-**Generated:** June 22, 2026
+**Generated:** June 27, 2026
 **Status:** Production-ready snapshot of the live backend codebase
-**Runtime:** FastAPI 0.115+ on Python 3.11+ with async SQLAlchemy 2.0
+**Runtime:** FastAPI 0.136.3 on Python 3.13.2 with async SQLAlchemy 2.0
 
 ---
 
@@ -10,20 +10,20 @@
 
 | Metric | Value |
 |--------|-------|
-| Source files | 620 Python files in `src/` |
-| Source LOC | ~52.6K LOC in `src/` |
-| Test files | 291 Python files in `tests/` |
+| Source files | 627 Python files in `src/` |
+| Source LOC | 53,972 LOC in `src/` |
+| Test files | 306 Python files in `tests/` |
 | Collected tests | 1,600+ collected tests |
-| API routers | 26 router registrations in `src/api/main.py` |
-| API endpoints | 83 endpoint decorators under `src/api/routes/` |
-| CQRS command files | 51 |
-| CQRS query files | 50 |
-| CQRS event files | 15 |
-| CQRS handler files | 87 |
-| Domain service files | 50 |
-| Port files | 26 |
-| Database model files | 47 |
-| ORM table declarations | 36 |
+| API router files | 28 route files under `src/api/routes/`; 26 contain endpoint decorators |
+| API endpoints | 85 endpoint decorators under `src/api/routes/` |
+| CQRS command files | 37 |
+| CQRS query files | 34 |
+| CQRS event files | 10 |
+| CQRS handler files | 75 |
+| Domain service files | 46 |
+| Port files | 25 |
+| Database model files | 39 |
+| ORM table declarations | 39 |
 
 ---
 
@@ -31,10 +31,10 @@
 
 | Layer | Files | LOC | Notes |
 |-------|-------|-----|-------|
-| API | 89 | ~10.4K | Routes, middleware, schemas, dependency wiring, and API mappers |
-| Application | 208 | ~11.0K | Commands, queries, handlers, and orchestration services |
-| Domain | 160 | ~15.5K | Entities, services, ports, policies, and bounded contexts |
-| Infrastructure | 154 | ~15.0K | Database, cache, adapters, observability, and service integrations |
+| API | 91 | 10,624 | Routes, middleware, schemas, dependency wiring, and API mappers |
+| Application | 207 | 11,192 | Commands, queries, handlers, and orchestration services |
+| Domain | 166 | 16,283 | Entities, services, ports, policies, and bounded contexts |
+| Infrastructure | 154 | 15,134 | Database, cache, adapters, observability, and service integrations |
 
 ---
 
@@ -54,7 +54,7 @@ The current HTTP surface includes:
 
 - Runtime DB access uses PostgreSQL/Neon via `src/infra/database/config_async.py` and `asyncpg`.
 - Redis is optional and used for cache-aside and AI-context caching, not as the source of truth.
-- Database migrations are Alembic-managed and run before app startup through the entrypoint/pre-deploy flow.
+- Database migrations live in `migrations/versions/` and are applied with standard Alembic commands.
 - The event bus is a singleton PyMediator registry wired from `src/api/dependencies/event_bus.py`.
 
 ---
@@ -63,17 +63,17 @@ The current HTTP surface includes:
 
 | Directory | Files | Purpose |
 |-----------|-------|---------|
-| `src/api/routes/v1/` | 17 | 60+ REST endpoints |
-| `src/api/schemas/` | 34 | Pydantic DTOs |
-| `src/app/commands/` | 30 | Write operations |
-| `src/app/queries/` | 31 | Read operations |
-| `src/app/handlers/` | 51+ | CQRS handlers |
-| `src/domain/model/` | 44 | Domain entities (8 bounded contexts) |
-| `src/domain/services/` | 50+ | Domain services |
-| `src/infra/database/models/` | 13+ | Database tables |
-| `src/infra/repositories/` | 10+ | Data access |
-| `src/infra/services/` | 8+ | External services |
-| `tests/` | 92 | 681+ tests (70%+ coverage) |
+| `src/api/routes/v1/` | 25 | Versioned REST route modules |
+| `src/api/schemas/` | 35 | Pydantic DTOs |
+| `src/app/commands/` | 50 | Write-operation command packages |
+| `src/app/queries/` | 52 | Read-operation query packages |
+| `src/app/handlers/` | 86 | CQRS handler packages |
+| `src/domain/model/` | 63 | Domain entities and value objects |
+| `src/domain/services/` | 54 | Domain services and policies |
+| `src/infra/database/models/` | 48 | ORM model packages and table declarations |
+| `src/infra/repositories/` | 23 | Data access adapters |
+| `src/infra/services/` | 27 | Infrastructure services and AI providers |
+| `tests/` | 306 | Unit, architecture, migration, and explicit integration tests |
 
 ---
 
@@ -95,7 +95,7 @@ The current HTTP surface includes:
 
 - **FastAPI app:** `src/api/main.py`
 - **CLI**: `python -m src.api.main` or `uvicorn src.api.main:app --reload`
-- **Tests:** `pytest` or `pytest -m unit`
+- **Tests:** `pytest` for the default non-integration suite; explicit integration tests must override the default ignore/marker config
 - **Migrations:** `alembic upgrade head` or `alembic revision --autogenerate -m "..."`
 
 ---
@@ -108,7 +108,7 @@ The current HTTP surface includes:
 | MealCoreService | Meal lifecycle & state machine |
 | NutritionCalculationService | Nutrition aggregation from food items |
 | SuggestionOrchestrationService | Session-based meal suggestions (4h Redis TTL) |
-| MealGenerationService | Multi-model Gemini for meal generation |
+| MealGenerationService | OpenAI-first meal generation with configured Cloudflare fallback |
 | TranslationService | 7-language support (en, vi, es, fr, de, ja, zh) |
 | MealDiscoveryService | Image-based meal discovery |
 

--- a/docs/cqrs-guide.md
+++ b/docs/cqrs-guide.md
@@ -102,7 +102,7 @@ Event handlers return `None` (side effects only — notifications, jobs, etc.).
 # Initialize once at app startup — prevents memory leaks from dynamic class generation
 event_bus = PyMediatorEventBus()
 
-result = await event_bus.send(CreateMealCommand(...))   # command/query
+result = await event_bus.send(CreateManualMealCommand(...))   # command/query
 await event_bus.publish(MealCreatedEvent(...))          # fire-and-forget
 ```
 
@@ -121,7 +121,7 @@ async def create_meal(
     request: CreateMealRequest,
     event_bus: EventBus = Depends(get_event_bus),
 ):
-    meal = await event_bus.send(CreateMealCommand(user_id=user.id, ...))
+    meal = await event_bus.send(CreateManualMealCommand(user_id=user.id, ...))
     return meal
 ```
 

--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -1,9 +1,9 @@
 # Backend Database Guide
 
-**Last Updated:** June 17, 2026
+**Last Updated:** June 27, 2026
 **Engine:** PostgreSQL (Neon) + SQLAlchemy 2.0 async runtime (asyncpg)
-**Migrations:** Alembic via deployment entrypoint/pre-deploy flow
-**Tables:** 36 ORM table declarations across core, normalized tracking, referral, notification, and cache models
+**Migrations:** Alembic via `migrations/versions/` and `migrations/run.py`
+**Tables:** 39 ORM model files across core, normalized tracking, referral, notification, and cache models
 
 ---
 
@@ -111,6 +111,9 @@ instead of the request/runtime session factory.
 | **referral_conversions** | Referral conversion audit | referrer_user_id, referred_user_id, status, commission fields |
 | **referral_wallets** | Referral wallet totals | user_id, balance, total_earned, total_withdrawn |
 | **payout_requests** | Referral payout workflow | user_id, amount, payment_method, typed masked destination, payment_details snapshot, status |
+| **affiliate_event_outbox** | Cross-service affiliate lifecycle dispatch | event_id, event_type, status, attempts, next_attempt_at |
+| **ai_handshake_guest_trial_quotas** | Guest trial quota state | install_hash, used_at, expires_at |
+| **promo_codes** / **promo_code_redemptions** | Promotional entitlement tracking | code, source_offering_id, redemption state |
 
 ---
 
@@ -162,15 +165,20 @@ alembic revision --autogenerate -m "description"  # Create new
 alembic downgrade -1                              # Rollback one
 ```
 
-Deployments run migrations before application startup through `docker-entrypoint.sh`
-for non-production environments or through a production pre-deploy job. Use
-timestamp naming for new migrations and keep app runtime URLs separate from
+Migration files live under `migrations/versions/`. Non-production Docker startup
+runs `python migrations/run.py`; production Render deploys should run the same
+command as a pre-deploy step before promoting the web service. Use timestamp
+naming for new migrations and keep app runtime URLs separate from
 migration/admin URLs.
 
 **Recent migrations:**
 
 | Version | Changes |
 |---------|---------|
+| 20260624000001 | Add journey_progress_seed_percent for existing-user journey progress seeding |
+| 20260620000001 | Add source_offering_id to promo codes |
+| 20260619000001 | Add ai_handshake_guest_trial_quotas for one-shot guest quota state |
+| 20260616000001 | Add beverage-specific columns to hydration entries |
 | 20260610000001 | Add affiliate_event_outbox for cross-service affiliate lifecycle dispatch |
 | 20260609000006 | Add normalized read-path indexes for active FCM tokens, notification reschedule/delete, and stale processing reclaim |
 | 20260609000005 | Add normalized food serving/nutrient tables, payout typed workflow fields, notification context schema version |

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,7 +1,7 @@
 # Backend External Services Integration
 
-**Last Updated:** June 18, 2026
-**Services:** Firebase, Cloudinary, Google Gemini, OpenAI, RevenueCat, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, Brave Search, Pexels, Unsplash, Resend, Cloudflare Workers AI, Google Imagen, Pollinations, nutree-affiliate
+**Last Updated:** June 27, 2026
+**Services:** Firebase, Cloudinary, OpenAI, Cloudflare Workers AI, RevenueCat, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, Brave Search, Pexels, Unsplash, Resend, Google Imagen, Pollinations, nutree-affiliate
 **Failure handling:** Optional integrations degrade when safe. Firebase Auth and the primary DB fail fast. Redis optional caches degrade by bypassing cache; any Redis-backed required state must be documented and health-checked separately.
 
 ---
@@ -28,7 +28,7 @@
 - Notifications rescheduled automatically on timezone changes — triggered from `UpdateTimezoneCommandHandler` and `RegisterFcmTokenCommandHandler`
 - Cron push entrypoint (`src/cron/push.py`) owns all push scheduling: precompute notification rows, schedule trial-expiry rows, claim due rows, batch-send, mark sent, clean expired rows
 - Cron dispatch helper (`CronNotificationDispatchService`) uses database row claiming (`pending` → `processing`) plus stale-processing recovery instead of a background loop or leader lock
-- APNs diagnostics surfaced at `/health/notifications` via `apns_diagnostics()` to verify `interruption-level` placement
+- APNs diagnostics surfaced at `/v1/health/notifications` via `apns_diagnostics()` to verify `interruption-level` placement
 
 ---
 
@@ -46,33 +46,25 @@
 
 ---
 
-## Google Gemini
+## AI Provider Routing
 
-**Purpose:** AI Meal Analysis + Content Generation (primary AI provider)
-
-### Multi-Model Strategy (Rate Distribution)
-
-| Purpose | Model | Env Key |
-|---------|-------|---------|
-| General / Recipe / Barcode | `gemini-2.5-flash` | `GEMINI_MODEL` |
-| Meal / ingredient image scan | `gemini-3.1-flash-lite` → `gemini-3.5-flash` → `gemini-2.5-flash` | code fallback chain |
-| Meal names | `gemini-2.5-flash-lite` | `GEMINI_MODEL_NAMES` |
-| Recipe generation | `gemini-2.5-flash-lite` | `GEMINI_MODEL_RECIPE` |
+**Purpose:** Text generation, structured output, and vision analysis.
 
 ### Provider Fallback Architecture
 
 `AIModelManager` orchestrates providers through `AIProviderPort`. Each purpose has a fallback chain; models are tried in order until one succeeds. The circuit breaker opens after 5 failures within 60s and allows retry after 30s.
 
-**Default text chain (e.g. RECIPE) when CF text enabled:**
+**Default model:** `gpt-5.4-mini-2026-03-17` for text and vision when `OPENAI_API_KEY` is configured.
+
+**Text chain when Cloudflare text routing is configured:**
 ```
 @cf/meta/llama-3.3-70b-instruct-fp8-fast  →  gpt-5.4-mini-2026-03-17
 ```
 
-**Vision chains (OpenAI-first even when CF vision is enabled):**
+**Vision chain when Cloudflare vision fallback is configured:**
 ```
 gpt-5.4-mini-2026-03-17  →  @cf/google/gemma-4-26b-a4b-it
 ```
-When CF vision is disabled, vision chains stay OpenAI-only.
 
 **Text purposes routed through Cloudflare by default:**
 ```
@@ -95,7 +87,7 @@ Logs emitted: `[AI-ATTEMPT]`, `[AI-FALLBACK-SUCCESS]`, `[AI-ATTEMPT-FAILED]`. Ne
 | Daily multi-meal | 3000 |
 | Single meal | 1500 |
 
-**Config:** `GOOGLE_API_KEY`
+**Config:** `OPENAI_API_KEY`, `OPENAI_TEXT_MODEL`, `OPENAI_VISION_MODEL`, `CLOUDFLARE_WORKERS_AI_*`
 
 ---
 
@@ -115,7 +107,7 @@ Logs emitted: `[AI-ATTEMPT]`, `[AI-FALLBACK-SUCCESS]`, `[AI-ATTEMPT-FAILED]`. Ne
 
 ## Cloudflare Workers AI (Text + Vision)
 
-**Purpose:** Primary AI provider for text tasks. Optional fallback for image scanning after OpenAI.
+**Purpose:** Optional routed provider for configured text purposes and optional fallback for image scanning after OpenAI.
 
 **Two independent routing paths:**
 - **Text path:** LangChain adapter (`ChatCloudflareWorkersAI`) for text-generation purposes.
@@ -127,8 +119,8 @@ Logs emitted: `[AI-ATTEMPT]`, `[AI-FALLBACK-SUCCESS]`, `[AI-ATTEMPT-FAILED]`. Ne
 - Vision: Posts `messages[].content[].image_url` (base64 data URL) directly to the Workers AI REST endpoint. Response is normalized from `result.response` or `result.choices[0].message.content`.
 - Cloudflare model IDs stored raw (`@cf/...`) in fallback chains; `AIModelManager` routes to the CF provider via an explicit ownership map.
 - If `CLOUDFLARE_AI_GATEWAY_ID` is set, LangChain passes it as the `ai_gateway` field to Workers AI.
-- Returns the same `dict` shape as `GeminiProvider` — handlers are provider-agnostic.
-- Circuit breaker trips on 429/5xx/timeout, same as Gemini.
+- Returns the same normalized `dict` shape as other AI providers — handlers are provider-agnostic.
+- Circuit breaker trips on 429/5xx/timeout.
 - Vision model: `@cf/google/gemma-4-26b-a4b-it` (Vision=Yes, messages/image_url contract). Deprecated model `@cf/unum/uform-gen2-qwen-500m` must not be used.
 
 ### Env Vars
@@ -146,7 +138,6 @@ Logs emitted: `[AI-ATTEMPT]`, `[AI-FALLBACK-SUCCESS]`, `[AI-ATTEMPT-FAILED]`. Ne
 | `CLOUDFLARE_WORKERS_AI_VISION_ENABLED` | `true` | Enable CF vision as image-analysis fallback after OpenAI |
 | `CLOUDFLARE_WORKERS_AI_VISION_MODEL` | `@cf/google/gemma-4-26b-a4b-it` | Vision model for image analysis |
 | `CLOUDFLARE_WORKERS_AI_VISION_PURPOSES` | `meal_scan,ingredient_scan` | Image purposes that include CF vision as fallback |
-| `CLOUDFLARE_AI_GATEWAY_GEMINI_VISION_ENABLED` | `false` | Route Gemini vision calls through CF AI Gateway (requires `CLOUDFLARE_AI_GATEWAY_ID` + `CLOUDFLARE_ACCOUNT_ID`) |
 
 ### Production Rollout (Vision)
 
@@ -181,7 +172,7 @@ CLOUDFLARE_WORKERS_AI_ENABLED=false
 
 ### Cloudflare AI Gateway
 
-Vision calls for both Workers AI and Gemini route through [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) when `CLOUDFLARE_AI_GATEWAY_ID` is set (Workers AI) or `CLOUDFLARE_AI_GATEWAY_GEMINI_VISION_ENABLED=true` (Gemini).
+Workers AI calls route through [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) when `CLOUDFLARE_AI_GATEWAY_ID` is set.
 
 Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 
@@ -191,7 +182,20 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 
 **Workers AI gateway routing** (Pattern B): the existing REST URL (`api.cloudflare.com`) is unchanged — CF routes internally when `cf-aig-gateway-id` header is present. No URL changes needed.
 
-**Gemini gateway routing:** uses `google-genai` SDK (`genai.Client` with `HttpOptions(base_url=...)`) — NOT LangChain. Gemini text calls with `cached_content` bypass the gateway (Google-side cache objects break when proxied).
+---
+
+## Food, Translation, Image, and Email Providers
+
+| Service | Purpose | Config |
+|---------|---------|--------|
+| DeepL | Meal and suggestion translation | `DEEPL_API_KEY` |
+| USDA FoodData Central | Manual meal food search/details | `USDA_FDC_API_KEY` |
+| FatSecret | Barcode and ingredient nutrition fallback | `FATSECRET_CLIENT_ID`, `FATSECRET_CLIENT_SECRET` |
+| OpenFoodFacts | Barcode product lookup | none |
+| Brave Search | Barcode nutrition and image validation fallback | `BRAVE_SEARCH_API_KEY` |
+| Pexels / Unsplash | Meal discovery food photos | `PEXELS_API_KEY`, `UNSPLASH_ACCESS_KEY` |
+| Pollinations / Google Imagen | Generated image fallback adapters | provider-specific adapter config |
+| Resend | Lifecycle and webhook-triggered email | `RESEND_API_KEY`, `EMAIL_ENABLED`, `EMAIL_FROM` |
 
 ---
 
@@ -252,7 +256,7 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 |------|--------------|
 | Food search/details | Cache; stable-ish data with high reuse |
 | Nutrition lookup | Cache; expensive lookup chain with bounded stale window |
-| Gemini explicit cache names | Cache; cost optimization only, fall back to uncached calls |
+| AI provider cache names | Cache; cost optimization only, fall back to uncached calls |
 | Daily/weekly nutrition read models | Conditional cache; short TTL plus write/event invalidation |
 | Auth UID mapping | Process-local TTL cache, not Redis |
 | Notification precompute and FCM token ownership | Do not cache; database is source of truth |
@@ -264,7 +268,7 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 
 **Purpose:** Error tracking, Sentry Logs, operational metrics, performance profiling, crash reporting
 
-- Sentry is an infrastructure connector only. Runtime code calls `src.infra.monitoring` facade functions; direct `sentry_sdk` imports belong only in `src/infra/monitoring/sentry.py`.
+- Sentry is an infrastructure connector only. Runtime code calls `src.observability` facade functions; direct `sentry_sdk` imports belong only in `src/infra/monitoring/sentry.py`.
 - FastAPI, Starlette, SQLAlchemy, and logging integrations are initialized before the `FastAPI` app is created.
 - Sentry Logs are emitted only through the provider-neutral `log_event(...)` facade when `SENTRY_ENABLE_LOGS=true`.
 - Operational metrics are emitted only through provider-neutral metric facade calls when `SENTRY_ENABLE_METRICS=true`.
@@ -367,15 +371,13 @@ GET /v1/health/notifications   # FCM health
 |---------|--------------|----------|
 | Firebase Auth | Fail fast (401) | Requests rejected |
 | PostgreSQL | Fail fast (503) | Requests rejected |
-| Gemini | Circuit breaker → try fallback | Falls through to next model in chain |
-| Workers AI | Circuit breaker (429/5xx/timeout) | Trips same circuit breaker; chain exhausted → AIUnavailableError |
+| AI provider stack | Circuit breaker → try fallback | Falls through to next model in chain; exhausted chain raises AIUnavailableError |
+| Workers AI | Circuit breaker (429/5xx/timeout) | Optional routed provider; disable with env flags |
 | Cloudinary | Degrade (fallback URL) | Continue with best-effort image |
-| RevenueCat | Degrade (assume premium from cache) | Continue with last-known status |
+| RevenueCat | Webhook/cache degradation | Continue with last-known subscription state where available; premium route gates are not yet enforced |
 | PostHog | Degrade (log warning) | Continue without analytics |
 | Redis | Degrade (bypass cache) | Continue without caching |
 | Sentry | Degrade (log locally) | Continue with local logging |
-
----
 
 ---
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,14 +1,14 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
-**Version:** 0.6.5
-**Last Updated:** June 13, 2026
-**Status:** Production-ready. 430 Python files, ~38.5K LOC across 4 layers. 681+ tests, 70%+ coverage. Latest: configurable referral commissions, BMR floor protection, custom unit normalization, email Universal Links, AsyncUnitOfWork concurrency guard, AI nutrition validation retries.
+**Version:** 0.6.6
+**Last Updated:** June 27, 2026
+**Status:** Production-ready. 627 Python files in `src/`, 53,972 LOC in `src/`, 306 Python files in `tests/`, and 1,600+ collected tests. Latest verified changes: OpenAI-first AI routing, journey progress seed, upload-token smoke coverage, and pydantic-settings/CI alignment.
 
 ---
 
 ## Executive Summary
 
-MealTrack Backend is a FastAPI-based service powering intelligent meal tracking and nutritional analysis. It implements Clean Architecture with CQRS pattern across 4 layers (430 files, ~38K LOC), integrating AI vision (Gemini 2.5 Flash with 6 analysis strategies) and chat (streaming responses via MessageOrchestrationService, AIResponseCoordinator) for real-time food recognition and personalized nutrition planning. The system handles 50+ REST endpoints across 12 route modules, supports 7 languages, and maintains 70%+ test coverage with 681+ tests. Latest stats: API (76 files, 8,605 LOC), App (140 files, 6,229 LOC), Domain (133 files, 14,556 LOC), Infra (80 files, 8,895 LOC).
+MealTrack Backend is a FastAPI-based service for meal tracking and nutritional analysis. It implements Clean Architecture with CQRS across 4 layers, while `src/` also includes bootstrap, cron, and observability modules outside the layer directories. The current API surface spans 28 route files, 26 endpoint-bearing route modules, and 85 endpoint decorators; the test suite is unit-biased by default and exceeds 1,600 collected tests.
 
 ---
 
@@ -18,7 +18,7 @@ MealTrack Backend is a FastAPI-based service powering intelligent meal tracking 
 Empower users to understand their nutrition through effortless, AI-driven tracking and personalized recommendations.
 
 ### Primary Goals
-1. **Accuracy**: >90% food recognition accuracy via Gemini Vision.
+1. **Accuracy**: >90% food recognition accuracy via the vision provider stack.
 2. **Efficiency**: Meal logging in < 30 seconds.
 3. **Personalization**: Goal-based (CUT, BULK, RECOMP) nutritional targets.
 4. **Performance**: API p95 < 500ms.
@@ -30,14 +30,14 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 ### 1. AI-Powered Meal Analysis
 - 6 analysis strategies: basic, portion-aware, ingredient-aware, weight-aware, user-context-aware, combined.
 - Multi-food detection in single image with confidence scoring.
-- Gemini 2.5 Flash with strategy pattern for flexible context handling.
-- Returns results in <3 seconds through state machine (PROCESSING → ANALYZING → READY/FAILED).
+- OpenAI is the default provider; configured Cloudflare Workers AI can take routed text purposes first and vision purposes as fallback.
+- Returns results in <3 seconds through the meal state machine (PROCESSING → ANALYZING → READY/FAILED).
 
-### 2. RESTful API (60+ Endpoints across 17 Route Modules)
+### 2. RESTful API (85 endpoint decorators across 26 endpoint route modules)
 - **Meals**: image/analyze, manual, parse-text, streak, weekly/daily-breakdown, weekly/budget, daily/macros, /{id} (GET/DELETE), ingredients (PUT).
 - **User Profiles**: create, metrics (GET/POST), TDEE, custom-macros.
 - **Users**: sync, Firebase UID lookups, metrics, timezone, language, delete.
-- **Meal Suggestions**: generate (3/session, 4h TTL), discover (6 meals + images), recipes, save.
+- **Meal Suggestions**: discover (6 meals + images), recipes, save.
 - **Saved Suggestions**: list, save, delete.
 - **Foods**: USDA FDC search, details by FDC ID, barcode lookup (6-step cascade).
 - **Ingredients**: image-based recognition.
@@ -87,13 +87,13 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 ---
 
 ## 3. Technical Stack
-- **Framework**: FastAPI 0.115+ (Python 3.13)
-- **Database**: PostgreSQL (Neon) with SQLAlchemy 2.0 async runtime, 13+ core tables
+- **Framework**: FastAPI 0.136.3 (Python 3.13.2)
+- **Database**: PostgreSQL (Neon) with SQLAlchemy 2.0 async runtime and 39 ORM model files
 - **Cache**: Redis 7.0 for selective optional caching and AI-cost optimization; required state must be modeled separately
 - **Vector DB**: Pinecone Inference API (1024-dim, llama-text-embed-v2)
-- **AI Services**: Google Gemini 2.5 Flash (multi-model for rate distribution)
+- **AI Services**: OpenAI default routing with optional Cloudflare Workers AI fallbacks for configured text and vision purposes
 
-**AI Output Validation (2026-06)**: All Gemini vision and text-parse flows now use canonical Pydantic contracts (`VisionNutritionResponse`, `MealTextNutritionResponse`) with bounded retry. Invalid AI output (over-limit quantities, empty foods) is rejected at the contract boundary with one automatic retry. The parser is a deterministic mapper, not a silent repair engine. Calories are always derived from backend macros, never from AI-reported kcal.
+**AI Output Validation (2026-06)**: Structured meal image and text flows use canonical Pydantic contracts (`VisionNutritionResponse`, `MealTextNutritionResponse`) with one bounded retry. Invalid AI output (over-limit quantities, empty foods) is rejected at the contract boundary. The parser is a deterministic mapper, not a silent repair engine. Calories are always derived from backend macros, never from AI-reported kcal.
 - **Storage**: Cloudinary (image storage with folder organization)
 - **Image Search**: Unsplash + Pexels adapters (meal discovery)
 - **Auth**: Firebase JWT with development bypass middleware
@@ -106,11 +106,11 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 ## 4. Non-Functional Requirements
 - **Reliability**: 99.9% uptime with graceful degradation for external services.
-- **Test Coverage**: 70%+ overall (681+ tests), 100% critical paths.
+- **Test Coverage**: CI enforces unit coverage at 65% minimum; documentation targets remain 70%+ overall and 100% critical paths.
 - **Maintainability**: <200 LOC per file, 4-Layer Clean Architecture with strict separation.
 - **Security**: Firebase JWT verification, RevenueCat webhook auth, soft deletes, input sanitization.
 - **Performance**: Request-scoped DB sessions, Redis caching with TTL, eager loading for queries.
-- **Scalability**: Dynamic connection pool sizing, multi-model Gemini for rate distribution.
+- **Scalability**: Dynamic connection pool sizing and provider fallback routing for AI workloads.
 - **Observability**: Request ID tracking, slow request detection (>1s), structured error responses.
 
 ---
@@ -119,6 +119,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 0.6.6 | Jun 27, 2026 | Documentation refresh for current runtime versions, current codebase metrics, OpenAI-first AI routing, and updated test/CI defaults. |
 | 0.6.5 | Jun 13, 2026 | Added validation retry orchestration for structured AI nutrition output, with exactly one repair attempt for meal image scan and text parse flows, controlled `AIOutputValidationError` handling, preserved ingredient-recognition's unstructured contract, and kept calorie divergence checks anchored to backend-derived macro calories. |
 | 0.6.4 | Jun 13, 2026 | Added canonical AI nutrition contracts for image and text flows, rejected impossible over-limit food quantities at validation time, preserved current text-parse macro compatibility, and removed silent invalid-food filtering from the legacy parser. |
 | 0.6.2 | May 15, 2026 | Configurable referral commissions (`REFERRAL_COMMISSIONS` env var, per-currency JSON). Custom unit-to-grams fix in nutrition calculation. BMR floor raised to 85% of standard daily; cutting deficit 500→300 kcal; clinical minimums 1200F/1500M. Email Universal Links (apple-app-site-association, /app-download). AsyncUnitOfWork concurrency guard (asyncio.Lock). Variable-length referral codes (3–15 chars). |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,8 +1,8 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.5
-**Last Updated:** June 16, 2026
-**Status:** Production-ready. 430 source files, ~38K LOC across 4 layers (API: 76, App: 140, Domain: 133, Infra: 80). 1649+ unit tests, 70%+ coverage.
+**Version:** 0.6.6
+**Last Updated:** June 27, 2026
+**Status:** Production-ready. 627 source files in `src/`, 53,972 LOC in `src/`, 306 Python test files, and 1,600+ collected tests. Default `pytest` is unit-biased because integration tests are ignored by config.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
 
 ---
@@ -22,6 +22,12 @@
 - [x] Strict active-period filtering keeps only `period_start <= action_time < period_end`; existing users without `goal_started_at` fall back to the stable 2026-06-21 feature start in their local timezone.
 - [x] Onboarding and target-weight updates now set the journey baseline fields that anchor the active period.
 - [x] Existing-user migration can now seed journey progress from pre-release action logs with a bounded `journey_progress_seed_percent`, while post-release actions continue filling the remaining progress.
+
+### June 2026: Provider and Contract Refresh
+- [x] OpenAI is the default AI provider for text and vision; configured Cloudflare Workers AI can prepend text-purpose chains and append vision fallbacks.
+- [x] OpenAI model ownership is explicit in `src/infra/services/ai/ai_model_manager.py` with `gpt-5.4-mini-2026-03-17` as the base default.
+- [x] Upload-token smoke coverage is part of the current API verification set.
+- [x] `pydantic-settings` and the CI/test default flow were updated to Python 3.13.2, FastAPI 0.136.3, and unit-biased pytest defaults.
 
 ### June 2026: Single-Owner Logger System
 - [x] Established log-or-raise rule: one root-cause `ERROR` per unexpected request failure; expected 4xx exceptions produce zero ERROR logs.
@@ -47,7 +53,7 @@
 
 ### June 2026: Vision Parser Resilience
 - [x] Canonical AI nutrition contracts now reject impossible over-limit food quantities before domain hydration, invalid AI items now fail instead of being silently repaired, and structured meal image/text output retries exactly once before raising controlled `AIOutputValidationError`.
-- [x] Meal image analysis now carries an explicit `is_food` guard through Gemini schema validation, adapter mapping, parsers, command handlers, and API error mapping so explicit non-food images reject before nutrition parsing without changing successful meal response shape.
+- [x] Meal image analysis now carries an explicit `is_food` guard through provider schema validation, adapter mapping, parsers, command handlers, and API error mapping so explicit non-food images reject before nutrition parsing without changing successful meal response shape.
 - [x] LLM nutrition output contracts: Structured Pydantic contracts for all AI meal-analysis flows; bounded validation retry; parser becomes deterministic mapping; `quantity=150000` and similar impossible AI outputs are rejected before persistence. Background event handler sanitizes `AIOutputValidationError` into a user-friendly failure message. `PromptEvalLoop` tracks schema `validation_success_rate` as a separate observable metric alongside `parse_success_rate`.
 - [x] Beverage image scans now persist only normalized `hydration_entries` rows, with no compatibility meal row, while preserving the existing meal-shaped scan response.
 
@@ -202,7 +208,7 @@
 - [ ] Refactor hardcoded values (MAX_FILE_SIZE, SLOW_REQUEST_THRESHOLD) to config
 
 ### Medium Priority
-- [ ] Add monitoring for Gemini API quota and Cloudinary storage limits
+- [ ] Add monitoring for AI provider quota and Cloudinary storage limits
 - [ ] Consider using DI for CloudinaryImageStore instead of direct instantiation in routes
 - [ ] Tune rate limiting thresholds for meal_suggestions endpoints based on usage patterns
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,9 +1,9 @@
 # Backend System Architecture Overview
 
-**Last Updated:** June 22, 2026
+**Last Updated:** June 27, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
-**Codebase:** 620 Python files, ~52.6K LOC in `src/`
+**Codebase:** 627 Python files, 53,972 LOC in `src/`
 
 ---
 
@@ -11,17 +11,17 @@
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                      API Layer (89 files)                    │
+│                      API Layer (91 files)                    │
 │  HTTP Routing │ Pydantic Validation │ Auth │ Middleware      │
 └────────────────────────┬────────────────────────────────────┘
                          │ Commands/Queries
 ┌────────────────────────▼────────────────────────────────────┐
-│              Application Layer (208 files)                   │
+│              Application Layer (207 files)                   │
 │  CQRS Handlers │ Event Publishing │ App Services             │
 └────────────────────────┬────────────────────────────────────┘
                          │ Domain Services
 ┌────────────────────────▼────────────────────────────────────┐
-│                Domain Layer (160 files)                      │
+│                Domain Layer (166 files)                      │
 │  Business Logic │ Domain Models │ Port Interfaces            │
 └────────────────────────┬────────────────────────────────────┘
                          │ Port Implementations
@@ -37,11 +37,11 @@
 
 | Layer | Files | LOC | Key Contents |
 |-------|-------|-----|-------------|
-| API | 89 | ~10,361 | 26 router registrations, 83 endpoint decorators, schemas, middleware, dependencies |
-| App | 208 | ~10,984 | 51 command files, 50 query files, 15 event files, 87 handler files |
-| Domain | 160 | ~15,460 | Meal, nutrition, user, hydration, movement, progress, notification, planning, referral-facing policies |
-| Infra | 154 | ~15,041 | PostgreSQL/pgvector, Redis, PyMediator, external adapters, observability, push/email services |
-| **Total** | **611** | **~51,846** | Layer directories only; `src/` also has bootstrap, cron, and observability modules |
+| API | 91 | 10,624 | 28 route files, 26 endpoint route modules, 85 endpoint decorators, schemas, middleware, dependencies |
+| App | 207 | 11,192 | 37 command files, 34 query files, 10 event files, 75 handler files |
+| Domain | 166 | 16,283 | Meal, nutrition, user, hydration, movement, progress, notification, planning, referral-facing policies |
+| Infra | 154 | 15,134 | PostgreSQL/pgvector, Redis, PyMediator, external adapters, observability, push/email services |
+| **Total** | **618** | **53,233** | Layer directories only; `src/` also has bootstrap, cron, and observability modules |
 
 **Layer rule:** Domain has ZERO external dependencies. See `cqrs-guide.md` for handler patterns.
 
@@ -53,13 +53,13 @@
 Domain defines port interfaces; infrastructure implements them. Handlers depend on abstractions.
 
 ### CQRS
-- **Commands** — write operations, publish events (CreateMeal, UpdateUserMetrics)
+- **Commands** — write operations, publish events (CreateManualMeal, UpdateUserMetrics)
 - **Queries** — read-only, return immediately (GetMealById, SearchFoods)
 - **Events** — fire-and-forget, processed async (MealCreated, UserOnboarded)
 
 ### Event Bus (PyMediator Singleton)
 ```python
-result = await event_bus.send(CreateMealCommand(...))    # synchronous
+result = await event_bus.send(CreateManualMealCommand(...))    # synchronous
 await event_bus.publish(MealCreatedEvent(...))           # fire-and-forget
 ```
 
@@ -69,7 +69,7 @@ Background subscriber tasks are owned by `BackgroundTaskManager` (`src/infra/eve
 Async SQLAlchemy repositories are accessed through `AsyncUnitOfWork`. The UoW owns commit/rollback boundaries; repositories flush only when generated IDs or relationship state are needed.
 
 ### Observability Connector
-Observability uses a provider-neutral facade at `src.observability` so API middleware does not import infrastructure directly. Infrastructure owns the Sentry connector, and startup composition wires it through `src.bootstrap.observability`. The compatibility export at `src.infra.monitoring` remains for cron and infrastructure services. Direct `sentry_sdk` imports are isolated to `src/infra/monitoring/sentry.py`.
+Observability uses a provider-neutral facade at `src.observability` so API middleware does not import infrastructure directly. Startup composition wires it through `src.bootstrap.observability`. The compatibility export at `src.infra.monitoring` remains for cron and infrastructure services. Direct `sentry_sdk` imports are isolated to `src/infra/monitoring/sentry.py`.
 
 The connector sends unexpected API failures, `ERROR` logs, sampled request/SQL/cron spans, explicit Sentry Logs, operational metrics, swallowed cron failures, and affiliate outbox permanent failures. It does not send expected 4xx/business errors, product analytics, request bodies, auth headers, Firebase claims, emails, food payloads, raw image URLs, provider payloads, or secrets. Context, log attributes, and metric attributes are allowlisted scalar values.
 
@@ -114,7 +114,7 @@ Architecture guardrails enforced by `tests/unit/architecture/test_logging_owners
 4. Handler uploads to Cloudinary, creates Meal (PROCESSING), publishes `MealImageUploadedEvent`
 5. Handler returns Meal immediately to API (synchronous response to client)
 6. `EventBus.publish()` → `MealAnalysisEventHandler` (background)
-7. Background: calls `VisionAIService` (Gemini), parses nutrition, updates Meal to READY
+7. Background: calls `VisionAIService` through the provider stack, parses nutrition, updates Meal to READY
 
 ---
 

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -1,8 +1,8 @@
 # Backend Testing Standards
 
-**Last Updated:** June 17, 2026
-**Coverage Target:** 70%+ overall, 100% critical paths, 80%+ new features  
-**Suite Size:** 291 Python files in `tests/`; latest collection reaches 1,600+ tests
+**Last Updated:** June 27, 2026
+**Coverage Target:** CI gate 65% for unit coverage; docs target 70%+ overall, 100% critical paths, 80%+ new features
+**Suite Size:** 306 Python files in `tests/`; latest collection reaches 1,600+ tests
 
 ---
 
@@ -49,7 +49,7 @@ def test_repository_find_by_id_raises_not_found_when_missing():
 def test_feature_condition_expected():
     # Arrange: set up data
     user = create_test_user()
-    command = CreateMealCommand(user_id=user.id, ...)
+    command = CreateManualMealCommand(user_id=user.id, ...)
     
     # Act: execute
     meal = await handler.handle(command)
@@ -90,9 +90,13 @@ def test_meal_creation_saves_to_db():
 **Run specific tests:**
 ```bash
 pytest -m unit                      # Unit tests only
-pytest -m integration               # Integration tests only
+pytest tests/integration -o addopts="" -m integration  # Explicit integration run
 pytest --cov=src --cov-report=html  # With coverage report
 ```
+
+Default `pytest` uses `pytest.ini` addopts that ignore `tests/integration` and
+select `not integration`. CI runs `lint-imports` and then
+`pytest tests/unit --cov=src --cov-fail-under=65`.
 
 ---
 
@@ -116,7 +120,8 @@ def mock_vision_ai():
 
 ## Fixtures (Reusable)
 
-Place in `conftest.py`:
+Place shared fixtures in `tests/conftest.py`; keep domain-specific fixtures in
+`tests/fixtures/` or the nearest package-level `conftest.py`:
 
 ```python
 @pytest.fixture
@@ -136,12 +141,13 @@ async def event_bus():
 
 ## Performance Testing
 
-For integration tests with DB access:
+For integration tests with DB access, assert timing directly unless the
+`pytest-benchmark` plugin is added to the environment:
 
 ```python
 @pytest.mark.integration
-def test_meal_repository_find_by_id_performance(benchmark):
-    result = benchmark(repo.find_by_id, "meal-1")
+async def test_meal_repository_find_by_id_performance():
+    result = await repo.find_by_id("meal-1")
     assert result is not None
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Backend Troubleshooting Guide
 
-**Last Updated:** June 17, 2026
+**Last Updated:** June 27, 2026
 
 ---
 
@@ -12,7 +12,7 @@
 
 **Diagnosis:**
 ```bash
-python -c "from src.app.commands.meal import CreateMealCommand"
+python -c "from src.app.commands.meal.upload_meal_image_immediately_command import UploadMealImageImmediatelyCommand"
 ```
 
 **Solutions:**
@@ -94,7 +94,7 @@ redis-cli ping
 
 **Diagnosis:**
 ```bash
-SQLALCHEMY_ECHO=true python src/api/main.py
+SQLALCHEMY_ECHO=true uvicorn src.api.main:app --reload
 ```
 
 **Solutions:**
@@ -111,7 +111,7 @@ SQLALCHEMY_ECHO=true python src/api/main.py
 
 **Diagnosis:**
 ```bash
-grep -r "@handles" src/app/handlers/
+rg "@handles" src/app/handlers/
 ```
 
 **Solutions:**
@@ -124,13 +124,13 @@ grep -r "@handles" src/app/handlers/
 
 ### External Service Timeouts
 
-**Problem:** Gemini/Cloudinary/Firebase requests timeout
+**Problem:** OpenAI, Cloudflare Workers AI, Cloudinary, Firebase, RevenueCat, affiliate, or search provider requests timeout
 
 **Solutions:**
-1. Increase timeout (max 30s for FastAPI)
-2. Implement retry logic with exponential backoff
-3. Cache responses where possible
-4. Add circuit breaker for repeated failures
+1. Verify provider-specific timeout settings in `src/infra/config/settings.py`.
+2. Check circuit-breaker logs for `[AI-ATTEMPT-FAILED]` and `[AI-FALLBACK-SUCCESS]`.
+3. Cache only optional read/cost-optimization data where DB/API fallback is correct.
+4. Keep required integrations fail-fast or backed by durable retry state such as an outbox.
 
 ---
 
@@ -192,7 +192,7 @@ rg "log_event|increment_metric|gauge_metric|distribution_metric" src
 **Solutions:**
 1. Set `SENTRY_ENABLE_LOGS=true` for Sentry Logs ingestion.
 2. Set `SENTRY_ENABLE_METRICS=true` for application metric ingestion.
-3. Emit structured logs and metrics through `src.infra.monitoring`; Python `logging.info(...)` is not the same as a Sentry Logs facade call.
+3. Emit structured logs and metrics through `src.observability`; Python `logging.info(...)` is not the same as a Sentry Logs facade call.
 4. Keep attributes allowlisted and scalar. Non-allowlisted, `None`, list, and dict attributes are dropped before reaching Sentry.
 
 ---
@@ -232,7 +232,7 @@ See related: `code-standards.md`, `testing-standards.md`, `system-architecture.m
 
 ---
 
-## Database Connection Issues
+## Neon Connection Mode Issues
 
 ### asyncpg prepared statement error in pooler mode
 **Symptom:** `asyncpg.exceptions.InvalidSQLStatementNameError: prepared statement ... does not exist`  


### PR DESCRIPTION
## Summary
- refresh backend docs with current FastAPI/Python/runtime details
- update API surface, layer metrics, provider routing, and testing notes
- align README and docs references with current documentation files

## Validation
- wc -l docs/*.md
- git diff --check

## Notes
- Custom docs validator command `node /Users/tonytran/.claude/scripts/validate-docs.cjs docs/` was started but produced no output and was interrupted after roughly 90 seconds.