### PR TITLE
NM-149: Add AI meal value insights

### DIFF
--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -396,6 +396,13 @@ def get_deepl_text_translation_service():
     return _deepl_text_translation_service
 
 
+def get_ai_model_manager():
+    """Get provider-agnostic AI manager singleton."""
+    from src.infra.services.ai.ai_model_manager import AIModelManager
+
+    return AIModelManager.get_instance()
+
+
 # IngredientNutritionResolver singleton reuses fatsecret and food references.
 _ingredient_nutrition_resolver = None
 

--- a/src/api/dependencies/task_manager.py
+++ b/src/api/dependencies/task_manager.py
@@ -27,6 +27,11 @@ def get_task_manager() -> BackgroundTaskManager:
     return _instance
 
 
+def get_optional_task_manager() -> BackgroundTaskManager | None:
+    """Return the process-wide instance if lifespan startup completed."""
+    return _instance
+
+
 def set_task_manager(manager: BackgroundTaskManager) -> None:
     """Register the process-wide instance. Called once during lifespan startup."""
     global _instance

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -254,6 +254,10 @@ class MealMapper:
 
     @staticmethod
     def _value_insights_response(insights: MealValueInsights | None):
+        return MealMapper.to_value_insights_response(insights)
+
+    @staticmethod
+    def to_value_insights_response(insights: MealValueInsights | None):
         from src.api.schemas.response.meal_responses import (
             IngredientValueInsightResponse,
             MealValueBulletResponse,
@@ -264,7 +268,11 @@ class MealMapper:
             return None
         return MealValueInsightsResponse(
             meal_bullets=[
-                MealValueBulletResponse(text=item.text, category=item.category)
+                MealValueBulletResponse(
+                    text=item.text,
+                    category=item.category,
+                    highlights=item.highlights[:1],
+                )
                 for item in insights.meal_bullets
             ],
             ingredient_insights=[
@@ -272,6 +280,7 @@ class MealMapper:
                     ingredient_name=item.ingredient_name,
                     text=item.text,
                     category=item.category,
+                    highlights=item.highlights[:1],
                 )
                 for item in insights.ingredient_insights
             ],

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -16,6 +16,7 @@ from src.api.schemas.response import (
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.domain.model.meal import Meal
 from src.domain.model.nutrition import FoodItem, Macros, Micros, Nutrition
+from src.domain.services.meal_value_insight_contract import MealValueInsights
 from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
 
 # Status mapping from domain to API
@@ -59,6 +60,7 @@ class MealMapper:
         meal: Meal,
         image_url: str | None = None,
         target_language: str | None = None,
+        value_insights: MealValueInsights | None = None,
     ) -> DetailedMealResponse:
         """
         Convert Meal domain model to DetailedMealResponse DTO.
@@ -198,6 +200,8 @@ class MealMapper:
                     for i, fi in enumerate(food_items):
                         fi.name = tr.meal_ingredients[i]
 
+        value_insights_response = MealMapper._value_insights_response(value_insights)
+
         # --- Build translations dict for the response ---
         translations_response = None
         if meal.translations:
@@ -239,12 +243,38 @@ class MealMapper:
             total_nutrition=total_nutrition,
             translations=translations_response,
             food_label_metadata=MealMapper._food_label_metadata(meal),
+            value_insights=value_insights_response,
             description=getattr(meal, "description", None),
             instructions=instructions,
             prep_time_min=getattr(meal, "prep_time_min", None),
             cook_time_min=getattr(meal, "cook_time_min", None),
             cuisine_type=getattr(meal, "cuisine_type", None),
             origin_country=getattr(meal, "origin_country", None),
+        )
+
+    @staticmethod
+    def _value_insights_response(insights: MealValueInsights | None):
+        from src.api.schemas.response.meal_responses import (
+            IngredientValueInsightResponse,
+            MealValueBulletResponse,
+            MealValueInsightsResponse,
+        )
+
+        if not insights:
+            return None
+        return MealValueInsightsResponse(
+            meal_bullets=[
+                MealValueBulletResponse(text=item.text, category=item.category)
+                for item in insights.meal_bullets
+            ],
+            ingredient_insights=[
+                IngredientValueInsightResponse(
+                    ingredient_name=item.ingredient_name,
+                    text=item.text,
+                    category=item.category,
+                )
+                for item in insights.ingredient_insights
+            ],
         )
 
     @staticmethod

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -23,7 +23,7 @@ from fastapi import (
 
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
-from src.api.base_dependencies import get_image_store
+from src.api.base_dependencies import get_cache_service, get_image_store
 from src.api.exceptions import handle_exception, ValidationException
 from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
@@ -57,6 +57,8 @@ from src.app.queries.meal import (
 )
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
 from src.domain.services.prompts.input_sanitizer import sanitize_user_description
+from src.domain.services.meal_value_insight_service import MealValueInsightService
+from src.infra.cache.cache_service import CacheService
 from src.infra.event_bus import EventBus
 from src.api.dependencies.guest_quota import get_guest_quota_service
 from src.api.services.guest_parse_quota import (
@@ -507,6 +509,7 @@ async def get_meal(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
+    cache_service: CacheService | None = Depends(get_cache_service),
 ):
     """Get detailed information about a specific meal.
 
@@ -526,9 +529,45 @@ async def get_meal(
 
     # Get language from Accept-Language header via middleware
     language = get_request_language(request)
+    value_insights = await MealValueInsightService().build_ai(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        ingredient_names_by_id=_translated_food_item_names(meal, language),
+        language=language,
+        cache_service=cache_service,
+    )
 
     # Use mapper to convert to response with translation support
-    return MealMapper.to_detailed_response(meal, image_url, target_language=language)
+    return MealMapper.to_detailed_response(
+        meal,
+        image_url,
+        target_language=language,
+        value_insights=value_insights,
+    )
+
+
+def _translated_food_item_names(meal, language: str) -> dict[str, str]:
+    if language == "en" or not getattr(meal, "translations", None):
+        return {}
+    translation = meal.translations.get(language)
+    if not translation:
+        return {}
+    names_by_id = {
+        str(item.food_item_id): item.name
+        for item in translation.food_items
+        if item.name
+    }
+    if names_by_id:
+        return names_by_id
+    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
+    if translation.meal_ingredients and len(translation.meal_ingredients) == len(
+        food_items
+    ):
+        return {
+            str(item.id): translation.meal_ingredients[index]
+            for index, item in enumerate(food_items)
+        }
+    return {}
 
 
 @router.delete("/{meal_id}")

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -15,60 +15,67 @@ from fastapi import (
     File,
     Header,
     HTTPException,
-    UploadFile,
     Query,
     Request,
+    UploadFile,
     status,
 )
 
+from src.api.base_dependencies import (
+    get_cache_service,
+    get_deepl_text_translation_service,
+    get_image_store,
+)
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.dependencies.guest_quota import get_guest_quota_service
 from src.api.dependencies.task_manager import get_task_manager
-from src.api.base_dependencies import get_cache_service, get_image_store
-from src.api.exceptions import handle_exception, ValidationException
+from src.api.exceptions import ValidationException, handle_exception
+from src.api.mappers.meal_mapper import MealMapper
 from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
-from src.api.mappers.meal_mapper import MealMapper
+from src.api.schemas.progress_schemas import DailyBreakdownResponse, StreakResponse
 from src.api.schemas.request.meal_requests import (
-    EditMealIngredientsRequest,
     CreateManualMealFromFoodsRequest,
+    EditMealIngredientsRequest,
     ParseMealTextRequest,
 )
 from src.api.schemas.response import DetailedMealResponse, ManualMealCreationResponse
-from src.api.schemas.response.meal_responses import ParseMealTextResponse
-from src.api.schemas.progress_schemas import DailyBreakdownResponse, StreakResponse
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
+from src.api.schemas.response.meal_responses import ParseMealTextResponse
 from src.api.schemas.response.weekly_budget_response import WeeklyBudgetResponse
-from src.app.commands.meal import EditMealCommand, FoodItemChange, CustomNutritionData
+from src.api.services.guest_parse_quota import (
+    GuestParseQuotaService,
+    QuotaAlreadyUsedError,
+    QuotaInFlightError,
+    QuotaUnavailableError,
+    validate_install_id,
+)
+from src.app.commands.meal import CustomNutritionData, EditMealCommand, FoodItemChange
 from src.app.commands.meal.create_manual_meal_command import (
     CreateManualMealCommand,
     CustomNutrition,
     ManualMealItem,
 )
-from src.app.commands.meal.parse_meal_text_command import ParseMealTextCommand
 from src.app.commands.meal.delete_meal_command import DeleteMealCommand
+from src.app.commands.meal.parse_meal_text_command import ParseMealTextCommand
 from src.app.commands.meal.upload_meal_image_immediately_command import (
     UploadMealImageImmediatelyCommand,
 )
-from src.app.queries.meal import (
-    GetMealByIdQuery,
-    GetDailyMacrosQuery,
-    GetStreakQuery,
-    GetDailyBreakdownQuery,
-)
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
-from src.domain.services.prompts.input_sanitizer import sanitize_user_description
+from src.app.queries.meal import (
+    GetDailyBreakdownQuery,
+    GetDailyMacrosQuery,
+    GetMealByIdQuery,
+    GetStreakQuery,
+)
 from src.domain.services.meal_value_insight_service import MealValueInsightService
+from src.domain.services.prompts.input_sanitizer import sanitize_user_description
+from src.domain.services.translation.deepl_text_translation_service import (
+    DeepLTextTranslationService,
+)
 from src.infra.cache.cache_service import CacheService
 from src.infra.event_bus import BackgroundTaskManager, EventBus
-from src.api.dependencies.guest_quota import get_guest_quota_service
-from src.api.services.guest_parse_quota import (
-    GuestParseQuotaService,
-    QuotaAlreadyUsedError,
-    QuotaUnavailableError,
-    QuotaInFlightError,
-    validate_install_id,
-)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/meals", tags=["Meals"])
@@ -114,6 +121,9 @@ async def analyze_meal_image_immediate(
     image_store=Depends(get_image_store),
     cache_service: CacheService | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    text_translation_service: DeepLTextTranslationService | None = Depends(
+        get_deepl_text_translation_service
+    ),
 ):
     """
     Send meal photo and return immediate meal analysis with nutritional data.
@@ -203,6 +213,7 @@ async def analyze_meal_image_immediate(
             meal,
             language=language,
             cache_service=cache_service,
+            text_translation_service=text_translation_service,
         )
 
         return MealMapper.to_detailed_response(
@@ -223,6 +234,9 @@ async def create_manual_meal(
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CacheService | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    text_translation_service: DeepLTextTranslationService | None = Depends(
+        get_deepl_text_translation_service
+    ),
 ) -> ManualMealCreationResponse:
     """
     Create a manual meal from USDA FDC items.
@@ -286,6 +300,7 @@ async def create_manual_meal(
             meal,
             language=get_request_language(request),
             cache_service=cache_service,
+            text_translation_service=text_translation_service,
         )
 
         return ManualMealCreationResponse(
@@ -531,6 +546,9 @@ async def get_meal(
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
     cache_service: CacheService | None = Depends(get_cache_service),
+    text_translation_service: DeepLTextTranslationService | None = Depends(
+        get_deepl_text_translation_service
+    ),
 ):
     """Get detailed information about a specific meal.
 
@@ -554,6 +572,7 @@ async def get_meal(
         meal,
         language=language,
         cache_service=cache_service,
+        text_translation_service=text_translation_service,
     )
 
     # Use mapper to convert to response with translation support
@@ -570,11 +589,14 @@ async def _build_value_insights_for_meal(
     *,
     language: str,
     cache_service: CacheService | None,
+    text_translation_service: DeepLTextTranslationService | None,
 ):
-    return await MealValueInsightService().build_ai(
+    return await MealValueInsightService(
+        text_translation_service=text_translation_service,
+    ).build_ai(
         dish_name=meal.dish_name,
         nutrition=meal.nutrition,
-        ingredient_names_by_id=_translated_food_item_names(meal, language),
+        ingredient_names_by_id={},
         language=language,
         cache_service=cache_service,
     )
@@ -586,6 +608,7 @@ def _schedule_value_insight_generation(
     *,
     language: str,
     cache_service: CacheService | None,
+    text_translation_service: DeepLTextTranslationService | None,
 ) -> None:
     if cache_service is None:
         return
@@ -595,6 +618,7 @@ def _schedule_value_insight_generation(
             meal,
             language=language,
             cache_service=cache_service,
+            text_translation_service=text_translation_service,
         ),
     )
 
@@ -674,6 +698,9 @@ async def update_meal_ingredients(
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CacheService | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    text_translation_service: DeepLTextTranslationService | None = Depends(
+        get_deepl_text_translation_service
+    ),
 ):
     """
     Update meal ingredients and portions.
@@ -725,6 +752,7 @@ async def update_meal_ingredients(
         meal,
         language=get_request_language(http_request),
         cache_service=cache_service,
+        text_translation_service=text_translation_service,
     )
     return result
 

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -29,7 +29,7 @@ from src.api.base_dependencies import (
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.dependencies.guest_quota import get_guest_quota_service
-from src.api.dependencies.task_manager import get_task_manager
+from src.api.dependencies.task_manager import get_optional_task_manager
 from src.api.exceptions import ValidationException, handle_exception
 from src.api.mappers.meal_mapper import MealMapper
 from src.api.middleware.accept_language import get_request_language
@@ -123,7 +123,7 @@ async def analyze_meal_image_immediate(
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
     cache_service: CachePort | None = Depends(get_cache_service),
-    task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
@@ -238,7 +238,7 @@ async def create_manual_meal(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CachePort | None = Depends(get_cache_service),
-    task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
@@ -553,7 +553,7 @@ async def get_meal(
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
     cache_service: CachePort | None = Depends(get_cache_service),
-    task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
@@ -613,7 +613,7 @@ async def get_meal_value_insights(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CachePort | None = Depends(get_cache_service),
-    task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
@@ -688,7 +688,7 @@ async def _build_value_insights_for_meal(
 
 
 def _schedule_value_insight_generation(
-    task_manager: BackgroundTaskManager,
+    task_manager: BackgroundTaskManager | None,
     meal,
     *,
     language: str,
@@ -696,7 +696,7 @@ def _schedule_value_insight_generation(
     text_translation_service: DeepLTranslationPort | None,
     ai_manager: MealInsightAIPort,
 ) -> None:
-    if cache_service is None:
+    if cache_service is None or task_manager is None:
         return
     task_manager.spawn(
         f"meal-value-insights:{meal.meal_id}",
@@ -784,7 +784,7 @@ async def update_meal_ingredients(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CachePort | None = Depends(get_cache_service),
-    task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -111,6 +111,7 @@ async def analyze_meal_image_immediate(
     ),
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
+    cache_service: CacheService | None = Depends(get_cache_service),
 ):
     """
     Send meal photo and return immediate meal analysis with nutritional data.
@@ -195,8 +196,17 @@ async def analyze_meal_image_immediate(
         if meal.image:
             image_url = meal.image.url or image_store.get_url(meal.image.image_id)
 
+        value_insights = await _build_value_insights_for_meal(
+            meal,
+            language=language,
+            cache_service=cache_service,
+        )
+
         return MealMapper.to_detailed_response(
-            meal, image_url, target_language=language
+            meal,
+            image_url,
+            target_language=language,
+            value_insights=value_insights,
         )
 
     except Exception as e:
@@ -205,9 +215,11 @@ async def analyze_meal_image_immediate(
 
 @router.post("/manual", response_model=ManualMealCreationResponse)
 async def create_manual_meal(
+    request: Request,
     payload: CreateManualMealFromFoodsRequest,
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
+    cache_service: CacheService | None = Depends(get_cache_service),
 ) -> ManualMealCreationResponse:
     """
     Create a manual meal from USDA FDC items.
@@ -265,6 +277,11 @@ async def create_manual_meal(
             "manual_save timing: user=%s total_handler_ms=%.1f",
             user_id,
             _elapsed_ms,
+        )
+        await _build_value_insights_for_meal(
+            meal,
+            language=get_request_language(request),
+            cache_service=cache_service,
         )
 
         return ManualMealCreationResponse(
@@ -529,10 +546,8 @@ async def get_meal(
 
     # Get language from Accept-Language header via middleware
     language = get_request_language(request)
-    value_insights = await MealValueInsightService().build_ai(
-        dish_name=meal.dish_name,
-        nutrition=meal.nutrition,
-        ingredient_names_by_id=_translated_food_item_names(meal, language),
+    value_insights = await _build_value_insights_for_meal(
+        meal,
         language=language,
         cache_service=cache_service,
     )
@@ -543,6 +558,21 @@ async def get_meal(
         image_url,
         target_language=language,
         value_insights=value_insights,
+    )
+
+
+async def _build_value_insights_for_meal(
+    meal,
+    *,
+    language: str,
+    cache_service: CacheService | None,
+):
+    return await MealValueInsightService().build_ai(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        ingredient_names_by_id=_translated_food_item_names(meal, language),
+        language=language,
+        cache_service=cache_service,
     )
 
 
@@ -615,9 +645,11 @@ async def get_daily_macros(
 @router.put("/{meal_id}/ingredients", response_model=None)
 async def update_meal_ingredients(
     meal_id: str,
-    request: EditMealIngredientsRequest,
+    payload: EditMealIngredientsRequest,
+    http_request: Request,
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
+    cache_service: CacheService | None = Depends(get_cache_service),
 ):
     """
     Update meal ingredients and portions.
@@ -628,7 +660,7 @@ async def update_meal_ingredients(
     logger.info("Updating meal ingredients for meal %s", meal_id)
     # Convert request to command
     food_item_changes = []
-    for change_request in request.food_item_changes:
+    for change_request in payload.food_item_changes:
         custom_nutrition = None
         if change_request.custom_nutrition:
             custom_nutrition = CustomNutritionData(
@@ -655,14 +687,20 @@ async def update_meal_ingredients(
     command = EditMealCommand(
         meal_id=meal_id,
         user_id=user_id,
-        dish_name=request.dish_name,
-        created_at=request.created_at,
-        meal_type=request.meal_type,
+        dish_name=payload.dish_name,
+        created_at=payload.created_at,
+        meal_type=payload.meal_type,
         food_item_changes=food_item_changes,
     )
 
     logger.info("Sending command to event bus: %s", command)
     result = await event_bus.send(command)
+    meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
+    await _build_value_insights_for_meal(
+        meal,
+        language=get_request_language(http_request),
+        cache_service=cache_service,
+    )
     return result
 
 

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -7,7 +7,6 @@ import logging
 import time
 import uuid
 from datetime import datetime
-from typing import Optional
 
 from fastapi import (
     APIRouter,
@@ -40,7 +39,11 @@ from src.api.schemas.request.meal_requests import (
     EditMealIngredientsRequest,
     ParseMealTextRequest,
 )
-from src.api.schemas.response import DetailedMealResponse, ManualMealCreationResponse
+from src.api.schemas.response import (
+    DetailedMealResponse,
+    ManualMealCreationResponse,
+    MealValueInsightsStatusResponse,
+)
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.api.schemas.response.meal_responses import ParseMealTextResponse
 from src.api.schemas.response.weekly_budget_response import WeeklyBudgetResponse
@@ -106,10 +109,10 @@ async def analyze_meal_image_immediate(
     request: Request,
     file: UploadFile = File(...),
     user_id: str = Depends(get_current_user_id),
-    target_date: Optional[str] = Query(
+    target_date: str | None = Query(
         None, description="Target date in YYYY-MM-DD format for meal association"
     ),
-    user_description: Optional[str] = Query(
+    user_description: str | None = Query(
         None,
         description="Optional user context (max 200 chars): 'no sugar', 'grilled', etc.",
     ),
@@ -146,7 +149,7 @@ async def analyze_meal_image_immediate(
 
         if len(contents) > MAX_FILE_SIZE:
             raise ValidationException(
-                message=f"File size exceeds maximum allowed ({MAX_FILE_SIZE // (1024*1024)} MB)",
+                message=f"File size exceeds maximum allowed ({MAX_FILE_SIZE // (1024 * 1024)} MB)",
                 error_code="FILE_SIZE_EXCEEDS_MAXIMUM",
                 details={"size": len(contents), "max_size": MAX_FILE_SIZE},
             )
@@ -408,7 +411,7 @@ async def parse_meal_text_guest_trial(
 
     try:
         id_hash = await quota.reserve(x_guest_install_id)
-    except QuotaAlreadyUsedError:
+    except QuotaAlreadyUsedError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
@@ -416,8 +419,8 @@ async def parse_meal_text_guest_trial(
                 "message": "Your guest trial has already been used.",
                 "details": {},
             },
-        )
-    except (QuotaUnavailableError, QuotaInFlightError):
+        ) from exc
+    except (QuotaUnavailableError, QuotaInFlightError) as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={
@@ -425,7 +428,7 @@ async def parse_meal_text_guest_trial(
                 "message": "The guest trial is temporarily unavailable. Please try again later.",
                 "details": {},
             },
-        )
+        ) from exc
 
     language = get_request_language(request)
     command = ParseMealTextCommand(
@@ -500,7 +503,7 @@ async def get_streak(
 async def get_daily_breakdown(
     request: Request,
     user_id: str = Depends(get_current_user_id),
-    week_start: Optional[str] = Query(
+    week_start: str | None = Query(
         None,
         description="Week start date (Monday) in YYYY-MM-DD format. Defaults to current week.",
     ),
@@ -546,6 +549,7 @@ async def get_meal(
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
     cache_service: CacheService | None = Depends(get_cache_service),
+    task_manager: BackgroundTaskManager = Depends(get_task_manager),
     text_translation_service: DeepLTextTranslationService | None = Depends(
         get_deepl_text_translation_service
     ),
@@ -568,12 +572,24 @@ async def get_meal(
 
     # Get language from Accept-Language header via middleware
     language = get_request_language(request)
-    value_insights = await _build_value_insights_for_meal(
-        meal,
-        language=language,
-        cache_service=cache_service,
+    insight_service = MealValueInsightService(
         text_translation_service=text_translation_service,
     )
+    value_insights = await insight_service.get_cached_ai(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        ingredient_names_by_id={},
+        language=language,
+        cache_service=cache_service,
+    )
+    if value_insights is None:
+        _schedule_value_insight_generation(
+            task_manager,
+            meal,
+            language=language,
+            cache_service=cache_service,
+            text_translation_service=text_translation_service,
+        )
 
     # Use mapper to convert to response with translation support
     return MealMapper.to_detailed_response(
@@ -581,6 +597,65 @@ async def get_meal(
         image_url,
         target_language=language,
         value_insights=value_insights,
+    )
+
+
+@router.get("/{meal_id}/value-insights", response_model=MealValueInsightsStatusResponse)
+async def get_meal_value_insights(
+    request: Request,
+    meal_id: str,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+    cache_service: CacheService | None = Depends(get_cache_service),
+    task_manager: BackgroundTaskManager = Depends(get_task_manager),
+    text_translation_service: DeepLTextTranslationService | None = Depends(
+        get_deepl_text_translation_service
+    ),
+):
+    """Return current value-insight cache status for a meal."""
+    meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
+    language = get_request_language(request)
+    insight_service = MealValueInsightService(
+        text_translation_service=text_translation_service,
+    )
+    version = insight_service.version(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        ingredient_names_by_id={},
+        language=language,
+    )
+    if version is None or cache_service is None:
+        return MealValueInsightsStatusResponse(
+            status="unavailable",
+            value_insights=None,
+            version=version,
+        )
+
+    value_insights = await insight_service.get_cached_ai(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        ingredient_names_by_id={},
+        language=language,
+        cache_service=cache_service,
+    )
+    if value_insights is None:
+        _schedule_value_insight_generation(
+            task_manager,
+            meal,
+            language=language,
+            cache_service=cache_service,
+            text_translation_service=text_translation_service,
+        )
+        return MealValueInsightsStatusResponse(
+            status="generating",
+            value_insights=None,
+            version=version,
+        )
+
+    return MealValueInsightsStatusResponse(
+        status="fresh",
+        value_insights=MealMapper.to_value_insights_response(value_insights),
+        version=version,
     )
 
 
@@ -663,7 +738,7 @@ async def delete_meal(
 async def get_daily_macros(
     request: Request,
     user_id: str = Depends(get_current_user_id),
-    date: Optional[str] = Query(None, description="Date in YYYY-MM-DD format"),
+    date: str | None = Query(None, description="Date in YYYY-MM-DD format"),
     event_bus: EventBus = Depends(get_configured_event_bus),
 ):
     """
@@ -761,7 +836,7 @@ async def update_meal_ingredients(
 async def get_weekly_budget(
     request: Request,
     user_id: str = Depends(get_current_user_id),
-    week_start: Optional[str] = Query(
+    week_start: str | None = Query(
         None,
         description="Week start date in YYYY-MM-DD format (Monday). Defaults to current week.",
     ),

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -21,6 +21,7 @@ from fastapi import (
 )
 
 from src.api.base_dependencies import (
+    get_ai_model_manager,
     get_cache_service,
     get_deepl_text_translation_service,
     get_image_store,
@@ -73,11 +74,10 @@ from src.app.queries.meal import (
     GetStreakQuery,
 )
 from src.domain.services.meal_value_insight_service import MealValueInsightService
+from src.domain.ports.cache_port import CachePort
+from src.domain.ports.deepl_translation_port import DeepLTranslationPort
+from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.services.prompts.input_sanitizer import sanitize_user_description
-from src.domain.services.translation.deepl_text_translation_service import (
-    DeepLTextTranslationService,
-)
-from src.infra.cache.cache_service import CacheService
 from src.infra.event_bus import BackgroundTaskManager, EventBus
 
 logger = logging.getLogger(__name__)
@@ -122,11 +122,12 @@ async def analyze_meal_image_immediate(
     ),
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
-    cache_service: CacheService | None = Depends(get_cache_service),
+    cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
-    text_translation_service: DeepLTextTranslationService | None = Depends(
+    text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
+    ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """
     Send meal photo and return immediate meal analysis with nutritional data.
@@ -217,6 +218,7 @@ async def analyze_meal_image_immediate(
             language=language,
             cache_service=cache_service,
             text_translation_service=text_translation_service,
+            ai_manager=ai_manager,
         )
 
         return MealMapper.to_detailed_response(
@@ -235,11 +237,12 @@ async def create_manual_meal(
     payload: CreateManualMealFromFoodsRequest,
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
-    cache_service: CacheService | None = Depends(get_cache_service),
+    cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
-    text_translation_service: DeepLTextTranslationService | None = Depends(
+    text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
+    ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ) -> ManualMealCreationResponse:
     """
     Create a manual meal from USDA FDC items.
@@ -304,6 +307,7 @@ async def create_manual_meal(
             language=get_request_language(request),
             cache_service=cache_service,
             text_translation_service=text_translation_service,
+            ai_manager=ai_manager,
         )
 
         return ManualMealCreationResponse(
@@ -548,11 +552,12 @@ async def get_meal(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
-    cache_service: CacheService | None = Depends(get_cache_service),
+    cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
-    text_translation_service: DeepLTextTranslationService | None = Depends(
+    text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
+    ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """Get detailed information about a specific meal.
 
@@ -589,6 +594,7 @@ async def get_meal(
             language=language,
             cache_service=cache_service,
             text_translation_service=text_translation_service,
+            ai_manager=ai_manager,
         )
 
     # Use mapper to convert to response with translation support
@@ -606,11 +612,12 @@ async def get_meal_value_insights(
     meal_id: str,
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
-    cache_service: CacheService | None = Depends(get_cache_service),
+    cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
-    text_translation_service: DeepLTextTranslationService | None = Depends(
+    text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
+    ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """Return current value-insight cache status for a meal."""
     meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
@@ -645,6 +652,7 @@ async def get_meal_value_insights(
             language=language,
             cache_service=cache_service,
             text_translation_service=text_translation_service,
+            ai_manager=ai_manager,
         )
         return MealValueInsightsStatusResponse(
             status="generating",
@@ -663,10 +671,12 @@ async def _build_value_insights_for_meal(
     meal,
     *,
     language: str,
-    cache_service: CacheService | None,
-    text_translation_service: DeepLTextTranslationService | None,
+    cache_service: CachePort | None,
+    text_translation_service: DeepLTranslationPort | None,
+    ai_manager: MealInsightAIPort,
 ):
     return await MealValueInsightService(
+        ai_manager=ai_manager,
         text_translation_service=text_translation_service,
     ).build_ai(
         dish_name=meal.dish_name,
@@ -682,8 +692,9 @@ def _schedule_value_insight_generation(
     meal,
     *,
     language: str,
-    cache_service: CacheService | None,
-    text_translation_service: DeepLTextTranslationService | None,
+    cache_service: CachePort | None,
+    text_translation_service: DeepLTranslationPort | None,
+    ai_manager: MealInsightAIPort,
 ) -> None:
     if cache_service is None:
         return
@@ -694,6 +705,7 @@ def _schedule_value_insight_generation(
             language=language,
             cache_service=cache_service,
             text_translation_service=text_translation_service,
+            ai_manager=ai_manager,
         ),
     )
 
@@ -771,11 +783,12 @@ async def update_meal_ingredients(
     http_request: Request,
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
-    cache_service: CacheService | None = Depends(get_cache_service),
+    cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager = Depends(get_task_manager),
-    text_translation_service: DeepLTextTranslationService | None = Depends(
+    text_translation_service: DeepLTranslationPort | None = Depends(
         get_deepl_text_translation_service
     ),
+    ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """
     Update meal ingredients and portions.
@@ -828,6 +841,7 @@ async def update_meal_ingredients(
         language=get_request_language(http_request),
         cache_service=cache_service,
         text_translation_service=text_translation_service,
+        ai_manager=ai_manager,
     )
     return result
 

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -23,6 +23,7 @@ from fastapi import (
 
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.dependencies.task_manager import get_task_manager
 from src.api.base_dependencies import get_cache_service, get_image_store
 from src.api.exceptions import handle_exception, ValidationException
 from src.api.middleware.accept_language import get_request_language
@@ -59,7 +60,7 @@ from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
 from src.domain.services.prompts.input_sanitizer import sanitize_user_description
 from src.domain.services.meal_value_insight_service import MealValueInsightService
 from src.infra.cache.cache_service import CacheService
-from src.infra.event_bus import EventBus
+from src.infra.event_bus import BackgroundTaskManager, EventBus
 from src.api.dependencies.guest_quota import get_guest_quota_service
 from src.api.services.guest_parse_quota import (
     GuestParseQuotaService,
@@ -112,6 +113,7 @@ async def analyze_meal_image_immediate(
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
     cache_service: CacheService | None = Depends(get_cache_service),
+    task_manager: BackgroundTaskManager = Depends(get_task_manager),
 ):
     """
     Send meal photo and return immediate meal analysis with nutritional data.
@@ -196,7 +198,8 @@ async def analyze_meal_image_immediate(
         if meal.image:
             image_url = meal.image.url or image_store.get_url(meal.image.image_id)
 
-        value_insights = await _build_value_insights_for_meal(
+        _schedule_value_insight_generation(
+            task_manager,
             meal,
             language=language,
             cache_service=cache_service,
@@ -206,7 +209,6 @@ async def analyze_meal_image_immediate(
             meal,
             image_url,
             target_language=language,
-            value_insights=value_insights,
         )
 
     except Exception as e:
@@ -220,6 +222,7 @@ async def create_manual_meal(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CacheService | None = Depends(get_cache_service),
+    task_manager: BackgroundTaskManager = Depends(get_task_manager),
 ) -> ManualMealCreationResponse:
     """
     Create a manual meal from USDA FDC items.
@@ -278,7 +281,8 @@ async def create_manual_meal(
             user_id,
             _elapsed_ms,
         )
-        await _build_value_insights_for_meal(
+        _schedule_value_insight_generation(
+            task_manager,
             meal,
             language=get_request_language(request),
             cache_service=cache_service,
@@ -576,6 +580,25 @@ async def _build_value_insights_for_meal(
     )
 
 
+def _schedule_value_insight_generation(
+    task_manager: BackgroundTaskManager,
+    meal,
+    *,
+    language: str,
+    cache_service: CacheService | None,
+) -> None:
+    if cache_service is None:
+        return
+    task_manager.spawn(
+        f"meal-value-insights:{meal.meal_id}",
+        _build_value_insights_for_meal(
+            meal,
+            language=language,
+            cache_service=cache_service,
+        ),
+    )
+
+
 def _translated_food_item_names(meal, language: str) -> dict[str, str]:
     if language == "en" or not getattr(meal, "translations", None):
         return {}
@@ -650,6 +673,7 @@ async def update_meal_ingredients(
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CacheService | None = Depends(get_cache_service),
+    task_manager: BackgroundTaskManager = Depends(get_task_manager),
 ):
     """
     Update meal ingredients and portions.
@@ -696,7 +720,8 @@ async def update_meal_ingredients(
     logger.info("Sending command to event bus: %s", command)
     result = await event_bus.send(command)
     meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
-    await _build_value_insights_for_meal(
+    _schedule_value_insight_generation(
+        task_manager,
         meal,
         language=get_request_language(http_request),
         cache_service=cache_service,

--- a/src/api/schemas/response/__init__.py
+++ b/src/api/schemas/response/__init__.py
@@ -5,66 +5,71 @@ Response DTOs for API endpoints.
 # Daily nutrition responses
 from .daily_nutrition_response import (
     DailyNutritionResponse,
+)
+from .daily_nutrition_response import (
     MacrosResponse as DailyMacrosResponse,
 )
 
 # Ingredient recognition responses
 from .ingredient_recognition_responses import (
-    IngredientRecognitionResponse,
     IngredientCategoryEnum,
+    IngredientRecognitionResponse,
 )
 
 # Ingredient responses
 # Macros responses
 # Meal responses
 from .meal_responses import (
-    SimpleMealResponse,
     DetailedMealResponse,
-    MealListResponse,
-    MealPhotoAnalysisResponse,
-    MealSearchResponse,
-    NutritionSummaryResponse,
-    MacrosResponse,
-    NutritionResponse,
     FoodItemResponse,
     FoodLabelMetadataResponse,
     FoodLabelServingSizeResponse,
+    MacrosResponse,
     ManualMealCreationResponse,
+    MealListResponse,
+    MealPhotoAnalysisResponse,
+    MealSearchResponse,
     MealStatusEnum,
+    MealValueInsightsStatusResponse,
+    NutritionResponse,
+    NutritionSummaryResponse,
+    SimpleMealResponse,
+)
+from .meal_suggestion_responses import (
+    MacrosSchema as MealSuggestionMacrosSchema,
 )
 
 # Meal suggestion responses
 from .meal_suggestion_responses import (
     MealSuggestionItem,
-    MacrosSchema as MealSuggestionMacrosSchema,
 )
 
 # Onboarding responses
 from .onboarding_responses import (
     OnboardingFieldResponse,
+    OnboardingResponse,
+    OnboardingResponseResponse,
     OnboardingSectionResponse,
     OnboardingSectionsResponse,
-    OnboardingResponseResponse,
-    OnboardingResponse,
 )
 
 # TDEE responses
 from .tdee_responses import (
-    TdeeCalculationResponse,
     BatchTdeeCalculationResponse,
-    TdeeComparisonResponse,
-    TdeeHistoryResponse,
-    TdeeErrorResponse,
     MacroTargetsResponse,
+    TdeeCalculationResponse,
+    TdeeComparisonResponse,
+    TdeeErrorResponse,
+    TdeeHistoryResponse,
 )
 
 # User responses
 from .user_responses import (
-    UserProfileResponse,
-    UserSyncResponse,
-    UserStatusResponse,
-    UserUpdateResponse,
     UserMetricsResponse,
+    UserProfileResponse,
+    UserStatusResponse,
+    UserSyncResponse,
+    UserUpdateResponse,
 )
 
 __all__ = [
@@ -81,6 +86,7 @@ __all__ = [
     "FoodLabelMetadataResponse",
     "FoodLabelServingSizeResponse",
     "ManualMealCreationResponse",
+    "MealValueInsightsStatusResponse",
     "MealStatusEnum",
     # TDEE
     "TdeeCalculationResponse",

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -149,6 +149,11 @@ class MealValueBulletResponse(BaseModel):
 
     text: str = Field(..., max_length=120)
     category: ValueInsightCategoryEnum
+    highlights: List[str] = Field(
+        default_factory=list,
+        max_length=1,
+        description="Exact localized substrings to bold",
+    )
 
 
 class IngredientValueInsightResponse(BaseModel):
@@ -157,6 +162,11 @@ class IngredientValueInsightResponse(BaseModel):
     ingredient_name: str = Field(..., description="Ingredient display name")
     text: str = Field(..., max_length=120)
     category: ValueInsightCategoryEnum
+    highlights: List[str] = Field(
+        default_factory=list,
+        max_length=1,
+        description="Exact localized substrings to bold",
+    )
 
 
 class MealValueInsightsResponse(BaseModel):
@@ -165,6 +175,21 @@ class MealValueInsightsResponse(BaseModel):
     meal_bullets: List[MealValueBulletResponse] = Field(default_factory=list)
     ingredient_insights: List[IngredientValueInsightResponse] = Field(
         default_factory=list
+    )
+
+
+class MealValueInsightsStatusResponse(BaseModel):
+    """Cache status for meal value insights."""
+
+    status: str = Field(
+        ...,
+        description="Insight freshness: fresh, generating, or unavailable",
+    )
+    value_insights: Optional[MealValueInsightsResponse] = Field(
+        None, description="Fresh insights when available"
+    )
+    version: Optional[str] = Field(
+        None, description="Stable fingerprint for the meal insight payload"
     )
 
 

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -25,6 +25,14 @@ class MealStatusEnum(str, Enum):
     failed = "failed"
 
 
+class ValueInsightCategoryEnum(str, Enum):
+    """Meal value insight category."""
+
+    benefit = "benefit"
+    caution = "caution"
+    balance = "balance"
+
+
 # Translation Response DTOs
 
 
@@ -136,6 +144,30 @@ class FoodLabelMetadataResponse(BaseModel):
     label_notes: List[str] = Field(default_factory=list)
 
 
+class MealValueBulletResponse(BaseModel):
+    """Short meal-level value insight."""
+
+    text: str = Field(..., max_length=120)
+    category: ValueInsightCategoryEnum
+
+
+class IngredientValueInsightResponse(BaseModel):
+    """Short ingredient-level value insight."""
+
+    ingredient_name: str = Field(..., description="Ingredient display name")
+    text: str = Field(..., max_length=120)
+    category: ValueInsightCategoryEnum
+
+
+class MealValueInsightsResponse(BaseModel):
+    """Value insights shown on meal detail."""
+
+    meal_bullets: List[MealValueBulletResponse] = Field(default_factory=list)
+    ingredient_insights: List[IngredientValueInsightResponse] = Field(
+        default_factory=list
+    )
+
+
 class FoodItemResponse(BaseModel):
     """Response DTO for food item information."""
 
@@ -189,6 +221,9 @@ class DetailedMealResponse(SimpleMealResponse):
     )
     food_label_metadata: Optional[FoodLabelMetadataResponse] = Field(
         None, description="Nutrition Facts metadata for food-label scans"
+    )
+    value_insights: Optional[MealValueInsightsResponse] = Field(
+        None, description="AI-generated meal and ingredient value insights"
     )
     # Recipe details (populated for AI suggestions, null for scanned/manual meals)
     description: Optional[str] = Field(None, description="Meal description")

--- a/src/domain/ports/meal_insight_ai_port.py
+++ b/src/domain/ports/meal_insight_ai_port.py
@@ -1,0 +1,23 @@
+"""Port for AI generation used by meal insight services."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from src.domain.model.ai.model_purpose import ModelPurpose
+
+
+class MealInsightAIPort(ABC):
+    """Interface for structured AI generation used by meal value insights."""
+
+    @abstractmethod
+    async def generate(
+        self,
+        *,
+        purpose: ModelPurpose,
+        prompt: str,
+        system_message: str,
+        response_type: str = "json",
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Generate a structured response for meal insight copy."""

--- a/src/domain/services/meal_value_insight_contract.py
+++ b/src/domain/services/meal_value_insight_contract.py
@@ -1,0 +1,105 @@
+"""Validated meal value insight payload helpers."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ValueInsight:
+    """Short insight text and UI category."""
+
+    text: str
+    category: str
+
+
+@dataclass(frozen=True)
+class IngredientValueInsight:
+    """Short ingredient insight."""
+
+    ingredient_name: str
+    text: str
+    category: str
+
+
+@dataclass(frozen=True)
+class MealValueInsights:
+    """Meal detail insight payload."""
+
+    meal_bullets: list[ValueInsight]
+    ingredient_insights: list[IngredientValueInsight]
+
+
+def parse_ai_result(result: Any) -> MealValueInsights | None:
+    if not isinstance(result, dict):
+        return None
+    meal_bullets = [
+        item
+        for raw in result.get("meal_bullets", [])[:2]
+        if (item := _parse_value_insight(raw))
+    ]
+    ingredient_insights = [
+        item
+        for raw in result.get("ingredient_insights", [])[:2]
+        if (item := _parse_ingredient_insight(raw))
+    ]
+    if not meal_bullets and not ingredient_insights:
+        return None
+    return MealValueInsights(
+        meal_bullets=meal_bullets,
+        ingredient_insights=ingredient_insights,
+    )
+
+
+def serialize_insights(insights: MealValueInsights) -> dict[str, list[dict[str, str]]]:
+    return {
+        "meal_bullets": [
+            {"text": item.text, "category": item.category}
+            for item in insights.meal_bullets
+        ],
+        "ingredient_insights": [
+            {
+                "ingredient_name": item.ingredient_name,
+                "text": item.text,
+                "category": item.category,
+            }
+            for item in insights.ingredient_insights
+        ],
+    }
+
+
+def _parse_value_insight(raw: Any) -> ValueInsight | None:
+    if not isinstance(raw, dict):
+        return None
+    text = _bounded_text(raw.get("text"))
+    category = _category(raw.get("category"))
+    if not text:
+        return None
+    return ValueInsight(text=text, category=category)
+
+
+def _parse_ingredient_insight(raw: Any) -> IngredientValueInsight | None:
+    if not isinstance(raw, dict):
+        return None
+    name = _bounded_text(raw.get("ingredient_name"), max_length=60)
+    text = _bounded_text(raw.get("text"))
+    category = _category(raw.get("category"))
+    if not name or not text:
+        return None
+    return IngredientValueInsight(
+        ingredient_name=name,
+        text=text,
+        category=category,
+    )
+
+
+def _bounded_text(value: Any, max_length: int = 120) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = " ".join(value.strip().split())
+    return text[:max_length].rstrip()
+
+
+def _category(value: Any) -> str:
+    if value in {"benefit", "caution", "balance"}:
+        return str(value)
+    return "balance"

--- a/src/domain/services/meal_value_insight_contract.py
+++ b/src/domain/services/meal_value_insight_contract.py
@@ -1,7 +1,16 @@
 """Validated meal value insight payload helpers."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+_TEXT_LABEL_PREFIXES = (
+    "benefit",
+    "balance",
+    "balanced",
+    "caution",
+    "warning",
+    "warn",
+)
 
 
 @dataclass(frozen=True)
@@ -10,6 +19,7 @@ class ValueInsight:
 
     text: str
     category: str
+    highlights: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -19,6 +29,7 @@ class IngredientValueInsight:
     ingredient_name: str
     text: str
     category: str
+    highlights: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -50,10 +61,14 @@ def parse_ai_result(result: Any) -> MealValueInsights | None:
     )
 
 
-def serialize_insights(insights: MealValueInsights) -> dict[str, list[dict[str, str]]]:
+def serialize_insights(insights: MealValueInsights) -> dict[str, list[dict[str, Any]]]:
     return {
         "meal_bullets": [
-            {"text": item.text, "category": item.category}
+            {
+                "text": item.text,
+                "category": item.category,
+                "highlights": item.highlights,
+            }
             for item in insights.meal_bullets
         ],
         "ingredient_insights": [
@@ -61,6 +76,7 @@ def serialize_insights(insights: MealValueInsights) -> dict[str, list[dict[str, 
                 "ingredient_name": item.ingredient_name,
                 "text": item.text,
                 "category": item.category,
+                "highlights": item.highlights,
             }
             for item in insights.ingredient_insights
         ],
@@ -72,9 +88,10 @@ def _parse_value_insight(raw: Any) -> ValueInsight | None:
         return None
     text = _bounded_text(raw.get("text"))
     category = _category(raw.get("category"))
-    if not text:
+    highlights = _highlights(raw, text)
+    if not text or len(highlights) != 1:
         return None
-    return ValueInsight(text=text, category=category)
+    return ValueInsight(text=text, category=category, highlights=highlights)
 
 
 def _parse_ingredient_insight(raw: Any) -> IngredientValueInsight | None:
@@ -83,12 +100,14 @@ def _parse_ingredient_insight(raw: Any) -> IngredientValueInsight | None:
     name = _bounded_text(raw.get("ingredient_name"), max_length=60)
     text = _bounded_text(raw.get("text"))
     category = _category(raw.get("category"))
-    if not name or not text:
+    highlights = _highlights(raw, text)
+    if not name or not text or len(highlights) != 1:
         return None
     return IngredientValueInsight(
         ingredient_name=name,
         text=text,
         category=category,
+        highlights=highlights,
     )
 
 
@@ -96,6 +115,7 @@ def _bounded_text(value: Any, max_length: int = 120) -> str:
     if not isinstance(value, str):
         return ""
     text = " ".join(value.strip().split())
+    text = _strip_text_label(text)
     return text[:max_length].rstrip()
 
 
@@ -103,3 +123,30 @@ def _category(value: Any) -> str:
     if value in {"benefit", "caution", "balance"}:
         return str(value)
     return "balance"
+
+
+def _strip_text_label(text: str) -> str:
+    label, separator, rest = text.partition(":")
+    if separator and label.strip().casefold() in _TEXT_LABEL_PREFIXES:
+        return rest.strip()
+    return text
+
+
+def _highlights(raw: dict[str, Any], text: str) -> list[str]:
+    values = raw.get("highlights")
+    if not isinstance(values, list):
+        values = [raw.get("highlight")]
+
+    highlights: list[str] = []
+    for value in values:
+        highlight = _bounded_text(value, max_length=40)
+        if not highlight:
+            continue
+        if highlight.casefold() not in text.casefold():
+            continue
+        if highlight.casefold() in {item.casefold() for item in highlights}:
+            continue
+        highlights.append(highlight)
+        if len(highlights) == 1:
+            break
+    return highlights

--- a/src/domain/services/meal_value_insight_service.py
+++ b/src/domain/services/meal_value_insight_service.py
@@ -1,0 +1,181 @@
+"""AI-backed value insights for meal details."""
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+from src.domain.model.ai.model_purpose import ModelPurpose
+from src.domain.model.nutrition import Nutrition
+from src.domain.services.meal_value_insight_contract import (
+    MealValueInsights,
+    parse_ai_result,
+    serialize_insights,
+)
+from src.infra.services.ai.ai_model_manager import AIModelManager
+from src.observability import log_event
+
+INSIGHT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7
+logger = logging.getLogger(__name__)
+
+
+class MealValueInsightService:
+    """Build practical, non-medical meal insights using backend AI."""
+
+    def __init__(self, ai_manager: AIModelManager | None = None) -> None:
+        self._ai_manager = ai_manager
+
+    async def build_ai(
+        self,
+        *,
+        dish_name: str | None,
+        nutrition: Nutrition | None,
+        ingredient_names_by_id: dict[str, str] | None = None,
+        language: str = "en",
+        user_context: dict[str, Any] | None = None,
+        cache_service: Any | None = None,
+    ) -> MealValueInsights | None:
+        """Generate validated AI insights, falling back without blocking detail view."""
+        if not nutrition:
+            return None
+
+        summary = self._summary(
+            dish_name=dish_name,
+            nutrition=nutrition,
+            ingredient_names_by_id=ingredient_names_by_id or {},
+            language=language,
+            user_context=user_context or {},
+        )
+        cache_key = self._cache_key(summary)
+        cached = await self._get_cached(cache_service, cache_key)
+        if cached:
+            return cached
+
+        try:
+            ai_manager = self._ai_manager or AIModelManager.get_instance()
+            result = await ai_manager.generate(
+                purpose=ModelPurpose.GENERAL,
+                prompt=self._prompt(summary),
+                system_message=self._system_message(),
+                response_type="json",
+                max_tokens=450,
+            )
+            insights = parse_ai_result(result)
+        except Exception as exc:
+            logger.warning(
+                "Meal value insight AI generation failed: %s", type(exc).__name__
+            )
+            log_event(
+                "warning",
+                "meal_value_insights.generation_failed",
+                attributes={
+                    "component": "meal_value_insight_service",
+                    "failure_kind": type(exc).__name__,
+                    "language": summary["language"],
+                },
+            )
+            insights = None
+
+        if insights is None:
+            log_event(
+                "info",
+                "meal_value_insights.empty",
+                attributes={
+                    "component": "meal_value_insight_service",
+                    "language": summary["language"],
+                },
+            )
+            return None
+
+        if insights:
+            await self._set_cached(cache_service, cache_key, insights)
+        return insights
+
+    def _summary(
+        self,
+        *,
+        dish_name: str | None,
+        nutrition: Nutrition,
+        ingredient_names_by_id: dict[str, str],
+        language: str,
+        user_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        macros = nutrition.macros
+        return {
+            "dish_name": dish_name,
+            "language": language if language in {"en", "vi"} else "en",
+            "macros": {
+                "calories": nutrition.calories,
+                "protein_g": macros.protein,
+                "carbs_g": macros.carbs,
+                "fat_g": macros.fat,
+                "fiber_g": macros.fiber,
+                "sugar_g": macros.sugar,
+                "confidence": nutrition.confidence_score,
+            },
+            "ingredients": [
+                {
+                    "id": str(item.id),
+                    "name": ingredient_names_by_id.get(str(item.id), item.name),
+                    "quantity": item.quantity,
+                    "unit": item.unit,
+                    "calories": item.calories,
+                    "protein_g": item.macros.protein,
+                    "carbs_g": item.macros.carbs,
+                    "fat_g": item.macros.fat,
+                    "fiber_g": item.macros.fiber,
+                    "sugar_g": item.macros.sugar,
+                    "confidence": item.confidence,
+                }
+                for item in (nutrition.food_items or [])[:8]
+            ],
+            "user_context": user_context,
+        }
+
+    def _system_message(self) -> str:
+        return (
+            "You are Nutree's nutrition insight writer. Return only valid JSON. "
+            "Give practical food guidance, not medical diagnosis. Avoid disease "
+            "claims, treatment claims, and unsupported certainty."
+        )
+
+    def _prompt(self, summary: dict[str, Any]) -> str:
+        return (
+            "Generate concise meal value insights from this logged meal.\n"
+            "Rules:\n"
+            "- Output language must match language.\n"
+            "- meal_bullets: max 2 items, each text <=120 characters.\n"
+            "- ingredient_insights: max 2 key ingredients, one line each, text <=120 characters.\n"
+            "- category must be benefit, caution, or balance.\n"
+            "- Ground claims in ingredients/macros/confidence. If uncertain, be generic or return empty arrays.\n"
+            "- Keep total card copy near 280-320 characters or less.\n\n"
+            "JSON shape:\n"
+            '{"meal_bullets":[{"text":"...","category":"benefit"}],'
+            '"ingredient_insights":[{"ingredient_name":"Egg","text":"...","category":"balance"}]}\n\n'
+            f"Meal data:\n{json.dumps(summary, ensure_ascii=False)}"
+        )
+
+    def _cache_key(self, summary: dict[str, Any]) -> str:
+        payload = json.dumps(summary, ensure_ascii=False, sort_keys=True)
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+        return f"meal-value-insights:v1:{digest}"
+
+    async def _get_cached(self, cache_service: Any | None, key: str):
+        if cache_service is None:
+            return None
+        cached = await cache_service.get_json(key)
+        return parse_ai_result(cached)
+
+    async def _set_cached(
+        self,
+        cache_service: Any | None,
+        key: str,
+        insights: MealValueInsights,
+    ) -> None:
+        if cache_service is None:
+            return
+        await cache_service.set_json(
+            key,
+            serialize_insights(insights),
+            INSIGHT_CACHE_TTL_SECONDS,
+        )

--- a/src/domain/services/meal_value_insight_service.py
+++ b/src/domain/services/meal_value_insight_service.py
@@ -63,7 +63,9 @@ class MealValueInsightService:
         cache_key = self._cache_key(summary)
         localized_cache_key = self._localized_cache_key(cache_key, target_language)
         if target_language != "en":
-            cached_localized = await self._get_cached(cache_service, localized_cache_key)
+            cached_localized = await self._get_cached(
+                cache_service, localized_cache_key
+            )
             if cached_localized:
                 return cached_localized
 
@@ -121,6 +123,70 @@ class MealValueInsightService:
             localized_cache_key=localized_cache_key,
         )
 
+    async def get_cached_ai(
+        self,
+        *,
+        dish_name: str | None,
+        nutrition: Nutrition | None,
+        ingredient_names_by_id: dict[str, str] | None = None,
+        language: str = "en",
+        user_context: dict[str, Any] | None = None,
+        cache_service: Any | None = None,
+    ) -> MealValueInsights | None:
+        if not nutrition or cache_service is None:
+            return None
+
+        target_language = self._target_language(language)
+        summary = self._summary(
+            dish_name=dish_name,
+            nutrition=nutrition,
+            ingredient_names_by_id=ingredient_names_by_id or {},
+            language="en",
+            user_context=user_context or {},
+        )
+        cache_key = self._cache_key(summary)
+        localized_cache_key = self._localized_cache_key(cache_key, target_language)
+        if target_language != "en":
+            cached_localized = await self._get_cached(
+                cache_service, localized_cache_key
+            )
+            if cached_localized:
+                return cached_localized
+
+        cached = await self._get_cached(cache_service, cache_key)
+        if cached is None:
+            return None
+        return await self._localize_insights(
+            cached,
+            target_language=target_language,
+            cache_service=cache_service,
+            localized_cache_key=localized_cache_key,
+        )
+
+    def version(
+        self,
+        *,
+        dish_name: str | None,
+        nutrition: Nutrition | None,
+        ingredient_names_by_id: dict[str, str] | None = None,
+        language: str = "en",
+        user_context: dict[str, Any] | None = None,
+    ) -> str | None:
+        if not nutrition:
+            return None
+        target_language = self._target_language(language)
+        summary = self._summary(
+            dish_name=dish_name,
+            nutrition=nutrition,
+            ingredient_names_by_id=ingredient_names_by_id or {},
+            language="en",
+            user_context=user_context or {},
+        )
+        cache_key = self._cache_key(summary)
+        if target_language == "en":
+            return cache_key
+        return self._localized_cache_key(cache_key, target_language)
+
     def _summary(
         self,
         *,
@@ -131,6 +197,23 @@ class MealValueInsightService:
         user_context: dict[str, Any],
     ) -> dict[str, Any]:
         macros = nutrition.macros
+        ingredients = [
+            {
+                "id": str(item.id),
+                "name": ingredient_names_by_id.get(str(item.id), item.name),
+                "quantity": item.quantity,
+                "unit": item.unit,
+                "calories": item.calories,
+                "protein_g": item.macros.protein,
+                "carbs_g": item.macros.carbs,
+                "fat_g": item.macros.fat,
+                "fiber_g": item.macros.fiber,
+                "sugar_g": item.macros.sugar,
+                "confidence": item.confidence,
+            }
+            for item in (nutrition.food_items or [])[:8]
+        ]
+        ingredient_overview = self._ingredient_overview(ingredients)
         return {
             "dish_name": dish_name,
             "language": language,
@@ -143,24 +226,93 @@ class MealValueInsightService:
                 "sugar_g": macros.sugar,
                 "confidence": nutrition.confidence_score,
             },
-            "ingredients": [
-                {
-                    "id": str(item.id),
-                    "name": ingredient_names_by_id.get(str(item.id), item.name),
-                    "quantity": item.quantity,
-                    "unit": item.unit,
-                    "calories": item.calories,
-                    "protein_g": item.macros.protein,
-                    "carbs_g": item.macros.carbs,
-                    "fat_g": item.macros.fat,
-                    "fiber_g": item.macros.fiber,
-                    "sugar_g": item.macros.sugar,
-                    "confidence": item.confidence,
-                }
-                for item in (nutrition.food_items or [])[:8]
-            ],
+            "ingredients": ingredients,
+            "ingredient_overview": ingredient_overview,
+            "risk_flags": self._risk_flags(macros, ingredient_overview),
             "user_context": user_context,
         }
+
+    def _ingredient_overview(
+        self, ingredients: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        grouped: dict[str, dict[str, Any]] = {}
+        for item in ingredients:
+            key = " ".join(str(item["name"]).casefold().split())
+            entry = grouped.setdefault(
+                key,
+                {
+                    "name": item["name"],
+                    "count": 0,
+                    "unit": item["unit"],
+                    "total_quantity": 0.0,
+                    "mixed_units": False,
+                    "calories": 0.0,
+                    "protein_g": 0.0,
+                    "carbs_g": 0.0,
+                    "fat_g": 0.0,
+                    "fiber_g": 0.0,
+                    "sugar_g": 0.0,
+                },
+            )
+            entry["count"] += 1
+            if entry["unit"] == item["unit"]:
+                entry["total_quantity"] += item["quantity"]
+            else:
+                entry["mixed_units"] = True
+            for field in (
+                "calories",
+                "protein_g",
+                "carbs_g",
+                "fat_g",
+                "fiber_g",
+                "sugar_g",
+            ):
+                entry[field] += item[field]
+
+        overview = []
+        for entry in grouped.values():
+            overview.append(
+                {
+                    **entry,
+                    "dominant_macro": self._dominant_macro(entry),
+                    "repeated": entry["count"] > 1,
+                    "large_portion": (
+                        not entry["mixed_units"]
+                        and entry["unit"] == "g"
+                        and entry["total_quantity"] >= 250
+                    ),
+                }
+            )
+        return sorted(
+            overview,
+            key=lambda item: (item["repeated"], item["calories"]),
+            reverse=True,
+        )[:6]
+
+    def _dominant_macro(self, item: dict[str, Any]) -> str:
+        macros = {
+            "protein": item["protein_g"] * 4,
+            "carbs": item["carbs_g"] * 4,
+            "fat": item["fat_g"] * 9,
+        }
+        return max(macros, key=macros.get)
+
+    def _risk_flags(
+        self,
+        macros,
+        ingredient_overview: list[dict[str, Any]],
+    ) -> list[str]:
+        flags: list[str] = []
+        if macros.protein >= 120:
+            flags.append("very_high_protein")
+        if macros.carbs >= 120 and macros.fiber < 8:
+            flags.append("high_carbs_low_fiber")
+        for item in ingredient_overview:
+            if item["repeated"]:
+                flags.append(f"repeated_{item['dominant_macro']}_ingredient")
+            if item["large_portion"]:
+                flags.append(f"large_{item['dominant_macro']}_portion")
+        return flags[:6]
 
     def _system_message(self) -> str:
         return (
@@ -176,19 +328,33 @@ class MealValueInsightService:
             "- Output language must match language.\n"
             "- meal_bullets: max 2 items, each text <=120 characters.\n"
             "- ingredient_insights: max 2 key ingredients, one line each, text <=120 characters.\n"
+            "- Text should mention relevant nutrients or macros when they explain the body effect.\n"
+            "- Ingredient insights must call out what macro is high or low for that ingredient, then connect it to the body effect.\n"
+            "- Use ingredient_overview to notice repeated ingredients or large portions; surface those as caution when they skew the meal.\n"
+            "- Use risk_flags first. If risk_flags includes repeated_* or large_* for an ingredient, that ingredient insight must be caution.\n"
+            "- Do not frame extreme protein, repeated protein ingredients, or very large portions as a benefit just because protein is usually useful.\n"
+            "- For repeated or large portions, mention the repeated/large amount and the likely burden, such as heaviness, digestive load, or crowding out balance.\n"
+            "- Each item should have one clear stance: benefit, caution, or neutral balance.\n"
+            "- Avoid mixing helpful and harmful effects in the same item; do not use tradeoff wording like but, though, however, while, or although.\n"
+            "- For benefit, describe the helpful effect only. For caution, describe the limiting or harmful effect only.\n"
+            "- Do not include category labels inside text, such as Benefit:, Balance:, Caution:, or Warning:.\n"
+            "- For each item, set highlights to exactly 1 exact substring from text worth spotlighting.\n"
+            "- Each highlight must describe only how the meal may affect the body, such as fullness, steadier energy, digestion, recovery, hydration, or heaviness.\n"
+            "- Do not include standalone nutrient or macro words like protein, carbs, fat, fiber, sugar, calories, or kcal in highlights.\n"
+            "- The highlight must be localized, present verbatim in text, and <=40 characters.\n"
             "- category must be benefit, caution, or balance.\n"
             "- Ground claims in ingredients/macros/confidence. If uncertain, be generic or return empty arrays.\n"
             "- Keep total card copy near 280-320 characters or less.\n\n"
             "JSON shape:\n"
-            '{"meal_bullets":[{"text":"...","category":"benefit"}],'
-            '"ingredient_insights":[{"ingredient_name":"Egg","text":"...","category":"balance"}]}\n\n'
+            '{"meal_bullets":[{"text":"...","category":"benefit","highlights":["..."]}],'
+            '"ingredient_insights":[{"ingredient_name":"Egg","text":"...","category":"balance","highlights":["..."]}]}\n\n'
             f"Meal data:\n{json.dumps(summary, ensure_ascii=False)}"
         )
 
     def _cache_key(self, summary: dict[str, Any]) -> str:
         payload = json.dumps(summary, ensure_ascii=False, sort_keys=True)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
-        return f"meal-value-insights:v1:{digest}"
+        return f"meal-value-insights:v8:{digest}"
 
     def _localized_cache_key(self, canonical_cache_key: str, language: str) -> str:
         return f"{canonical_cache_key}:lang:{language}"
@@ -219,9 +385,11 @@ class MealValueInsightService:
         insights: MealValueInsights,
         target_language: str,
     ) -> MealValueInsights | None:
-        texts = [item.text for item in insights.meal_bullets]
+        texts: list[str] = []
+        for item in insights.meal_bullets:
+            texts.extend([item.text, *item.highlights[:1]])
         for item in insights.ingredient_insights:
-            texts.extend([item.ingredient_name, item.text])
+            texts.extend([item.ingredient_name, item.text, *item.highlights[:1]])
 
         translated = await self._text_translation_service.translate_texts(
             texts,
@@ -235,21 +403,28 @@ class MealValueInsightService:
         index = 0
         meal_bullets = []
         for item in insights.meal_bullets:
+            highlight_count = len(item.highlights[:1])
             meal_bullets.append(
-                ValueInsight(text=translated[index], category=item.category)
+                ValueInsight(
+                    text=translated[index],
+                    category=item.category,
+                    highlights=translated[index + 1 : index + 1 + highlight_count],
+                )
             )
-            index += 1
+            index += 1 + highlight_count
 
         ingredient_insights = []
         for item in insights.ingredient_insights:
+            highlight_count = len(item.highlights[:1])
             ingredient_insights.append(
                 IngredientValueInsight(
                     ingredient_name=translated[index],
                     text=translated[index + 1],
                     category=item.category,
+                    highlights=translated[index + 2 : index + 2 + highlight_count],
                 )
             )
-            index += 2
+            index += 2 + highlight_count
 
         localized = MealValueInsights(
             meal_bullets=meal_bullets,

--- a/src/domain/services/meal_value_insight_service.py
+++ b/src/domain/services/meal_value_insight_service.py
@@ -8,9 +8,14 @@ from typing import Any
 from src.domain.model.ai.model_purpose import ModelPurpose
 from src.domain.model.nutrition import Nutrition
 from src.domain.services.meal_value_insight_contract import (
+    IngredientValueInsight,
     MealValueInsights,
+    ValueInsight,
     parse_ai_result,
     serialize_insights,
+)
+from src.domain.services.translation.deepl_text_translation_service import (
+    DeepLTextTranslationService,
 )
 from src.infra.services.ai.ai_model_manager import AIModelManager
 from src.observability import log_event
@@ -19,11 +24,19 @@ INSIGHT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7
 logger = logging.getLogger(__name__)
 
 
+SUPPORTED_INSIGHT_LANGUAGES = {"en", "vi", "es", "fr", "de", "ja", "zh"}
+
+
 class MealValueInsightService:
     """Build practical, non-medical meal insights using backend AI."""
 
-    def __init__(self, ai_manager: AIModelManager | None = None) -> None:
+    def __init__(
+        self,
+        ai_manager: AIModelManager | None = None,
+        text_translation_service: DeepLTextTranslationService | None = None,
+    ) -> None:
         self._ai_manager = ai_manager
+        self._text_translation_service = text_translation_service
 
     async def build_ai(
         self,
@@ -39,17 +52,29 @@ class MealValueInsightService:
         if not nutrition:
             return None
 
+        target_language = self._target_language(language)
         summary = self._summary(
             dish_name=dish_name,
             nutrition=nutrition,
             ingredient_names_by_id=ingredient_names_by_id or {},
-            language=language,
+            language="en",
             user_context=user_context or {},
         )
         cache_key = self._cache_key(summary)
+        localized_cache_key = self._localized_cache_key(cache_key, target_language)
+        if target_language != "en":
+            cached_localized = await self._get_cached(cache_service, localized_cache_key)
+            if cached_localized:
+                return cached_localized
+
         cached = await self._get_cached(cache_service, cache_key)
         if cached:
-            return cached
+            return await self._localize_insights(
+                cached,
+                target_language=target_language,
+                cache_service=cache_service,
+                localized_cache_key=localized_cache_key,
+            )
 
         try:
             ai_manager = self._ai_manager or AIModelManager.get_instance()
@@ -89,7 +114,12 @@ class MealValueInsightService:
 
         if insights:
             await self._set_cached(cache_service, cache_key, insights)
-        return insights
+        return await self._localize_insights(
+            insights,
+            target_language=target_language,
+            cache_service=cache_service,
+            localized_cache_key=localized_cache_key,
+        )
 
     def _summary(
         self,
@@ -103,7 +133,7 @@ class MealValueInsightService:
         macros = nutrition.macros
         return {
             "dish_name": dish_name,
-            "language": language if language in {"en", "vi"} else "en",
+            "language": language,
             "macros": {
                 "calories": nutrition.calories,
                 "protein_g": macros.protein,
@@ -159,6 +189,73 @@ class MealValueInsightService:
         payload = json.dumps(summary, ensure_ascii=False, sort_keys=True)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
         return f"meal-value-insights:v1:{digest}"
+
+    def _localized_cache_key(self, canonical_cache_key: str, language: str) -> str:
+        return f"{canonical_cache_key}:lang:{language}"
+
+    def _target_language(self, language: str) -> str:
+        normalized = (language or "en").split("-")[0].lower()
+        return normalized if normalized in SUPPORTED_INSIGHT_LANGUAGES else "en"
+
+    async def _localize_insights(
+        self,
+        insights: MealValueInsights,
+        *,
+        target_language: str,
+        cache_service: Any | None,
+        localized_cache_key: str,
+    ) -> MealValueInsights:
+        if target_language == "en" or self._text_translation_service is None:
+            return insights
+
+        localized = await self._translate_insights(insights, target_language)
+        if localized is None:
+            return insights
+        await self._set_cached(cache_service, localized_cache_key, localized)
+        return localized
+
+    async def _translate_insights(
+        self,
+        insights: MealValueInsights,
+        target_language: str,
+    ) -> MealValueInsights | None:
+        texts = [item.text for item in insights.meal_bullets]
+        for item in insights.ingredient_insights:
+            texts.extend([item.ingredient_name, item.text])
+
+        translated = await self._text_translation_service.translate_texts(
+            texts,
+            target_language,
+        )
+        while len(translated) < len(texts):
+            translated.append(texts[len(translated)])
+        if translated == texts:
+            return None
+
+        index = 0
+        meal_bullets = []
+        for item in insights.meal_bullets:
+            meal_bullets.append(
+                ValueInsight(text=translated[index], category=item.category)
+            )
+            index += 1
+
+        ingredient_insights = []
+        for item in insights.ingredient_insights:
+            ingredient_insights.append(
+                IngredientValueInsight(
+                    ingredient_name=translated[index],
+                    text=translated[index + 1],
+                    category=item.category,
+                )
+            )
+            index += 2
+
+        localized = MealValueInsights(
+            meal_bullets=meal_bullets,
+            ingredient_insights=ingredient_insights,
+        )
+        return parse_ai_result(serialize_insights(localized))
 
     async def _get_cached(self, cache_service: Any | None, key: str):
         if cache_service is None:

--- a/src/domain/services/meal_value_insight_service.py
+++ b/src/domain/services/meal_value_insight_service.py
@@ -6,6 +6,9 @@ import logging
 from typing import Any
 
 from src.domain.model.ai.model_purpose import ModelPurpose
+from src.domain.ports.cache_port import CachePort
+from src.domain.ports.deepl_translation_port import DeepLTranslationPort
+from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.model.nutrition import Nutrition
 from src.domain.services.meal_value_insight_contract import (
     IngredientValueInsight,
@@ -14,10 +17,6 @@ from src.domain.services.meal_value_insight_contract import (
     parse_ai_result,
     serialize_insights,
 )
-from src.domain.services.translation.deepl_text_translation_service import (
-    DeepLTextTranslationService,
-)
-from src.infra.services.ai.ai_model_manager import AIModelManager
 from src.observability import log_event
 
 INSIGHT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7
@@ -32,8 +31,8 @@ class MealValueInsightService:
 
     def __init__(
         self,
-        ai_manager: AIModelManager | None = None,
-        text_translation_service: DeepLTextTranslationService | None = None,
+        ai_manager: MealInsightAIPort | None = None,
+        text_translation_service: DeepLTranslationPort | None = None,
     ) -> None:
         self._ai_manager = ai_manager
         self._text_translation_service = text_translation_service
@@ -46,7 +45,7 @@ class MealValueInsightService:
         ingredient_names_by_id: dict[str, str] | None = None,
         language: str = "en",
         user_context: dict[str, Any] | None = None,
-        cache_service: Any | None = None,
+        cache_service: CachePort | None = None,
     ) -> MealValueInsights | None:
         """Generate validated AI insights, falling back without blocking detail view."""
         if not nutrition:
@@ -79,8 +78,9 @@ class MealValueInsightService:
             )
 
         try:
-            ai_manager = self._ai_manager or AIModelManager.get_instance()
-            result = await ai_manager.generate(
+            if self._ai_manager is None:
+                raise RuntimeError("meal insight AI manager is not configured")
+            result = await self._ai_manager.generate(
                 purpose=ModelPurpose.GENERAL,
                 prompt=self._prompt(summary),
                 system_message=self._system_message(),
@@ -131,7 +131,7 @@ class MealValueInsightService:
         ingredient_names_by_id: dict[str, str] | None = None,
         language: str = "en",
         user_context: dict[str, Any] | None = None,
-        cache_service: Any | None = None,
+        cache_service: CachePort | None = None,
     ) -> MealValueInsights | None:
         if not nutrition or cache_service is None:
             return None
@@ -368,7 +368,7 @@ class MealValueInsightService:
         insights: MealValueInsights,
         *,
         target_language: str,
-        cache_service: Any | None,
+        cache_service: CachePort | None,
         localized_cache_key: str,
     ) -> MealValueInsights:
         if target_language == "en" or self._text_translation_service is None:
@@ -432,21 +432,21 @@ class MealValueInsightService:
         )
         return parse_ai_result(serialize_insights(localized))
 
-    async def _get_cached(self, cache_service: Any | None, key: str):
+    async def _get_cached(self, cache_service: CachePort | None, key: str):
         if cache_service is None:
             return None
-        cached = await cache_service.get_json(key)
+        cached = await cache_service.get(key)
         return parse_ai_result(cached)
 
     async def _set_cached(
         self,
-        cache_service: Any | None,
+        cache_service: CachePort | None,
         key: str,
         insights: MealValueInsights,
     ) -> None:
         if cache_service is None:
             return
-        await cache_service.set_json(
+        await cache_service.set(
             key,
             serialize_insights(insights),
             INSIGHT_CACHE_TTL_SECONDS,

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -702,15 +702,17 @@ class TestMealMapper:
             value_insights=MealValueInsights(
                 meal_bullets=[
                     ValueInsight(
-                        text="Strong protein base; add plants for more volume.",
+                        text="Strong protein helps fullness; add plants for more volume.",
                         category="benefit",
+                        highlights=["fullness"],
                     )
                 ],
                 ingredient_insights=[
                     IngredientValueInsight(
                         ingredient_name="Rice",
-                        text="Main carb source; portion size drives much of the energy.",
+                        text="Rice gives carbs for steady energy; portion size shapes fullness.",
                         category="balance",
+                        highlights=["steady energy"],
                     )
                 ],
             ),
@@ -785,15 +787,17 @@ class TestMealMapper:
             value_insights=MealValueInsights(
                 meal_bullets=[
                     ValueInsight(
-                        text="Giàu protein, phù hợp để giúp bữa ăn no lâu hơn.",
+                        text="Giàu protein giúp no lâu và ít béo giúp nhẹ bụng.",
                         category="benefit",
+                        highlights=["no lâu"],
                     )
                 ],
                 ingredient_insights=[
                     IngredientValueInsight(
                         ingredient_name="Ức gà",
-                        text="Bổ sung nhiều protein nạc cho bữa ăn.",
+                        text="Ức gà bổ sung protein nạc giúp phục hồi và ít béo giúp nhẹ bụng.",
                         category="benefit",
+                        highlights=["phục hồi"],
                     )
                 ],
             ),
@@ -808,33 +812,39 @@ class TestMealMapper:
             {
                 "meal_bullets": [
                     {
-                        "text": "Egg gives this meal useful protein and fat, while rice supplies quick energy.",
+                        "text": "Egg gives protein for fullness and fat for satiety.",
                         "category": "benefit",
+                        "highlights": ["fullness"],
                     },
                     {
-                        "text": "Add vegetables if you want more fiber and volume from this bowl.",
+                        "text": "Add vegetables for fiber-supported digestion and volume for fullness.",
                         "category": "balance",
+                        "highlights": ["digestion"],
                     },
                     {
                         "text": "This third item should be ignored.",
                         "category": "caution",
+                        "highlights": ["third item"],
                     },
                 ],
                 "ingredient_insights": [
                     {
                         "ingredient_name": "Egg",
-                        "text": "Provides protein and richness, so it can help the meal feel more satisfying.",
+                        "text": "Provides protein for fullness and richness for satisfaction.",
                         "category": "benefit",
+                        "highlights": ["fullness"],
                     },
                     {
                         "ingredient_name": "Rice",
-                        "text": "Main carb source; portion size shapes most of the energy.",
+                        "text": "Rice offers carbs for energy and starch for quick fuel.",
                         "category": "balance",
+                        "highlights": ["energy"],
                     },
                     {
                         "ingredient_name": "Sauce",
                         "text": "This third ingredient should be ignored.",
                         "category": "caution",
+                        "highlights": ["third ingredient"],
                     },
                 ],
             }
@@ -845,6 +855,63 @@ class TestMealMapper:
         assert len(insights.ingredient_insights) <= 2
         assert all(len(item.text) <= 120 for item in insights.meal_bullets)
         assert all(len(item.text) <= 120 for item in insights.ingredient_insights)
+
+    def test_meal_value_insight_service_keeps_one_body_effect_highlight(self):
+        """Highlights spotlight body effects, not macro keywords."""
+        insights = parse_ai_result(
+            {
+                "meal_bullets": [
+                    {
+                        "text": "Egg adds protein that supports fullness after this meal.",
+                        "category": "benefit",
+                        "highlights": ["fullness"],
+                    }
+                ],
+                "ingredient_insights": [
+                    {
+                        "ingredient_name": "Rice",
+                        "text": "Rice is high in carbs and low in protein, so fullness may fade sooner.",
+                        "category": "caution",
+                        "highlights": ["fullness may fade sooner"],
+                    }
+                ],
+            }
+        )
+
+        assert insights is not None
+        assert insights.meal_bullets[0].highlights == ["fullness"]
+        assert insights.ingredient_insights[0].category == "caution"
+        assert insights.ingredient_insights[0].highlights == [
+            "fullness may fade sooner"
+        ]
+
+    def test_meal_value_insight_service_strips_category_labels_from_text(self):
+        """AI category labels are metadata and should not appear in copy."""
+        insights = parse_ai_result(
+            {
+                "meal_bullets": [
+                    {
+                        "text": "Benefit: High protein supports fullness.",
+                        "category": "benefit",
+                        "highlights": ["fullness"],
+                    }
+                ],
+                "ingredient_insights": [
+                    {
+                        "ingredient_name": "Rice",
+                        "text": "Balance: High carbs provide quick fuel.",
+                        "category": "balance",
+                        "highlights": ["quick fuel"],
+                    }
+                ],
+            }
+        )
+
+        assert insights is not None
+        assert insights.meal_bullets[0].text == "High protein supports fullness."
+        assert insights.ingredient_insights[0].text == (
+            "High carbs provide quick fuel."
+        )
 
     def test_meal_value_insight_service_omits_invalid_ai_output(self):
         """Invalid AI output does not produce deterministic copy."""

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -11,6 +11,12 @@ import pytest
 from src.api.mappers.meal_mapper import STATUS_MAPPING, MealMapper
 from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
 from src.domain.model.meal import FoodItemTranslation, MealTranslation
+from src.domain.services.meal_value_insight_contract import (
+    IngredientValueInsight,
+    MealValueInsights,
+    ValueInsight,
+    parse_ai_result,
+)
 
 
 class TestMealMapper:
@@ -641,3 +647,209 @@ class TestMealMapper:
         assert result.total_nutrition.protein == 30
         assert result.total_nutrition.carbs == 45
         assert result.total_nutrition.fat == 12
+
+    def test_to_detailed_response_serializes_value_insights(self):
+        """Detailed responses serialize provided value insights."""
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/insights.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+                width=800,
+                height=600,
+            ),
+            dish_name="Egg Rice Bowl",
+            ready_at=datetime(2025, 1, 15, 17, 0),
+            created_at=datetime(2025, 1, 15, 16, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=31, carbs=54, fat=14, fiber=7),
+                confidence_score=0.92,
+                food_items=[
+                    FoodItem(
+                        id="egg-1",
+                        name="Egg",
+                        quantity=2,
+                        unit="piece",
+                        macros=Macros(protein=16, carbs=1, fat=10),
+                        confidence=0.9,
+                    ),
+                    FoodItem(
+                        id="rice-1",
+                        name="Rice",
+                        quantity=180,
+                        unit="g",
+                        macros=Macros(protein=4, carbs=52, fat=1),
+                        confidence=0.9,
+                    ),
+                    FoodItem(
+                        id="sauce-1",
+                        name="Sauce",
+                        quantity=20,
+                        unit="g",
+                        macros=Macros(protein=0, carbs=8, fat=0),
+                        confidence=0.9,
+                    ),
+                ],
+            ),
+        )
+
+        result = MealMapper.to_detailed_response(
+            meal,
+            value_insights=MealValueInsights(
+                meal_bullets=[
+                    ValueInsight(
+                        text="Strong protein base; add plants for more volume.",
+                        category="benefit",
+                    )
+                ],
+                ingredient_insights=[
+                    IngredientValueInsight(
+                        ingredient_name="Rice",
+                        text="Main carb source; portion size drives much of the energy.",
+                        category="balance",
+                    )
+                ],
+            ),
+        )
+
+        assert result.value_insights is not None
+        assert len(result.value_insights.meal_bullets) <= 2
+        assert len(result.value_insights.ingredient_insights) <= 2
+        assert all(len(item.text) <= 120 for item in result.value_insights.meal_bullets)
+        assert all(
+            len(item.text) <= 120 for item in result.value_insights.ingredient_insights
+        )
+        assert {item.category.value for item in result.value_insights.meal_bullets} <= {
+            "benefit",
+            "caution",
+            "balance",
+        }
+        assert result.value_insights.ingredient_insights[0].ingredient_name == "Rice"
+
+    def test_to_detailed_response_serializes_translated_insight_names(self):
+        """Ingredient insight labels can follow translated response names."""
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/translated.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+                width=800,
+                height=600,
+            ),
+            dish_name="Chicken and Rice",
+            ready_at=datetime(2025, 1, 15, 17, 0),
+            created_at=datetime(2025, 1, 15, 16, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=44, carbs=43, fat=5.4),
+                food_items=[
+                    FoodItem(
+                        id="item-1",
+                        name="Chicken Breast",
+                        quantity=200,
+                        unit="g",
+                        macros=Macros(protein=40, carbs=0, fat=5),
+                    ),
+                    FoodItem(
+                        id="item-2",
+                        name="Rice",
+                        quantity=150,
+                        unit="g",
+                        macros=Macros(protein=4, carbs=43, fat=0.4),
+                    ),
+                ],
+            ),
+            translations={
+                "vi": MealTranslation(
+                    meal_id="meal-1",
+                    language="vi",
+                    dish_name="Cơm gà",
+                    food_items=[
+                        FoodItemTranslation(food_item_id="item-1", name="Ức gà"),
+                        FoodItemTranslation(food_item_id="item-2", name="Cơm"),
+                    ],
+                )
+            },
+        )
+
+        result = MealMapper.to_detailed_response(
+            meal,
+            target_language="vi",
+            value_insights=MealValueInsights(
+                meal_bullets=[
+                    ValueInsight(
+                        text="Giàu protein, phù hợp để giúp bữa ăn no lâu hơn.",
+                        category="benefit",
+                    )
+                ],
+                ingredient_insights=[
+                    IngredientValueInsight(
+                        ingredient_name="Ức gà",
+                        text="Bổ sung nhiều protein nạc cho bữa ăn.",
+                        category="benefit",
+                    )
+                ],
+            ),
+        )
+
+        assert result.value_insights is not None
+        assert result.value_insights.ingredient_insights[0].ingredient_name == "Ức gà"
+
+    def test_meal_value_insight_service_parses_bounded_ai_output(self):
+        """AI insight output is capped to the v1 response bounds."""
+        insights = parse_ai_result(
+            {
+                "meal_bullets": [
+                    {
+                        "text": "Egg gives this meal useful protein and fat, while rice supplies quick energy.",
+                        "category": "benefit",
+                    },
+                    {
+                        "text": "Add vegetables if you want more fiber and volume from this bowl.",
+                        "category": "balance",
+                    },
+                    {
+                        "text": "This third item should be ignored.",
+                        "category": "caution",
+                    },
+                ],
+                "ingredient_insights": [
+                    {
+                        "ingredient_name": "Egg",
+                        "text": "Provides protein and richness, so it can help the meal feel more satisfying.",
+                        "category": "benefit",
+                    },
+                    {
+                        "ingredient_name": "Rice",
+                        "text": "Main carb source; portion size shapes most of the energy.",
+                        "category": "balance",
+                    },
+                    {
+                        "ingredient_name": "Sauce",
+                        "text": "This third ingredient should be ignored.",
+                        "category": "caution",
+                    },
+                ],
+            }
+        )
+
+        assert insights is not None
+        assert len(insights.meal_bullets) <= 2
+        assert len(insights.ingredient_insights) <= 2
+        assert all(len(item.text) <= 120 for item in insights.meal_bullets)
+        assert all(len(item.text) <= 120 for item in insights.ingredient_insights)
+
+    def test_meal_value_insight_service_omits_invalid_ai_output(self):
+        """Invalid AI output does not produce deterministic copy."""
+        insights = parse_ai_result(
+            {"meal_bullets": [{"text": "", "category": "benefit"}]}
+        )
+
+        assert insights is None

--- a/tests/unit/domain/services/test_meal_value_insight_service.py
+++ b/tests/unit/domain/services/test_meal_value_insight_service.py
@@ -1,0 +1,148 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+from src.domain.services.meal_value_insight_contract import (
+    MealValueInsights,
+    ValueInsight,
+    serialize_insights,
+)
+from src.domain.services.meal_value_insight_service import MealValueInsightService
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+
+    async def get_json(self, key):
+        return self.values.get(key)
+
+    async def set_json(self, key, value, ttl):
+        self.values[key] = value
+        return True
+
+
+def _nutrition():
+    return Nutrition(
+        macros=Macros(protein=20, carbs=30, fat=10),
+        food_items=[
+            FoodItem(
+                id="egg-1",
+                name="Egg",
+                quantity=100,
+                unit="g",
+                macros=Macros(protein=12, carbs=1, fat=10),
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_english_reuses_canonical_ai_result_and_caches_translation():
+    ai_manager = AsyncMock()
+    ai_manager.generate.return_value = {
+        "meal_bullets": [
+            {"text": "Egg adds protein and fat for satiety.", "category": "benefit"}
+        ],
+        "ingredient_insights": [
+            {
+                "ingredient_name": "Egg",
+                "text": "A compact source of protein and fat.",
+                "category": "balance",
+            }
+        ],
+    }
+    text_service = AsyncMock()
+    text_service.translate_texts.return_value = [
+        "Trứng bổ sung protein và chất béo giúp no lâu.",
+        "Trứng",
+        "Nguồn protein và chất béo nhỏ gọn.",
+    ]
+    cache = FakeCache()
+    service = MealValueInsightService(
+        ai_manager=ai_manager,
+        text_translation_service=text_service,
+    )
+
+    result = await service.build_ai(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="vi",
+        cache_service=cache,
+    )
+
+    assert result is not None
+    assert result.meal_bullets[0].text == "Trứng bổ sung protein và chất béo giúp no lâu."
+    assert result.ingredient_insights[0].ingredient_name == "Trứng"
+    ai_manager.generate.assert_awaited_once()
+    text_service.translate_texts.assert_awaited_once()
+    assert len(cache.values) == 2
+
+
+@pytest.mark.asyncio
+async def test_localized_cache_hit_skips_ai_and_deepl():
+    cached = MealValueInsights(
+        meal_bullets=[
+            ValueInsight(text="Trứng bổ sung protein.", category="benefit")
+        ],
+        ingredient_insights=[],
+    )
+    canonical_key = MealValueInsightService()._cache_key(
+        MealValueInsightService()._summary(
+            dish_name="Egg bowl",
+            nutrition=_nutrition(),
+            ingredient_names_by_id={},
+            language="en",
+            user_context={},
+        )
+    )
+    cache = FakeCache()
+    cache.values[f"{canonical_key}:lang:vi"] = serialize_insights(cached)
+    ai_manager = AsyncMock()
+    text_service = AsyncMock()
+
+    result = await MealValueInsightService(
+        ai_manager=ai_manager,
+        text_translation_service=text_service,
+    ).build_ai(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="vi",
+        cache_service=cache,
+    )
+
+    assert result is not None
+    assert result.meal_bullets[0].text == "Trứng bổ sung protein."
+    ai_manager.generate.assert_not_called()
+    text_service.translate_texts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deepl_english_fallback_is_not_cached_as_localized_result():
+    ai_manager = AsyncMock()
+    ai_manager.generate.return_value = {
+        "meal_bullets": [
+            {"text": "Egg adds protein and fat for satiety.", "category": "benefit"}
+        ],
+        "ingredient_insights": [],
+    }
+    text_service = AsyncMock()
+    text_service.translate_texts.return_value = [
+        "Egg adds protein and fat for satiety.",
+    ]
+    cache = FakeCache()
+
+    result = await MealValueInsightService(
+        ai_manager=ai_manager,
+        text_translation_service=text_service,
+    ).build_ai(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="vi",
+        cache_service=cache,
+    )
+
+    assert result is not None
+    assert result.meal_bullets[0].text == "Egg adds protein and fat for satiety."
+    assert len(cache.values) == 1

--- a/tests/unit/domain/services/test_meal_value_insight_service.py
+++ b/tests/unit/domain/services/test_meal_value_insight_service.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from starlette.requests import Request
 
+from src.api.routes.v1.meals import get_meal_value_insights
 from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 from src.domain.services.meal_value_insight_contract import (
     MealValueInsights,
@@ -38,26 +41,88 @@ def _nutrition():
     )
 
 
+def _nutrition_with_repeated_chicken():
+    return Nutrition(
+        macros=Macros(protein=120, carbs=43, fat=15),
+        food_items=[
+            FoodItem(
+                id="chicken-1",
+                name="Chicken",
+                quantity=150,
+                unit="g",
+                macros=Macros(protein=40, carbs=0, fat=5),
+            ),
+            FoodItem(
+                id="chicken-2",
+                name="Chicken",
+                quantity=150,
+                unit="g",
+                macros=Macros(protein=40, carbs=0, fat=5),
+            ),
+            FoodItem(
+                id="chicken-3",
+                name="Chicken",
+                quantity=150,
+                unit="g",
+                macros=Macros(protein=40, carbs=0, fat=5),
+            ),
+            FoodItem(
+                id="rice-1",
+                name="Rice",
+                quantity=150,
+                unit="g",
+                macros=Macros(protein=4, carbs=43, fat=0.4),
+            ),
+        ],
+    )
+
+
+class FakeEventBus:
+    def __init__(self, meal):
+        self.meal = meal
+
+    async def send(self, query):
+        return self.meal
+
+
+def _request(language: str = "en") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"accept-language", language.encode("utf-8"))],
+        }
+    )
+
+
 @pytest.mark.asyncio
 async def test_non_english_reuses_canonical_ai_result_and_caches_translation():
     ai_manager = AsyncMock()
     ai_manager.generate.return_value = {
         "meal_bullets": [
-            {"text": "Egg adds protein and fat for satiety.", "category": "benefit"}
+            {
+                "text": "Egg adds protein for fullness and fat for satiety.",
+                "category": "benefit",
+                "highlights": ["fullness"],
+            }
         ],
         "ingredient_insights": [
             {
                 "ingredient_name": "Egg",
-                "text": "A compact source of protein and fat.",
+                "text": "Egg offers protein for recovery and fat for satisfaction.",
                 "category": "balance",
+                "highlights": ["recovery"],
             }
         ],
     }
     text_service = AsyncMock()
     text_service.translate_texts.return_value = [
-        "Trứng bổ sung protein và chất béo giúp no lâu.",
+        "Trứng bổ sung protein giúp no và chất béo giúp hài lòng.",
+        "no",
         "Trứng",
-        "Nguồn protein và chất béo nhỏ gọn.",
+        "Trứng cung cấp protein để phục hồi và chất béo để no lâu.",
+        "phục hồi",
     ]
     cache = FakeCache()
     service = MealValueInsightService(
@@ -73,18 +138,113 @@ async def test_non_english_reuses_canonical_ai_result_and_caches_translation():
     )
 
     assert result is not None
-    assert result.meal_bullets[0].text == "Trứng bổ sung protein và chất béo giúp no lâu."
+    assert (
+        result.meal_bullets[0].text
+        == "Trứng bổ sung protein giúp no và chất béo giúp hài lòng."
+    )
+    assert result.meal_bullets[0].highlights == ["no"]
     assert result.ingredient_insights[0].ingredient_name == "Trứng"
+    assert result.ingredient_insights[0].highlights == ["phục hồi"]
     ai_manager.generate.assert_awaited_once()
     text_service.translate_texts.assert_awaited_once()
     assert len(cache.values) == 2
+
+
+def test_version_matches_current_cache_key_for_english():
+    service = MealValueInsightService()
+    version = service.version(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="en",
+    )
+    expected = service._cache_key(
+        service._summary(
+            dish_name="Egg bowl",
+            nutrition=_nutrition(),
+            ingredient_names_by_id={},
+            language="en",
+            user_context={},
+        )
+    )
+
+    assert version == expected
+
+
+def test_summary_groups_repeated_ingredients_for_overview():
+    summary = MealValueInsightService()._summary(
+        dish_name="Chicken rice",
+        nutrition=_nutrition_with_repeated_chicken(),
+        ingredient_names_by_id={},
+        language="en",
+        user_context={},
+    )
+
+    chicken = summary["ingredient_overview"][0]
+    assert chicken["name"] == "Chicken"
+    assert chicken["count"] == 3
+    assert chicken["total_quantity"] == 450
+    assert chicken["repeated"] is True
+    assert chicken["large_portion"] is True
+    assert chicken["dominant_macro"] == "protein"
+    assert "very_high_protein" in summary["risk_flags"]
+    assert "repeated_protein_ingredient" in summary["risk_flags"]
+    assert "large_protein_portion" in summary["risk_flags"]
+
+
+@pytest.mark.asyncio
+async def test_value_insights_endpoint_returns_fresh_cached_payload():
+    meal = SimpleNamespace(
+        meal_id="meal-1",
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+    )
+    insights = MealValueInsights(
+        meal_bullets=[
+            ValueInsight(
+                text="Egg adds protein for fullness and fat for satiety.",
+                category="benefit",
+                highlights=["fullness"],
+            )
+        ],
+        ingredient_insights=[],
+    )
+    service = MealValueInsightService()
+    cache_key = service.version(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        language="en",
+    )
+    cache = FakeCache()
+    cache.values[cache_key] = serialize_insights(insights)
+
+    response = await get_meal_value_insights(
+        request=_request(),
+        meal_id=meal.meal_id,
+        user_id="user-1",
+        event_bus=FakeEventBus(meal),
+        cache_service=cache,
+        task_manager=AsyncMock(),
+        text_translation_service=None,
+    )
+
+    assert response.status == "fresh"
+    assert response.version == cache_key
+    assert response.value_insights is not None
+    assert response.value_insights.meal_bullets[0].text == (
+        "Egg adds protein for fullness and fat for satiety."
+    )
+    assert response.value_insights.meal_bullets[0].highlights == ["fullness"]
 
 
 @pytest.mark.asyncio
 async def test_localized_cache_hit_skips_ai_and_deepl():
     cached = MealValueInsights(
         meal_bullets=[
-            ValueInsight(text="Trứng bổ sung protein.", category="benefit")
+            ValueInsight(
+                text="Trứng bổ sung protein giúp no và chất béo giúp hài lòng.",
+                category="benefit",
+                highlights=["no"],
+            )
         ],
         ingredient_insights=[],
     )
@@ -113,9 +273,67 @@ async def test_localized_cache_hit_skips_ai_and_deepl():
     )
 
     assert result is not None
-    assert result.meal_bullets[0].text == "Trứng bổ sung protein."
+    assert (
+        result.meal_bullets[0].text
+        == "Trứng bổ sung protein giúp no và chất béo giúp hài lòng."
+    )
     ai_manager.generate.assert_not_called()
     text_service.translate_texts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cached_only_miss_skips_ai_generation():
+    ai_manager = AsyncMock()
+    cache = FakeCache()
+
+    result = await MealValueInsightService(ai_manager=ai_manager).get_cached_ai(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="en",
+        cache_service=cache,
+    )
+
+    assert result is None
+    ai_manager.generate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cached_only_hit_returns_cached_result():
+    cached = MealValueInsights(
+        meal_bullets=[
+            ValueInsight(
+                text="Egg adds protein for fullness and fat for satiety.",
+                category="benefit",
+                highlights=["fullness"],
+            )
+        ],
+        ingredient_insights=[],
+    )
+    canonical_key = MealValueInsightService()._cache_key(
+        MealValueInsightService()._summary(
+            dish_name="Egg bowl",
+            nutrition=_nutrition(),
+            ingredient_names_by_id={},
+            language="en",
+            user_context={},
+        )
+    )
+    cache = FakeCache()
+    cache.values[canonical_key] = serialize_insights(cached)
+    ai_manager = AsyncMock()
+
+    result = await MealValueInsightService(ai_manager=ai_manager).get_cached_ai(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="en",
+        cache_service=cache,
+    )
+
+    assert result is not None
+    assert result.meal_bullets[0].text == (
+        "Egg adds protein for fullness and fat for satiety."
+    )
+    ai_manager.generate.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -123,13 +341,18 @@ async def test_deepl_english_fallback_is_not_cached_as_localized_result():
     ai_manager = AsyncMock()
     ai_manager.generate.return_value = {
         "meal_bullets": [
-            {"text": "Egg adds protein and fat for satiety.", "category": "benefit"}
+            {
+                "text": "Egg adds protein for fullness and fat for satiety.",
+                "category": "benefit",
+                "highlights": ["fullness"],
+            }
         ],
         "ingredient_insights": [],
     }
     text_service = AsyncMock()
     text_service.translate_texts.return_value = [
-        "Egg adds protein and fat for satiety.",
+        "Egg adds protein for fullness and fat for satiety.",
+        "fullness",
     ]
     cache = FakeCache()
 
@@ -144,5 +367,7 @@ async def test_deepl_english_fallback_is_not_cached_as_localized_result():
     )
 
     assert result is not None
-    assert result.meal_bullets[0].text == "Egg adds protein and fat for satiety."
+    assert result.meal_bullets[0].text == (
+        "Egg adds protein for fullness and fat for satiety."
+    )
     assert len(cache.values) == 1

--- a/tests/unit/domain/services/test_meal_value_insight_service.py
+++ b/tests/unit/domain/services/test_meal_value_insight_service.py
@@ -18,10 +18,10 @@ class FakeCache:
     def __init__(self):
         self.values = {}
 
-    async def get_json(self, key):
+    async def get(self, key):
         return self.values.get(key)
 
-    async def set_json(self, key, value, ttl):
+    async def set(self, key, value, ttl):
         self.values[key] = value
         return True
 


### PR DESCRIPTION
## Summary
- add AI-backed meal value insight contract for meal detail responses
- validate and bound AI JSON output for meal and ingredient insight copy
- omit insights when AI output fails or is invalid, avoiding hardcoded deterministic fallback copy
- emit backend observability events for insight generation failure/empty output

## Validation
- python3 -m py_compile src/api/routes/v1/meals.py src/api/schemas/response/meal_responses.py src/api/mappers/meal_mapper.py src/domain/services/meal_value_insight_contract.py src/domain/services/meal_value_insight_service.py tests/unit/api/test_meal_mapper.py
- SENTRY_PROFILE_SESSION_SAMPLE_RATE=0 uv run pytest tests/unit/api/test_meal_mapper.py -q

Jira: NM-149