### PR TITLE
feat: implement food label scan flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,7 +119,7 @@ CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS=60
 # Rollback: set CLOUDFLARE_WORKERS_AI_VISION_ENABLED=false (no redeploy needed).
 CLOUDFLARE_WORKERS_AI_VISION_ENABLED=true
 CLOUDFLARE_WORKERS_AI_VISION_MODEL=@cf/google/gemma-4-26b-a4b-it
-CLOUDFLARE_WORKERS_AI_VISION_PURPOSES=meal_scan,ingredient_scan
+CLOUDFLARE_WORKERS_AI_VISION_PURPOSES=meal_scan,food_label_scan,ingredient_scan
 # ---------------------------------------------------------------------------
 # DeepL Translation (required for non-English meal translation)
 # Get from https://www.deepl.com/pro-api

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -52,6 +52,7 @@
       application logs.
 
 ### June 2026: Vision Parser Resilience
+- [x] Food-label custom nutrition now preserves fiber and sugar through manual meal creation, meal edit requests, response mapping, and serving-size recalculation, with gram-based per-100g validation extended to the new fields. Completed 2026-06-28.
 - [x] Canonical AI nutrition contracts now reject impossible over-limit food quantities before domain hydration, invalid AI items now fail instead of being silently repaired, and structured meal image/text output retries exactly once before raising controlled `AIOutputValidationError`.
 - [x] Meal image analysis now carries an explicit `is_food` guard through provider schema validation, adapter mapping, parsers, command handlers, and API error mapping so explicit non-food images reject before nutrition parsing without changing successful meal response shape.
 - [x] LLM nutrition output contracts: Structured Pydantic contracts for all AI meal-analysis flows; bounded validation retry; parser becomes deterministic mapping; `quantity=150000` and similar impossible AI outputs are rejected before persistence. Background event handler sanitizes `AIOutputValidationError` into a user-friendly failure message. `PromptEvalLoop` tracks schema `validation_success_rate` as a separate observable metric alongside `parse_success_rate`.

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -146,6 +146,12 @@ class MealMapper:
                             fat_per_100g=(
                                 item.macros.fat * scale_factor if item.macros else 0.0
                             ),
+                            fiber_per_100g=(
+                                item.macros.fiber * scale_factor if item.macros else 0.0
+                            ),
+                            sugar_per_100g=(
+                                item.macros.sugar * scale_factor if item.macros else 0.0
+                            ),
                         )
 
                     food_item_dto = FoodItemResponse(
@@ -344,14 +350,12 @@ class MealMapper:
         Returns:
             FoodItem domain model
         """
-        # Extract calories and macros from nutrition dict if present
-        calories = item_dict.get("calories", 0)
+        # Extract macros from nutrition dict if present.
         macros = Macros(protein=0, carbs=0, fat=0)
         micros = None
 
         if "nutrition" in item_dict and item_dict["nutrition"]:
             nutrition_data = item_dict["nutrition"]
-            calories = nutrition_data.get("calories", 0)
             macros = Macros(
                 protein=nutrition_data.get("protein_g", 0),
                 carbs=nutrition_data.get("carbs_g", 0),

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -2,18 +2,16 @@
 Mapper for meal-related DTOs and domain models.
 """
 
-from typing import List, Optional
-
 from src.api.schemas.response import (
-    SimpleMealResponse,
     DetailedMealResponse,
-    MealListResponse,
     FoodItemResponse,
+    MealListResponse,
     NutritionResponse,
+    SimpleMealResponse,
 )
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.domain.model.meal import Meal
-from src.domain.model.nutrition import FoodItem, Nutrition, Macros, Micros
+from src.domain.model.nutrition import FoodItem, Macros, Micros, Nutrition
 from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
 
 # Status mapping from domain to API
@@ -54,8 +52,8 @@ class MealMapper:
     @staticmethod
     def to_detailed_response(
         meal: Meal,
-        image_url: Optional[str] = None,
-        target_language: Optional[str] = None,
+        image_url: str | None = None,
+        target_language: str | None = None,
     ) -> DetailedMealResponse:
         """
         Convert Meal domain model to DetailedMealResponse DTO.
@@ -70,8 +68,8 @@ class MealMapper:
             DetailedMealResponse DTO
         """
         from src.api.schemas.response.meal_responses import (
-            MacrosResponse,
             CustomNutritionResponse,
+            MacrosResponse,
             MealTranslationResponse,
             TranslatedFoodItemResponse,
         )
@@ -173,7 +171,19 @@ class MealMapper:
                     dish_name = tr.dish_name
                 if tr.meal_instruction:
                     instructions = tr.meal_instruction
-                if tr.meal_ingredients and len(tr.meal_ingredients) == len(food_items):
+                translated_names_by_id = {
+                    str(item.food_item_id): item.name
+                    for item in tr.food_items
+                    if item.name
+                }
+                if translated_names_by_id:
+                    for fi in food_items:
+                        translated_name = translated_names_by_id.get(str(fi.id))
+                        if translated_name:
+                            fi.name = translated_name
+                elif tr.meal_ingredients and len(tr.meal_ingredients) == len(
+                    food_items
+                ):
                     for i, fi in enumerate(food_items):
                         fi.name = tr.meal_ingredients[i]
 
@@ -225,7 +235,7 @@ class MealMapper:
         )
 
     @staticmethod
-    def _normalize_instructions(instructions: Optional[list]) -> Optional[list]:
+    def _normalize_instructions(instructions: list | None) -> list | None:
         """Normalize instructions to structured format.
 
         Converts legacy List[str] to List[dict] with {instruction, duration_minutes}.
@@ -243,11 +253,11 @@ class MealMapper:
 
     @staticmethod
     def to_meal_list_response(
-        meals: List[Meal],
+        meals: list[Meal],
         total: int,
         page: int = 1,
         page_size: int = 10,
-        image_urls: Optional[dict] = None,
+        image_urls: dict | None = None,
     ) -> MealListResponse:
         """
         Convert list of Meal domain models to MealListResponse DTO.
@@ -316,14 +326,12 @@ class MealMapper:
         Returns:
             FoodItem domain model
         """
-        # Extract calories and macros from nutrition dict if present
-        calories = item_dict.get("calories", 0)
+        # Extract macros from nutrition dict if present; calories are derived.
         macros = Macros(protein=0, carbs=0, fat=0)
         micros = None
 
         if "nutrition" in item_dict and item_dict["nutrition"]:
             nutrition_data = item_dict["nutrition"]
-            calories = nutrition_data.get("calories", 0)
             macros = Macros(
                 protein=nutrition_data.get("protein_g", 0),
                 carbs=nutrition_data.get("carbs_g", 0),
@@ -355,12 +363,12 @@ class MealMapper:
         Returns:
             DailyNutritionResponse DTO
         """
+        from src.api.exceptions import ResourceNotFoundException
         from src.api.schemas.response.daily_nutrition_response import (
+            HydrationSummaryResponse,
             MacrosResponse,
             WeeklyContextResponse,
-            HydrationSummaryResponse,
         )
-        from src.api.exceptions import ResourceNotFoundException
 
         # Extract data - require actual user targets, no hardcoded defaults
         target_calories = daily_macros_data.get("target_calories")

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -2,6 +2,7 @@
 Mapper for meal-related DTOs and domain models.
 """
 
+import json
 from typing import List, Optional
 
 from src.api.schemas.response import (
@@ -9,6 +10,8 @@ from src.api.schemas.response import (
     DetailedMealResponse,
     MealListResponse,
     FoodItemResponse,
+    FoodLabelMetadataResponse,
+    FoodLabelServingSizeResponse,
     NutritionResponse,
 )
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
@@ -46,6 +49,7 @@ class MealMapper:
             dish_name=meal.dish_name,
             emoji=meal.emoji,
             meal_type=meal.meal_type,
+            source=meal.source,
             ready_at=meal.ready_at,
             error_message=meal.error_message,
             created_at=meal.created_at,
@@ -204,6 +208,7 @@ class MealMapper:
             dish_name=dish_name,
             emoji=meal.emoji,
             meal_type=meal.meal_type,
+            source=meal.source,
             ready_at=meal.ready_at,
             error_message=meal.error_message,
             created_at=meal.created_at,
@@ -216,6 +221,7 @@ class MealMapper:
             ),
             total_nutrition=total_nutrition,
             translations=translations_response,
+            food_label_metadata=MealMapper._food_label_metadata(meal),
             description=getattr(meal, "description", None),
             instructions=instructions,
             prep_time_min=getattr(meal, "prep_time_min", None),
@@ -223,6 +229,28 @@ class MealMapper:
             cuisine_type=getattr(meal, "cuisine_type", None),
             origin_country=getattr(meal, "origin_country", None),
         )
+
+    @staticmethod
+    def _food_label_metadata(meal: Meal) -> Optional["FoodLabelMetadataResponse"]:
+        if meal.source != "food_label" or not meal.raw_gpt_json:
+            return None
+        try:
+            data = json.loads(meal.raw_gpt_json)
+            serving_size = data.get("serving_size") or {}
+            return FoodLabelMetadataResponse(
+                product_name=data["product_name"],
+                brand=data.get("brand"),
+                serving_size=FoodLabelServingSizeResponse(
+                    display_text=serving_size["display_text"],
+                    grams=float(serving_size["grams"]),
+                ),
+                servings_per_package=float(data["servings_per_package"]),
+                label_calories_per_serving=data.get("label_calories_per_serving"),
+                confidence=float(data.get("confidence", 0.5)),
+                label_notes=list(data.get("label_notes") or []),
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return None
 
     @staticmethod
     def _normalize_instructions(instructions: Optional[list]) -> Optional[list]:

--- a/src/api/routes/v1/foods.py
+++ b/src/api/routes/v1/foods.py
@@ -1,5 +1,5 @@
 """
-Foods API routes: search and details via USDA, barcode lookup via OpenFoodFacts.
+Foods API routes: manual search/autocomplete, details, and barcode lookup.
 
 Uses a lightweight singleton event bus to avoid re-initializing
 heavy services (Cloudinary, AI providers, etc.) on every request.
@@ -26,10 +26,28 @@ async def search_foods(
     q: str = Query(..., min_length=1),
     limit: int = Query(20, ge=1, le=50),
 ):
-    """Search foods using lightweight singleton event bus."""
+    """Search foods for manual logging using the lightweight event bus."""
     event_bus = get_food_search_event_bus()
     language = get_request_language(request)
     query = SearchFoodsQuery(query=q, limit=limit, language=language)
+    return await event_bus.send(query)
+
+
+@router.get("/autocomplete")
+async def autocomplete_foods(
+    request: Request,
+    q: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=20),
+):
+    """Autocomplete foods for manual logging using the search provider path."""
+    event_bus = get_food_search_event_bus()
+    language = get_request_language(request)
+    query = SearchFoodsQuery(
+        query=q,
+        limit=limit,
+        language=language,
+        autocomplete=True,
+    )
     return await event_bus.send(query)
 
 

--- a/src/api/routes/v1/meal_scan_by_url.py
+++ b/src/api/routes/v1/meal_scan_by_url.py
@@ -28,6 +28,7 @@ class ScanByUrlRequest(BaseModel):
     image_id: str
     user_description: Optional[str] = None
     target_date: Optional[str] = None
+    scan_mode: str = "scanner"
 
 
 @router.post(
@@ -57,6 +58,13 @@ async def scan_meal_by_url(
                 details={"image_id": body.image_id},
             )
 
+        if body.scan_mode not in {"scanner", "food_label"}:
+            raise ValidationException(
+                message="scan_mode must be scanner or food_label",
+                error_code="INVALID_SCAN_MODE",
+                details={"scan_mode": body.scan_mode},
+            )
+
         parsed_target_date = None
         if body.target_date:
             try:
@@ -79,6 +87,7 @@ async def scan_meal_by_url(
             user_description=sanitized_description,
             target_date=parsed_target_date,
             language=language,
+            scan_mode=body.scan_mode,
         )
 
         try:

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -9,7 +9,17 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, Header, HTTPException, UploadFile, Query, Request, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Header,
+    HTTPException,
+    UploadFile,
+    Query,
+    Request,
+    status,
+)
 
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
@@ -516,9 +526,7 @@ async def get_meal(
     language = get_request_language(request)
 
     # Use mapper to convert to response with translation support
-    return MealMapper.to_detailed_response(
-        meal, image_url, target_language=language
-    )
+    return MealMapper.to_detailed_response(meal, image_url, target_language=language)
 
 
 @router.delete("/{meal_id}")
@@ -605,6 +613,8 @@ async def update_meal_ingredients(
         meal_id=meal_id,
         user_id=user_id,
         dish_name=request.dish_name,
+        created_at=request.created_at,
+        meal_type=request.meal_type,
         food_item_changes=food_item_changes,
     )
 

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -222,6 +222,8 @@ async def create_manual_meal(
                     protein_per_100g=i.custom_nutrition.protein_per_100g,
                     carbs_per_100g=i.custom_nutrition.carbs_per_100g,
                     fat_per_100g=i.custom_nutrition.fat_per_100g,
+                    fiber_per_100g=i.custom_nutrition.fiber_per_100g,
+                    sugar_per_100g=i.custom_nutrition.sugar_per_100g,
                 )
             items.append(
                 ManualMealItem(
@@ -595,6 +597,8 @@ async def update_meal_ingredients(
                 protein_per_100g=change_request.custom_nutrition.protein_per_100g,
                 carbs_per_100g=change_request.custom_nutrition.carbs_per_100g,
                 fat_per_100g=change_request.custom_nutrition.fat_per_100g,
+                fiber_per_100g=change_request.custom_nutrition.fiber_per_100g,
+                sugar_per_100g=change_request.custom_nutrition.sugar_per_100g,
             )
 
         food_item_changes.append(

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -93,6 +93,10 @@ async def analyze_meal_image_immediate(
         None,
         description="Optional user context (max 200 chars): 'no sugar', 'grilled', etc.",
     ),
+    scan_mode: str = Query(
+        "scanner",
+        description="scanner for meal photos, food_label for Nutrition Facts labels",
+    ),
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
 ):
@@ -122,6 +126,13 @@ async def analyze_meal_image_immediate(
                 details={"size": len(contents), "max_size": MAX_FILE_SIZE},
             )
 
+        if scan_mode not in {"scanner", "food_label"}:
+            raise ValidationException(
+                message="scan_mode must be scanner or food_label",
+                error_code="INVALID_SCAN_MODE",
+                details={"scan_mode": scan_mode},
+            )
+
         parsed_target_date = None
         if target_date:
             try:
@@ -146,6 +157,7 @@ async def analyze_meal_image_immediate(
             target_date=parsed_target_date,
             user_description=sanitized_description,
             language=language,
+            scan_mode=scan_mode,
         )
 
         try:

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -3,6 +3,7 @@ Meal-related request DTOs.
 """
 
 import warnings
+from datetime import datetime
 from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -226,8 +227,8 @@ class CreateManualMealFromFoodsRequest(BaseModel):
             ):
                 continue
 
-            is_legacy_prompt_payload = (
-                source in prompt_sources or not _is_gram_unit(item.unit or "")
+            is_legacy_prompt_payload = source in prompt_sources or not _is_gram_unit(
+                item.unit or ""
             )
             if not is_legacy_prompt_payload:
                 raise ValueError(
@@ -305,14 +306,33 @@ class EditMealIngredientsRequest(BaseModel):
     dish_name: Optional[str] = Field(
         None, min_length=1, max_length=200, description="Updated meal name"
     )
-    food_item_changes: list[FoodItemChangeRequest] = Field(
-        ..., min_items=1, description="List of ingredient changes"
+    created_at: Optional[datetime] = Field(
+        None, description="Updated meal log timestamp"
     )
+    meal_type: Optional[str] = Field(
+        None, description="Updated meal type derived from the user's local log time"
+    )
+    food_item_changes: list[FoodItemChangeRequest] = Field(
+        default_factory=list, description="List of ingredient changes"
+    )
+
+    @model_validator(mode="after")
+    def validate_has_change(self):
+        if (
+            self.dish_name is None
+            and self.created_at is None
+            and self.meal_type is None
+            and not self.food_item_changes
+        ):
+            raise ValueError("At least one meal edit field is required")
+        return self
 
     class Config:
         json_schema_extra = {
             "example": {
                 "dish_name": "Updated Grilled Chicken Salad",
+                "created_at": "2026-06-28T12:30:00Z",
+                "meal_type": "lunch",
                 "food_item_changes": [
                     {
                         "action": "update",

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -304,7 +304,7 @@ class EditMealIngredientsRequest(BaseModel):
     """Request DTO for editing meal ingredients."""
 
     dish_name: Optional[str] = Field(
-        None, min_length=1, max_length=200, description="Updated meal name"
+        None, min_length=0, max_length=200, description="Updated meal name"
     )
     created_at: Optional[datetime] = Field(
         None, description="Updated meal log timestamp"

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -143,7 +143,13 @@ class AnalyzeMealImageRequest(BaseModel):
 def _has_macro_over_100(nutrition) -> bool:
     return any(
         getattr(nutrition, field, 0) > 100
-        for field in ("protein_per_100g", "carbs_per_100g", "fat_per_100g")
+        for field in (
+            "protein_per_100g",
+            "carbs_per_100g",
+            "fat_per_100g",
+            "fiber_per_100g",
+            "sugar_per_100g",
+        )
     )
 
 
@@ -163,12 +169,18 @@ class ManualMealCustomNutritionRequest(BaseModel):
     protein_per_100g: float = Field(..., ge=0, description="Protein per 100g")
     carbs_per_100g: float = Field(..., ge=0, description="Carbohydrates per 100g")
     fat_per_100g: float = Field(..., ge=0, description="Fat per 100g")
+    fiber_per_100g: float = Field(0.0, ge=0, description="Fiber per 100g")
+    sugar_per_100g: float = Field(0.0, ge=0, description="Sugar per 100g")
 
     @property
     def calories_per_100g(self) -> float:
-        """Derive calories from macros: P*4 + C*4 + F*9."""
+        """Derive calories from macros using fiber-aware formula."""
+        net_carbs = max(0.0, self.carbs_per_100g - self.fiber_per_100g)
         return round(
-            self.protein_per_100g * 4 + self.carbs_per_100g * 4 + self.fat_per_100g * 9,
+            self.protein_per_100g * 4
+            + net_carbs * 4
+            + self.fiber_per_100g * 2
+            + self.fat_per_100g * 9,
             2,
         )
 
@@ -271,7 +283,7 @@ class FoodItemChangeRequest(BaseModel):
 class CustomNutritionRequest(BaseModel):
     """Request DTO for custom nutrition data.
 
-    Calories always derived from macros: P*4 + C*4 + F*9.
+    Calories always derived from macros using the canonical fiber-aware formula.
     """
 
     protein_per_100g: float = Field(
@@ -281,12 +293,22 @@ class CustomNutritionRequest(BaseModel):
         ..., ge=0, le=100, description="Carbohydrates per 100g in grams"
     )
     fat_per_100g: float = Field(..., ge=0, le=100, description="Fat per 100g in grams")
+    fiber_per_100g: float = Field(
+        0.0, ge=0, le=100, description="Fiber per 100g in grams"
+    )
+    sugar_per_100g: float = Field(
+        0.0, ge=0, le=100, description="Sugar per 100g in grams"
+    )
 
     @property
     def calories_per_100g(self) -> float:
-        """Derive calories from macros: P*4 + C*4 + F*9."""
+        """Derive calories from macros using fiber-aware formula."""
+        net_carbs = max(0.0, self.carbs_per_100g - self.fiber_per_100g)
         return round(
-            self.protein_per_100g * 4 + self.carbs_per_100g * 4 + self.fat_per_100g * 9,
+            self.protein_per_100g * 4
+            + net_carbs * 4
+            + self.fiber_per_100g * 2
+            + self.fat_per_100g * 9,
             2,
         )
 
@@ -296,6 +318,8 @@ class CustomNutritionRequest(BaseModel):
                 "protein_per_100g": 31.0,
                 "carbs_per_100g": 0.0,
                 "fat_per_100g": 3.6,
+                "fiber_per_100g": 0.0,
+                "sugar_per_100g": 0.0,
             }
         }
 

--- a/src/api/schemas/response/__init__.py
+++ b/src/api/schemas/response/__init__.py
@@ -27,6 +27,8 @@ from .meal_responses import (
     MacrosResponse,
     NutritionResponse,
     FoodItemResponse,
+    FoodLabelMetadataResponse,
+    FoodLabelServingSizeResponse,
     ManualMealCreationResponse,
     MealStatusEnum,
 )
@@ -76,6 +78,8 @@ __all__ = [
     "MacrosResponse",
     "NutritionResponse",
     "FoodItemResponse",
+    "FoodLabelMetadataResponse",
+    "FoodLabelServingSizeResponse",
     "ManualMealCreationResponse",
     "MealStatusEnum",
     # TDEE

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -115,6 +115,25 @@ class CustomNutritionResponse(BaseModel):
     fat_per_100g: float = Field(..., description="Fat per 100g")
 
 
+class FoodLabelServingSizeResponse(BaseModel):
+    """Serving-size metadata extracted from a Nutrition Facts label."""
+
+    display_text: str = Field(..., description="Serving size text from label")
+    grams: float = Field(..., gt=0, description="Serving size in grams")
+
+
+class FoodLabelMetadataResponse(BaseModel):
+    """Client-facing metadata for a food-label scan."""
+
+    product_name: str = Field(..., description="Product name")
+    brand: Optional[str] = Field(None, description="Brand when visible")
+    serving_size: FoodLabelServingSizeResponse
+    servings_per_package: float = Field(..., gt=0)
+    label_calories_per_serving: Optional[float] = Field(None, ge=0)
+    confidence: float = Field(..., ge=0, le=1)
+    label_notes: List[str] = Field(default_factory=list)
+
+
 class FoodItemResponse(BaseModel):
     """Response DTO for food item information."""
 
@@ -144,6 +163,7 @@ class SimpleMealResponse(BaseModel):
     meal_type: Optional[str] = Field(
         None, description="Meal type (breakfast, lunch, dinner, snack)"
     )
+    source: Optional[str] = Field(None, description="Meal source")
     ready_at: Optional[datetime] = Field(None, description="When analysis completed")
     error_message: Optional[str] = Field(None, description="Error message if failed")
     created_at: datetime = Field(..., description="Creation timestamp")
@@ -164,6 +184,9 @@ class DetailedMealResponse(SimpleMealResponse):
     total_nutrition: Optional[MacrosResponse] = Field(None, description="Total macros")
     translations: Optional[Dict[str, MealTranslationResponse]] = Field(
         None, description="Translations keyed by language code"
+    )
+    food_label_metadata: Optional[FoodLabelMetadataResponse] = Field(
+        None, description="Nutrition Facts metadata for food-label scans"
     )
     # Recipe details (populated for AI suggestions, null for scanned/manual meals)
     description: Optional[str] = Field(None, description="Meal description")

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -113,6 +113,8 @@ class CustomNutritionResponse(BaseModel):
     protein_per_100g: float = Field(..., description="Protein per 100g")
     carbs_per_100g: float = Field(..., description="Carbs per 100g")
     fat_per_100g: float = Field(..., description="Fat per 100g")
+    fiber_per_100g: float = Field(0, ge=0, description="Fiber per 100g")
+    sugar_per_100g: float = Field(0, ge=0, description="Sugar per 100g")
 
 
 class FoodLabelServingSizeResponse(BaseModel):

--- a/src/app/commands/meal/create_manual_meal_command.py
+++ b/src/app/commands/meal/create_manual_meal_command.py
@@ -17,6 +17,8 @@ class CustomNutrition:
     protein_per_100g: float
     carbs_per_100g: float
     fat_per_100g: float
+    fiber_per_100g: float = 0.0
+    sugar_per_100g: float = 0.0
 
 
 @dataclass

--- a/src/app/commands/meal/edit_meal_command.py
+++ b/src/app/commands/meal/edit_meal_command.py
@@ -3,6 +3,7 @@ Command to edit meal ingredients and portions.
 """
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Optional, List
 
 from src.app.events.base import Command
@@ -16,6 +17,8 @@ class EditMealCommand(Command):
     meal_id: str
     user_id: str = ""
     dish_name: Optional[str] = None
+    created_at: Optional[datetime] = None
+    meal_type: Optional[str] = None
     food_item_changes: List[FoodItemChange] = field(default_factory=list)
 
 

--- a/src/app/commands/meal/scan_by_url_command.py
+++ b/src/app/commands/meal/scan_by_url_command.py
@@ -17,3 +17,4 @@ class ScanByUrlCommand(Command):
     user_description: Optional[str] = None
     target_date: Optional[date] = None
     language: str = "en"
+    scan_mode: str = "scanner"

--- a/src/app/commands/meal/upload_meal_image_immediately_command.py
+++ b/src/app/commands/meal/upload_meal_image_immediately_command.py
@@ -24,3 +24,4 @@ class UploadMealImageImmediatelyCommand(Command):
     target_date: Optional[date] = None
     user_description: Optional[str] = None  # User-provided context for better accuracy
     language: str = "en"  # ISO 639-1 language code from Accept-Language header
+    scan_mode: str = "scanner"

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -15,6 +15,9 @@ from src.app.events.base import EventHandler, handles
 from src.app.events.meal import MealEditedEvent
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.domain.model.meal import MealStatus
+from src.domain.services.meal_type_determination_service import (
+    determine_meal_type_from_timestamp,
+)
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.utils.timezone_utils import utc_now
 
@@ -60,19 +63,38 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 # 3. Recalculate nutrition
                 updated_nutrition = self._calculate_total_nutrition(updated_food_items)
 
+                updated_created_at = command.created_at or meal.created_at
+                if command.meal_type is not None:
+                    updated_meal_type = command.meal_type
+                elif command.created_at is not None:
+                    updated_meal_type = determine_meal_type_from_timestamp(
+                        command.created_at
+                    )
+                else:
+                    updated_meal_type = meal.meal_type
+
                 # 4. Update meal
                 updated_meal = meal.mark_edited(
                     nutrition=updated_nutrition,
                     dish_name=command.dish_name or meal.dish_name,
+                    created_at=updated_created_at,
+                    meal_type=updated_meal_type,
                 )
 
                 # 5. Persist changes
                 saved_meal = await uow.meals.save(updated_meal)
                 await uow.commit()
 
+                old_meal_date = (meal.created_at or utc_now()).date()
                 meal_date = (saved_meal.created_at or utc_now()).date()
                 if self.cache_invalidation:
-                    await self.cache_invalidation.after_meal_write(saved_meal.user_id, meal_date)
+                    if old_meal_date != meal_date:
+                        await self.cache_invalidation.after_meal_write(
+                            saved_meal.user_id, old_meal_date
+                        )
+                    await self.cache_invalidation.after_meal_write(
+                        saved_meal.user_id, meal_date
+                    )
 
                 # 6. Calculate nutrition delta for event
                 nutrition_delta = self._calculate_nutrition_delta(

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -14,7 +14,8 @@ from src.app.commands.meal import EditMealCommand
 from src.app.events.base import EventHandler, handles
 from src.app.events.meal import MealEditedEvent
 from src.app.services.cache_invalidation_service import CacheInvalidationService
-from src.domain.model.meal import MealStatus
+from src.domain.model.meal import FoodItemTranslation, MealStatus
+from src.domain.model.meal_projection import MealProjection
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.utils.timezone_utils import utc_now
 
@@ -38,7 +39,9 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         async with self.uow as uow:
             try:
                 # 1. Validate meal exists
-                meal = await uow.meals.find_by_id(command.meal_id)
+                meal = await uow.meals.find_by_id(
+                    command.meal_id, projection=MealProjection.FULL_WITH_TRANSLATIONS
+                )
                 if not meal:
                     raise ResourceNotFoundException("Meal not found")
 
@@ -56,6 +59,9 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                     meal.nutrition.food_items if meal.nutrition else [],
                     command.food_item_changes,
                 )
+                self._realign_translations_after_food_item_changes(
+                    meal, updated_food_items
+                )
 
                 # 3. Recalculate nutrition
                 updated_nutrition = self._calculate_total_nutrition(updated_food_items)
@@ -68,11 +74,14 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
                 # 5. Persist changes
                 saved_meal = await uow.meals.save(updated_meal)
+                await self._save_realigned_translations(uow, updated_meal.translations)
                 await uow.commit()
 
                 meal_date = (saved_meal.created_at or utc_now()).date()
                 if self.cache_invalidation:
-                    await self.cache_invalidation.after_meal_write(saved_meal.user_id, meal_date)
+                    await self.cache_invalidation.after_meal_write(
+                        saved_meal.user_id, meal_date
+                    )
 
                 # 6. Calculate nutrition delta for event
                 nutrition_delta = self._calculate_nutrition_delta(
@@ -119,7 +128,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 await uow.rollback()
                 logger.warning(f"Validation error editing meal: {str(e)}")
                 raise ValidationException(str(e)) from None
-            except Exception as e:
+            except Exception:
                 await uow.rollback()
                 raise
 
@@ -151,6 +160,65 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 logger.warning(f"Unknown action: {change.action}")
 
         return list(food_items_dict.values())
+
+    def _realign_translations_after_food_item_changes(self, meal, updated_food_items):
+        """Keep cached translations aligned to the edited food item order."""
+        if not meal.translations or not meal.nutrition or not meal.nutrition.food_items:
+            return
+
+        previous_food_items = meal.nutrition.food_items
+        for translation in meal.translations.values():
+            translated_names_by_id = self._translated_names_by_id(
+                translation, previous_food_items
+            )
+            if not translated_names_by_id:
+                continue
+
+            realigned_ingredients = []
+            realigned_food_items = []
+            for item in updated_food_items:
+                translated_name = translated_names_by_id.get(str(item.id), item.name)
+                realigned_ingredients.append(translated_name)
+                realigned_food_items.append(
+                    FoodItemTranslation(
+                        food_item_id=str(item.id),
+                        name=translated_name,
+                    )
+                )
+
+            translation.meal_ingredients = realigned_ingredients
+            translation.food_items = realigned_food_items
+
+    def _translated_names_by_id(self, translation, previous_food_items):
+        translated_names_by_id = {
+            str(item.food_item_id): item.name
+            for item in translation.food_items
+            if item.name
+        }
+        if translated_names_by_id:
+            return translated_names_by_id
+
+        if translation.meal_ingredients and len(translation.meal_ingredients) == len(
+            previous_food_items
+        ):
+            return {
+                str(item.id): translation.meal_ingredients[index]
+                for index, item in enumerate(previous_food_items)
+                if translation.meal_ingredients[index]
+            }
+
+        return {}
+
+    async def _save_realigned_translations(self, uow, translations):
+        if not translations:
+            return
+
+        translation_repo = getattr(uow, "meal_translations", None)
+        if translation_repo is None:
+            return
+
+        for translation in translations.values():
+            await translation_repo.save(translation)
 
     def _calculate_total_nutrition(self, food_items):
         """Calculate total nutrition from food items using nutrition service."""

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -76,7 +76,11 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 # 4. Update meal
                 updated_meal = meal.mark_edited(
                     nutrition=updated_nutrition,
-                    dish_name=command.dish_name or meal.dish_name,
+                    dish_name=(
+                        command.dish_name
+                        if command.dish_name is not None
+                        else meal.dish_name
+                    ),
                     created_at=updated_created_at,
                     meal_type=updated_meal_type,
                 )

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -99,7 +99,11 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
             )
 
             # Vision analysis via bytes path (never sends URL to the AI provider)
-            if command.user_description:
+            if command.scan_mode == "food_label":
+                vision_result = await self.vision_service.analyze_food_label(
+                    image_bytes
+                )
+            elif command.user_description:
                 from src.domain.strategies.meal_analysis_strategy import (
                     AnalysisStrategyFactory,
                 )
@@ -120,6 +124,58 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                 if isinstance(vision_result, dict)
                 else {}
             )
+
+            if command.scan_mode == "food_label":
+                nutrition = self.gpt_parser.parse_food_label_to_nutrition(
+                    vision_result
+                )
+                label_metadata = self.gpt_parser.parse_food_label_metadata(
+                    vision_result
+                )
+                if not label_metadata.get("is_food_label", True):
+                    raise ValueError(
+                        "Nutrition Facts label could not be read. "
+                        "Please retake the label photo and try again."
+                    )
+
+                meal = Meal(
+                    meal_id=str(uuid4()),
+                    user_id=command.user_id,
+                    status=MealStatus.READY,
+                    created_at=meal_datetime,
+                    meal_type=meal_type,
+                    image=MealImage(
+                        image_id=image_id,
+                        format="jpeg",
+                        size_bytes=len(raw_bytes),
+                        url=command.image_url,
+                    ),
+                    source="food_label",
+                    dish_name=self.gpt_parser.parse_food_label_name(vision_result)
+                    or "Food label",
+                    ready_at=utc_now(),
+                    raw_gpt_json=self.gpt_parser.extract_raw_json(vision_result),
+                    nutrition=nutrition,
+                )
+
+                async with self.uow as uow:
+                    saved_meal = await uow.meals.save(meal)
+                    await uow.commit()
+
+                logger.info(
+                    "[SCAN-BY-URL-FOOD-LABEL-COMPLETE] meal=%s vision=%.2fs total=%.2fs",
+                    saved_meal.meal_id,
+                    vision_elapsed,
+                    time.time() - start,
+                )
+
+                if self.cache_invalidation:
+                    await self.cache_invalidation.after_meal_write(
+                        command.user_id, meal_date
+                    )
+
+                return saved_meal
+
             bev_meta = structured_data.get("beverage_metadata") if structured_data else None
 
             if bev_meta and bev_meta.get("is_packaged_beverage"):

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -11,6 +11,7 @@ import httpx
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.domain.constants import MealDefaults
 from src.domain.model.hydration import HydrationEntry
 from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_projection import MealProjection
@@ -151,8 +152,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                         url=command.image_url,
                     ),
                     source="food_label",
-                    dish_name=self.gpt_parser.parse_food_label_name(vision_result)
-                    or "Food label",
+                    dish_name=MealDefaults.UNNAMED_FOOD_NAME,
                     ready_at=utc_now(),
                     raw_gpt_json=self.gpt_parser.extract_raw_json(vision_result),
                     nutrition=nutrition,

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from src.app.commands.meal import UploadMealImageImmediatelyCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.domain.constants import MealDefaults
 from src.domain.model.hydration import HydrationEntry
 from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_projection import MealProjection
@@ -202,7 +203,6 @@ class UploadMealImageImmediatelyHandler(
 
         if command.scan_mode == "food_label":
             nutrition = self.gpt_parser.parse_food_label_to_nutrition(analysis_result)
-            dish_name = self.gpt_parser.parse_food_label_name(analysis_result)
             label_metadata = self.gpt_parser.parse_food_label_metadata(analysis_result)
             if not label_metadata.get("is_food_label", True):
                 raise ValueError(
@@ -239,7 +239,7 @@ class UploadMealImageImmediatelyHandler(
                         url=image_url,
                     ),
                     source="food_label",
-                    dish_name=dish_name or "Food label",
+                    dish_name=MealDefaults.UNNAMED_FOOD_NAME,
                     ready_at=utc_now(),
                     raw_gpt_json=self.gpt_parser.extract_raw_json(analysis_result),
                     nutrition=nutrition,

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -81,6 +81,15 @@ class UploadMealImageImmediatelyHandler(
 
         for attempt in range(1, max_attempts + 1):
             try:
+                if command.scan_mode == "food_label":
+                    logger.info(
+                        f"[PHASE-1-START] meal={meal_id} | "
+                        f"food label analysis | attempt={attempt}/{max_attempts}"
+                    )
+                    return await self.vision_service.analyze_food_label(
+                        command.file_contents
+                    )
+
                 if command.user_description:
                     from src.domain.strategies.meal_analysis_strategy import (
                         AnalysisStrategyFactory,
@@ -190,6 +199,61 @@ class UploadMealImageImmediatelyHandler(
         logger.info(
             f"[ANALYSIS-COMPLETE] image_id={image_id} | elapsed={analysis_elapsed:.2f}s"
         )
+
+        if command.scan_mode == "food_label":
+            nutrition = self.gpt_parser.parse_food_label_to_nutrition(analysis_result)
+            dish_name = self.gpt_parser.parse_food_label_name(analysis_result)
+            label_metadata = self.gpt_parser.parse_food_label_metadata(analysis_result)
+            if not label_metadata.get("is_food_label", True):
+                raise ValueError(
+                    "Nutrition Facts label could not be read. "
+                    "Please retake the label photo and try again."
+                )
+
+            async with self.uow as uow:
+                user_timezone = await uow.users.get_user_timezone(command.user_id)
+                if not user_timezone or not is_valid_timezone(user_timezone):
+                    user_timezone = "UTC"
+
+                now = utc_now()
+                meal_date = command.target_date if command.target_date else now.date()
+                if command.target_date and command.target_date != now.date():
+                    meal_datetime = noon_utc_for_date(meal_date, user_timezone)
+                else:
+                    meal_datetime = now
+
+                zone_info = get_zone_info(user_timezone)
+                local_datetime = meal_datetime.astimezone(zone_info)
+                meal_type = determine_meal_type_from_timestamp(local_datetime)
+
+                meal = Meal(
+                    meal_id=str(uuid4()),
+                    user_id=command.user_id,
+                    status=MealStatus.READY,
+                    created_at=meal_datetime,
+                    meal_type=meal_type,
+                    image=MealImage(
+                        image_id=image_id,
+                        format="jpeg" if "jpeg" in command.content_type else "png",
+                        size_bytes=len(command.file_contents),
+                        url=image_url,
+                    ),
+                    source="food_label",
+                    dish_name=dish_name or "Food label",
+                    ready_at=utc_now(),
+                    raw_gpt_json=self.gpt_parser.extract_raw_json(analysis_result),
+                    nutrition=nutrition,
+                )
+
+                saved_meal = await uow.meals.save(meal)
+                await uow.commit()
+
+            if self.cache_invalidation:
+                await self.cache_invalidation.after_meal_write(
+                    command.user_id, meal_date
+                )
+
+            return saved_meal
 
         # Step 5a: Beverage scan routing — redirect packaged beverages to hydration_entries
         structured_data = (

--- a/src/app/handlers/query_handlers/search_foods_query_handler.py
+++ b/src/app/handlers/query_handlers/search_foods_query_handler.py
@@ -1,10 +1,7 @@
-"""
-SearchFoodsQueryHandler - Individual handler file.
-Auto-extracted for better maintainability.
-"""
+"""Search foods for manual logging using the configured provider."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from src.app.events.base import EventHandler, handles
 from src.app.queries.food.search_foods_query import SearchFoodsQuery
@@ -17,22 +14,22 @@ logger = logging.getLogger(__name__)
 
 
 @handles(SearchFoodsQuery)
-class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, Dict[str, Any]]):
-    """Handler for searching foods in the database."""
+class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
+    """Handler for FatSecret-backed food search and autocomplete."""
 
     def __init__(
         self,
         cache_service,
         mapping_service: FoodMappingService,
-        fat_secret_service: Optional[Any] = None,
-        translation_service: Optional[DeepLTextTranslationService] = None,
+        fat_secret_service: Any | None = None,
+        translation_service: DeepLTextTranslationService | None = None,
     ):
         self.cache_service = cache_service
         self.mapping_service = mapping_service
         self.fat_secret_service = fat_secret_service
         self.translation_service = translation_service
 
-    async def handle(self, event: SearchFoodsQuery) -> Dict[str, Any]:
+    async def handle(self, event: SearchFoodsQuery) -> dict[str, Any]:
         if not event.query or not event.query.strip():
             return {"results": [], "query": event.query, "total": 0}
 
@@ -44,6 +41,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, Dict[str, Any]]):
         cached = await self.cache_service.get_cached_search(cache_key)
         if cached is not None:
             processed_cached = self._process_search_results(cached)
+            processed_cached = processed_cached[: event.limit]
             for item in processed_cached:
                 if "source" not in item:
                     item["source"] = "fatsecret"
@@ -73,7 +71,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, Dict[str, Any]]):
 
     async def _search_localized(
         self, query: str, limit: int, language: str, cache_key: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Search with localization: try native region first, fallback only if empty."""
         from src.infra.adapters.fat_secret_service import LANGUAGE_TO_REGION
 
@@ -131,8 +129,8 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, Dict[str, Any]]):
         return results
 
     def _process_search_results(
-        self, raw_results: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, raw_results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """Process search results: deduplicate and capitalize names."""
         if not raw_results:
             return raw_results

--- a/src/app/queries/food/search_foods_query.py
+++ b/src/app/queries/food/search_foods_query.py
@@ -1,5 +1,5 @@
 """
-Query to search foods via external database (USDA FDC).
+Query to search foods via the configured manual logging provider.
 """
 
 from dataclasses import dataclass
@@ -12,3 +12,4 @@ class SearchFoodsQuery(Query):
     query: str
     limit: int = 20
     language: str = "en"
+    autocomplete: bool = False

--- a/src/domain/constants/__init__.py
+++ b/src/domain/constants/__init__.py
@@ -6,6 +6,7 @@ values used throughout the domain layer.
 """
 
 from .meal_constants import (
+    MealDefaults,
     MealDistribution,
     NutritionConstants,
     PortionUnits,
@@ -16,6 +17,7 @@ from .meal_constants import (
 )
 
 __all__ = [
+    "MealDefaults",
     "MealDistribution",
     "NutritionConstants",
     "PortionUnits",

--- a/src/domain/constants/meal_constants.py
+++ b/src/domain/constants/meal_constants.py
@@ -24,6 +24,12 @@ class MealDistribution:
     DINNER_WITH_SNACK = 0.27  # 30% * 0.9
 
 
+class MealDefaults:
+    """Default values for user-facing meal fields."""
+
+    UNNAMED_FOOD_NAME = "Unnamed Food"
+
+
 class NutritionConstants:
     """Constants for nutrition calculations."""
 

--- a/src/domain/model/ai/__init__.py
+++ b/src/domain/model/ai/__init__.py
@@ -13,6 +13,8 @@ from .gpt_response_errors import (
 from .model_purpose import ModelPurpose
 from .nutrition_contracts import (
     AINutritionMacros,
+    FoodLabelNutritionResponse,
+    FoodLabelServingSize,
     MealTextFoodEstimate,
     MealTextNutritionResponse,
     VisionFoodEstimate,
@@ -25,6 +27,8 @@ from .vision_food_identity_contract import (
 
 __all__ = [
     "AINutritionMacros",
+    "FoodLabelNutritionResponse",
+    "FoodLabelServingSize",
     "MealTextFoodEstimate",
     "MealTextNutritionResponse",
     "GPTMacros",

--- a/src/domain/model/ai/model_purpose.py
+++ b/src/domain/model/ai/model_purpose.py
@@ -5,6 +5,7 @@ from enum import Enum
 
 class ModelPurpose(Enum):
     MEAL_SCAN = "meal_scan"
+    FOOD_LABEL_SCAN = "food_label_scan"
     INGREDIENT_SCAN = "ingredient_scan"
     PARSE_TEXT = "parse_text"
     BARCODE = "barcode"

--- a/src/domain/model/ai/nutrition_contracts.py
+++ b/src/domain/model/ai/nutrition_contracts.py
@@ -114,6 +114,43 @@ class BeverageMetadata(BaseModel):
     label_source: Literal["nutrition_panel", "front_label", "estimate"] = "estimate"
 
 
+class FoodLabelServingSize(BaseModel):
+    """Serving-size details read from a packaged nutrition label."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_text: str = Field(..., min_length=1, max_length=80)
+    grams: float = Field(..., gt=0, le=MAX_FOOD_ITEM_QUANTITY)
+
+    @field_validator("display_text")
+    @classmethod
+    def validate_display_text(cls, value: str) -> str:
+        return _strip_required_text(value)
+
+
+class FoodLabelNutritionResponse(BaseModel):
+    """Structured nutrition facts label response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    is_food_label: bool = Field(True, description="Whether a Nutrition Facts label is visible")
+    product_name: str = Field(..., min_length=1, max_length=200)
+    brand: str | None = Field(None, max_length=100)
+    serving_size: FoodLabelServingSize
+    servings_per_package: float = Field(..., gt=0, le=1000)
+    label_calories_per_serving: float | None = Field(None, ge=0, le=5000)
+    macros_per_serving: AIVisionNutritionMacros
+    confidence: float = Field(0.5, ge=0, le=1)
+    label_notes: list[str] = Field(default_factory=list, max_length=6)
+
+    @field_validator("product_name", "brand")
+    @classmethod
+    def validate_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _strip_required_text(value)
+
+
 class VisionNutritionResponse(BaseModel):
     """Structured image meal-analysis response."""
 

--- a/src/domain/model/meal/food_item_change.py
+++ b/src/domain/model/meal/food_item_change.py
@@ -28,3 +28,5 @@ class CustomNutritionData:
     protein_per_100g: float
     carbs_per_100g: float
     fat_per_100g: float
+    fiber_per_100g: float = 0.0
+    sugar_per_100g: float = 0.0

--- a/src/domain/model/meal/meal.py
+++ b/src/domain/model/meal/meal.py
@@ -216,13 +216,19 @@ class Meal:
             **self._recipe_fields(),
         )
 
-    def mark_edited(self, nutrition: Nutrition, dish_name: str) -> "Meal":
+    def mark_edited(
+        self,
+        nutrition: Nutrition,
+        dish_name: str,
+        created_at: datetime | None = None,
+        meal_type: str | None = None,
+    ) -> "Meal":
         """Mark meal as edited with updated nutrition."""
         return Meal(
             meal_id=self.meal_id,
             user_id=self.user_id,
             status=MealStatus.READY,
-            created_at=self.created_at,
+            created_at=created_at or self.created_at,
             image=self.image,
             dish_name=dish_name,
             nutrition=nutrition,
@@ -233,7 +239,7 @@ class Meal:
             last_edited_at=utc_now(),
             edit_count=self.edit_count + 1,
             is_manually_edited=True,
-            meal_type=self.meal_type,
+            meal_type=meal_type or self.meal_type,
             translations=self.translations,
             source=self.source,
             **self._recipe_fields(),

--- a/src/domain/parsers/vision_response_parser.py
+++ b/src/domain/parsers/vision_response_parser.py
@@ -4,7 +4,10 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
+from src.domain.model.ai.nutrition_contracts import (
+    FoodLabelNutritionResponse,
+    VisionNutritionResponse,
+)
 from src.domain.model.nutrition import (
     FoodItem,
     Macros,
@@ -73,6 +76,67 @@ class VisionResponseParser:
         except (KeyError, ValueError, TypeError, ValidationError) as e:
             raise VisionResponseParsingError(
                 f"Failed to parse GPT response: {str(e)}"
+            ) from e
+
+    def parse_food_label_to_nutrition(self, gpt_response: dict[str, Any]) -> Nutrition:
+        """Parse Nutrition Facts label output into a one-serving meal."""
+        try:
+            data = gpt_response.get("structured_data")
+            if not data:
+                raise VisionResponseParsingError(
+                    "No structured data found in GPT response"
+                )
+
+            canonical = FoodLabelNutritionResponse.model_validate(dict(data))
+            macros = Macros(
+                protein=float(canonical.macros_per_serving.protein_g),
+                carbs=float(canonical.macros_per_serving.carbs_g),
+                fat=float(canonical.macros_per_serving.fat_g),
+                fiber=float(canonical.macros_per_serving.fiber_g),
+                sugar=float(canonical.macros_per_serving.sugar_g),
+            )
+            food_item = FoodItem(
+                id=str(uuid.uuid4()),
+                name=canonical.product_name,
+                quantity=float(canonical.serving_size.grams),
+                unit="g",
+                macros=macros,
+                micros=None,
+                confidence=min(max(0.0, float(canonical.confidence)), 1.0),
+                is_custom=True,
+            )
+            return Nutrition(
+                macros=macros,
+                micros=None,
+                food_items=[food_item],
+                confidence_score=min(max(0.0, float(canonical.confidence)), 1.0),
+            )
+        except (KeyError, ValueError, TypeError, ValidationError) as e:
+            raise VisionResponseParsingError(
+                f"Failed to parse food label response: {str(e)}"
+            ) from e
+
+    def parse_food_label_name(self, gpt_response: dict[str, Any]) -> str | None:
+        """Return a display name for a scanned packaged food label."""
+        try:
+            structured_data = gpt_response.get("structured_data", {})
+            product_name = structured_data.get("product_name")
+            brand = structured_data.get("brand")
+            if brand and product_name and brand.lower() not in product_name.lower():
+                return f"{brand} {product_name}"
+            return product_name
+        except (KeyError, TypeError):
+            return None
+
+    def parse_food_label_metadata(self, gpt_response: dict[str, Any]) -> dict[str, Any]:
+        """Return client-facing label metadata after schema validation."""
+        try:
+            structured_data = gpt_response.get("structured_data", {})
+            canonical = FoodLabelNutritionResponse.model_validate(dict(structured_data))
+            return canonical.model_dump()
+        except (KeyError, TypeError, ValidationError, ValueError) as e:
+            raise VisionResponseParsingError(
+                f"Failed to validate food label metadata: {str(e)}"
             ) from e
 
     def validate_structured_data(self, data: dict[str, Any]) -> VisionNutritionResponse:

--- a/src/domain/ports/vision_ai_service_port.py
+++ b/src/domain/ports/vision_ai_service_port.py
@@ -32,6 +32,19 @@ class VisionAIServicePort(ABC):
         pass
 
     @abstractmethod
+    async def analyze_food_label(self, image_bytes: bytes) -> dict[str, Any]:
+        """
+        Analyze a packaged food Nutrition Facts label image.
+
+        Args:
+            image_bytes: The raw bytes of the image to analyze
+
+        Returns:
+            JSON-compatible dictionary with the raw AI response
+        """
+        pass
+
+    @abstractmethod
     async def analyze_by_url_with_strategy(
         self, image_url: str, strategy: MealAnalysisStrategy
     ) -> dict[str, Any]:

--- a/src/domain/services/meal_analysis/deepl_meal_translation_service.py
+++ b/src/domain/services/meal_analysis/deepl_meal_translation_service.py
@@ -6,11 +6,12 @@ Uses the core DeepLTextTranslationService internally for actual API calls.
 Checks the meal_translation table first; only calls DeepL when a fully-
 cached translation does not yet exist.
 """
+
 import asyncio
 import inspect
 import logging
 
-from src.domain.model.meal import Meal, MealTranslation
+from src.domain.model.meal import FoodItemTranslation, Meal, MealTranslation
 from src.domain.model.nutrition import FoodItem
 from src.domain.ports.meal_translation_repository_port import (
     MealTranslationRepositoryPort,
@@ -71,7 +72,8 @@ class DeepLMealTranslationService:
             if existing and existing.is_fully_cached():
                 logger.debug(
                     "Translation cache hit: meal=%s lang=%s",
-                    meal.meal_id, target_language
+                    meal.meal_id,
+                    target_language,
                 )
                 return existing
 
@@ -82,7 +84,9 @@ class DeepLMealTranslationService:
                     if isinstance(step, dict):
                         normalised_steps.append(step)
                     elif isinstance(step, str):
-                        normalised_steps.append({"instruction": step, "duration_minutes": None})
+                        normalised_steps.append(
+                            {"instruction": step, "duration_minutes": None}
+                        )
 
             ingredient_names = [item.name for item in food_items if item.name]
             instruction_texts = [s.get("instruction", "") for s in normalised_steps]
@@ -103,10 +107,20 @@ class DeepLMealTranslationService:
             translated_dish_name = translated[0]
 
             n = len(ingredient_names)
-            translated_ingredients = translated[1:1 + n]
+            translated_ingredients = translated[1 : 1 + n]
+            translated_food_items = [
+                FoodItemTranslation(
+                    food_item_id=str(item.id),
+                    name=translated_name,
+                )
+                for item, translated_name in zip(
+                    food_items, translated_ingredients, strict=False
+                )
+                if item.name
+            ]
 
             m = len(instruction_texts)
-            translated_instruction_texts = translated[1 + n:1 + n + m]
+            translated_instruction_texts = translated[1 + n : 1 + n + m]
 
             translated_instruction_list: list | None = None
             if normalised_steps:
@@ -125,7 +139,7 @@ class DeepLMealTranslationService:
                 meal_id=meal.meal_id,
                 language=target_language,
                 dish_name=translated_dish_name,
-                food_items=[],  # Ingredients stored in meal_ingredients, not child table
+                food_items=translated_food_items,
                 meal_instruction=translated_instruction_list,
                 meal_ingredients=translated_ingredients,
                 translated_at=utc_now(),
@@ -134,14 +148,18 @@ class DeepLMealTranslationService:
             saved = await self._save(translation)
             logger.info(
                 "DeepL translation saved: meal=%s lang=%s dish='%s'",
-                meal.meal_id, target_language, translated_dish_name
+                meal.meal_id,
+                target_language,
+                translated_dish_name,
             )
             return saved
 
         except Exception as exc:
             logger.warning(
                 "DeepL translation failed for meal=%s lang=%s: %s",
-                meal.meal_id, target_language, exc
+                meal.meal_id,
+                target_language,
+                exc,
             )
             return None
 

--- a/src/domain/services/meal_service.py
+++ b/src/domain/services/meal_service.py
@@ -48,6 +48,8 @@ class MealService:
                         protein=change.custom_nutrition.protein_per_100g * scale_factor,
                         carbs=change.custom_nutrition.carbs_per_100g * scale_factor,
                         fat=change.custom_nutrition.fat_per_100g * scale_factor,
+                        fiber=change.custom_nutrition.fiber_per_100g * scale_factor,
+                        sugar=change.custom_nutrition.sugar_per_100g * scale_factor,
                     )
                 else:
                     # Default values when no custom nutrition provided
@@ -93,9 +95,13 @@ class MealService:
                         if change.unit is not None:
                             item.unit = change.unit
                         if change.custom_nutrition is not None:
-                            # Recalculate macros from custom nutrition (calories derived automatically)
+                            # Recalculate macros from custom nutrition.
                             item_name = change.name or item.name
-                            item_quantity = change.quantity or item.quantity
+                            item_quantity = (
+                                change.quantity
+                                if change.quantity is not None
+                                else item.quantity
+                            )
                             item_unit = change.unit or item.unit
                             quantity_grams = convert_quantity_to_grams(
                                 item_quantity, item_unit, item_name
@@ -107,6 +113,10 @@ class MealService:
                                 carbs=change.custom_nutrition.carbs_per_100g
                                 * scale_factor,
                                 fat=change.custom_nutrition.fat_per_100g * scale_factor,
+                                fiber=change.custom_nutrition.fiber_per_100g
+                                * scale_factor,
+                                sugar=change.custom_nutrition.sugar_per_100g
+                                * scale_factor,
                             )
                             item.is_custom = True
                         logger.info(f"Updated food item: {change.id}")

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -407,6 +407,7 @@ class NutritionCalculationService:
 
         food_items = []
         total_protein = total_carbs = total_fat = 0.0
+        total_fiber = total_sugar = 0.0
 
         for item in items:
             if not item.custom_nutrition:
@@ -419,16 +420,26 @@ class NutritionCalculationService:
             protein = item.custom_nutrition.protein_per_100g * factor
             carbs = item.custom_nutrition.carbs_per_100g * factor
             fat = item.custom_nutrition.fat_per_100g * factor
+            fiber = item.custom_nutrition.fiber_per_100g * factor
+            sugar = item.custom_nutrition.sugar_per_100g * factor
             total_protein += protein
             total_carbs += carbs
             total_fat += fat
+            total_fiber += fiber
+            total_sugar += sugar
             food_items.append(
                 FoodItem(
                     id=uuid4(),
                     name=item_name,
                     quantity=item.quantity,
                     unit=item.unit,
-                    macros=Macros(protein=protein, carbs=carbs, fat=fat),
+                    macros=Macros(
+                        protein=protein,
+                        carbs=carbs,
+                        fat=fat,
+                        fiber=fiber,
+                        sugar=sugar,
+                    ),
                     micros=None,
                     confidence=1.0,
                     fdc_id=getattr(item, "fdc_id", None),
@@ -440,6 +451,8 @@ class NutritionCalculationService:
                 protein=round(total_protein, 1),
                 carbs=round(total_carbs, 1),
                 fat=round(total_fat, 1),
+                fiber=round(total_fiber, 1),
+                sugar=round(total_sugar, 1),
             ),
             food_items=food_items,
             confidence_score=1.0,

--- a/src/domain/services/prompts/system_prompts.py
+++ b/src/domain/services/prompts/system_prompts.py
@@ -304,6 +304,39 @@ WORKED EXAMPLE 4 — Pocari Sweat bottle where nutrition panel is hidden:
 
 Return ONLY valid JSON matching the structure above."""
 
+    FOOD_LABEL_ANALYSIS = """You are a nutrition-label extraction assistant. Analyze the image as a packaged food Nutrition Facts label and return structured data as JSON only. No markdown, no prose.
+
+RESPONSE FORMAT — return exactly this structure:
+{
+  "is_food_label": true,
+  "product_name": "Product name in English if visible, otherwise concise packaged food name",
+  "brand": "Brand name if visible, otherwise null",
+  "serving_size": {"display_text": "2/3 cup (55g)", "grams": 55.0},
+  "servings_per_package": 8.0,
+  "label_calories_per_serving": 230.0,
+  "macros_per_serving": {
+    "protein_g": 3.0,
+    "carbs_g": 37.0,
+    "fat_g": 8.0,
+    "fiber_g": 4.0,
+    "sugar_g": 12.0
+  },
+  "confidence": 0.92,
+  "label_notes": ["Includes 10g added sugars"]
+}
+
+RULES:
+- Only extract values that belong to one serving on the visible Nutrition Facts label.
+- serving_size.grams is required. Convert ounces to grams when grams are not printed.
+- servings_per_package is required. Use the printed "servings per container/package" value.
+- macros_per_serving values are grams per serving. Total carbohydrate maps to carbs_g, total fat maps to fat_g, dietary fiber maps to fiber_g, total sugars maps to sugar_g, protein maps to protein_g.
+- label_calories_per_serving is optional label metadata. The backend will derive logged calories from macros, so do not alter macros to force calories to match.
+- If the product or brand is not visible, infer a concise generic product_name from the label context and set brand to null.
+- Do not extract ingredients. Ingredients are hidden unless confidently read by a separate ingredient flow.
+- If no Nutrition Facts label is visible, set "is_food_label": false and still return the same keys with conservative values only when the serving size and macros are readable.
+
+Return ONLY valid JSON matching the structure above."""
+
     # Supported language codes (ISO 639-1)
     SUPPORTED_LANGUAGES = {"en", "vi", "es", "fr", "de", "ja", "zh"}
 

--- a/src/domain/strategies/meal_analysis_strategy.py
+++ b/src/domain/strategies/meal_analysis_strategy.py
@@ -160,6 +160,19 @@ class IngredientIdentificationStrategy(MealAnalysisStrategy):
         return "IngredientIdentification"
 
 
+class FoodLabelAnalysisStrategy(MealAnalysisStrategy):
+    """Strategy for extracting packaged food Nutrition Facts labels."""
+
+    def get_analysis_prompt(self) -> str:
+        return SystemPrompts.FOOD_LABEL_ANALYSIS
+
+    def get_user_message(self) -> str:
+        return "Extract the visible Nutrition Facts label for one serving:"
+
+    def get_strategy_name(self) -> str:
+        return "FoodLabelAnalysis"
+
+
 class UserContextAwareAnalysisStrategy(MealAnalysisStrategy):
     """
     Analysis strategy that incorporates user-provided context.
@@ -225,6 +238,11 @@ class AnalysisStrategyFactory:
     def create_ingredient_identification_strategy() -> MealAnalysisStrategy:
         """Create an ingredient identification strategy for photo recognition."""
         return IngredientIdentificationStrategy()
+
+    @staticmethod
+    def create_food_label_strategy() -> MealAnalysisStrategy:
+        """Create a packaged food-label extraction strategy."""
+        return FoodLabelAnalysisStrategy()
 
     @staticmethod
     def create_user_context_strategy(user_description: str) -> MealAnalysisStrategy:

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -23,7 +23,8 @@ def _validate_quantity_grams(quantity_grams: float, quantity: float, unit: str) 
     """Raise ValueError if quantity in grams exceeds the realistic limit."""
     if quantity_grams > MAX_QUANTITY_GRAMS:
         raise ValueError(
-            f"Quantity {quantity} {unit} ({quantity_grams:.0f}g) exceeds maximum allowed ({MAX_QUANTITY_GRAMS:.0f}g)"
+            f"Quantity {quantity} {unit} ({quantity_grams:.0f}g) exceeds "
+            f"maximum allowed ({MAX_QUANTITY_GRAMS:.0f}g)"
         )
 
 
@@ -93,6 +94,8 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     protein=change.custom_nutrition.protein_per_100g * scale_factor,
                     carbs=change.custom_nutrition.carbs_per_100g * scale_factor,
                     fat=change.custom_nutrition.fat_per_100g * scale_factor,
+                    fiber=change.custom_nutrition.fiber_per_100g * scale_factor,
+                    sugar=change.custom_nutrition.sugar_per_100g * scale_factor,
                 ),
                 micros=existing_item.micros,
                 confidence=0.8,
@@ -136,7 +139,7 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             else:
                 # Fallback to simple scaling
                 logger.warning(
-                    f"Could not fetch nutrition for unit change, using scaling"
+                    "Could not fetch nutrition for unit change, using scaling"
                 )
                 self._apply_simple_scaling(
                     food_items_dict, change, existing_item, new_quantity, new_unit
@@ -182,6 +185,8 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 protein=existing_item.macros.protein * scale_factor,
                 carbs=existing_item.macros.carbs * scale_factor,
                 fat=existing_item.macros.fat * scale_factor,
+                fiber=existing_item.macros.fiber * scale_factor,
+                sugar=existing_item.macros.sugar * scale_factor,
             ),
             micros=existing_item.micros,
             confidence=existing_item.confidence,
@@ -279,6 +284,8 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                 protein=custom_nutrition.protein_per_100g * scale_factor,
                 carbs=custom_nutrition.carbs_per_100g * scale_factor,
                 fat=custom_nutrition.fat_per_100g * scale_factor,
+                fiber=custom_nutrition.fiber_per_100g * scale_factor,
+                sugar=custom_nutrition.sugar_per_100g * scale_factor,
             ),
             confidence=0.8,
             fdc_id=None,

--- a/src/infra/adapters/vision_ai_service.py
+++ b/src/infra/adapters/vision_ai_service.py
@@ -12,13 +12,17 @@ from src.domain.exceptions.ai_exceptions import (
     AIOutputValidationError,
     AIUnavailableError,
 )
-from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
+from src.domain.model.ai.nutrition_contracts import (
+    FoodLabelNutritionResponse,
+    VisionNutritionResponse,
+)
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
 from src.domain.services.ai_output_validation_service import (
     validate_ai_output,
 )
 from src.domain.strategies.meal_analysis_strategy import (
     AnalysisStrategyFactory,
+    FoodLabelAnalysisStrategy,
     IngredientIdentificationStrategy,
     MealAnalysisStrategy,
 )
@@ -32,6 +36,7 @@ MAX_URL_IMAGE_BYTES = 5 * 1024 * 1024
 URL_FETCH_TIMEOUT_SECONDS = 10
 ALLOWED_URL_IMAGE_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 VISION_VALIDATION_PURPOSE = "meal_scan"
+FOOD_LABEL_VALIDATION_PURPOSE = "food_label_scan"
 
 
 class VisionAIService(VisionAIServicePort):
@@ -99,18 +104,28 @@ class VisionAIService(VisionAIServicePort):
             return await self._analyze_without_nutrition_contract(image_bytes, strategy)
 
         try:
+            schema = (
+                FoodLabelNutritionResponse
+                if isinstance(strategy, FoodLabelAnalysisStrategy)
+                else VisionNutritionResponse
+            )
+            validation_purpose = (
+                FOOD_LABEL_VALIDATION_PURPOSE
+                if isinstance(strategy, FoodLabelAnalysisStrategy)
+                else VISION_VALIDATION_PURPOSE
+            )
             result = await self._ai_manager.generate_with_vision(
                 purpose=ModelPurpose.MEAL_SCAN,
                 prompt=strategy.get_user_message(),
                 image_data=image_bytes,
                 system_message=strategy.get_analysis_prompt(),
                 max_tokens=self._max_output_tokens,
-                schema=VisionNutritionResponse,
+                schema=schema,
             )
             structured_data = validate_ai_output(
                 result,
-                schema=VisionNutritionResponse,
-                purpose=VISION_VALIDATION_PURPOSE,
+                schema=schema,
+                purpose=validation_purpose,
                 attempt_count=1,
             )
             return {
@@ -122,7 +137,7 @@ class VisionAIService(VisionAIServicePort):
             logger.warning(
                 "[AI-OUTPUT-VALIDATION-FAILED] purpose=%s strategy=%s attempt=%s "
                 "details=%s",
-                VISION_VALIDATION_PURPOSE,
+                validation_purpose,
                 strategy.get_strategy_name(),
                 exc.attempt_count,
                 exc.validation_details,
@@ -223,6 +238,11 @@ class VisionAIService(VisionAIServicePort):
         strategy = AnalysisStrategyFactory.create_basic_strategy(
             optimized_prompt_enabled=self._optimized_prompt_enabled
         )
+        return await self.analyze_with_strategy(image_bytes, strategy)
+
+    async def analyze_food_label(self, image_bytes: bytes) -> dict[str, Any]:
+        """Analyze a packaged food Nutrition Facts label image."""
+        strategy = AnalysisStrategyFactory.create_food_label_strategy()
         return await self.analyze_with_strategy(image_bytes, strategy)
 
     async def analyze_with_portion_context(

--- a/src/infra/adapters/vision_ai_service.py
+++ b/src/infra/adapters/vision_ai_service.py
@@ -114,8 +114,13 @@ class VisionAIService(VisionAIServicePort):
                 if isinstance(strategy, FoodLabelAnalysisStrategy)
                 else VISION_VALIDATION_PURPOSE
             )
+            model_purpose = (
+                ModelPurpose.FOOD_LABEL_SCAN
+                if isinstance(strategy, FoodLabelAnalysisStrategy)
+                else ModelPurpose.MEAL_SCAN
+            )
             result = await self._ai_manager.generate_with_vision(
-                purpose=ModelPurpose.MEAL_SCAN,
+                purpose=model_purpose,
                 prompt=strategy.get_user_message(),
                 image_data=image_bytes,
                 system_message=strategy.get_analysis_prompt(),

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -260,7 +260,7 @@ class Settings(BaseSettings):
         description="Workers AI model for image analysis (must support vision input)",
     )
     CLOUDFLARE_WORKERS_AI_VISION_PURPOSES: str = Field(
-        default="meal_scan,ingredient_scan",
+        default="meal_scan,food_label_scan,ingredient_scan",
         description="Comma-separated ModelPurpose values where Workers AI vision is included in routing",
     )
     # Meal analysis settings

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -28,6 +28,7 @@ TEXT_PURPOSES: set[ModelPurpose] = {
 }
 VISION_PURPOSES: set[ModelPurpose] = {
     ModelPurpose.MEAL_SCAN,
+    ModelPurpose.FOOD_LABEL_SCAN,
     ModelPurpose.INGREDIENT_SCAN,
 }
 
@@ -36,6 +37,9 @@ FALLBACK_CHAINS: dict[ModelPurpose, list[str]] = {
     # VISION TASKS: OpenAI primary, optional provider routes append as fallback
     # ==========================================================================
     ModelPurpose.MEAL_SCAN: [
+        DEFAULT_OPENAI_MODEL,
+    ],
+    ModelPurpose.FOOD_LABEL_SCAN: [
         DEFAULT_OPENAI_MODEL,
     ],
     ModelPurpose.INGREDIENT_SCAN: [

--- a/tests/fixtures/mock_adapters/mock_vision_ai_service.py
+++ b/tests/fixtures/mock_adapters/mock_vision_ai_service.py
@@ -18,6 +18,10 @@ class MockVisionAIService(VisionAIServicePort):
         """Return mock analysis result."""
         return self.mock_response
 
+    async def analyze_food_label(self, image_bytes: bytes) -> Dict[str, Any]:
+        """Return mock food-label analysis result."""
+        return self.mock_response
+
     async def analyze_by_url_with_strategy(
         self, image_url: str, strategy: MealAnalysisStrategy
     ) -> Dict[str, Any]:

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -3,6 +3,7 @@ Unit tests for meal edit request validation.
 """
 
 import pytest
+from datetime import datetime
 from pydantic import ValidationError
 
 from src.api.schemas.request.meal_requests import (
@@ -318,11 +319,26 @@ class TestEditMealIngredientsRequest:
         assert request.dish_name is None
         assert len(request.food_item_changes) == 1
 
-    def test_empty_food_item_changes(self):
-        """Test empty food item changes validation."""
-        # Arrange & Act & Assert
+    def test_metadata_only_edit_request(self):
+        """Test meal metadata edits without ingredient changes."""
+        created_at = datetime(2026, 6, 28, 8, 30)
+
+        request = EditMealIngredientsRequest(
+            dish_name="Updated Meal",
+            created_at=created_at,
+            meal_type="breakfast",
+            food_item_changes=[],
+        )
+
+        assert request.dish_name == "Updated Meal"
+        assert request.created_at == created_at
+        assert request.meal_type == "breakfast"
+        assert request.food_item_changes == []
+
+    def test_empty_edit_request(self):
+        """Test empty edit requests are rejected."""
         with pytest.raises(ValidationError):
-            EditMealIngredientsRequest(food_item_changes=[])
+            EditMealIngredientsRequest()
 
     def test_dish_name_too_long(self):
         """Test dish name too long validation."""

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -239,6 +239,31 @@ class TestCreateManualMealFromFoodsRequest:
 
         assert request.source == "manual"
 
+    def test_prompt_source_allows_legacy_back_calculated_fiber_and_sugar_rates(self):
+        request = CreateManualMealFromFoodsRequest(
+            dish_name="Smoothie bowl",
+            source="prompt",
+            items=[
+                {
+                    "name": "Smoothie bowl",
+                    "quantity": 1.0,
+                    "unit": "bowl",
+                    "custom_nutrition": {
+                        "protein_per_100g": 120.0,
+                        "carbs_per_100g": 600.0,
+                        "fat_per_100g": 80.0,
+                        "fiber_per_100g": 150.0,
+                        "sugar_per_100g": 240.0,
+                    },
+                }
+            ],
+        )
+
+        nutrition = request.items[0].custom_nutrition
+        assert nutrition is not None
+        assert nutrition.fiber_per_100g == 150.0
+        assert nutrition.sugar_per_100g == 240.0
+
     def test_missing_source_rejects_impossible_gram_macro_rates(self):
         with pytest.raises(ValidationError):
             CreateManualMealFromFoodsRequest(
@@ -271,6 +296,27 @@ class TestCreateManualMealFromFoodsRequest:
                             "protein_per_100g": 3000.0,
                             "carbs_per_100g": 10.0,
                             "fat_per_100g": 5.0,
+                        },
+                    }
+                ],
+            )
+
+    def test_gram_custom_nutrition_rejects_impossible_fiber_and_sugar_rates(self):
+        with pytest.raises(ValidationError):
+            CreateManualMealFromFoodsRequest(
+                dish_name="Granola",
+                source="manual",
+                items=[
+                    {
+                        "name": "Granola",
+                        "quantity": 100.0,
+                        "unit": "g",
+                        "custom_nutrition": {
+                            "protein_per_100g": 10.0,
+                            "carbs_per_100g": 60.0,
+                            "fat_per_100g": 8.0,
+                            "fiber_per_100g": 120.0,
+                            "sugar_per_100g": 140.0,
                         },
                     }
                 ],

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -354,17 +354,14 @@ class TestEditMealIngredientsRequest:
             )
 
     def test_empty_dish_name(self):
-        """Test empty dish name validation."""
-        # Arrange & Act & Assert
-        with pytest.raises(ValidationError):
-            EditMealIngredientsRequest(
-                dish_name="",
-                food_item_changes=[
-                    FoodItemChangeRequest(
-                        action="add", name="Test Food", quantity=100.0, unit="g"
-                    )
-                ],
-            )
+        """Test empty dish name is accepted for clearing a meal name."""
+        request = EditMealIngredientsRequest(
+            dish_name="",
+            food_item_changes=[],
+        )
+
+        assert request.dish_name == ""
+        assert request.food_item_changes == []
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -4,6 +4,7 @@ Unit tests for MealMapper.
 
 import uuid
 from datetime import datetime
+import json
 
 import pytest
 
@@ -202,6 +203,72 @@ class TestMealMapper:
         assert result.food_items[0].custom_nutrition.calories_per_100g == pytest.approx(
             108.0
         )  # derived: (1*4+8*4+2*9) * (100/50)
+
+    def test_to_detailed_response_includes_food_label_metadata(self):
+        """Food-label meal details expose serving and package metadata."""
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/label.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            dish_name="Protein Bar",
+            ready_at=datetime(2025, 1, 15, 15, 0),
+            created_at=datetime(2025, 1, 15, 14, 30),
+            source="food_label",
+            raw_gpt_json=json.dumps(
+                {
+                    "product_name": "Protein Bar",
+                    "brand": "Example",
+                    "serving_size": {
+                        "display_text": "1 bar (55g)",
+                        "grams": 55,
+                    },
+                    "servings_per_package": 8,
+                    "label_calories_per_serving": 230,
+                    "confidence": 0.92,
+                    "label_notes": ["Calories differ from derived macros."],
+                }
+            ),
+            nutrition=Nutrition(
+                macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
+                food_items=[
+                    FoodItem(
+                        id="label-item",
+                        name="Protein Bar",
+                        quantity=55,
+                        unit="g",
+                        macros=Macros(
+                            protein=10,
+                            carbs=20,
+                            fat=5,
+                            fiber=4,
+                            sugar=8,
+                        ),
+                        is_custom=True,
+                    )
+                ],
+            ),
+        )
+
+        result = MealMapper.to_detailed_response(meal)
+
+        assert result.source == "food_label"
+        assert result.food_label_metadata is not None
+        assert result.food_label_metadata.product_name == "Protein Bar"
+        assert result.food_label_metadata.brand == "Example"
+        assert result.food_label_metadata.serving_size.display_text == "1 bar (55g)"
+        assert result.food_label_metadata.serving_size.grams == 55
+        assert result.food_label_metadata.servings_per_package == 8
+        assert result.food_label_metadata.label_calories_per_serving == 230
+        assert result.food_label_metadata.confidence == 0.92
+        assert result.food_label_metadata.label_notes == [
+            "Calories differ from derived macros."
+        ]
 
     def test_to_detailed_response_custom_nutrition_uses_grams_for_large_units(self):
         """Custom nutrition is projected per 100g, not per serving count."""

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -163,7 +163,7 @@ class TestMealMapper:
                 name="Homemade Sauce",
                 quantity=50,
                 unit="g",
-                macros=Macros(protein=1, carbs=8, fat=2),
+                macros=Macros(protein=1, carbs=8, fat=2, fiber=1, sugar=3),
                 confidence=1.0,
                 fdc_id=None,
                 is_custom=True,
@@ -171,7 +171,8 @@ class TestMealMapper:
         ]
 
         nutrition = Nutrition(
-            macros=Macros(protein=1, carbs=8, fat=2), food_items=food_items
+            macros=Macros(protein=1, carbs=8, fat=2, fiber=1, sugar=3),
+            food_items=food_items,
         )
 
         image = MealImage(
@@ -201,8 +202,14 @@ class TestMealMapper:
         assert result.food_items[0].fdc_id is None
         assert result.food_items[0].custom_nutrition is not None
         assert result.food_items[0].custom_nutrition.calories_per_100g == pytest.approx(
-            108.0
-        )  # derived: (1*4+8*4+2*9) * (100/50)
+            104.0
+        )  # derived fiber-aware then scaled to 100g
+        assert result.food_items[0].custom_nutrition.fiber_per_100g == pytest.approx(
+            2.0
+        )
+        assert result.food_items[0].custom_nutrition.sugar_per_100g == pytest.approx(
+            6.0
+        )
 
     def test_to_detailed_response_includes_food_label_metadata(self):
         """Food-label meal details expose serving and package metadata."""

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -7,8 +7,9 @@ from datetime import datetime
 
 import pytest
 
-from src.api.mappers.meal_mapper import MealMapper, STATUS_MAPPING
-from src.domain.model import Meal, MealStatus, MealImage, Nutrition, FoodItem, Macros
+from src.api.mappers.meal_mapper import STATUS_MAPPING, MealMapper
+from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
+from src.domain.model.meal import FoodItemTranslation, MealTranslation
 
 
 class TestMealMapper:
@@ -153,6 +154,68 @@ class TestMealMapper:
         assert result.image_url == "https://example.com/image.jpg"
         # total_weight_grams is calculated from food items
         assert result.total_weight_grams == 350 or result.total_weight_grams is None
+
+    def test_to_detailed_response_uses_item_id_translations_when_list_is_stale(self):
+        """Translated food item IDs preserve locale after ingredient add/remove."""
+        food_items = [
+            FoodItem(
+                id="item-1",
+                name="Chicken Breast",
+                quantity=200,
+                unit="g",
+                macros=Macros(protein=40, carbs=0, fat=5),
+            ),
+            FoodItem(
+                id="item-2",
+                name="Rice",
+                quantity=150,
+                unit="g",
+                macros=Macros(protein=4, carbs=43, fat=0.4),
+            ),
+        ]
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/detailed.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+                width=800,
+                height=600,
+            ),
+            dish_name="Chicken and Rice",
+            ready_at=datetime(2025, 1, 15, 14, 0),
+            created_at=datetime(2025, 1, 15, 13, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=44, carbs=43, fat=5.4),
+                food_items=food_items,
+            ),
+            translations={
+                "vi": MealTranslation(
+                    meal_id="meal-1",
+                    language="vi",
+                    dish_name="Cơm gà",
+                    meal_ingredients=["Ức gà", "Cơm", "Bông cải"],
+                    food_items=[
+                        FoodItemTranslation(
+                            food_item_id="item-1",
+                            name="Ức gà",
+                        ),
+                        FoodItemTranslation(
+                            food_item_id="item-2",
+                            name="Cơm",
+                        ),
+                    ],
+                )
+            },
+        )
+
+        result = MealMapper.to_detailed_response(meal, target_language="vi")
+
+        assert result.dish_name == "Cơm gà"
+        assert [item.name for item in result.food_items] == ["Ức gà", "Cơm"]
 
     def test_to_detailed_response_with_custom_food_item(self):
         """Test detailed response with custom food item."""

--- a/tests/unit/api/test_small_v1_routers.py
+++ b/tests/unit/api/test_small_v1_routers.py
@@ -1,4 +1,5 @@
 """Thin v1 routers: foods, activities, cheat_days, ingredients — mocked buses / auth."""
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -6,6 +7,7 @@ from fastapi.testclient import TestClient
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.exception_handlers import register_exception_handlers
+from src.api.middleware.accept_language import AcceptLanguageMiddleware
 from src.api.routes.v1 import activities as activities_mod
 from src.api.routes.v1 import cheat_days as cheat_days_mod
 from src.api.routes.v1 import foods as foods_mod
@@ -15,6 +17,7 @@ from src.api.routes.v1 import ingredients as ingredients_mod
 def _make_app(*routers):
     """Create a test FastAPI app with global exception handlers registered."""
     app = FastAPI()
+    app.add_middleware(AcceptLanguageMiddleware)
     register_exception_handlers(app)
     for router in routers:
         app.include_router(router)
@@ -43,6 +46,21 @@ def test_foods_search(foods_app, monkeypatch):
     r = TestClient(foods_app).get("/v1/foods/search?q=rice")
     assert r.status_code == 200
     assert r.json()["query"] == "rice"
+
+
+def test_foods_autocomplete_uses_search_query(foods_app, monkeypatch):
+    bus = _Bus({"query": "ric", "results": [], "total": 0})
+    monkeypatch.setattr(foods_mod, "get_food_search_event_bus", lambda: bus)
+    r = TestClient(foods_app).get(
+        "/v1/foods/autocomplete?q=ric&limit=5",
+        headers={"Accept-Language": "vi"},
+    )
+    assert r.status_code == 200
+    assert r.json()["query"] == "ric"
+    assert bus.sent[0].query == "ric"
+    assert bus.sent[0].limit == 5
+    assert bus.sent[0].language == "vi"
+    assert bus.sent[0].autocomplete is True
 
 
 def test_foods_search_500(foods_app, monkeypatch):
@@ -228,7 +246,9 @@ def test_cheat_days_handle_exception(cheat_app):
             raise RuntimeError("db")
 
     cheat_app.dependency_overrides[get_configured_event_bus] = lambda: _Bad()
-    r = TestClient(cheat_app, raise_server_exceptions=False).post("/v1/cheat-days?date=2026-06-15")
+    r = TestClient(cheat_app, raise_server_exceptions=False).post(
+        "/v1/cheat-days?date=2026-06-15"
+    )
     assert r.status_code == 500
 
 

--- a/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
+++ b/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
@@ -194,7 +194,6 @@ class TestVisionRetryRouting:
                 )
             ],
         )
-        parser.parse_food_label_name.return_value = "Protein Bar"
         parser.parse_food_label_metadata.return_value = {"is_food_label": True}
         parser.extract_raw_json.return_value = '{"product_name":"Protein Bar"}'
         parser.parse_is_food = Mock()
@@ -215,9 +214,10 @@ class TestVisionRetryRouting:
 
         assert meal.status.value == "READY"
         assert meal.source == "food_label"
-        assert meal.dish_name == "Protein Bar"
+        assert meal.dish_name == "Unnamed Food"
         assert meal.emoji is None
         assert meal.nutrition.food_items[0].quantity == 55
         uow.meals.save.assert_awaited_once()
         cache.after_meal_write.assert_awaited_once()
         parser.parse_is_food.assert_not_called()
+        parser.parse_food_label_name.assert_not_called()

--- a/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
+++ b/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
@@ -1,5 +1,6 @@
 """Tests for UploadMealImageImmediatelyHandler — focusing on retry/fallback routing."""
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -12,10 +13,11 @@ def _make_command():
     cmd = Mock(spec=UploadMealImageImmediatelyCommand)
     cmd.file_contents = b"fake_image_bytes"
     cmd.content_type = "image/jpeg"
-    cmd.user_id = "user-123"
+    cmd.user_id = "00000000-0000-0000-0000-000000000001"
     cmd.user_description = None
     cmd.target_date = None
     cmd.language = None
+    cmd.scan_mode = "scanner"
     return cmd
 
 
@@ -33,6 +35,7 @@ def _make_handler(vision_analyze_mock, max_attempts: int = 3):
 
     vision_service = Mock()
     vision_service.analyze = vision_analyze_mock
+    vision_service.analyze_food_label = AsyncMock()
 
     handler = UploadMealImageImmediatelyHandler(
         uow=Mock(),
@@ -45,6 +48,18 @@ def _make_handler(vision_analyze_mock, max_attempts: int = 3):
         cache_invalidation=None,
     )
     return handler
+
+
+def _make_uow():
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    uow.users = MagicMock()
+    uow.users.get_user_timezone = AsyncMock(return_value="UTC")
+    uow.meals = MagicMock()
+    uow.meals.save = AsyncMock(side_effect=lambda meal: meal)
+    uow.commit = AsyncMock()
+    return uow
 
 
 class TestVisionRetryRouting:
@@ -129,3 +144,80 @@ class TestVisionRetryRouting:
             await handler._run_vision_analysis(_make_command(), meal_id="meal-abc")
 
         assert analyze_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_food_label_mode_uses_label_analyzer(self):
+        """Food-label scans route through the label-specific analyzer."""
+        analyze_mock = AsyncMock()
+        handler = _make_handler(analyze_mock, max_attempts=3)
+        command = _make_command()
+        command.scan_mode = "food_label"
+        handler.vision_service.analyze_food_label = AsyncMock(
+            return_value={"is_food_label": True}
+        )
+
+        result = await handler._run_vision_analysis(command, meal_id="meal-abc")
+
+        assert result == {"is_food_label": True}
+        handler.vision_service.analyze_food_label.assert_awaited_once_with(
+            command.file_contents
+        )
+        analyze_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_food_label_parallel_upload_persists_ready_label_meal(self):
+        from src.app.handlers.command_handlers.upload_meal_image_immediately_command_handler import (
+            UploadMealImageImmediatelyHandler,
+        )
+        from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+
+        command = _make_command()
+        command.scan_mode = "food_label"
+        uow = _make_uow()
+        image_store = Mock()
+        image_store.save_async = AsyncMock(return_value="https://cdn.test/label.jpg")
+        vision_service = Mock()
+        vision_service.analyze_food_label = AsyncMock(
+            return_value={"is_food_label": True, "product_name": "Protein Bar"}
+        )
+        parser = Mock()
+        parser.parse_food_label_to_nutrition.return_value = Nutrition(
+            macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
+            food_items=[
+                FoodItem(
+                    id="label-item",
+                    name="Protein Bar",
+                    quantity=55,
+                    unit="g",
+                    macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
+                    is_custom=True,
+                )
+            ],
+        )
+        parser.parse_food_label_name.return_value = "Protein Bar"
+        parser.parse_food_label_metadata.return_value = {"is_food_label": True}
+        parser.extract_raw_json.return_value = '{"product_name":"Protein Bar"}'
+        parser.parse_is_food = Mock()
+        cache = Mock()
+        cache.after_meal_write = AsyncMock()
+
+        handler = UploadMealImageImmediatelyHandler(
+            uow=uow,
+            event_bus=Mock(),
+            image_store=image_store,
+            vision_service=vision_service,
+            gpt_parser=parser,
+            fast_path_policy=_make_fast_path_policy(),
+            cache_invalidation=cache,
+        )
+
+        meal = await handler._handle_parallel_upload(command)
+
+        assert meal.status.value == "READY"
+        assert meal.source == "food_label"
+        assert meal.dish_name == "Protein Bar"
+        assert meal.emoji is None
+        assert meal.nutrition.food_items[0].quantity == 55
+        uow.meals.save.assert_awaited_once()
+        cache.after_meal_write.assert_awaited_once()
+        parser.parse_is_food.assert_not_called()

--- a/tests/unit/domain/model/ai/test_nutrition_contracts.py
+++ b/tests/unit/domain/model/ai/test_nutrition_contracts.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from src.domain.model.ai.nutrition_contracts import (
     AINutritionMacros,
     BeverageMetadata,
+    FoodLabelNutritionResponse,
     MealTextNutritionResponse,
     VisionNutritionResponse,
 )
@@ -277,6 +278,39 @@ class TestVisionNutritionResponse:
                 {
                     "is_packaged_beverage": True,
                     "brand": "X" * 101,
+                }
+            )
+
+
+class TestFoodLabelNutritionResponse:
+    def test_accepts_food_label_serving_contract(self):
+        response = FoodLabelNutritionResponse.model_validate(
+            {
+                "product_name": "Cereal",
+                "brand": "Acme",
+                "serving_size": {"display_text": "2/3 cup (55g)", "grams": 55},
+                "servings_per_package": 8,
+                "label_calories_per_serving": 230,
+                "macros_per_serving": _valid_macros(),
+                "confidence": 0.91,
+                "label_notes": ["Includes 10g added sugars"],
+            }
+        )
+
+        assert response.is_food_label is True
+        assert response.product_name == "Cereal"
+        assert response.serving_size.grams == pytest.approx(55)
+        assert response.servings_per_package == pytest.approx(8)
+        assert response.macros_per_serving.protein_g == pytest.approx(35)
+
+    def test_rejects_missing_serving_grams(self):
+        with pytest.raises(ValidationError):
+            FoodLabelNutritionResponse.model_validate(
+                {
+                    "product_name": "Cereal",
+                    "serving_size": {"display_text": "2/3 cup"},
+                    "servings_per_package": 8,
+                    "macros_per_serving": _valid_macros(),
                 }
             )
 

--- a/tests/unit/domain/parsers/test_gpt_response_parser.py
+++ b/tests/unit/domain/parsers/test_gpt_response_parser.py
@@ -361,3 +361,48 @@ class TestGPTResponseParserQuantityGMapping:
         # Calories = protein*4 + carbs*4 + fat*9 = 3*4 + 28*4 + 0.5*9 = 12 + 112 + 4.5 = 128.5
         assert nutrition.calories == pytest.approx(128.5, abs=1.0)
         assert nutrition.calories < 500
+
+
+def test_parse_food_label_to_nutrition_logs_one_serving(gpt_parser):
+    gpt_response = {
+        "structured_data": {
+            "product_name": "Cereal",
+            "brand": "Acme",
+            "serving_size": {"display_text": "2/3 cup (55g)", "grams": 55},
+            "servings_per_package": 8,
+            "label_calories_per_serving": 230,
+            "macros_per_serving": {
+                "protein_g": 3,
+                "carbs_g": 37,
+                "fat_g": 8,
+                "fiber_g": 4,
+                "sugar_g": 12,
+            },
+            "confidence": 0.91,
+        }
+    }
+
+    nutrition = gpt_parser.parse_food_label_to_nutrition(gpt_response)
+
+    assert nutrition.food_items[0].name == "Cereal"
+    assert nutrition.food_items[0].quantity == pytest.approx(55)
+    assert nutrition.food_items[0].unit == "g"
+    assert nutrition.calories == pytest.approx(224)
+
+
+def test_parse_food_label_metadata_returns_validated_label_data(gpt_parser):
+    gpt_response = {
+        "structured_data": {
+            "product_name": "Cereal",
+            "serving_size": {"display_text": "55g", "grams": 55},
+            "servings_per_package": 8,
+            "macros_per_serving": {"protein_g": 3, "carbs_g": 37, "fat_g": 8},
+            "confidence": 0.91,
+        }
+    }
+
+    metadata = gpt_parser.parse_food_label_metadata(gpt_response)
+
+    assert metadata["product_name"] == "Cereal"
+    assert metadata["serving_size"]["grams"] == pytest.approx(55)
+    assert metadata["servings_per_package"] == pytest.approx(8)

--- a/tests/unit/domain/services/test_deepl_meal_translation_service.py
+++ b/tests/unit/domain/services/test_deepl_meal_translation_service.py
@@ -24,7 +24,9 @@ def meal():
         user_id=str(uuid4()),
         status=MealStatus.PROCESSING,
         created_at=datetime.utcnow(),
-        image=MealImage(image_id=str(uuid4()), format="jpeg", size_bytes=1024, url="https://x/y.jpg"),
+        image=MealImage(
+            image_id=str(uuid4()), format="jpeg", size_bytes=1024, url="https://x/y.jpg"
+        ),
     )
 
 
@@ -88,7 +90,9 @@ def async_repo_service(async_repo, text_translation_service):
 
 
 @pytest.mark.asyncio
-async def test_translate_meal_skips_english(service, meal, food_items, text_translation_service, repo):
+async def test_translate_meal_skips_english(
+    service, meal, food_items, text_translation_service, repo
+):
     result = await service.translate_meal(meal, "Grilled chicken", food_items, "en")
     assert result is None
     text_translation_service.translate_texts.assert_not_called()
@@ -96,7 +100,9 @@ async def test_translate_meal_skips_english(service, meal, food_items, text_tran
 
 
 @pytest.mark.asyncio
-async def test_translate_meal_uses_cache_when_fully_cached(service, meal, food_items, text_translation_service, repo):
+async def test_translate_meal_uses_cache_when_fully_cached(
+    service, meal, food_items, text_translation_service, repo
+):
     cached = MealTranslation(
         meal_id=meal.meal_id,
         language="vi",
@@ -107,7 +113,9 @@ async def test_translate_meal_uses_cache_when_fully_cached(service, meal, food_i
     )
     repo.get_by_meal_and_language.return_value = cached
 
-    result = await service.translate_meal(meal, "Grilled chicken", food_items, "vi", instructions=["Step"])
+    result = await service.translate_meal(
+        meal, "Grilled chicken", food_items, "vi", instructions=["Step"]
+    )
 
     assert result == cached
     text_translation_service.translate_texts.assert_not_called()
@@ -115,12 +123,14 @@ async def test_translate_meal_uses_cache_when_fully_cached(service, meal, food_i
 
 
 @pytest.mark.asyncio
-async def test_translate_meal_calls_deepl_and_saves(service, meal, food_items, text_translation_service, repo):
+async def test_translate_meal_calls_deepl_and_saves(
+    service, meal, food_items, text_translation_service, repo
+):
     text_translation_service.translate_texts.return_value = [
-        "Gà nướng",          # dish
-        "Ức gà",             # ingredient 1
-        "Cơm gạo lứt",        # ingredient 2
-        "Bước 1",            # instruction
+        "Gà nướng",  # dish
+        "Ức gà",  # ingredient 1
+        "Cơm gạo lứt",  # ingredient 2
+        "Bước 1",  # instruction
     ]
 
     result = await service.translate_meal(
@@ -134,7 +144,14 @@ async def test_translate_meal_calls_deepl_and_saves(service, meal, food_items, t
     assert result is not None
     assert result.dish_name == "Gà nướng"
     assert result.meal_ingredients == ["Ức gà", "Cơm gạo lứt"]
-    assert result.meal_instruction == [{"instruction": "Bước 1", "duration_minutes": None}]
+    assert [item.food_item_id for item in result.food_items] == [
+        str(food_items[0].id),
+        str(food_items[1].id),
+    ]
+    assert [item.name for item in result.food_items] == ["Ức gà", "Cơm gạo lứt"]
+    assert result.meal_instruction == [
+        {"instruction": "Bước 1", "duration_minutes": None}
+    ]
     repo.save.assert_called_once()
     text_translation_service.translate_texts.assert_awaited_once()
 
@@ -162,7 +179,9 @@ async def test_translate_meal_awaits_async_translation_repo(
 
 
 @pytest.mark.asyncio
-async def test_translate_meal_normalizes_instruction_dicts(service, meal, food_items, text_translation_service):
+async def test_translate_meal_normalizes_instruction_dicts(
+    service, meal, food_items, text_translation_service
+):
     text_translation_service.translate_texts.return_value = [
         "Gà nướng",
         "Ức gà",
@@ -189,7 +208,9 @@ async def test_translate_meal_normalizes_instruction_dicts(service, meal, food_i
 
 
 @pytest.mark.asyncio
-async def test_translate_meal_pads_when_deepl_returns_short(service, meal, food_items, text_translation_service):
+async def test_translate_meal_pads_when_deepl_returns_short(
+    service, meal, food_items, text_translation_service
+):
     # Only dish name returned, rest should be padded with originals.
     text_translation_service.translate_texts.return_value = ["Gà nướng"]
 
@@ -205,11 +226,15 @@ async def test_translate_meal_pads_when_deepl_returns_short(service, meal, food_
     # Ingredients padded to original ingredient names
     assert result.meal_ingredients == [fi.name for fi in food_items]
     # Instruction padded to original
-    assert result.meal_instruction == [{"instruction": "Step 1", "duration_minutes": None}]
+    assert result.meal_instruction == [
+        {"instruction": "Step 1", "duration_minutes": None}
+    ]
 
 
 @pytest.mark.asyncio
-async def test_translate_meal_returns_none_on_exception(service, meal, food_items, text_translation_service, repo):
+async def test_translate_meal_returns_none_on_exception(
+    service, meal, food_items, text_translation_service, repo
+):
     text_translation_service.translate_texts.side_effect = Exception("DeepL down")
 
     result = await service.translate_meal(

--- a/tests/unit/domain/test_meal_edit_domain.py
+++ b/tests/unit/domain/test_meal_edit_domain.py
@@ -106,6 +106,40 @@ class TestMealEditDomain:
         assert edited_meal.edit_count == 3
         assert edited_meal.is_manually_edited is True
 
+    def test_meal_mark_edited_updates_log_time_and_meal_type(self):
+        """Test that mark_edited can update meal timestamp metadata."""
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            created_at=datetime(2026, 6, 28, 8, 0),
+            image=MealImage(
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=100000,
+                url="https://example.com/image.jpg",
+            ),
+            dish_name="Test Meal",
+            nutrition=Nutrition(
+                macros=Macros(protein=30.0, carbs=50.0, fat=20.0),
+                food_items=[],
+                confidence_score=0.9,
+            ),
+            ready_at=datetime(2026, 6, 28, 8, 1),
+            meal_type="breakfast",
+        )
+        updated_at = datetime(2026, 6, 28, 19, 30)
+
+        edited_meal = meal.mark_edited(
+            meal.nutrition,
+            "Test Meal",
+            created_at=updated_at,
+            meal_type="dinner",
+        )
+
+        assert edited_meal.created_at == updated_at
+        assert edited_meal.meal_type == "dinner"
+
     def test_meal_preserves_other_fields_when_edited(self):
         """Test that mark_edited preserves other meal fields."""
         # Arrange

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -568,6 +568,8 @@ class TestAddFoodItemStrategy:
             protein_per_100g=10.0,
             carbs_per_100g=20.0,
             fat_per_100g=5.0,
+            fiber_per_100g=4.0,
+            sugar_per_100g=8.0,
         )
 
         test_cases = [
@@ -591,11 +593,13 @@ class TestAddFoodItemStrategy:
 
             # Assert
             added_item = list(food_items_dict.values())[0]
-            # calories derived: (10*scale)*4 + (20*scale)*4 + (5*scale)*9 = 165*scale
-            assert added_item.calories == pytest.approx(165.0 * scale, rel=0.01)
+            # calories derived: protein + net carbs + fiber + fat = 157*scale
+            assert added_item.calories == pytest.approx(157.0 * scale, rel=0.01)
             assert added_item.macros.protein == pytest.approx(10.0 * scale, rel=0.01)
             assert added_item.macros.carbs == pytest.approx(20.0 * scale, rel=0.01)
             assert added_item.macros.fat == pytest.approx(5.0 * scale, rel=0.01)
+            assert added_item.macros.fiber == pytest.approx(4.0 * scale, rel=0.01)
+            assert added_item.macros.sugar == pytest.approx(8.0 * scale, rel=0.01)
 
     @pytest.mark.asyncio
     async def test_add_priority_custom_nutrition_over_service(self):

--- a/tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
@@ -4,14 +4,18 @@ Unit tests for meal edit command handlers.
 
 import pytest
 
-from src.api.exceptions import ValidationException, ResourceNotFoundException
+from src.api.exceptions import ResourceNotFoundException, ValidationException
 from src.app.commands.meal import (
-    EditMealCommand,
     AddCustomIngredientCommand,
-    FoodItemChange,
     CustomNutritionData,
+    EditMealCommand,
+    FoodItemChange,
 )
 from src.app.events.meal import MealEditedEvent
+from src.app.handlers.command_handlers.edit_meal_command_handler import (
+    EditMealCommandHandler,
+)
+from src.domain.model.meal import MealTranslation
 
 
 @pytest.mark.unit
@@ -279,6 +283,35 @@ class TestEditMealCommandHandler:
         with pytest.raises(ResourceNotFoundException, match="Meal not found"):
             await event_bus.send(command)
 
+    def test_realigns_legacy_translation_list_after_remove(
+        self, sample_meal_with_nutrition
+    ):
+        """Removing an item should not drop every translated ingredient to English."""
+        meal = sample_meal_with_nutrition
+        original_items = meal.nutrition.food_items
+        translated_names = [
+            f"vi ingredient {index}" for index, _ in enumerate(original_items)
+        ]
+        meal.translations = {
+            "vi": MealTranslation(
+                meal_id=meal.meal_id,
+                language="vi",
+                dish_name="Bữa ăn",
+                food_items=[],
+                meal_ingredients=translated_names,
+            )
+        }
+        updated_items = original_items[1:]
+        handler = EditMealCommandHandler(uow=None)
+
+        handler._realign_translations_after_food_item_changes(meal, updated_items)
+
+        translation = meal.translations["vi"]
+        assert translation.meal_ingredients == translated_names[1:]
+        assert len(translation.food_items) == len(updated_items)
+        assert translation.food_items[0].food_item_id == str(original_items[1].id)
+        assert translation.food_items[0].name == translated_names[1]
+
 
 @pytest.mark.unit
 class TestAddCustomIngredientCommandHandler:
@@ -291,7 +324,6 @@ class TestAddCustomIngredientCommandHandler:
         """Test successful custom ingredient addition."""
         # Arrange
         meal = sample_meal_with_nutrition
-        original_calories = meal.nutrition.calories
 
         command = AddCustomIngredientCommand(
             meal_id=meal.meal_id,

--- a/tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
@@ -12,6 +12,7 @@ from src.app.commands.meal import (
     CustomNutritionData,
 )
 from src.app.events.meal import MealEditedEvent
+from src.infra.database.models import MealORM
 
 
 @pytest.mark.unit
@@ -195,6 +196,27 @@ class TestEditMealCommandHandler:
         assert "Updated portion" in summary
         assert "Removed ingredient" in summary
         assert "Added New Ingredient" in summary
+
+    @pytest.mark.asyncio
+    async def test_edit_meal_allows_clearing_dish_name(
+        self, event_bus, sample_meal_with_nutrition, test_session
+    ):
+        """Test metadata edit can clear meal name."""
+        meal = sample_meal_with_nutrition
+
+        command = EditMealCommand(
+            meal_id=meal.meal_id,
+            dish_name="",
+            food_item_changes=[],
+        )
+
+        result = await event_bus.send(command)
+
+        assert result["success"] is True
+        saved_meal = (
+            test_session.query(MealORM).filter(MealORM.meal_id == meal.meal_id).one()
+        )
+        assert saved_meal.dish_name == ""
 
     @pytest.mark.asyncio
     async def test_edit_meal_unauthorized_user(

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -21,7 +21,7 @@ def _make_uow() -> MagicMock:
     uow.users = MagicMock()
     uow.users.get_user_timezone = AsyncMock(return_value="UTC")
     uow.meals = MagicMock()
-    uow.meals.save = AsyncMock()
+    uow.meals.save = AsyncMock(side_effect=lambda meal: meal)
     uow.meals.find_by_id = AsyncMock()
     uow.hydration_entries = MagicMock()
     uow.hydration_entries.add = AsyncMock(side_effect=lambda entry: entry)
@@ -111,3 +111,60 @@ async def test_scan_by_url_beverage_creates_hydration_entry_not_meal(monkeypatch
     assert result.meal_type == "hydration"
     assert result.source == "scan_beverage"
     assert result.image.url == _IMAGE_URL
+
+
+@pytest.mark.asyncio
+async def test_scan_by_url_food_label_creates_ready_meal(monkeypatch):
+    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+
+    _install_fake_image_download(monkeypatch)
+    uow = _make_uow()
+    cache = MagicMock()
+    cache.after_meal_write = AsyncMock()
+    handler = ScanByUrlCommandHandler(
+        uow=uow,
+        event_bus=MagicMock(),
+        vision_service=MagicMock(),
+        gpt_parser=MagicMock(),
+        cache_invalidation=cache,
+    )
+    handler.vision_service.analyze_food_label = AsyncMock(
+        return_value={"is_food_label": True, "product_name": "Protein Bar"}
+    )
+    handler.gpt_parser.parse_food_label_to_nutrition.return_value = Nutrition(
+        macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
+        food_items=[
+            FoodItem(
+                id="label-item",
+                name="Protein Bar",
+                quantity=55,
+                unit="g",
+                macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
+                is_custom=True,
+            )
+        ],
+    )
+    handler.gpt_parser.parse_food_label_metadata.return_value = {"is_food_label": True}
+    handler.gpt_parser.parse_food_label_name.return_value = "Protein Bar"
+    handler.gpt_parser.extract_raw_json.return_value = '{"product_name":"Protein Bar"}'
+    handler.gpt_parser.parse_is_food = MagicMock()
+
+    result = await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id="mealtrack/00000000-0000-0000-0000-000000000002",
+            scan_mode="food_label",
+        )
+    )
+
+    handler.vision_service.analyze_food_label.assert_awaited_once_with(
+        b"fake-image-bytes"
+    )
+    uow.meals.save.assert_awaited_once()
+    handler.gpt_parser.parse_is_food.assert_not_called()
+    cache.after_meal_write.assert_awaited_once()
+    assert result.source == "food_label"
+    assert result.dish_name == "Protein Bar"
+    assert result.emoji is None
+    assert result.nutrition.food_items[0].quantity == 55

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -145,7 +145,6 @@ async def test_scan_by_url_food_label_creates_ready_meal(monkeypatch):
         ],
     )
     handler.gpt_parser.parse_food_label_metadata.return_value = {"is_food_label": True}
-    handler.gpt_parser.parse_food_label_name.return_value = "Protein Bar"
     handler.gpt_parser.extract_raw_json.return_value = '{"product_name":"Protein Bar"}'
     handler.gpt_parser.parse_is_food = MagicMock()
 
@@ -165,6 +164,7 @@ async def test_scan_by_url_food_label_creates_ready_meal(monkeypatch):
     handler.gpt_parser.parse_is_food.assert_not_called()
     cache.after_meal_write.assert_awaited_once()
     assert result.source == "food_label"
-    assert result.dish_name == "Protein Bar"
+    assert result.dish_name == "Unnamed Food"
     assert result.emoji is None
     assert result.nutrition.food_items[0].quantity == 55
+    handler.gpt_parser.parse_food_label_name.assert_not_called()

--- a/tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py
+++ b/tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py
@@ -80,3 +80,46 @@ async def test_empty_localized_result_runs_fallback():
     await handler.handle(query)
 
     assert fat_secret.search_foods.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_english_search_calls_fatsecret_first():
+    """Manual food search should use FatSecret directly on cache miss."""
+    handler, fat_secret, cache = _make_handler(
+        localized_results=[{"description": "Chicken breast", "source": "fatsecret"}]
+    )
+
+    query = SearchFoodsQuery(query="chicken", language="en", limit=7)
+    result = await handler.handle(query)
+
+    cache.get_cached_search.assert_awaited_once_with("chicken")
+    fat_secret.search_foods.assert_awaited_once_with("chicken", max_results=7)
+    assert result["results"][0]["source"] == "fatsecret"
+
+
+@pytest.mark.asyncio
+async def test_cached_search_respects_requested_limit():
+    cache = MagicMock()
+    cache.get_cached_search = AsyncMock(
+        return_value=[
+            {"description": "Rice", "source": "fatsecret"},
+            {"description": "Rice noodles", "source": "fatsecret"},
+        ]
+    )
+    cache.cache_search = AsyncMock()
+    fat_secret = MagicMock()
+    fat_secret.search_foods = AsyncMock()
+    mapping = MagicMock()
+    mapping.map_search_item.side_effect = lambda x: x
+    handler = SearchFoodsQueryHandler(
+        cache_service=cache,
+        mapping_service=mapping,
+        fat_secret_service=fat_secret,
+    )
+
+    result = await handler.handle(
+        SearchFoodsQuery(query="rice", language="en", limit=1, autocomplete=True)
+    )
+
+    assert len(result["results"]) == 1
+    fat_secret.search_foods.assert_not_awaited()

--- a/tests/unit/infra/adapters/test_vision_ai_service.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service.py
@@ -168,6 +168,7 @@ async def test_analyze_food_label_uses_food_label_schema():
     from src.domain.model.ai.nutrition_contracts import FoodLabelNutritionResponse
 
     call_kwargs = service._ai_manager.generate_with_vision.call_args.kwargs
+    assert call_kwargs["purpose"].value == "food_label_scan"
     assert call_kwargs["schema"] is FoodLabelNutritionResponse
     assert "Nutrition Facts label" in call_kwargs["system_message"]
 

--- a/tests/unit/infra/adapters/test_vision_ai_service.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service.py
@@ -33,10 +33,15 @@ def _valid_vision_response() -> dict:
     }
 
 
-def _make_service(max_output_tokens: int | None = None) -> VisionAIService:
+def _make_service(
+    max_output_tokens: int | None = None,
+    response: dict | None = None,
+) -> VisionAIService:
     with patch(_MGR_PATCH) as mock_cls:
         mock_manager = MagicMock()
-        mock_manager.generate_with_vision = AsyncMock(return_value=_valid_vision_response())
+        mock_manager.generate_with_vision = AsyncMock(
+            return_value=response or _valid_vision_response()
+        )
         mock_cls.get_instance.return_value = mock_manager
         return VisionAIService(max_output_tokens=max_output_tokens)
 
@@ -143,6 +148,28 @@ async def test_analyze_with_strategy_allows_max_token_override():
 
     call_kwargs = service._ai_manager.generate_with_vision.call_args.kwargs
     assert call_kwargs.get("max_tokens") == 4096
+
+
+@pytest.mark.asyncio
+async def test_analyze_food_label_uses_food_label_schema():
+    service = _make_service(
+        response={
+            "product_name": "Cereal",
+            "serving_size": {"display_text": "55g", "grams": 55},
+            "servings_per_package": 8,
+            "macros_per_serving": {"protein_g": 3, "carbs_g": 37, "fat_g": 8},
+            "confidence": 0.91,
+        }
+    )
+
+    image = _make_jpeg(400, 300)
+    await service.analyze_food_label(image)
+
+    from src.domain.model.ai.nutrition_contracts import FoodLabelNutritionResponse
+
+    call_kwargs = service._ai_manager.generate_with_vision.call_args.kwargs
+    assert call_kwargs["schema"] is FoodLabelNutritionResponse
+    assert "Nutrition Facts label" in call_kwargs["system_message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
+++ b/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
@@ -55,7 +55,9 @@ def _fake_settings_with_cf_text_and_vision():
     )
     settings.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = True
     settings.CLOUDFLARE_WORKERS_AI_VISION_MODEL = "cf-vision-model"
-    settings.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = "meal_scan,ingredient_scan"
+    settings.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = (
+        "meal_scan,food_label_scan,ingredient_scan"
+    )
     return settings
 
 
@@ -65,8 +67,13 @@ def test_openai_provider_receives_prompt_cache_settings(mock_circuit_breaker):
     settings.OPENAI_PROMPT_CACHE_RETENTION = "in_memory"
     settings.OPENAI_PROMPT_CACHE_KEY_PREFIX = "mealtrack-test"
 
-    with patch("src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker", return_value=mock_circuit_breaker):
-        with patch("src.infra.services.ai.ai_model_manager.OpenAIProvider") as provider_cls:
+    with patch(
+        "src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker",
+        return_value=mock_circuit_breaker,
+    ):
+        with patch(
+            "src.infra.services.ai.ai_model_manager.OpenAIProvider"
+        ) as provider_cls:
             AIModelManager(settings=settings)
 
     provider_cls.assert_called_once()
@@ -84,7 +91,9 @@ def test_text_purposes_prefer_cf_and_fallback_to_openai(mock_circuit_breaker):
         return_value=mock_circuit_breaker,
     ):
         with patch("src.infra.services.ai.ai_model_manager.OpenAIProvider"):
-            with patch("src.infra.services.ai.ai_model_manager.CloudflareWorkersAIProvider"):
+            with patch(
+                "src.infra.services.ai.ai_model_manager.CloudflareWorkersAIProvider"
+            ):
                 manager = AIModelManager(settings=settings)
 
     for purpose in {
@@ -109,10 +118,16 @@ def test_image_scan_purposes_prefer_openai_and_fallback_to_cf(mock_circuit_break
         return_value=mock_circuit_breaker,
     ):
         with patch("src.infra.services.ai.ai_model_manager.OpenAIProvider"):
-            with patch("src.infra.services.ai.ai_model_manager.CloudflareWorkersAIProvider"):
+            with patch(
+                "src.infra.services.ai.ai_model_manager.CloudflareWorkersAIProvider"
+            ):
                 manager = AIModelManager(settings=settings)
 
-    for purpose in {ModelPurpose.MEAL_SCAN, ModelPurpose.INGREDIENT_SCAN}:
+    for purpose in {
+        ModelPurpose.MEAL_SCAN,
+        ModelPurpose.FOOD_LABEL_SCAN,
+        ModelPurpose.INGREDIENT_SCAN,
+    }:
         assert manager.get_fallback_chain(purpose)[:2] == [
             "openai-vision-model",
             "cf-vision-model",
@@ -140,7 +155,10 @@ def mock_circuit_breaker():
 def mock_openai_provider():
     provider = Mock()
     provider.provider_name = "openai"
-    provider.supported_capabilities = {AICapability.VISION, AICapability.TEXT_GENERATION}
+    provider.supported_capabilities = {
+        AICapability.VISION,
+        AICapability.TEXT_GENERATION,
+    }
     provider.generate_with_vision = AsyncMock(return_value={"result": "vision_success"})
     provider.extract_error_code = Mock(return_value=503)
     return provider
@@ -151,15 +169,28 @@ def mock_cf_vision_provider():
     provider = Mock()
     provider.provider_name = "cloudflare-workers-ai"
     provider.supported_capabilities = {AICapability.VISION}
-    provider.generate_with_vision = AsyncMock(return_value={"result": "cf_vision_success"})
+    provider.generate_with_vision = AsyncMock(
+        return_value={"result": "cf_vision_success"}
+    )
     provider.extract_error_code = Mock(return_value=503)
     return provider
 
 
-def _build_manager(mock_circuit_breaker, mock_openai_provider, extra_providers=None, cf_vision_model=None):
+def _build_manager(
+    mock_circuit_breaker,
+    mock_openai_provider,
+    extra_providers=None,
+    cf_vision_model=None,
+):
     """Construct AIModelManager with injected mocks bypassing real provider init."""
-    with patch("src.infra.services.ai.ai_model_manager.OpenAIProvider", return_value=mock_openai_provider):
-        with patch("src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker", return_value=mock_circuit_breaker):
+    with patch(
+        "src.infra.services.ai.ai_model_manager.OpenAIProvider",
+        return_value=mock_openai_provider,
+    ):
+        with patch(
+            "src.infra.services.ai.ai_model_manager.ProviderCircuitBreaker",
+            return_value=mock_circuit_breaker,
+        ):
             mgr = AIModelManager(settings=_fake_settings())
 
     # Replace internals with mocks
@@ -188,7 +219,9 @@ def manager(mock_circuit_breaker, mock_openai_provider):
 
 
 @pytest.fixture
-def manager_with_cf_vision(mock_circuit_breaker, mock_openai_provider, mock_cf_vision_provider):
+def manager_with_cf_vision(
+    mock_circuit_breaker, mock_openai_provider, mock_cf_vision_provider
+):
     return _build_manager(
         mock_circuit_breaker,
         mock_openai_provider,
@@ -200,7 +233,11 @@ def manager_with_cf_vision(mock_circuit_breaker, mock_openai_provider, mock_cf_v
 class TestVisionFailureKindRouting:
     @pytest.mark.asyncio
     async def test_schema_fail_advances_without_circuit_break(
-        self, manager_with_cf_vision, mock_openai_provider, mock_circuit_breaker, mock_cf_vision_provider
+        self,
+        manager_with_cf_vision,
+        mock_openai_provider,
+        mock_circuit_breaker,
+        mock_cf_vision_provider,
     ):
         """Schema validation failure must advance to next provider without tripping circuit breaker."""
         mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
@@ -225,13 +262,23 @@ class TestVisionFailureKindRouting:
 
         assert result == {"result": "openai_vision_success"}
         mock_openai_provider.generate_with_vision.assert_awaited()
-        assert mock_cf_vision_provider.generate_with_vision.await_args.kwargs["schema"] is VisionNutritionResponse
-        assert mock_openai_provider.generate_with_vision.await_args.kwargs["schema"] is VisionNutritionResponse
+        assert (
+            mock_cf_vision_provider.generate_with_vision.await_args.kwargs["schema"]
+            is VisionNutritionResponse
+        )
+        assert (
+            mock_openai_provider.generate_with_vision.await_args.kwargs["schema"]
+            is VisionNutritionResponse
+        )
         mock_circuit_breaker.record_failure.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_json_parse_fail_advances_without_circuit_break(
-        self, manager_with_cf_vision, mock_openai_provider, mock_circuit_breaker, mock_cf_vision_provider
+        self,
+        manager_with_cf_vision,
+        mock_openai_provider,
+        mock_circuit_breaker,
+        mock_cf_vision_provider,
     ):
         """JSON parse failure must advance to next provider without tripping circuit breaker."""
         mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)

--- a/tests/unit/infra/test_food_database.py
+++ b/tests/unit/infra/test_food_database.py
@@ -2,7 +2,7 @@
 Unit tests for food database feature: search, details, and manual meal creation.
 """
 
-from typing import List, Optional, Dict, Any
+from typing import Any
 
 import pytest
 
@@ -11,18 +11,21 @@ import pytest
 class StubFoodDataService:
     async def search_foods(
         self, query: str, limit: int = 20, max_results: int = 20
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         return [
             {
-                "fdcId": 12345,
                 "description": "Chicken, breast, grilled",
-                "brandOwner": None,
-                "dataType": "Foundation",
-                "publishedDate": "2020-01-01",
+                "brand": None,
+                "source": "fatsecret",
+                "food_id": "12345",
+                "calories_100g": 165.0,
+                "protein_100g": 31.0,
+                "carbs_100g": 0.0,
+                "fat_100g": 3.6,
             }
         ]
 
-    async def get_food_details(self, fdc_id: int) -> Dict[str, Any]:
+    async def get_food_details(self, fdc_id: int) -> dict[str, Any]:
         # Return USDA-style details with nutrient IDs
         return {
             "fdcId": fdc_id,
@@ -63,19 +66,19 @@ class StubFoodDataService:
 
 
 class NoopFoodCacheService:
-    async def get_cached_search(self, query: str) -> Optional[List[Dict[str, Any]]]:
+    async def get_cached_search(self, query: str) -> list[dict[str, Any]] | None:
         return None
 
     async def cache_search(
-        self, query: str, results: List[Dict[str, Any]], ttl: int = 3600
+        self, query: str, results: list[dict[str, Any]], ttl: int = 3600
     ):
         return None
 
-    async def get_cached_food(self, fdc_id: int) -> Optional[Dict[str, Any]]:
+    async def get_cached_food(self, fdc_id: int) -> dict[str, Any] | None:
         return None
 
     async def cache_food(
-        self, fdc_id: int, food_data: Dict[str, Any], ttl: int = 86400
+        self, fdc_id: int, food_data: dict[str, Any], ttl: int = 86400
     ):
         return None
 
@@ -83,7 +86,7 @@ class NoopFoodCacheService:
 # Lightweight in-memory meal repository stub
 class InMemoryMealRepository:
     def __init__(self):
-        self._store: Dict[str, Any] = {}
+        self._store: dict[str, Any] = {}
 
     async def save(self, meal):
         self._store[meal.meal_id] = meal
@@ -96,8 +99,8 @@ class InMemoryMealRepository:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_search_foods_query_handler_returns_mapped_results(monkeypatch):
-    from src.app.queries.food.search_foods_query import SearchFoodsQuery
     from src.app.handlers.query_handlers import SearchFoodsQueryHandler
+    from src.app.queries.food.search_foods_query import SearchFoodsQuery
     from src.domain.services.food_mapping_service import FoodMappingService
 
     handler = SearchFoodsQueryHandler(
@@ -112,16 +115,18 @@ async def test_search_foods_query_handler_returns_mapped_results(monkeypatch):
     assert "results" in result
     assert len(result["results"]) == 1
     item = result["results"][0]
-    assert item["fdc_id"] == 12345
+    assert item["fdc_id"] is None
+    assert item["food_id"] == "12345"
     assert item["name"].lower().startswith("chicken")
-    assert item["data_type"] == "Foundation"
+    assert item["data_type"] == "fatsecret"
+    assert item["source"] == "fatsecret"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_food_details_query_handler_maps_nutrients():
-    from src.app.queries.food.get_food_details_query import GetFoodDetailsQuery
     from src.app.handlers.query_handlers import GetFoodDetailsQueryHandler
+    from src.app.queries.food.get_food_details_query import GetFoodDetailsQuery
     from src.domain.services.food_mapping_service import FoodMappingService
 
     handler = GetFoodDetailsQueryHandler(
@@ -147,10 +152,11 @@ async def test_get_food_details_query_handler_maps_nutrients():
 async def test_create_manual_meal_command_handler_aggregates_items(monkeypatch):
     # Arrange
     from unittest.mock import AsyncMock, MagicMock
+
     from src.app.commands.meal.create_manual_meal_command import (
         CreateManualMealCommand,
-        ManualMealItem,
         CustomNutrition,
+        ManualMealItem,
     )
     from src.app.handlers.command_handlers.create_manual_meal_command_handler import (
         CreateManualMealCommandHandler,


### PR DESCRIPTION
## Summary
- add ChatGPT food-label nutrition contract, prompt, parser, and vision service strategy
- support scan_mode=food_label for multipart upload and direct-upload scan-by-url paths
- persist food-label scans as ready meals with one-serving nutrition and detail metadata, without generated meal emoji
- default food-label meal titles to `Unnamed Food` and avoid using parsed product names as `Meal.dish_name`
- add `/v1/foods/autocomplete` for manual logging, routed through the existing FatSecret-backed food search query path
- verify manual food search is FatSecret-first on cache miss and localized by the existing `Accept-Language` middleware
- keep label scan handlers free of FatSecret, barcode lookup, food_reference lookup, and product enrichment calls

## Tests
- .venv/bin/python -m py_compile src/domain/constants/meal_constants.py src/domain/constants/__init__.py src/app/handlers/command_handlers/scan_by_url_command_handler.py src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
- .venv/bin/pytest tests/unit/api/test_meal_mapper.py tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/domain/parsers/test_gpt_response_parser.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py tests/unit/handlers/command_handlers/test_food_guard_command_handlers.py
- .venv/bin/python -m py_compile src/api/routes/v1/foods.py src/app/queries/food/search_foods_query.py src/app/handlers/query_handlers/search_foods_query_handler.py tests/unit/api/test_small_v1_routers.py tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py tests/unit/infra/test_food_database.py
- .venv/bin/black --check src/api/routes/v1/foods.py src/app/queries/food/search_foods_query.py src/app/handlers/query_handlers/search_foods_query_handler.py tests/unit/api/test_small_v1_routers.py tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py tests/unit/infra/test_food_database.py
- .venv/bin/ruff check src/api/routes/v1/foods.py src/app/queries/food/search_foods_query.py src/app/handlers/query_handlers/search_foods_query_handler.py tests/unit/api/test_small_v1_routers.py tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py tests/unit/infra/test_food_database.py
- .venv/bin/pytest tests/unit/api/test_small_v1_routers.py::test_foods_search tests/unit/api/test_small_v1_routers.py::test_foods_autocomplete_uses_search_query tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py tests/unit/infra/test_food_database.py::test_search_foods_query_handler_returns_mapped_results tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py::test_scan_by_url_food_label_creates_ready_meal tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py::TestVisionRetryRouting::test_food_label_parallel_upload_persists_ready_label_meal
- .venv/bin/pytest tests/unit/api/test_small_v1_routers.py

## Known local test environment gap
- .venv/bin/pytest tests/integration/routes/test_foods_api.py cannot start locally because `pymysql` is not installed in this worktree venv.
