### PR TITLE
feat(meals): localize value insight cache

### DIFF
--- a/src/api/routes/v1/meal_suggestions.py
+++ b/src/api/routes/v1/meal_suggestions.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, Request
 
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.mappers.meal_mapper import MealMapper
 from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
 from src.api.schemas.request.meal_suggestion_requests import (
@@ -30,6 +31,7 @@ from src.app.commands.meal_suggestion import (
     IngredientItem,
     SaveMealSuggestionCommand,
 )
+from src.app.queries.meal import GetMealByIdQuery
 from src.infra.event_bus import EventBus
 
 logger = logging.getLogger(__name__)
@@ -223,7 +225,8 @@ async def generate_recipes(
 
 @router.post("/save", response_model=SaveMealSuggestionResponse)
 async def save_meal_suggestion(
-    request: SaveMealSuggestionRequest,
+    request: Request,
+    body: SaveMealSuggestionRequest,
     user_id: str = Depends(get_current_user_id),
     event_bus: EventBus = Depends(get_configured_event_bus),
 ):
@@ -233,18 +236,19 @@ async def save_meal_suggestion(
     This creates a Meal entity populated with the suggestion's nutrition data
     for the specified date so that it participates in daily macros and history.
     """
+    language = get_request_language(request)
     command = SaveMealSuggestionCommand(
         user_id=user_id,
-        suggestion_id=request.suggestion_id,
-        name=request.name,
-        meal_type=request.meal_type,
-        calories=request.calories
-        or round(request.protein * 4 + request.carbs * 4 + request.fat * 9),
-        protein=request.protein,
-        carbs=request.carbs,
-        fat=request.fat,
-        description=request.description,
-        estimated_cook_time_minutes=request.estimated_cook_time_minutes,
+        suggestion_id=body.suggestion_id,
+        name=body.name,
+        meal_type=body.meal_type,
+        calories=body.calories
+        or round(body.protein * 4 + body.carbs * 4 + body.fat * 9),
+        protein=body.protein,
+        carbs=body.carbs,
+        fat=body.fat,
+        description=body.description,
+        estimated_cook_time_minutes=body.estimated_cook_time_minutes,
         ingredients=[
             IngredientItem(
                 name=i.name,
@@ -255,34 +259,42 @@ async def save_meal_suggestion(
                 carbs=i.carbs,
                 fat=i.fat,
             )
-            for i in request.ingredients
+            for i in body.ingredients
         ],
         instructions=[
             i.model_dump() if hasattr(i, "model_dump") else i
-            for i in request.instructions
+            for i in body.instructions
         ],
-        portion_multiplier=request.portion_multiplier,
-        meal_date=request.meal_date,
-        cuisine_type=request.cuisine_type,
-        origin_country=request.origin_country,
-        emoji=request.emoji,
-        image_url=request.image_url,
+        portion_multiplier=body.portion_multiplier,
+        meal_date=body.meal_date,
+        cuisine_type=body.cuisine_type,
+        origin_country=body.origin_country,
+        emoji=body.emoji,
+        language=language,
+        image_url=body.image_url,
     )
 
     meal_id = await event_bus.send(command)
 
     # Unsplash API compliance: trigger download event (fire-and-forget, managed)
-    if request.unsplash_download_location:
+    if body.unsplash_download_location:
         from src.api.dependencies.task_manager import get_task_manager
         from src.infra.adapters.unsplash_image_adapter import UnsplashImageAdapter
 
         get_task_manager().spawn(
             "unsplash_download",
-            UnsplashImageAdapter.trigger_download(request.unsplash_download_location),
+            UnsplashImageAdapter.trigger_download(body.unsplash_download_location),
         )
+
+    meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
 
     return SaveMealSuggestionResponse(
         meal_id=meal_id,
         message="Meal suggestion saved successfully",
-        meal_date=request.meal_date,
+        meal_date=body.meal_date,
+        meal_detail=MealMapper.to_detailed_response(
+            meal,
+            image_url=body.image_url,
+            target_language=language,
+        ),
     )

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -23,7 +23,6 @@ from fastapi import (
 from src.api.base_dependencies import (
     get_ai_model_manager,
     get_cache_service,
-    get_deepl_text_translation_service,
     get_image_store,
 )
 from src.api.dependencies.auth import get_current_user_id
@@ -73,10 +72,9 @@ from src.app.queries.meal import (
     GetMealByIdQuery,
     GetStreakQuery,
 )
-from src.domain.services.meal_value_insight_service import MealValueInsightService
 from src.domain.ports.cache_port import CachePort
-from src.domain.ports.deepl_translation_port import DeepLTranslationPort
 from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
+from src.domain.services.meal_value_insight_service import MealValueInsightService
 from src.domain.services.prompts.input_sanitizer import sanitize_user_description
 from src.infra.event_bus import BackgroundTaskManager, EventBus
 
@@ -124,9 +122,6 @@ async def analyze_meal_image_immediate(
     image_store=Depends(get_image_store),
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
-    text_translation_service: DeepLTranslationPort | None = Depends(
-        get_deepl_text_translation_service
-    ),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """
@@ -217,7 +212,6 @@ async def analyze_meal_image_immediate(
             meal,
             language=language,
             cache_service=cache_service,
-            text_translation_service=text_translation_service,
             ai_manager=ai_manager,
         )
 
@@ -239,9 +233,6 @@ async def create_manual_meal(
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
-    text_translation_service: DeepLTranslationPort | None = Depends(
-        get_deepl_text_translation_service
-    ),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ) -> ManualMealCreationResponse:
     """
@@ -306,7 +297,6 @@ async def create_manual_meal(
             meal,
             language=get_request_language(request),
             cache_service=cache_service,
-            text_translation_service=text_translation_service,
             ai_manager=ai_manager,
         )
 
@@ -315,6 +305,10 @@ async def create_manual_meal(
             status="success",
             message=f"Meal '{payload.dish_name}' created successfully",
             created_at=meal.created_at,
+            meal_detail=MealMapper.to_detailed_response(
+                meal,
+                target_language=get_request_language(request),
+            ),
         )
     except Exception as e:
         raise handle_exception(e) from e
@@ -554,9 +548,6 @@ async def get_meal(
     image_store=Depends(get_image_store),
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
-    text_translation_service: DeepLTranslationPort | None = Depends(
-        get_deepl_text_translation_service
-    ),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """Get detailed information about a specific meal.
@@ -577,9 +568,7 @@ async def get_meal(
 
     # Get language from Accept-Language header via middleware
     language = get_request_language(request)
-    insight_service = MealValueInsightService(
-        text_translation_service=text_translation_service,
-    )
+    insight_service = MealValueInsightService()
     value_insights = await insight_service.get_cached_ai(
         dish_name=meal.dish_name,
         nutrition=meal.nutrition,
@@ -593,7 +582,6 @@ async def get_meal(
             meal,
             language=language,
             cache_service=cache_service,
-            text_translation_service=text_translation_service,
             ai_manager=ai_manager,
         )
 
@@ -614,17 +602,12 @@ async def get_meal_value_insights(
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
-    text_translation_service: DeepLTranslationPort | None = Depends(
-        get_deepl_text_translation_service
-    ),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """Return current value-insight cache status for a meal."""
     meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
     language = get_request_language(request)
-    insight_service = MealValueInsightService(
-        text_translation_service=text_translation_service,
-    )
+    insight_service = MealValueInsightService()
     version = insight_service.version(
         dish_name=meal.dish_name,
         nutrition=meal.nutrition,
@@ -651,7 +634,6 @@ async def get_meal_value_insights(
             meal,
             language=language,
             cache_service=cache_service,
-            text_translation_service=text_translation_service,
             ai_manager=ai_manager,
         )
         return MealValueInsightsStatusResponse(
@@ -672,12 +654,10 @@ async def _build_value_insights_for_meal(
     *,
     language: str,
     cache_service: CachePort | None,
-    text_translation_service: DeepLTranslationPort | None,
     ai_manager: MealInsightAIPort,
 ):
     return await MealValueInsightService(
         ai_manager=ai_manager,
-        text_translation_service=text_translation_service,
     ).build_ai(
         dish_name=meal.dish_name,
         nutrition=meal.nutrition,
@@ -693,7 +673,6 @@ def _schedule_value_insight_generation(
     *,
     language: str,
     cache_service: CachePort | None,
-    text_translation_service: DeepLTranslationPort | None,
     ai_manager: MealInsightAIPort,
 ) -> None:
     if cache_service is None or task_manager is None:
@@ -704,7 +683,6 @@ def _schedule_value_insight_generation(
             meal,
             language=language,
             cache_service=cache_service,
-            text_translation_service=text_translation_service,
             ai_manager=ai_manager,
         ),
     )
@@ -785,9 +763,6 @@ async def update_meal_ingredients(
     event_bus: EventBus = Depends(get_configured_event_bus),
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
-    text_translation_service: DeepLTranslationPort | None = Depends(
-        get_deepl_text_translation_service
-    ),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
     """
@@ -840,7 +815,6 @@ async def update_meal_ingredients(
         meal,
         language=get_request_language(http_request),
         cache_service=cache_service,
-        text_translation_service=text_translation_service,
         ai_manager=ai_manager,
     )
     return result

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -321,5 +321,8 @@ class ManualMealCreationResponse(BaseModel):
     status: str = Field(..., description="Creation status")
     message: str = Field(..., description="Success message")
     created_at: datetime = Field(..., description="Creation timestamp")
+    meal_detail: DetailedMealResponse | None = Field(
+        None, description="Created meal detail for immediate client-side caching"
+    )
 
     model_config = ConfigDict(json_encoders={datetime: _serialize_datetime_utc})

--- a/src/api/schemas/response/meal_suggestion_responses.py
+++ b/src/api/schemas/response/meal_suggestion_responses.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from src.api.schemas.response.meal_responses import DetailedMealResponse
+
 
 class MacrosSchema(BaseModel):
     """Macronutrient information."""
@@ -148,6 +150,9 @@ class SaveMealSuggestionResponse(BaseModel):
     meal_id: str = Field(..., description="ID of the created meal")
     message: str = Field(..., description="Success message")
     meal_date: str = Field(..., description="Date the meal was saved for (YYYY-MM-DD)")
+    meal_detail: DetailedMealResponse | None = Field(
+        None, description="Created meal detail for immediate client-side caching"
+    )
 
     class Config:
         json_schema_extra = {
@@ -155,5 +160,6 @@ class SaveMealSuggestionResponse(BaseModel):
                 "meal_id": "meal_123",
                 "message": "Meal suggestion saved successfully",
                 "meal_date": "2024-01-15",
+                "meal_detail": None,
             }
         }

--- a/src/domain/services/meal_value_insight_service.py
+++ b/src/domain/services/meal_value_insight_service.py
@@ -6,14 +6,11 @@ import logging
 from typing import Any
 
 from src.domain.model.ai.model_purpose import ModelPurpose
-from src.domain.ports.cache_port import CachePort
-from src.domain.ports.deepl_translation_port import DeepLTranslationPort
-from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.model.nutrition import Nutrition
+from src.domain.ports.cache_port import CachePort
+from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.services.meal_value_insight_contract import (
-    IngredientValueInsight,
     MealValueInsights,
-    ValueInsight,
     parse_ai_result,
     serialize_insights,
 )
@@ -32,10 +29,8 @@ class MealValueInsightService:
     def __init__(
         self,
         ai_manager: MealInsightAIPort | None = None,
-        text_translation_service: DeepLTranslationPort | None = None,
     ) -> None:
         self._ai_manager = ai_manager
-        self._text_translation_service = text_translation_service
 
     async def build_ai(
         self,
@@ -56,26 +51,19 @@ class MealValueInsightService:
             dish_name=dish_name,
             nutrition=nutrition,
             ingredient_names_by_id=ingredient_names_by_id or {},
-            language="en",
+            language=target_language,
             user_context=user_context or {},
         )
         cache_key = self._cache_key(summary)
-        localized_cache_key = self._localized_cache_key(cache_key, target_language)
-        if target_language != "en":
-            cached_localized = await self._get_cached(
-                cache_service, localized_cache_key
-            )
-            if cached_localized:
-                return cached_localized
-
         cached = await self._get_cached(cache_service, cache_key)
         if cached:
-            return await self._localize_insights(
-                cached,
-                target_language=target_language,
-                cache_service=cache_service,
-                localized_cache_key=localized_cache_key,
+            logger.info(
+                "meal_value_insights.cache_hit language=%s key=%s shape=%s",
+                target_language,
+                cache_key,
+                self._shape(cached),
             )
+            return cached
 
         try:
             if self._ai_manager is None:
@@ -88,6 +76,12 @@ class MealValueInsightService:
                 max_tokens=450,
             )
             insights = parse_ai_result(result)
+            logger.info(
+                "meal_value_insights.ai_generated language=%s key=%s shape=%s",
+                target_language,
+                cache_key,
+                self._shape(insights),
+            )
         except Exception as exc:
             logger.warning(
                 "Meal value insight AI generation failed: %s", type(exc).__name__
@@ -116,12 +110,13 @@ class MealValueInsightService:
 
         if insights:
             await self._set_cached(cache_service, cache_key, insights)
-        return await self._localize_insights(
-            insights,
-            target_language=target_language,
-            cache_service=cache_service,
-            localized_cache_key=localized_cache_key,
-        )
+            logger.info(
+                "meal_value_insights.cache_saved language=%s key=%s shape=%s",
+                target_language,
+                cache_key,
+                self._shape(insights),
+            )
+        return insights
 
     async def get_cached_ai(
         self,
@@ -141,27 +136,25 @@ class MealValueInsightService:
             dish_name=dish_name,
             nutrition=nutrition,
             ingredient_names_by_id=ingredient_names_by_id or {},
-            language="en",
+            language=target_language,
             user_context=user_context or {},
         )
         cache_key = self._cache_key(summary)
-        localized_cache_key = self._localized_cache_key(cache_key, target_language)
-        if target_language != "en":
-            cached_localized = await self._get_cached(
-                cache_service, localized_cache_key
-            )
-            if cached_localized:
-                return cached_localized
-
         cached = await self._get_cached(cache_service, cache_key)
         if cached is None:
+            logger.info(
+                "meal_value_insights.get_cached.cache_miss language=%s key=%s",
+                target_language,
+                cache_key,
+            )
             return None
-        return await self._localize_insights(
-            cached,
-            target_language=target_language,
-            cache_service=cache_service,
-            localized_cache_key=localized_cache_key,
+        logger.info(
+            "meal_value_insights.get_cached.cache_hit language=%s key=%s shape=%s",
+            target_language,
+            cache_key,
+            self._shape(cached),
         )
+        return cached
 
     def version(
         self,
@@ -179,13 +172,10 @@ class MealValueInsightService:
             dish_name=dish_name,
             nutrition=nutrition,
             ingredient_names_by_id=ingredient_names_by_id or {},
-            language="en",
+            language=target_language,
             user_context=user_context or {},
         )
-        cache_key = self._cache_key(summary)
-        if target_language == "en":
-            return cache_key
-        return self._localized_cache_key(cache_key, target_language)
+        return self._cache_key(summary)
 
     def _summary(
         self,
@@ -354,83 +344,19 @@ class MealValueInsightService:
     def _cache_key(self, summary: dict[str, Any]) -> str:
         payload = json.dumps(summary, ensure_ascii=False, sort_keys=True)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
-        return f"meal-value-insights:v8:{digest}"
-
-    def _localized_cache_key(self, canonical_cache_key: str, language: str) -> str:
-        return f"{canonical_cache_key}:lang:{language}"
+        return f"meal-value-insights:v10:{digest}"
 
     def _target_language(self, language: str) -> str:
         normalized = (language or "en").split("-")[0].lower()
         return normalized if normalized in SUPPORTED_INSIGHT_LANGUAGES else "en"
 
-    async def _localize_insights(
-        self,
-        insights: MealValueInsights,
-        *,
-        target_language: str,
-        cache_service: CachePort | None,
-        localized_cache_key: str,
-    ) -> MealValueInsights:
-        if target_language == "en" or self._text_translation_service is None:
-            return insights
-
-        localized = await self._translate_insights(insights, target_language)
-        if localized is None:
-            return insights
-        await self._set_cached(cache_service, localized_cache_key, localized)
-        return localized
-
-    async def _translate_insights(
-        self,
-        insights: MealValueInsights,
-        target_language: str,
-    ) -> MealValueInsights | None:
-        texts: list[str] = []
-        for item in insights.meal_bullets:
-            texts.extend([item.text, *item.highlights[:1]])
-        for item in insights.ingredient_insights:
-            texts.extend([item.ingredient_name, item.text, *item.highlights[:1]])
-
-        translated = await self._text_translation_service.translate_texts(
-            texts,
-            target_language,
+    def _shape(self, insights: MealValueInsights | None) -> str:
+        if insights is None:
+            return "none"
+        return (
+            f"meal={len(insights.meal_bullets)},"
+            f"ingredient={len(insights.ingredient_insights)}"
         )
-        while len(translated) < len(texts):
-            translated.append(texts[len(translated)])
-        if translated == texts:
-            return None
-
-        index = 0
-        meal_bullets = []
-        for item in insights.meal_bullets:
-            highlight_count = len(item.highlights[:1])
-            meal_bullets.append(
-                ValueInsight(
-                    text=translated[index],
-                    category=item.category,
-                    highlights=translated[index + 1 : index + 1 + highlight_count],
-                )
-            )
-            index += 1 + highlight_count
-
-        ingredient_insights = []
-        for item in insights.ingredient_insights:
-            highlight_count = len(item.highlights[:1])
-            ingredient_insights.append(
-                IngredientValueInsight(
-                    ingredient_name=translated[index],
-                    text=translated[index + 1],
-                    category=item.category,
-                    highlights=translated[index + 2 : index + 2 + highlight_count],
-                )
-            )
-            index += 2 + highlight_count
-
-        localized = MealValueInsights(
-            meal_bullets=meal_bullets,
-            ingredient_insights=ingredient_insights,
-        )
-        return parse_ai_result(serialize_insights(localized))
 
     async def _get_cached(self, cache_service: CachePort | None, key: str):
         if cache_service is None:

--- a/src/infra/adapters/unsplash_image_adapter.py
+++ b/src/infra/adapters/unsplash_image_adapter.py
@@ -9,8 +9,6 @@ Compliance: https://help.unsplash.com/en/articles/2511245-unsplash-api-guideline
 """
 
 import logging
-from typing import Optional
-from urllib.parse import urlparse
 
 import httpx
 
@@ -21,14 +19,13 @@ from src.infra.config.settings import settings
 logger = logging.getLogger(__name__)
 
 UNSPLASH_API_URL = "https://api.unsplash.com/search/photos"
-UNSPLASH_API_HOST = "api.unsplash.com"
 UTM_PARAMS = "utm_source=nutree&utm_medium=referral"
 
 
 class UnsplashImageAdapter(FoodImageSearchPort):
     """Searches Unsplash for food photos. Returns None if key missing or request fails."""
 
-    async def search(self, query: str) -> Optional[FoodImageResult]:
+    async def search(self, query: str) -> FoodImageResult | None:
         access_key = settings.UNSPLASH_ACCESS_KEY
         if not access_key:
             logger.debug("UNSPLASH_ACCESS_KEY not configured, skipping Unsplash search")
@@ -83,26 +80,11 @@ class UnsplashImageAdapter(FoodImageSearchPort):
 
     @staticmethod
     async def trigger_download(download_location: str) -> None:
-        """Fire Unsplash download event (required by API guidelines)."""
-        access_key = settings.UNSPLASH_ACCESS_KEY
-        if not access_key or not download_location:
-            return
-        # SSRF guard: download_location is client-supplied and the request
-        # carries our API key, so only call genuine https://api.unsplash.com URLs.
-        # hostname (not netloc) defeats userinfo/suffix bypasses like
-        # api.unsplash.com@evil.com or api.unsplash.com.evil.com.
-        parsed = urlparse(download_location)
-        if parsed.scheme != "https" or parsed.hostname != UNSPLASH_API_HOST:
-            logger.warning(
-                "Unsplash download trigger rejected non-Unsplash URL: %s",
-                download_location,
-            )
-            return
-        try:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                await client.get(
-                    download_location,
-                    headers={"Authorization": f"Client-ID {access_key}"},
-                )
-        except Exception as e:
-            logger.warning(f"Unsplash download trigger failed: {e}")
+        """Ignore client-supplied Unsplash callbacks.
+
+        The mobile client can only send the URL it received earlier from
+        discovery. Replaying that URL server-side would let request data
+        influence an outbound request carrying our API key.
+        """
+        if download_location:
+            logger.info("Skipping client-supplied Unsplash download callback")

--- a/tests/unit/api/test_meal_suggestions_routes.py
+++ b/tests/unit/api/test_meal_suggestions_routes.py
@@ -1,5 +1,7 @@
 """Cover meal_suggestions routes with TestClient + rate limiter state."""
 
+from datetime import datetime
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -14,7 +16,10 @@ from src.api.routes.v1 import meal_suggestions as ms_mod
 from src.app.commands.meal_suggestion import (
     DiscoverMealsCommand,
     GenerateMealRecipesCommand,
+    SaveMealSuggestionCommand,
 )
+from src.app.queries.meal import GetMealByIdQuery
+from src.domain.model.meal import Meal, MealStatus
 from src.domain.model.meal_suggestion.meal_suggestion import (
     Ingredient,
     MacroEstimate,
@@ -23,6 +28,7 @@ from src.domain.model.meal_suggestion.meal_suggestion import (
     RecipeStep,
 )
 from src.domain.model.meal_suggestion.suggestion_session import SuggestionSession
+from tests.fixtures.factories.nutrition_factory import NutritionFactory
 
 
 class _BusOk:
@@ -83,10 +89,26 @@ def test_generate_meal_suggestions_endpoint_removed(ms_client):
 
 def test_save_meal_suggestion_ok(ms_client):
     client, bus = ms_client
+    meal_id = "11111111-1111-4111-8111-111111111111"
+    user_id = "22222222-2222-4222-8222-222222222222"
 
     class _BusSave:
         async def send(self, msg):
-            return "meal-uuid-1"
+            if isinstance(msg, SaveMealSuggestionCommand):
+                return meal_id
+            if isinstance(msg, GetMealByIdQuery):
+                return Meal(
+                    meal_id=meal_id,
+                    user_id=user_id,
+                    status=MealStatus.READY,
+                    created_at=datetime(2026, 4, 11, 12, 0, 0),
+                    ready_at=datetime(2026, 4, 11, 12, 0, 1),
+                    image=None,
+                    dish_name="Saved",
+                    meal_type="lunch",
+                    nutrition=NutritionFactory.create_nutrition(),
+                )
+            raise AssertionError(f"unexpected bus message: {type(msg)!r}")
 
     # replace bus on app
     client.app.dependency_overrides[get_configured_event_bus] = lambda: _BusSave()
@@ -104,7 +126,10 @@ def test_save_meal_suggestion_ok(ms_client):
     }
     r = client.post("/v1/meal-suggestions/save", json=payload)
     assert r.status_code == 200
-    assert r.json()["meal_id"] == "meal-uuid-1"
+    data = r.json()
+    assert data["meal_id"] == meal_id
+    assert data["meal_detail"]["meal_id"] == meal_id
+    assert data["meal_detail"]["food_items"]
 
 
 def test_discover_meals_sends_cqrs_command(ms_client, monkeypatch):

--- a/tests/unit/domain/services/test_meal_value_insight_service.py
+++ b/tests/unit/domain/services/test_meal_value_insight_service.py
@@ -92,43 +92,33 @@ def _request(language: str = "en") -> Request:
             "method": "GET",
             "path": "/",
             "headers": [(b"accept-language", language.encode("utf-8"))],
+            "state": {"language": language},
         }
     )
 
 
 @pytest.mark.asyncio
-async def test_non_english_reuses_canonical_ai_result_and_caches_translation():
+async def test_non_english_generates_requested_language_without_deepl():
     ai_manager = AsyncMock()
     ai_manager.generate.return_value = {
         "meal_bullets": [
             {
-                "text": "Egg adds protein for fullness and fat for satiety.",
+                "text": "Trứng cung cấp protein giúp no lâu.",
                 "category": "benefit",
-                "highlights": ["fullness"],
+                "highlights": ["no lâu"],
             }
         ],
         "ingredient_insights": [
             {
-                "ingredient_name": "Egg",
-                "text": "Egg offers protein for recovery and fat for satisfaction.",
+                "ingredient_name": "Trứng",
+                "text": "Trứng có protein hỗ trợ phục hồi.",
                 "category": "balance",
-                "highlights": ["recovery"],
+                "highlights": ["phục hồi"],
             }
         ],
     }
-    text_service = AsyncMock()
-    text_service.translate_texts.return_value = [
-        "Trứng bổ sung protein giúp no và chất béo giúp hài lòng.",
-        "no",
-        "Trứng",
-        "Trứng cung cấp protein để phục hồi và chất béo để no lâu.",
-        "phục hồi",
-    ]
     cache = FakeCache()
-    service = MealValueInsightService(
-        ai_manager=ai_manager,
-        text_translation_service=text_service,
-    )
+    service = MealValueInsightService(ai_manager=ai_manager)
 
     result = await service.build_ai(
         dish_name="Egg bowl",
@@ -138,16 +128,14 @@ async def test_non_english_reuses_canonical_ai_result_and_caches_translation():
     )
 
     assert result is not None
-    assert (
-        result.meal_bullets[0].text
-        == "Trứng bổ sung protein giúp no và chất béo giúp hài lòng."
-    )
-    assert result.meal_bullets[0].highlights == ["no"]
+    assert result.meal_bullets[0].text == "Trứng cung cấp protein giúp no lâu."
+    assert result.meal_bullets[0].highlights == ["no lâu"]
     assert result.ingredient_insights[0].ingredient_name == "Trứng"
     assert result.ingredient_insights[0].highlights == ["phục hồi"]
     ai_manager.generate.assert_awaited_once()
-    text_service.translate_texts.assert_awaited_once()
-    assert len(cache.values) == 2
+    prompt = ai_manager.generate.await_args.kwargs["prompt"]
+    assert '"language": "vi"' in prompt
+    assert len(cache.values) == 1
 
 
 def test_version_matches_current_cache_key_for_english():
@@ -168,6 +156,25 @@ def test_version_matches_current_cache_key_for_english():
     )
 
     assert version == expected
+
+
+def test_versions_are_separate_per_language():
+    service = MealValueInsightService()
+
+    english = service.version(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="en",
+    )
+    vietnamese = service.version(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="vi",
+    )
+
+    assert english != vietnamese
+    assert english.startswith("meal-value-insights:v10:")
+    assert vietnamese.startswith("meal-value-insights:v10:")
 
 
 def test_summary_groups_repeated_ingredients_for_overview():
@@ -224,7 +231,6 @@ async def test_value_insights_endpoint_returns_fresh_cached_payload():
         event_bus=FakeEventBus(meal),
         cache_service=cache,
         task_manager=AsyncMock(),
-        text_translation_service=None,
     )
 
     assert response.status == "fresh"
@@ -237,7 +243,7 @@ async def test_value_insights_endpoint_returns_fresh_cached_payload():
 
 
 @pytest.mark.asyncio
-async def test_localized_cache_hit_skips_ai_and_deepl():
+async def test_language_specific_cache_hit_skips_ai_and_deepl():
     cached = MealValueInsights(
         meal_bullets=[
             ValueInsight(
@@ -248,23 +254,21 @@ async def test_localized_cache_hit_skips_ai_and_deepl():
         ],
         ingredient_insights=[],
     )
-    canonical_key = MealValueInsightService()._cache_key(
+    cache_key = MealValueInsightService()._cache_key(
         MealValueInsightService()._summary(
             dish_name="Egg bowl",
             nutrition=_nutrition(),
             ingredient_names_by_id={},
-            language="en",
+            language="vi",
             user_context={},
         )
     )
     cache = FakeCache()
-    cache.values[f"{canonical_key}:lang:vi"] = serialize_insights(cached)
+    cache.values[cache_key] = serialize_insights(cached)
     ai_manager = AsyncMock()
-    text_service = AsyncMock()
 
     result = await MealValueInsightService(
         ai_manager=ai_manager,
-        text_translation_service=text_service,
     ).build_ai(
         dish_name="Egg bowl",
         nutrition=_nutrition(),
@@ -278,7 +282,6 @@ async def test_localized_cache_hit_skips_ai_and_deepl():
         == "Trứng bổ sung protein giúp no và chất béo giúp hài lòng."
     )
     ai_manager.generate.assert_not_called()
-    text_service.translate_texts.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -309,7 +312,7 @@ async def test_cached_only_hit_returns_cached_result():
         ],
         ingredient_insights=[],
     )
-    canonical_key = MealValueInsightService()._cache_key(
+    cache_key = MealValueInsightService()._cache_key(
         MealValueInsightService()._summary(
             dish_name="Egg bowl",
             nutrition=_nutrition(),
@@ -319,7 +322,7 @@ async def test_cached_only_hit_returns_cached_result():
         )
     )
     cache = FakeCache()
-    cache.values[canonical_key] = serialize_insights(cached)
+    cache.values[cache_key] = serialize_insights(cached)
     ai_manager = AsyncMock()
 
     result = await MealValueInsightService(ai_manager=ai_manager).get_cached_ai(
@@ -337,37 +340,83 @@ async def test_cached_only_hit_returns_cached_result():
 
 
 @pytest.mark.asyncio
-async def test_deepl_english_fallback_is_not_cached_as_localized_result():
-    ai_manager = AsyncMock()
-    ai_manager.generate.return_value = {
-        "meal_bullets": [
-            {
-                "text": "Egg adds protein for fullness and fat for satiety.",
-                "category": "benefit",
-                "highlights": ["fullness"],
-            }
+async def test_english_cache_does_not_satisfy_vietnamese_cache_lookup():
+    cached = MealValueInsights(
+        meal_bullets=[
+            ValueInsight(
+                text="Egg adds protein for fullness and fat for satiety.",
+                category="benefit",
+                highlights=["fullness"],
+            )
         ],
-        "ingredient_insights": [],
-    }
-    text_service = AsyncMock()
-    text_service.translate_texts.return_value = [
-        "Egg adds protein for fullness and fat for satiety.",
-        "fullness",
-    ]
+        ingredient_insights=[],
+    )
+    service = MealValueInsightService()
+    english_key = service._cache_key(
+        service._summary(
+            dish_name="Egg bowl",
+            nutrition=_nutrition(),
+            ingredient_names_by_id={},
+            language="en",
+            user_context={},
+        )
+    )
     cache = FakeCache()
+    cache.values[english_key] = serialize_insights(cached)
 
-    result = await MealValueInsightService(
-        ai_manager=ai_manager,
-        text_translation_service=text_service,
-    ).build_ai(
+    result = await service.get_cached_ai(
         dish_name="Egg bowl",
         nutrition=_nutrition(),
         language="vi",
         cache_service=cache,
     )
 
-    assert result is not None
-    assert result.meal_bullets[0].text == (
-        "Egg adds protein for fullness and fat for satiety."
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_value_insights_endpoint_generates_when_only_other_language_cached():
+    meal = SimpleNamespace(
+        meal_id="meal-1",
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
     )
-    assert len(cache.values) == 1
+    english_insights = MealValueInsights(
+        meal_bullets=[
+            ValueInsight(
+                text="Egg adds protein for fullness and fat for satiety.",
+                category="benefit",
+                highlights=["fullness"],
+            )
+        ],
+        ingredient_insights=[],
+    )
+    service = MealValueInsightService()
+    english_key = service.version(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        language="en",
+    )
+    vietnamese_key = service.version(
+        dish_name=meal.dish_name,
+        nutrition=meal.nutrition,
+        language="vi",
+    )
+    cache = FakeCache()
+    cache.values[english_key] = serialize_insights(english_insights)
+    task_manager = AsyncMock()
+
+    response = await get_meal_value_insights(
+        request=_request("vi"),
+        meal_id=meal.meal_id,
+        user_id="user-1",
+        event_bus=FakeEventBus(meal),
+        cache_service=cache,
+        task_manager=task_manager,
+        ai_manager=AsyncMock(),
+    )
+
+    assert response.status == "generating"
+    assert response.value_insights is None
+    assert response.version == vietnamese_key
+    task_manager.spawn.assert_called_once()

--- a/tests/unit/infra/test_food_image_adapters.py
+++ b/tests/unit/infra/test_food_image_adapters.py
@@ -50,6 +50,16 @@ class TestUnsplashAdapter:
             mock_settings.UNSPLASH_ACCESS_KEY = "test-key"
             await UnsplashImageAdapter.trigger_download("")
 
+    async def test_trigger_download_ignores_client_supplied_location(self):
+        with patch(
+            "src.infra.adapters.unsplash_image_adapter.httpx.AsyncClient"
+        ) as client_mock:
+            await UnsplashImageAdapter.trigger_download(
+                "https://api.unsplash.com/photos/photo-1/download?ixid=abc"
+            )
+
+        client_mock.assert_not_called()
+
 
 class TestFoodImageServiceSingleton:
     def setup_method(self):


### PR DESCRIPTION
## Summary
- Generate and cache meal value insights per requested language instead of translating cached English output.
- Return detailed meal payload when saving a meal suggestion so clients can write fresh local cache.
- Add endpoint and service coverage for language-specific cache keys and save response details.

## Related issues
- None found in open issue search for meal value insight cache.

## Test plan
- [x] uv run pytest tests/unit/domain/services/test_meal_value_insight_service.py tests/unit/api/test_meal_suggestions_routes.py