### PR TITLE
fix(food-label): tolerate unbounded label notes

### DIFF
--- a/src/domain/model/ai/nutrition_contracts.py
+++ b/src/domain/model/ai/nutrition_contracts.py
@@ -133,7 +133,9 @@ class FoodLabelNutritionResponse(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    is_food_label: bool = Field(True, description="Whether a Nutrition Facts label is visible")
+    is_food_label: bool = Field(
+        True, description="Whether a Nutrition Facts label is visible"
+    )
     product_name: str = Field(..., min_length=1, max_length=200)
     brand: str | None = Field(None, max_length=100)
     serving_size: FoodLabelServingSize
@@ -141,7 +143,7 @@ class FoodLabelNutritionResponse(BaseModel):
     label_calories_per_serving: float | None = Field(None, ge=0, le=5000)
     macros_per_serving: AIVisionNutritionMacros
     confidence: float = Field(0.5, ge=0, le=1)
-    label_notes: list[str] = Field(default_factory=list, max_length=6)
+    label_notes: list[str] = Field(default_factory=list)
 
     @field_validator("product_name", "brand")
     @classmethod
@@ -149,6 +151,24 @@ class FoodLabelNutritionResponse(BaseModel):
         if value is None:
             return None
         return _strip_required_text(value)
+
+    @field_validator("label_notes", mode="before")
+    @classmethod
+    def normalize_label_notes(cls, value: Any) -> Any:
+        if value is None or not isinstance(value, list):
+            return value
+
+        notes: list[Any] = []
+        for note in value:
+            if isinstance(note, str):
+                stripped = note.strip()
+                if not stripped:
+                    continue
+                notes.append(stripped)
+            else:
+                notes.append(note)
+
+        return notes
 
 
 class VisionNutritionResponse(BaseModel):

--- a/src/domain/services/prompts/system_prompts.py
+++ b/src/domain/services/prompts/system_prompts.py
@@ -274,6 +274,7 @@ RULES:
 - servings_per_package is required. Use the printed "servings per container/package" value.
 - macros_per_serving values are grams per serving. Total carbohydrate maps to carbs_g, total fat maps to fat_g, dietary fiber maps to fiber_g, total sugars maps to sugar_g, protein maps to protein_g.
 - label_calories_per_serving is optional label metadata. The backend will derive logged calories from macros, so do not alter macros to force calories to match.
+- label_notes should stay concise. Include important assumptions, discrepancies, or label-specific caveats.
 - If the product or brand is not visible, infer a concise generic product_name from the label context and set brand to null.
 - Do not extract ingredients. Ingredients are hidden unless confidently read by a separate ingredient flow.
 - If no Nutrition Facts label is visible, set "is_food_label": false and still return the same keys with conservative values only when the serving size and macros are readable.

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -4,7 +4,10 @@ import logging
 import threading
 from typing import Any, Optional
 
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
 from src.domain.model.ai.model_purpose import ModelPurpose
 from src.domain.ports.ai_provider_port import AICapability
 from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
@@ -164,7 +167,9 @@ class AIModelManager:
         ):
             return
 
-        vision_enabled = getattr(settings, "CLOUDFLARE_WORKERS_AI_VISION_ENABLED", False)
+        vision_enabled = getattr(
+            settings, "CLOUDFLARE_WORKERS_AI_VISION_ENABLED", False
+        )
         vision_model = getattr(settings, "CLOUDFLARE_WORKERS_AI_VISION_MODEL", "")
         vision_purposes = getattr(settings, "CLOUDFLARE_WORKERS_AI_VISION_PURPOSES", "")
 
@@ -207,14 +212,20 @@ class AIModelManager:
 
     def _append_cf_to_text_chains(self, cf_model: str, text_purposes_csv: str) -> None:
         """Prepend raw CF model id to configured text-purpose chains."""
-        configured = {p.strip().lower() for p in text_purposes_csv.split(",") if p.strip()}
+        configured = {
+            p.strip().lower() for p in text_purposes_csv.split(",") if p.strip()
+        }
         for purpose in ModelPurpose:
             if purpose.value in configured:
                 self._prepend_model_for_purposes(cf_model, {purpose})
 
-    def _append_cf_to_vision_chains(self, cf_model: str, vision_purposes_csv: str) -> None:
+    def _append_cf_to_vision_chains(
+        self, cf_model: str, vision_purposes_csv: str
+    ) -> None:
         """Append CF vision model to configured vision-purpose chains."""
-        configured = {p.strip().lower() for p in vision_purposes_csv.split(",") if p.strip()}
+        configured = {
+            p.strip().lower() for p in vision_purposes_csv.split(",") if p.strip()
+        }
         valid_values = {mp.value for mp in ModelPurpose}
         unknown = configured - valid_values
         if unknown:
@@ -323,7 +334,14 @@ class AIModelManager:
                     f"model={model} | error={last_error[:100]}"
                 )
 
-        log_event("warning", "ai.provider.failure", attributes={"component": "ai_model_manager", "attempt_count": len(attempted)})
+        log_event(
+            "warning",
+            "ai.provider.failure",
+            attributes={
+                "component": "ai_model_manager",
+                "attempt_count": len(attempted),
+            },
+        )
         raise AIUnavailableError(
             f"All models failed for {purpose.value}",
             attempted_models=attempted,
@@ -347,6 +365,8 @@ class AIModelManager:
 
         attempted = []
         last_error = None
+        deterministic_failures: list[AIVisionError] = []
+        has_transient_failure = False
 
         for model in available:
             provider = self._get_provider_for_model(model)
@@ -402,11 +422,14 @@ class AIModelManager:
                     AIVisionFailureKind.schema_validation,
                     AIVisionFailureKind.json_parse,
                 ):
+                    deterministic_failures.append(e)
                     # Deterministic failure — schema/parse errors won't fix with same model;
                     # skip circuit breaker recording and advance to next provider
                     logger.warning(
                         "[AI-VISION-SCHEMA-FAIL] purpose=%s model=%s kind=%s",
-                        purpose.value, model, e.kind.value,
+                        purpose.value,
+                        model,
+                        e.kind.value,
                     )
                     metric_name = (
                         "ai.vision.schema_validation_failure.count"
@@ -436,6 +459,7 @@ class AIModelManager:
                     continue
 
                 # Transient/unknown — use circuit breaker as before
+                has_transient_failure = True
                 error_code = provider.extract_error_code(e)
                 if self._circuit_breaker.should_trip(error_code):
                     self._circuit_breaker.record_failure(model)
@@ -449,16 +473,50 @@ class AIModelManager:
                 )
                 logger.warning(
                     "[AI-ATTEMPT-FAILED] purpose=%s model=%s error=%s",
-                    purpose.value, model, last_error[:100],
+                    purpose.value,
+                    model,
+                    last_error[:100],
                 )
 
         increment_metric(
             "ai.vision.request.failure.count",
             attributes={"ai_purpose": purpose.value, "attempt_count": len(attempted)},
         )
-        log_event("warning", "ai.provider.failure", attributes={"component": "ai_model_manager", "attempt_count": len(attempted)})
+        if deterministic_failures and not has_transient_failure:
+            log_event(
+                "warning",
+                "ai.vision.output_validation.failure",
+                attributes={
+                    "component": "ai_model_manager",
+                    "attempt_count": len(attempted),
+                    "ai_purpose": purpose.value,
+                },
+            )
+            raise AIOutputValidationError(
+                "Invalid AI structured output",
+                purpose=purpose.value,
+                attempt_count=len(attempted),
+                validation_details=[
+                    _vision_failure_detail(failure)
+                    for failure in deterministic_failures[:5]
+                ],
+            )
+        log_event(
+            "warning",
+            "ai.provider.failure",
+            attributes={
+                "component": "ai_model_manager",
+                "attempt_count": len(attempted),
+            },
+        )
         raise AIUnavailableError(
             f"All vision models failed for {purpose.value}",
             attempted_models=attempted,
             last_error=last_error,
         )
+
+
+def _vision_failure_detail(error: AIVisionError) -> str:
+    provider = error.provider or "vision-provider"
+    model = error.model or "unknown-model"
+    return f"{provider}/{model}: {error.kind.value}"

--- a/src/infra/services/ai/providers/openai_provider.py
+++ b/src/infra/services/ai/providers/openai_provider.py
@@ -11,9 +11,11 @@ from openai import (
     APITimeoutError,
     RateLimitError,
 )
+from pydantic import ValidationError
 
 from src.domain.ports.ai_provider_port import AICapability, AIProviderPort
 from src.infra.adapters.ai_json_utils import extract_json as extract_ai_json
+from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 from src.infra.services.ai.langchain_openai_adapter import OpenAILangChainAdapter
 from src.infra.services.ai.openai_prompt_cache_policy import OpenAIPromptCachePolicy
 from src.observability import increment_metric
@@ -173,16 +175,24 @@ class OpenAIProvider(AIProviderPort):
             system_message=system_message,
         )
 
-        result = await self._langchain.generate_vision_structured(
-            model=model,
-            prompt=prompt,
-            image_data=image_data,
-            image_mime_type=image_mime_type,
-            system_message=system_message,
-            schema=schema,
-            max_tokens=max_tokens,
-            request_kwargs=prompt_cache_kwargs,
-        )
+        try:
+            result = await self._langchain.generate_vision_structured(
+                model=model,
+                prompt=prompt,
+                image_data=image_data,
+                image_mime_type=image_mime_type,
+                system_message=system_message,
+                schema=schema,
+                max_tokens=max_tokens,
+                request_kwargs=prompt_cache_kwargs,
+            )
+        except ValidationError as exc:
+            raise AIVisionError(
+                f"[OPENAI-VISION-SCHEMA-FAIL] provider=openai model={model}",
+                kind=AIVisionFailureKind.schema_validation,
+                provider="openai",
+                model=model,
+            ) from exc
         self._record_prompt_cache_usage(
             result.raw_message,
             model=model,

--- a/tests/unit/domain/model/ai/test_nutrition_contracts.py
+++ b/tests/unit/domain/model/ai/test_nutrition_contracts.py
@@ -306,6 +306,37 @@ class TestFoodLabelNutritionResponse:
                 }
             )
 
+    def test_accepts_unbounded_label_notes(self):
+        response = FoodLabelNutritionResponse.model_validate(
+            {
+                "product_name": "Cereal",
+                "serving_size": {"display_text": "2/3 cup (55g)", "grams": 55},
+                "servings_per_package": 8,
+                "macros_per_serving": _valid_macros(),
+                "label_notes": [
+                    " Calories per serving: 120 ",
+                    "Total fat: 3g",
+                    "Sodium: 140mg",
+                    "Carbohydrates: 24g",
+                    "Protein: 2g",
+                    "Calcium: 10mg",
+                    "Iron: 1mg",
+                    "Potassium: 50mg",
+                ],
+            }
+        )
+
+        assert response.label_notes == [
+            "Calories per serving: 120",
+            "Total fat: 3g",
+            "Sodium: 140mg",
+            "Carbohydrates: 24g",
+            "Protein: 2g",
+            "Calcium: 10mg",
+            "Iron: 1mg",
+            "Potassium: 50mg",
+        ]
+
 
 class TestMealTextNutritionResponse:
     def test_accepts_display_quantity_unit_and_optional_quantity_g(self):

--- a/tests/unit/infra/services/ai/providers/test_openai_provider.py
+++ b/tests/unit/infra/services/ai/providers/test_openai_provider.py
@@ -2,9 +2,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import ValidationError
 
 from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
 from src.domain.ports.ai_provider_port import AICapability
+from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 from src.infra.services.ai.langchain_openai_adapter import LangChainOpenAIResult
 from src.infra.services.ai.providers.openai_provider import OpenAIProvider
 
@@ -171,6 +173,34 @@ async def test_generate_with_vision_calls_adapter_with_prompt_cache_kwargs():
         "mealtrack-test:meal_scan:"
     )
     assert call_kwargs["request_kwargs"]["prompt_cache_retention"] == "in_memory"
+
+
+@pytest.mark.asyncio
+async def test_generate_with_vision_classifies_validation_errors():
+    provider = _provider()
+    validation_error = None
+    try:
+        VisionNutritionResponse.model_validate({"foods": []})
+    except ValidationError as exc:
+        validation_error = exc
+    assert validation_error is not None
+    provider._langchain.generate_vision_structured = AsyncMock(
+        side_effect=validation_error
+    )
+
+    with pytest.raises(AIVisionError) as exc_info:
+        await provider.generate_with_vision(
+            model="gpt-5.4-mini-2026-03-17",
+            prompt="Identify food.",
+            image_data=b"image-bytes",
+            system_message="Return canonical JSON.",
+            schema=VisionNutritionResponse,
+            purpose_hint="meal_scan",
+        )
+
+    assert exc_info.value.kind == AIVisionFailureKind.schema_validation
+    assert exc_info.value.provider == "openai"
+    assert exc_info.value.model == "gpt-5.4-mini-2026-03-17"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
+++ b/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
     AIUnavailableError,
     AIVisionError,
     AIVisionFailureKind,
@@ -301,6 +302,38 @@ class TestVisionFailureKindRouting:
         )
 
         assert result == {"result": "openai_fallback"}
+        mock_circuit_breaker.record_failure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_schema_failures_exhausting_chain_raise_output_validation(
+        self,
+        manager,
+        mock_openai_provider,
+        mock_circuit_breaker,
+    ):
+        mock_circuit_breaker.filter_available = Mock(side_effect=lambda models: models)
+        mock_openai_provider.generate_with_vision = AsyncMock(
+            side_effect=AIVisionError(
+                "[OPENAI-VISION-SCHEMA-FAIL] provider=openai model=test-model",
+                kind=AIVisionFailureKind.schema_validation,
+                provider="openai",
+                model="test-model",
+            )
+        )
+
+        with pytest.raises(AIOutputValidationError) as exc_info:
+            await manager.generate_with_vision(
+                purpose=ModelPurpose.MEAL_SCAN,
+                prompt="analyze food",
+                image_data=b"fake_image",
+                schema=VisionNutritionResponse,
+            )
+
+        assert exc_info.value.purpose == "meal_scan"
+        assert exc_info.value.attempt_count == 1
+        assert exc_info.value.validation_details == [
+            "openai/test-model: schema_validation"
+        ]
         mock_circuit_breaker.record_failure.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Allow food-label `label_notes` to be unbounded while still normalizing blank/whitespace-only notes.
- Classify OpenAI structured vision validation failures as deterministic schema failures.
- Surface exhausted deterministic vision schema failures as `AIOutputValidationError` instead of `AIUnavailableError`/503 provider outages.

## Test plan
- [x] `.venv/bin/python -m pytest tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/domain/parsers/test_gpt_response_parser.py tests/unit/infra/services/ai/providers/test_openai_provider.py tests/unit/infra/services/ai/test_ai_vision_failure_routing.py tests/unit/infra/adapters/test_vision_ai_service.py tests/unit/infra/adapters/test_vision_ai_service_resilience.py -q`
- [x] `.venv/bin/python -m ruff check src/domain/model/ai/nutrition_contracts.py src/domain/services/prompts/system_prompts.py src/infra/services/ai/providers/openai_provider.py src/infra/services/ai/ai_model_manager.py tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/infra/services/ai/providers/test_openai_provider.py tests/unit/infra/services/ai/test_ai_vision_failure_routing.py`
- [x] `.venv/bin/python -m ruff format --check src/domain/model/ai/nutrition_contracts.py src/domain/services/prompts/system_prompts.py src/infra/services/ai/providers/openai_provider.py src/infra/services/ai/ai_model_manager.py tests/unit/domain/model/ai/test_nutrition_contracts.py tests/unit/infra/services/ai/providers/test_openai_provider.py tests/unit/infra/services/ai/test_ai_vision_failure_routing.py`
- [x] `.venv/bin/python -m py_compile src/domain/model/ai/nutrition_contracts.py src/infra/services/ai/providers/openai_provider.py src/infra/services/ai/ai_model_manager.py`

Related issues: none found via GitHub issue search for `food label label_notes validation`.