### PR TITLE
feat(subscriptions): add trial discount winback flow

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,6 +1,6 @@
 # Backend Codebase Summary
 
-**Generated:** June 27, 2026
+**Generated:** July 2, 2026
 **Status:** Production-ready snapshot of the live backend codebase
 **Runtime:** FastAPI 0.136.3 on Python 3.13.2 with async SQLAlchemy 2.0
 
@@ -80,11 +80,11 @@ The current HTTP surface includes:
 ## Recent Features (June 2026)
 
 - **Canonical AI Nutrition Contracts + Validation Retry:** `src/domain/model/ai/nutrition_contracts.py` defines image and text nutrition contracts with bounded food counts, strict quantity validation, and backend-calorie authority; invalid structured meal image/text output now retries exactly once before a controlled `AIOutputValidationError`, while ingredient recognition keeps its unstructured `{name, confidence, category}` contract and the legacy parser no longer silently drops invalid AI food items.
-- **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry pushes at T-2d and T-1d; notifications rescheduled on timezone changes; cron push (`src/cron/push.py`) precomputes notification rows, schedules trial-expiry rows, dispatches due rows through database row claiming, and cleans expired rows
-- **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; PostHog lifecycle mirroring
-- **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` — fire-and-forget async capture; enabled by `POSTHOG_API_KEY`
+- **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry push schedules one pre-charge service reminder; notifications rescheduled on timezone changes; cron push (`src/cron/push.py`) precomputes notification rows, schedules trial-expiry rows, dispatches due rows through database row claiming, and cleans expired rows
+- **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; trial period/cancel/discount-claim fields persisted for D3 offer eligibility; PostHog lifecycle mirroring
+- **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` — fire-and-forget async capture; enabled by `POSTHOG_API_KEY`; intended owner for cancellation winback email workflows
 - **Parallel Recipe Generator:** `src/domain/services/meal_suggestion/parallel_recipe_generator.py` with per-recipe attempt logic in `recipe_attempt_builder.py`; 3-phase pipeline: name generation → parallel recipe generation → translation
-- **Cron Lifecycle Email Service:** `src/cron/email.py` runs re-engagement and trial-expiry lifecycle emails via `CronLifecycleEmailService`
+- **Lifecycle Email Ownership:** Legacy backend lifecycle email code remains in-tree but production infra disables it; cancellation winback email is intended to run in PostHog Workflows.
 - **Configurable Referral Commission:** `REFERRAL_COMMISSIONS` env var (JSON dict, per-currency, default 2 USD)
 - **Variable-Length Referral Codes:** 3–15 character codes
 - **AI Handshake Guest Trial Quota (Postgres):** `src/api/services/guest_parse_quota.py` + table `ai_handshake_guest_trial_quotas`; enforces one-shot AI trial per guest install HMAC hash using Postgres row-level locking (INSERT+conflict → SELECT FOR UPDATE); Redis not required for this endpoint.

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,6 +1,6 @@
 # Backend External Services Integration
 
-**Last Updated:** June 27, 2026
+**Last Updated:** July 2, 2026
 **Services:** Firebase, Cloudinary, OpenAI, Cloudflare Workers AI, RevenueCat, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, Brave Search, Pexels, Unsplash, Resend, Google Imagen, Pollinations, nutree-affiliate
 **Failure handling:** Optional integrations degrade when safe. Firebase Auth and the primary DB fail fast. Redis optional caches degrade by bypassing cache; any Redis-backed required state must be documented and health-checked separately.
 
@@ -24,7 +24,7 @@
 - `FirebaseService` rejects blank title/body before building APNs payloads and mobile `data` fields
 - Multi-device support via `user_fcm_tokens` table
 - Deduplication across workers via `notification_sent_log` table (migration 047)
-- Trial-expiry pushes at T-2d and T-1d via `CronTrialPushService` (`src/infra/services/cron_trial_push_service.py`)
+- Trial-expiry pushes use `CronTrialPushService` (`src/infra/services/cron_trial_push_service.py`) to schedule one service reminder about 2 hours before trial charge. Eligibility includes active and cancelled-but-unexpired trials that have not confirmed the trial-end discount purchase.
 - Notifications rescheduled automatically on timezone changes — triggered from `UpdateTimezoneCommandHandler` and `RegisterFcmTokenCommandHandler`
 - Cron push entrypoint (`src/cron/push.py`) owns all push scheduling: precompute notification rows, schedule trial-expiry rows, claim due rows, batch-send, mark sent, clean expired rows
 - Cron dispatch helper (`CronNotificationDispatchService`) uses database row claiming (`pending` → `processing`) plus stale-processing recovery instead of a background loop or leader lock
@@ -219,7 +219,7 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 | Brave Search | Barcode nutrition and image validation fallback | `BRAVE_SEARCH_API_KEY` |
 | Pexels / Unsplash | Meal discovery food photos | `PEXELS_API_KEY`, `UNSPLASH_ACCESS_KEY` |
 | Pollinations / Google Imagen | Generated image fallback adapters | provider-specific adapter config |
-| Resend | Lifecycle and webhook-triggered email | `RESEND_API_KEY`, `EMAIL_ENABLED`, `EMAIL_FROM` |
+| Resend | Legacy backend lifecycle email sender. Cancellation winback email is owned by PostHog Workflows unless `CANCELLATION_EMAIL_OWNER=backend` is explicitly set. | `RESEND_API_KEY`, `EMAIL_ENABLED`, `EMAIL_FROM`, `CANCELLATION_EMAIL_OWNER` |
 
 ---
 
@@ -228,6 +228,7 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 **Purpose:** Subscription Management
 
 - Webhook sync to local `subscriptions` table
+- Trial lifecycle fields are persisted from webhook events: `period_type`, trial start/end, cancellation reason, and trial-end discount claim markers.
 - Premium status check with Redis cache fallback
 - Signature verification via constant-time HMAC comparison
 - Webhook events handled in `src/api/routes/v1/webhooks.py`:
@@ -236,16 +237,16 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 |-------|--------|
 | `INITIAL_PURCHASE` | Create subscription record, credit referral wallet |
 | `RENEWAL` | Update expiry, reset billing-issue flag |
-| `CANCELLATION` | Set status to `cancelled` |
+| `CANCELLATION` | Set status to `cancelled`; access remains valid until `expires_at` |
 | `EXPIRATION` | Set status to `expired` |
 | `BILLING_ISSUE` | Set status to `billing_issue` |
 | `PRODUCT_CHANGE` | Update product ID and expiry |
 | `REFUND` | Set status to `refunded`, revoke referral credit |
 | `TRANSFER` | Re-point subscription to new subscriber ID |
 
-- PostHog lifecycle mirroring for CANCELLATION, EXPIRATION, BILLING_ISSUE, REFUND, RENEWAL, PRODUCT_CHANGE events (configurable via `POSTHOG_API_KEY`)
+- PostHog lifecycle mirroring for CANCELLATION, EXPIRATION, BILLING_ISSUE, REFUND, RENEWAL, PRODUCT_CHANGE events (configurable via `POSTHOG_API_KEY`). Mirrored properties include period type, cancel reason, days until expiration, trial expiration time, and whether the trial-end discount has been claimed.
 
-**Config:** `REVENUECAT_SECRET_API_KEY`, `REVENUECAT_WEBHOOK_SECRET`
+**Config:** `REVENUECAT_SECRET_API_KEY`, `REVENUECAT_WEBHOOK_SECRET`, `TRIAL_END_DISCOUNT_PRODUCT_IDS`, `TRIAL_END_DISCOUNT_IDENTIFIERS`
 
 **Status:** Premium feature gates planned, not currently enforced on routes
 
@@ -253,11 +254,12 @@ Dashboard: `https://dash.cloudflare.com → AI Gateway → {gateway_id}`
 
 ## PostHog
 
-**Purpose:** Product analytics — subscription lifecycle event capture
+**Purpose:** Product analytics and lifecycle workflow triggers
 
 - `src/infra/adapters/posthog_adapter.py`: fire-and-forget async capture via `httpx` (3s timeout)
 - Only sends events when `POSTHOG_API_KEY` is set; silently skips otherwise
-- Currently captures subscription lifecycle events mirrored from RevenueCat webhooks
+- Captures subscription lifecycle events mirrored from RevenueCat webhooks.
+- Cancellation winback email should run as a PostHog Workflow using the mirrored `subscription_cancelled` event. The backend webhook sender is legacy/rollback-only and disabled unless explicitly configured.
 
 **Config:** `POSTHOG_API_KEY`, `POSTHOG_HOST` (default: `https://app.posthog.com`)
 

--- a/migrations/versions/20260702000002_add_subscription_trial_offer_state.py
+++ b/migrations/versions/20260702000002_add_subscription_trial_offer_state.py
@@ -1,0 +1,60 @@
+"""Add subscription trial offer state.
+
+Revision ID: 20260702000002
+Revises: 20260702000001
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260702000002"
+down_revision = "20260702000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subscriptions", sa.Column("period_type", sa.String(32), nullable=True)
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("trial_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("trial_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "subscriptions", sa.Column("cancel_reason", sa.String(64), nullable=True)
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column(
+            "trial_end_discount_claimed_at", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("trial_end_discount_product_id", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("trial_end_discount_identifier", sa.String(255), nullable=True),
+    )
+    op.create_index(
+        "idx_subscription_trial_offer_candidates",
+        "subscriptions",
+        ["status", "expires_at", "period_type", "trial_end_discount_claimed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_subscription_trial_offer_candidates", table_name="subscriptions")
+    op.drop_column("subscriptions", "trial_end_discount_identifier")
+    op.drop_column("subscriptions", "trial_end_discount_product_id")
+    op.drop_column("subscriptions", "trial_end_discount_claimed_at")
+    op.drop_column("subscriptions", "cancel_reason")
+    op.drop_column("subscriptions", "trial_expires_at")
+    op.drop_column("subscriptions", "trial_started_at")
+    op.drop_column("subscriptions", "period_type")

--- a/plans/260702-1026-trial-d3-discount-winback/phase-01-revenuecat-lifecycle-contract.md
+++ b/plans/260702-1026-trial-d3-discount-winback/phase-01-revenuecat-lifecycle-contract.md
@@ -1,0 +1,107 @@
+---
+phase: 1
+title: "RevenueCat lifecycle contract"
+status: completed
+priority: P1
+effort: "0.5-1d"
+dependencies: []
+---
+
+# Phase 1: RevenueCat lifecycle contract
+
+## Context Links
+
+- Research: `research/researcher-01-revenuecat-posthog-workflows.md`
+- Scout: `research/researcher-02-codebase-scout.md`
+- Backend model: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/database/models/subscription.py`
+- RevenueCat webhook: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py`
+- Settings: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/config/settings.py`
+
+## Overview
+
+Create durable server-side facts for trial period, cancellation intent, and trial-end discount claim. This is the audience source of truth for push and email.
+
+## Key Insights
+
+- `subscriptions` currently caches only `status`, `product_id`, `purchased_at`, `expires_at`, and `cancelled_at`.
+- Cancellation sets `status='cancelled'`, but the user still has entitlement until `expires_at`.
+- `period_type`, `cancel_reason`, and discount fields arrive on RevenueCat events, but only some are mirrored to PostHog today.
+- Do not depend on `offering_id` unless a sandbox webhook proves it exists.
+
+## Requirements
+
+- Functional: persist latest RevenueCat `period_type`, trial start/expiry, cancellation reason, and whether the trial-end discount was claimed.
+- Functional: detect claim from configured discounted product IDs and/or RevenueCat discount identifiers.
+- Functional: keep RevenueCat as source of truth; backend only caches queryable campaign state.
+- Non-functional: no raw webhook payload persistence, no email/PII in logs, migration is Alembic-only.
+
+## Architecture
+
+RevenueCat webhook -> `webhooks.py` handler -> subscription cache columns -> PostHog lifecycle capture -> cron eligibility query.
+
+Minimum schema addition on `subscriptions`:
+
+- `period_type` nullable string, latest RevenueCat period type.
+- `trial_started_at` nullable timestamptz.
+- `trial_expires_at` nullable timestamptz.
+- `cancel_reason` nullable string.
+- `trial_end_discount_claimed_at` nullable timestamptz.
+- `trial_end_discount_product_id` nullable string.
+- `trial_end_discount_identifier` nullable string only if sandbox payload confirms a stable field.
+
+Config:
+
+- `TRIAL_END_DISCOUNT_PRODUCT_IDS`, comma-separated.
+- `TRIAL_END_DISCOUNT_IDENTIFIERS`, comma-separated, optional.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/database/models/subscription.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/config/settings.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/subscription_repository_async.py`
+- Create: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/migrations/versions/YYYYMMDDHHMMSS_subscription_trial_offer_state.py`
+- Modify/Add: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/api/test_webhook_handler.py`
+- Modify/Add: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/repositories/test_subscription_repository_async.py`
+
+## Implementation Steps
+
+1. Capture sanitized sandbox webhook samples for `INITIAL_PURCHASE`, `CANCELLATION`, and discounted conversion/purchase. Confirm whether `discount_identifier` exists.
+2. Add Alembic migration and ORM columns. Keep nullable to support existing rows.
+3. Add settings for discount product IDs and optional discount identifiers.
+4. Update `handle_purchase`, `handle_renewal`, and `get_or_create_subscription` to populate `period_type`, trial timestamps, and claim fields.
+5. Update `handle_cancellation` to persist `cancel_reason` while keeping `expires_at`.
+6. Update `capture_subscription_lifecycle_event` to include `trial_end_discount_claimed`, `trial_expires_at_ms`, and `days_until_expiration` when available.
+7. Add unit tests for trial purchase, cancellation during trial, normal conversion, and discounted claim detection.
+
+## Todo List
+
+- [ ] Verify RevenueCat sandbox payload fields for discounted purchase.
+- [x] Add migration and ORM columns.
+- [x] Add discount claim config.
+- [x] Persist trial and claim fields in webhook handlers.
+- [x] Extend PostHog lifecycle properties without PII.
+- [x] Add webhook and repository tests.
+
+## Success Criteria
+
+- [x] Backend can query "trial user, unexpired, not claimed discount" without relying on mobile local state.
+- [x] Cancelled-but-unexpired trial retains `expires_at`, `period_type`, and `cancel_reason`.
+- [x] Discount claim is marked only after a RevenueCat-confirmed discounted purchase/conversion.
+- [x] Existing RevenueCat webhook tests still pass.
+
+## Risk Assessment
+
+- Risk: RevenueCat payload lacks discount identifier. Mitigation: product ID config is primary, identifier is optional.
+- Risk: Existing rows have no `period_type`. Mitigation: fallback to `purchased_at` within 7 days only during rollout.
+- Risk: `webhooks.py` is already large. Mitigation: extract small pure helpers if new logic would grow the file further.
+
+## Security Considerations
+
+- Do not store raw webhook JSON.
+- Do not log RevenueCat aliases, emails, raw product payloads, or auth headers.
+- Keep webhook secret verification unchanged.
+
+## Next Steps
+
+Phase 2 uses these fields to build the push eligibility query.

--- a/plans/260702-1026-trial-d3-discount-winback/phase-02-trial-offer-eligibility-and-push.md
+++ b/plans/260702-1026-trial-d3-discount-winback/phase-02-trial-offer-eligibility-and-push.md
@@ -1,0 +1,98 @@
+---
+phase: 2
+title: "Trial offer eligibility and push"
+status: completed
+priority: P1
+effort: "0.5d"
+dependencies: [1]
+---
+
+# Phase 2: Trial offer eligibility and push
+
+## Context Links
+
+- Trial push service: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/cron_trial_push_service.py`
+- Subscription repository: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/subscription_repository_async.py`
+- Dispatch service: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/cron_notification_dispatch_service.py`
+- Message templates: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/services/notification_messages.py`
+- Push cron: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/cron/push.py`
+
+## Overview
+
+Extend the existing trial-expiry push job to target all near-D3 trial users who have not claimed the discount, including users who cancelled auto-renew but still have trial access.
+
+## Key Insights
+
+- Current service already inserts one `trial_expiry_1d` row and dispatch maps it to mobile `data.type=trial_expiry`.
+- Current repository method filters only `status='active'`, so cancellation-intent users are excluded.
+- Current message copy is already service-oriented and has no price. Keep it that way.
+
+## Requirements
+
+- Functional: include active trials and cancelled-but-unexpired trials.
+- Functional: exclude users who already claimed the trial-end discount.
+- Functional: dedupe with existing notification uniqueness and sent log behavior.
+- Functional: route mobile to existing `trial_expiry` notification type.
+- Non-functional: no PostHog push dependency, no hardcoded price in push, no Firebase token logging.
+
+## Architecture
+
+`src/cron/push.py` phase 2 -> `CronTrialPushService` -> new subscription eligibility query -> `notifications` queue -> `CronNotificationDispatchService` -> FCM -> mobile `trial_expiry` route.
+
+Timing recommendation: preserve current `expires_at - 2h` behavior for MVP. If product wants an earlier D3 morning nudge, make `_CHARGE_LEAD` configurable instead of hardcoding a second campaign.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/cron_trial_push_service.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/subscription_repository_async.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/ports/subscription_repository_port.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/services/notification_messages.py` only if copy needs tuning
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/services/test_cron_trial_push_service.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/repositories/test_subscription_repository_async.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/infra/test_cron_notification_dispatch_service.py`
+
+## Implementation Steps
+
+1. Add repository method `find_trial_end_offer_candidates(now, lookahead_days)` or equivalent.
+2. Query rules:
+   - `expires_at > now`
+   - `expires_at < now + lookahead`
+   - `status IN ('active', 'cancelled')`
+   - `period_type='TRIAL'` or rollout fallback `purchased_at >= now - 7 days`
+   - `trial_end_discount_claimed_at IS NULL`
+3. Update `CronTrialPushService._schedule_due_pushes` to call the new eligibility method.
+4. Keep notification type `trial_expiry_1d` unless a second timing is approved.
+5. Add safe context keys such as `campaign='trial_end_discount'` and `subscription_id` only if needed for analytics. Do not include price.
+6. Keep `_render_message` copy as service reminder, or lightly tune EN/VI copy without mentioning the discount.
+7. Add tests for active trial, cancelled-unexpired trial, expired trial, already-claimed discount, no token, and duplicate scheduling.
+
+## Todo List
+
+- [x] Add eligibility repository method and port signature.
+- [x] Update trial push service to use the new audience.
+- [x] Preserve dedupe on `(user_id, notification_type, scheduled_date)`.
+- [x] Add candidate and scheduling tests.
+- [x] Update docs if final timing differs from current docs.
+
+## Success Criteria
+
+- [x] Cancelled-but-unexpired trial users can receive the D3 service reminder.
+- [x] Users who claimed the discounted product do not receive the reminder.
+- [x] Push payload continues to route mobile as `trial_expiry`.
+- [x] Push copy contains no price or direct discount claim.
+
+## Risk Assessment
+
+- Risk: fallback `purchased_at >= now - 7 days` catches non-trial purchases. Mitigation: only use fallback for existing rows and prefer `period_type`.
+- Risk: duplicate sends from cron concurrency. Mitigation: keep existing database unique constraint and row claiming.
+- Risk: compliance drift. Mitigation: service reminder copy only; paywall shows price after user taps.
+
+## Security Considerations
+
+- Do not log FCM tokens or user email.
+- Keep notification context as immutable render snapshot only.
+- Do not add Redis state for eligibility.
+
+## Next Steps
+
+Phase 3 decides who sends winback email for cancellation-intent users.

--- a/plans/260702-1026-trial-d3-discount-winback/phase-03-cancellation-email-ownership-and-workflow.md
+++ b/plans/260702-1026-trial-d3-discount-winback/phase-03-cancellation-email-ownership-and-workflow.md
@@ -1,0 +1,100 @@
+---
+phase: 3
+title: "Cancellation email ownership and workflow"
+status: completed
+priority: P1
+effort: "0.5d"
+dependencies: [1]
+---
+
+# Phase 3: Cancellation email ownership and workflow
+
+## Context Links
+
+- RevenueCat webhook cancellation handler: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py`
+- Email service: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/services/email_service.py`
+- Disabled lifecycle email cron code: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/cron_lifecycle_email_service.py`
+- PostHog adapter: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/adapters/posthog_adapter.py`
+- Mobile PostHog identify includes email: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/core/observability/posthog_user_observer.dart`
+
+## Overview
+
+Make PostHog Workflow the cancellation winback email owner. Backend lifecycle email cron is disabled in infra and should not be extended; backend currently also has a separate immediate cancellation email inside the RevenueCat webhook, so implementation must gate or remove that path.
+
+## Key Insights
+
+- Backend already captures `subscription_cancelled` into PostHog with `period_type`, `cancel_reason`, and `expiration_at_ms`.
+- Backend already has code to send `trial_cancelled` email from `handle_cancellation`, separate from the disabled email cron.
+- PostHog email requires a verified channel and a person email property.
+
+## Requirements
+
+- Functional: make PostHog Workflow the default/target owner for cancellation winback email.
+- Functional: backend must not send immediate Resend cancellation email when email infra is disabled or PostHog owns the flow.
+- Functional: PostHog event properties must be enough to build workflow audience.
+- Non-functional: do not add new behavior to the disabled email cron; verify PostHog unsubscribe behavior before launch.
+
+## Architecture
+
+RevenueCat `CANCELLATION` -> backend persists subscription state -> backend captures `subscription_cancelled` -> PostHog Workflow sends delayed winback email.
+
+Recommended rollout: keep backend email sending off, create/QA PostHog Workflow in staging, then enable production workflow after verifying the webhook email path cannot send.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/config/settings.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/api/routes/test_webhooks_cancellation_email.py`
+- Modify/Add: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/api/test_webhook_handler.py`
+- Optional modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/domain/services/email_service.py` if backend remains email owner
+- External config: PostHog Workflow, email channel, and template
+
+## Implementation Steps
+
+1. Add `CANCELLATION_EMAIL_OWNER` setting with allowed values `posthog` and `off` if a switch is still useful; default to `posthog` for campaign ownership or `off` until the workflow is live.
+2. Gate or remove `handle_cancellation` Resend call so disabled email infra cannot double-send.
+3. Extend PostHog `subscription_cancelled` properties:
+   - `period_type`
+   - `cancel_reason`
+   - `expiration_at_ms`
+   - `days_until_expiration`
+   - `trial_end_discount_claimed`
+   - `email_owner`
+4. Update cancellation email tests for PostHog-owned/off modes and the stale webhook Resend path.
+5. Create PostHog Workflow:
+   - Trigger: `subscription_cancelled`
+   - Filters: `period_type = TRIAL`, `trial_end_discount_claimed != true`, `expiration_at_ms` in future, production only
+   - Delay: short cooling-off delay, e.g. 15-60 minutes
+   - Action: send winback email with CTA to app/paywall
+6. Verify workflow sends only after PostHog channel is configured and backend email path is off.
+
+## Todo List
+
+- [x] Add email owner/kill-switch config if needed.
+- [x] Gate or remove backend webhook cancellation email path.
+- [x] Extend PostHog cancellation properties.
+- [x] Update tests.
+- [ ] Configure PostHog Workflow after channel verification.
+
+## Success Criteria
+
+- [x] A cancellation event cannot produce backend Resend email plus PostHog winback email.
+- [x] PostHog audience can target trial cancellations that still have access.
+- [x] Disabled lifecycle email cron is not extended.
+- [x] Tests prove webhook email path is off when PostHog owns the flow.
+
+## Risk Assessment
+
+- Risk: PostHog person lacks email. Mitigation: verify identify flow before launch and monitor skipped workflow sends.
+- Risk: unsubscribe semantics differ between backend and PostHog. Mitigation: verify before production owner switch.
+- Risk: stale backend webhook email code still sends when infra changes. Mitigation: explicit config/test around `handle_cancellation`.
+
+## Security Considerations
+
+- Do not add email to backend PostHog lifecycle event unless privacy review approves.
+- Keep cancellation event properties non-PII.
+- Do not log email send failures with raw recipient address.
+
+## Next Steps
+
+Phase 4 makes the push/email CTA open the correct discounted paywall.

--- a/plans/260702-1026-trial-d3-discount-winback/phase-04-mobile-discounted-paywall-routing.md
+++ b/plans/260702-1026-trial-d3-discount-winback/phase-04-mobile-discounted-paywall-routing.md
@@ -1,0 +1,104 @@
+---
+phase: 4
+title: "Mobile discounted paywall routing"
+status: completed
+priority: P1
+effort: "0.5-1d"
+dependencies: [2]
+---
+
+# Phase 4: Mobile discounted paywall routing
+
+## Context Links
+
+- Notification navigation: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/notifications/application/notification_navigation_service.dart`
+- Subscription constants: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/core/constants/app_constants.dart`
+- Subscription route: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/presentation/router/subscription_routes.dart`
+- Paywall entry: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/presentation/screens/paywall_entry_screen.dart`
+- Paywall provider: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/paywall_provider.dart`
+- Price flag provider: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/paywall_price_test_provider.dart`
+- Discount offering provider: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/spin_wheel_discount_offering_provider.dart`
+
+## Overview
+
+Make `source=trial_expiry` open a real discounted RevenueCat offering so the paywall displays localized store prices. This should reuse current offering/purchase UI, not create a second paywall.
+
+## Key Insights
+
+- `trial_expiry` push routing already reaches `/subscription-required?source=trial_expiry`.
+- The app already reads `discount_offering_id` from `paywall_price_ab_new_onboarding_v1`.
+- `PaywallEntryScreen` and paywall screens accept `offeringId`, but that value is currently not wired into `paywallProvider`.
+- Paywall and discount UI already display RevenueCat `priceString`, which solves VN 299k vs other-country price localization.
+
+## Requirements
+
+- Functional: for `source=trial_expiry`, resolve a trial-end discount offering and show that offering in the paywall.
+- Functional: use `discount_offering_id` from PostHog payload when present; fallback to the configured standard discount offering.
+- Functional: if discount offering/product is missing, fail safe to current paywall instead of blank UI.
+- Non-functional: no hardcoded currency/price strings; no new paywall surface unless current UI cannot support the offer.
+
+## Architecture
+
+Notification tap -> route `source=trial_expiry` -> resolve discount offering ID -> scoped paywall offering override -> `paywallProvider` loads `offerings.all[override]` -> UI renders localized product prices.
+
+Preferred mobile implementation:
+
+- Add a small route-scoped provider for paywall offering override.
+- `paywallProvider` selection priority:
+  1. route override offering ID
+  2. price-test `offering_id`
+  3. NM-127/tiered/current offering fallback
+- `PaywallEntryScreen` passes source and offering override into the paywall via `ProviderScope` or equivalent Riverpod scoped override.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/paywall_provider.dart`
+- Create/Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/paywall_route_offering_provider.dart`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/presentation/router/subscription_routes.dart`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/presentation/screens/paywall_entry_screen.dart`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/presentation/screens/multi_step_paywall_screen.dart`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/docs/paywall-price-ab-testing.md`
+- Modify/Add tests near existing subscription provider/widget tests.
+
+## Implementation Steps
+
+1. Add `paywallRouteOfferingProvider` with default `null`.
+2. Update `paywallProvider` to read route override before PostHog price-test offering.
+3. In `subscription_routes.dart` or `PaywallEntryScreen`, when source is `trial_expiry`, resolve:
+   - `(await paywallPriceTestAssignmentProvider.future).discountOfferingId`
+   - fallback `spinWheelDiscountOfferingProvider.future`
+   - fallback current paywall if still null
+4. Pass the resolved offering into a scoped override around `MultiStepPaywallScreen`.
+5. Ensure analytics still reports `offering_id` via `paywall_variant_resolved`.
+6. Add tests for route source, offering resolution, missing offering fallback, and localized price display via `StoreProduct.priceString`.
+7. Run `dart run build_runner build --delete-conflicting-outputs` if provider code-gen changes.
+
+## Todo List
+
+- [x] Add route-scoped offering override provider.
+- [x] Wire override into `paywallProvider`.
+- [x] Resolve trial-expiry discount offering from current flag payload.
+- [x] Add tests and regenerate Riverpod code.
+- [x] Update paywall price-test docs.
+
+## Success Criteria
+
+- [x] Tapping a trial-expiry push opens paywall with the discount offering when configured.
+- [x] VN users see the RevenueCat/App Store localized VND price; other countries see their local price.
+- [x] Missing discount offering falls back gracefully.
+- [x] No user-facing string says `299k` unless it comes from store product price display.
+
+## Risk Assessment
+
+- Risk: scoped override leaks to later paywall opens. Mitigation: use route-scoped provider override, not global state.
+- Risk: price-test flag payload missing `discount_offering_id`. Mitigation: fallback to existing discount offering and log diagnostic analytics.
+- Risk: generated Riverpod files drift. Mitigation: run build_runner and targeted tests.
+
+## Security Considerations
+
+- Do not include user identifiers in route query params.
+- Do not trust route params for entitlement. RevenueCat purchase/entitlement still decides access.
+
+## Next Steps
+
+Phase 5 verifies analytics, docs, and rollout safety.

--- a/plans/260702-1026-trial-d3-discount-winback/phase-05-analytics-verification-and-rollout.md
+++ b/plans/260702-1026-trial-d3-discount-winback/phase-05-analytics-verification-and-rollout.md
@@ -1,0 +1,116 @@
+---
+phase: 5
+title: "Analytics verification and rollout"
+status: in_progress
+priority: P1
+effort: "0.5d"
+dependencies: [1, 2, 3, 4]
+---
+
+# Phase 5: Analytics verification and rollout
+
+## Context Links
+
+- Backend external services docs: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/external-services.md`
+- Backend analytics adapter: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/adapters/posthog_adapter.py`
+- Mobile analytics taxonomy: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/docs/analytics-taxonomy.md`
+- Mobile paywall price guide: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/docs/paywall-price-ab-testing.md`
+
+## Overview
+
+Verify that the full campaign is observable, non-duplicative, and rollback-safe before production launch.
+
+## Key Insights
+
+- Mobile analytics docs say RevenueCat/App Store lifecycle is commercial truth.
+- Backend docs currently mention T-2d/T-1d trial pushes, but current code schedules one `trial_expiry_1d` reminder about two hours before charge.
+- Backend lifecycle email cron is disabled in infra and expected to be removed, so rollout verification should focus on PostHog Workflow email and the webhook email kill switch.
+- PostHog Workflow setup is external config, so the plan must include manual verification gates.
+
+## Requirements
+
+- Functional: analytics distinguishes push reminder, paywall source, cancellation, discount claim, and paid conversion.
+- Functional: docs describe the final owner/timing truth.
+- Functional: rollout can be disabled by config/flag without app redeploy.
+- Non-functional: no PII in logs or analytics properties beyond existing PostHog person email identify.
+
+## Architecture
+
+RevenueCat is source of truth. Backend emits lifecycle events and schedules pushes. Mobile emits paywall UX events with `source=trial_expiry` and offering ID. PostHog Workflow, if enabled, consumes backend `subscription_cancelled`.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/external-services.md`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/codebase-summary.md` if feature summary changes
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/docs/analytics-taxonomy.md`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/docs/paywall-price-ab-testing.md`
+- Optional modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/core/services/analytics_service.dart`
+- Optional modify: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/core/services/analytics_events.dart`
+
+## Implementation Steps
+
+1. Add or verify analytics properties:
+   - push campaign: `trial_end_discount`
+   - paywall source: `trial_expiry`
+   - resolved `offering_id`
+   - cancellation `period_type`, `cancel_reason`, `days_until_expiration`
+   - discount claim state
+2. Update docs to reflect final timing and owner:
+   - backend push cron schedules one trial-end service reminder unless product chooses earlier D3 timing
+   - cancellation winback email is PostHog-owned
+   - backend lifecycle email cron is disabled/future removal
+   - webhook cancellation email path is off or explicitly gated
+3. Verification commands:
+   - Backend targeted: `.venv/bin/pytest tests/unit/infra/services/test_cron_trial_push_service.py tests/unit/infra/repositories/test_subscription_repository_async.py tests/unit/api/routes/test_webhooks_cancellation_email.py tests/unit/api/test_webhook_handler.py -q`
+   - Backend quality: `.venv/bin/ruff check src/infra/services/cron_trial_push_service.py src/infra/repositories/subscription_repository_async.py src/api/routes/v1/webhooks.py`
+   - Mobile generated code: `dart run build_runner build --delete-conflicting-outputs`
+   - Mobile quality: `flutter analyze && flutter test`
+4. Staging QA:
+   - RevenueCat sandbox trial start.
+   - Cancel trial auto-renew, verify PostHog `subscription_cancelled`.
+   - Verify user remains eligible for D3 push while unexpired.
+   - Tap push, verify discount offering/paywall price.
+   - Purchase discount, verify backend claim state.
+   - Verify no duplicate email.
+5. Production rollout:
+   - Publish RevenueCat discount offering/products.
+   - Set discount product ID config.
+   - Enable mobile flag payload with `discount_offering_id`.
+   - Verify PostHog email channel and enable workflow after confirming backend webhook email path is off.
+   - Monitor 30-60 minutes for push schedules, paywall resolves, purchases, and cancellation email volume.
+6. Rollback:
+   - Disable PostHog Workflow and keep backend webhook email path off unless product explicitly re-enables backend email.
+   - Remove/disable discount offering payload in PostHog flag.
+   - Clear discount product config to stop claim targeting.
+
+## Todo List
+
+- [x] Add analytics/docs updates.
+- [x] Run backend targeted tests and ruff.
+- [x] Run mobile build_runner/analyze/tests.
+- [ ] Complete staging RevenueCat/PostHog QA.
+- [ ] Prepare production rollout and rollback checklist.
+
+## Success Criteria
+
+- [ ] End-to-end staging path proves cancellation user remains eligible until expiry.
+- [x] Push opens localized discounted paywall.
+- [x] Discount purchase marks claim and removes future eligibility.
+- [x] No duplicate cancellation email.
+- [x] Docs match final code behavior.
+
+## Risk Assessment
+
+- Risk: external RevenueCat/App Store products not approved. Mitigation: do not enable flag/config until products are live.
+- Risk: PostHog workflow sends to sandbox/test users in prod. Mitigation: filter `environment != SANDBOX` and test with staging project first.
+- Risk: metrics mismatch between client purchase success and RevenueCat truth. Mitigation: report commercial conversion from RevenueCat/server lifecycle.
+
+## Security Considerations
+
+- Keep analytics properties non-PII.
+- Do not expose discount eligibility secrets to unauthenticated routes.
+- Keep RevenueCat webhook secret and PostHog API key in environment only.
+
+## Next Steps
+
+After this plan is approved, implement with `/ck:cook /Users/alexnguyen/Desktop/Nut/mealtrack_backend/plans/260702-1026-trial-d3-discount-winback/plan.md`.

--- a/plans/260702-1026-trial-d3-discount-winback/plan.md
+++ b/plans/260702-1026-trial-d3-discount-winback/plan.md
@@ -1,0 +1,63 @@
+---
+title: "Trial D3 Discount Reminder and Cancellation Winback"
+description: "Send trial-end service reminders to unconverted trial users, open a localized discounted paywall, and choose one cancellation winback email owner."
+status: in_progress
+priority: P1
+effort: "2-3d"
+branch: "main"
+tags: [feature, backend, mobile, subscriptions, notifications, analytics]
+blockedBy: []
+blocks: []
+created: "2026-07-02T03:26:46.507Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Trial D3 Discount Reminder and Cancellation Winback
+
+## Overview
+
+Feasible. MealTrack already owns the hard parts: RevenueCat webhook state, FCM queue/dispatch, disabled lifecycle email code, and PostHog lifecycle mirroring. Nutree mobile already routes `trial_expiry` pushes to the subscription paywall and already reads RevenueCat offering IDs from PostHog payloads.
+
+This plan keeps the push as a service reminder and lets the paywall reveal the localized discounted price. Do not hardcode `299k` in push/email copy. VN can show VND 299k because the RevenueCat/App Store product price says so; other storefronts show their local `StoreProduct.priceString`.
+
+Core decisions:
+- "Claimed offer" means server-confirmed discounted purchase/conversion, not local "saw offer". Mobile `discountOfferSeenKey` is device-local and not safe for backend audience selection.
+- Trial-end audience must include active trials and cancelled-but-unexpired trials. Backend currently marks cancellation as `status='cancelled'` while access remains until `expires_at`, so the current `status='active'` expiry query would miss cancellation-intent users.
+- PostHog Workflow is the intended cancellation winback email path. Backend lifecycle email cron is disabled in infra and expected to be removed, so do not build new campaign behavior on it. Still gate/remove the separate webhook cancellation-email path so it cannot double-send.
+- Backend FCM remains push owner. PostHog Workflows can own email/segmentation, not mobile push.
+
+Scope Challenge:
+- Existing code: RevenueCat webhook, PostHog lifecycle capture, FCM notification queue, trial-expiry push, disabled lifecycle email code, mobile notification routing, RevenueCat offering-based paywall.
+- Minimum change set: durable trial/claim fields, expanded eligibility query, one email-owner switch, mobile route/offering wiring, analytics/docs/tests.
+- Complexity: cross-repo, about 10-14 files plus migration/tests. One small policy/helper is acceptable; no new campaign platform.
+- Selected mode: `--hard` because subscription state + payment messaging + push/email compliance have high blast radius.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [RevenueCat lifecycle contract](./phase-01-revenuecat-lifecycle-contract.md) | Completed |
+| 2 | [Trial offer eligibility and push](./phase-02-trial-offer-eligibility-and-push.md) | Completed |
+| 3 | [Cancellation email ownership and workflow](./phase-03-cancellation-email-ownership-and-workflow.md) | Completed (code); PostHog workflow setup remains external |
+| 4 | [Mobile discounted paywall routing](./phase-04-mobile-discounted-paywall-routing.md) | Completed |
+| 5 | [Analytics verification and rollout](./phase-05-analytics-verification-and-rollout.md) | In Progress |
+
+## Dependencies
+
+- No unfinished backend plan blocks this work.
+- Related mobile reference: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/plans/260621-2254-d1-d3-retention-campaign-mobile/plan.md`.
+- External setup required before launch: RevenueCat discount offering/products published for every target storefront; PostHog email channel verified for winback email.
+- Useful docs: [PostHog Workflows](https://posthog.com/docs/workflows), [PostHog workflow channels](https://posthog.com/docs/workflows/configure-channels), [RevenueCat webhook events](https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields), [Apple notification guideline 4.5.4](https://developer.apple.com/app-store/review/guidelines/).
+
+## Validation Log
+
+- Verified backend trial push exists at `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/cron_trial_push_service.py:28`.
+- Verified current trial query only selects active subscriptions at `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/subscription_repository_async.py:91`.
+- Verified cancellation sets `status='cancelled'` but access remains until expiry at `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py:343`.
+- Verified backend already mirrors `subscription_cancelled` with `period_type`, `cancel_reason`, and `expiration_at_ms` at `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py:454`.
+- Verified backend already sends cancellation email via Resend at `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py:370`.
+- Verified mobile routes `trial_expiry` notification taps to `/subscription-required?source=trial_expiry` at `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/notifications/application/notification_navigation_service.dart:26`.
+- Verified mobile price-test payload supports `discount_offering_id` at `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/paywall_price_test_provider.dart:9`.
+- Verified mobile paywall displays localized RevenueCat product price strings at `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/subscriptions/application/providers/paywall_provider.dart:66`.
+- Red-team findings recorded in `reports/red-team-review.md`; all accepted findings are mapped into phases.

--- a/plans/260702-1026-trial-d3-discount-winback/reports/red-team-review.md
+++ b/plans/260702-1026-trial-d3-discount-winback/reports/red-team-review.md
@@ -1,0 +1,47 @@
+---
+title: "Red Team Review"
+type: report
+status: complete
+created: 2026-07-02
+---
+
+# Red Team Review
+
+## Findings
+
+1. Cancelled trial users are excluded from current push/email expiry queries.
+   - Evidence: cancellation sets `status='cancelled'` while access remains until `expires_at`; expiry queries filter `status='active'`.
+   - Resolution: Phase 2 adds an eligibility query for active and cancelled-but-unexpired trials.
+
+2. PostHog winback email can duplicate backend Resend cancellation email if stale webhook code remains enabled.
+   - Evidence: backend sends cancellation email inside `handle_cancellation`; user confirmed lifecycle email cron is disabled separately.
+   - Resolution: Phase 3 makes PostHog the intended owner and gates/removes the webhook email path.
+
+3. "Haven't claimed offer" is not currently a server-side fact.
+   - Evidence: mobile has local `discountOfferSeenKey`; backend does not track discounted purchase claim.
+   - Resolution: Phase 1 adds durable claim state from RevenueCat-confirmed purchase fields.
+
+4. Hardcoding VND 299k is wrong outside Vietnam and risky even in Vietnam if store price changes.
+   - Evidence: mobile already gets price strings from RevenueCat packages.
+   - Resolution: Phase 4 uses RevenueCat localized product prices only.
+
+5. RevenueCat webhook may not expose offering ID.
+   - Risk: implementation could silently fail to mark claims.
+   - Resolution: Phase 1 requires sandbox payload verification and supports product ID or discount identifier config.
+
+6. Push copy can drift into promotional messaging.
+   - Risk: Apple guideline 4.5.4 requires explicit marketing push opt-in and opt-out.
+   - Resolution: Phase 2 keeps push as service reminder; discount/price appears on paywall or email.
+
+7. Mobile `offeringId` seam is currently dead.
+   - Evidence: screen constructors accept `offeringId`, but no usage found beyond field assignment.
+   - Resolution: Phase 4 wires a scoped offering override into `paywallProvider`.
+
+8. Backend docs mention T-2d/T-1d, but code schedules one `trial_expiry_1d` row.
+   - Resolution: Phase 5 updates docs to match the implemented timing.
+
+## Whole-Plan Consistency Sweep
+
+- Files checked: `plan.md`, all five phase files after drafting.
+- Decision deltas: service push no price, server-side claim, include cancelled-unexpired trials, single email owner, RevenueCat localized price.
+- Unresolved contradictions: none after phase mapping.

--- a/plans/260702-1026-trial-d3-discount-winback/research/researcher-01-revenuecat-posthog-workflows.md
+++ b/plans/260702-1026-trial-d3-discount-winback/research/researcher-01-revenuecat-posthog-workflows.md
@@ -1,0 +1,40 @@
+---
+title: "RevenueCat and PostHog Workflow Research"
+type: research
+status: complete
+created: 2026-07-02
+---
+
+# RevenueCat and PostHog Workflow Research
+
+## Summary
+
+PostHog Workflow is feasible for winback email after cancellation if the person has an email property and the email channel is verified. It should not be the mobile push owner. Backend FCM remains the correct push path.
+
+## Findings
+
+- PostHog Workflows can trigger from events, delay, branch, and send email through configured channels.
+- PostHog email requires channel/domain setup before launch.
+- PostHog push notification support is not the reliable implementation path for this app now; backend FCM already exists.
+- RevenueCat webhooks provide lifecycle events that backend already mirrors into PostHog as `subscription_cancelled`, `subscription_expired`, `subscription_renewed`, and related actions.
+- Do not assume RevenueCat webhook includes `offering_id`. Verify sandbox payload before using any offer-specific field. Product IDs and discount identifiers are safer claim signals.
+- Apple guideline 4.5.4 allows promotional/direct marketing push only with explicit consent and in-app opt-out. Keep the D3 push as a service reminder and put price/discount on paywall/email surfaces.
+
+## Recommended Contract
+
+- Push: backend FCM, service reminder, no hardcoded price.
+- Paywall: mobile opens RevenueCat discount offering and renders `priceString`.
+- Claim: backend marks offer claimed only from RevenueCat-confirmed discounted product/discount identifier.
+- Email: choose one owner. If PostHog owns cancellation winback, disable/gate backend immediate cancellation email for that audience.
+
+## References
+
+- https://posthog.com/docs/workflows
+- https://posthog.com/docs/workflows/configure-channels
+- https://posthog.com/docs/workflows/launch-workflow
+- https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields
+- https://developer.apple.com/app-store/review/guidelines/
+
+## Unresolved Questions
+
+- Confirm exact RevenueCat sandbox payload fields for discounted purchase before coding the final claim detector.

--- a/plans/260702-1026-trial-d3-discount-winback/research/researcher-02-codebase-scout.md
+++ b/plans/260702-1026-trial-d3-discount-winback/research/researcher-02-codebase-scout.md
@@ -1,0 +1,40 @@
+---
+title: "Cross-Repo Codebase Scout"
+type: research
+status: complete
+created: 2026-07-02
+---
+
+# Cross-Repo Codebase Scout
+
+## Summary
+
+The plan should be backend-primary. MealTrack owns durable subscription state, FCM queueing, email, and RevenueCat/PostHog lifecycle events. Mobile mostly needs route-to-offering wiring and tests.
+
+## Backend Evidence
+
+- Push cron has trial scheduling, dispatch, and cleanup in `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/cron/push.py`.
+- Trial push service inserts a single `trial_expiry_1d` notification about two hours before charge in `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/services/cron_trial_push_service.py`.
+- Current expiry query only finds `Subscription.status == "active"` in `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/subscription_repository_async.py`.
+- Cancellation marks the subscription `cancelled`, records `cancelled_at`, but notes access remains until `expires_at` in `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py`.
+- Backend already sends immediate cancellation email via `EmailService.send_cancellation_email`.
+- Lifecycle email cron code exists, but user confirmed infra has disabled it and it is expected to be removed. Do not build this campaign on that cron.
+- Notification messages already contain EN/VI trial-expiry service copy and no price.
+
+## Mobile Evidence
+
+- Mobile `NotificationType.trialExpiry` exists and notification tap routes to `AppConstants.subscriptionTrialExpiryRoute`.
+- `AppConstants.subscriptionTrialExpiryRoute` is `/subscription-required?source=trial_expiry`.
+- Paywall price-test flag supports payload `{ "offering_id": "...", "discount_offering_id": "..." }`.
+- Discount offer UI uses RevenueCat `StoreProduct.priceString`, so storefront-localized prices are already the display path.
+- `PaywallEntryScreen` and paywall screen constructors accept `offeringId`, but the value is currently not used to override `paywallProvider` resolution.
+
+## Reuse First
+
+- Reuse `notifications` queue and unique `(user_id, notification_type, scheduled_date)` dedupe.
+- Reuse `PostHogAdapter.capture`.
+- Reuse existing paywall offering resolution where possible; add a scoped route override rather than a new paywall implementation.
+
+## Unresolved Questions
+
+- Exact D3 timing: preserve current two-hour pre-charge reminder, or send earlier on local D3 morning.

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -16,12 +16,13 @@ from sqlalchemy import select, text
 from src.domain.services.email_service import EmailService
 from src.domain.utils.timezone_utils import utc_now
 from src.infra.adapters.posthog_adapter import PostHogAdapter
-from src.observability import increment_metric
 from src.infra.adapters.resend_email_adapter import ResendEmailAdapter
+from src.infra.config.settings import settings
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.services.email_template_renderer import EmailTemplateRenderer
+from src.observability import increment_metric
 
 router = APIRouter(prefix="/v1/webhooks", tags=["Webhooks"])
 logger = logging.getLogger(__name__)
@@ -43,6 +44,8 @@ POSTHOG_LIFECYCLE_EVENTS = {
     "RENEWAL": "subscription_renewed",
     "PRODUCT_CHANGE": "subscription_product_changed",
 }
+
+_TRIAL_PERIOD_TYPE = "trial"
 
 
 def _get_email_service() -> EmailService:
@@ -94,7 +97,10 @@ async def revenuecat_webhook(
     async with AsyncUnitOfWork() as uow:
         if event_type == "TRANSFER":
             await handle_transfer(uow, event)
-            increment_metric("webhook.revenuecat.processed", attributes={"event_type": event_type, "status": "success"})
+            increment_metric(
+                "webhook.revenuecat.processed",
+                attributes={"event_type": event_type, "status": "success"},
+            )
             return {"status": "success"}
 
         user = await find_user_for_revenuecat_event(uow, event)
@@ -133,7 +139,10 @@ async def revenuecat_webhook(
         elif event_type == "REFUND":
             await handle_refund(uow, user, event)
 
-    increment_metric("webhook.revenuecat.processed", attributes={"event_type": event_type or "unknown", "status": "success"})
+    increment_metric(
+        "webhook.revenuecat.processed",
+        attributes={"event_type": event_type or "unknown", "status": "success"},
+    )
     return {"status": "success"}
 
 
@@ -246,6 +255,98 @@ def _preferred_transfer_target(transferred_to: list[str]) -> str | None:
     )
 
 
+def _normalized_csv(value: str | None) -> set[str]:
+    """Parse comma-separated env values into lowercase lookup keys."""
+    if not value:
+        return set()
+    return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+
+def _normalized_period_type(event: dict) -> str | None:
+    raw = event.get("period_type")
+    if not isinstance(raw, str):
+        return None
+    normalized = raw.strip().lower()
+    return normalized or None
+
+
+def _discount_identifier_from_event(event: dict) -> str | None:
+    for key in (
+        "discount_identifier",
+        "offer_identifier",
+        "promotional_offer_id",
+        "presented_offering_id",
+    ):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _is_trial_end_discount_claim(event: dict) -> bool:
+    product_id = event.get("product_id")
+    discount_identifier = _discount_identifier_from_event(event)
+    product_ids = _normalized_csv(settings.TRIAL_END_DISCOUNT_PRODUCT_IDS)
+    discount_identifiers = _normalized_csv(settings.TRIAL_END_DISCOUNT_IDENTIFIERS)
+
+    if isinstance(product_id, str) and product_id.strip().lower() in product_ids:
+        return True
+    if (
+        discount_identifier
+        and discount_identifier.strip().lower() in discount_identifiers
+    ):
+        return True
+    return False
+
+
+def _apply_revenuecat_lifecycle_state(
+    subscription: Subscription | None,
+    event: dict,
+) -> None:
+    """Persist RevenueCat lifecycle fields used by trial push and winback flows."""
+    if subscription is None:
+        return
+
+    period_type = _normalized_period_type(event)
+    purchased_at = parse_timestamp(event.get("purchased_at_ms"))
+    expires_at = parse_timestamp(event.get("expiration_at_ms"))
+    cancel_reason = event.get("cancel_reason")
+
+    if period_type:
+        subscription.period_type = period_type
+    if period_type == _TRIAL_PERIOD_TYPE:
+        if purchased_at and not subscription.trial_started_at:
+            subscription.trial_started_at = purchased_at
+        if expires_at:
+            subscription.trial_expires_at = expires_at
+    if isinstance(cancel_reason, str) and cancel_reason.strip():
+        subscription.cancel_reason = cancel_reason.strip()
+
+    if _is_trial_end_discount_claim(event):
+        subscription.trial_end_discount_claimed_at = purchased_at or utc_now()
+        subscription.trial_end_discount_product_id = event.get("product_id")
+        subscription.trial_end_discount_identifier = _discount_identifier_from_event(
+            event
+        )
+
+
+def _should_send_backend_cancellation_email(user) -> bool:
+    """Legacy sender is disabled unless explicitly selected as the email owner."""
+    owner = (settings.CANCELLATION_EMAIL_OWNER or "").strip().lower()
+    return owner == "backend" and settings.EMAIL_ENABLED and not user.email_opt_out
+
+
+def _timestamp_ms(value: datetime | None) -> int | None:
+    if value is None:
+        return None
+    return int(value.timestamp() * 1000)
+
+
+def _days_until(value: datetime | None) -> int | None:
+    if value is None:
+        return None
+    return (value - utc_now()).days
+
 
 async def handle_purchase(uow, user, event):
     """Handle initial purchase."""
@@ -272,6 +373,7 @@ async def handle_purchase(uow, user, event):
         store_transaction_id=event.get("transaction_id"),
         is_sandbox=event.get("environment") == "SANDBOX",
     )
+    _apply_revenuecat_lifecycle_state(subscription, event)
 
     uow.session.add(subscription)
     logger.info(f"User {user.id} purchased {subscription.product_id}")
@@ -284,8 +386,11 @@ async def handle_purchase(uow, user, event):
             "mealtrack_user_id": str(user.id),
             "product_id": event.get("product_id"),
             "period_type": event.get("period_type"),
-            "subscription_id": event.get("transaction_id") or event.get("original_transaction_id"),
-            "occurred_at": (parse_timestamp(event.get("purchased_at_ms")) or utc_now()).isoformat(),
+            "subscription_id": event.get("transaction_id")
+            or event.get("original_transaction_id"),
+            "occurred_at": (
+                parse_timestamp(event.get("purchased_at_ms")) or utc_now()
+            ).isoformat(),
         },
         event_id=event.get("id"),
     )
@@ -301,6 +406,7 @@ async def handle_renewal(uow, user, event):
         subscription.expires_at = parse_timestamp(event.get("expiration_at_ms"))
         subscription.status = "active"
         subscription.updated_at = utc_now()
+        _apply_revenuecat_lifecycle_state(subscription, event)
         logger.info(
             f"User {user.id} renewed subscription until {subscription.expires_at}"
         )
@@ -315,8 +421,11 @@ async def handle_renewal(uow, user, event):
             "mealtrack_user_id": str(user.id),
             "product_id": event.get("product_id"),
             "period_type": event.get("period_type"),
-            "subscription_id": event.get("transaction_id") or event.get("original_transaction_id"),
-            "occurred_at": (parse_timestamp(event.get("purchased_at_ms")) or utc_now()).isoformat(),
+            "subscription_id": event.get("transaction_id")
+            or event.get("original_transaction_id"),
+            "occurred_at": (
+                parse_timestamp(event.get("purchased_at_ms")) or utc_now()
+            ).isoformat(),
         },
         event_id=event.get("id"),
     )
@@ -348,6 +457,7 @@ async def handle_cancellation(uow, user, event):
         subscription.status = "cancelled"
         subscription.cancelled_at = utc_now()
         subscription.updated_at = utc_now()
+        _apply_revenuecat_lifecycle_state(subscription, event)
         # Note: User still has access until expires_at
         logger.info(
             f"User {user.id} cancelled subscription (expires {subscription.expires_at})"
@@ -361,20 +471,28 @@ async def handle_cancellation(uow, user, event):
         {
             "mealtrack_user_id": str(user.id),
             "product_id": event.get("product_id"),
-            "subscription_id": event.get("transaction_id") or event.get("original_transaction_id"),
+            "subscription_id": event.get("transaction_id")
+            or event.get("original_transaction_id"),
             "occurred_at": utc_now().isoformat(),
         },
         event_id=event.get("id"),
     )
 
-    # Send cancellation email
-    if not user.email_opt_out:
+    # Cancellation email is owned by PostHog Workflows by default. Keep this
+    # legacy sender gated for rollback only.
+    if _should_send_backend_cancellation_email(user):
         try:
             email_service = _get_email_service()
             await email_service.send_cancellation_email(user)
             logger.info(f"Cancellation email sent to user {user.id}")
         except Exception as e:
             logger.error(f"Failed to send cancellation email to {user.id}: {e}")
+    else:
+        logger.info(
+            "Backend cancellation email skipped for user %s; owner=%s",
+            user.id,
+            settings.CANCELLATION_EMAIL_OWNER,
+        )
 
 
 async def handle_expiration(uow, user, event):
@@ -384,6 +502,7 @@ async def handle_expiration(uow, user, event):
     if subscription:
         subscription.status = "expired"
         subscription.updated_at = utc_now()
+        _apply_revenuecat_lifecycle_state(subscription, event)
         logger.info(f"User {user.id} subscription expired")
 
     await capture_subscription_lifecycle_event(user, event, "EXPIRATION", subscription)
@@ -392,7 +511,8 @@ async def handle_expiration(uow, user, event):
         {
             "mealtrack_user_id": str(user.id),
             "product_id": event.get("product_id"),
-            "subscription_id": event.get("transaction_id") or event.get("original_transaction_id"),
+            "subscription_id": event.get("transaction_id")
+            or event.get("original_transaction_id"),
             "occurred_at": utc_now().isoformat(),
         },
         event_id=event.get("id"),
@@ -406,6 +526,7 @@ async def handle_billing_issue(uow, user, event):
     if subscription:
         subscription.status = "billing_issue"
         subscription.updated_at = utc_now()
+        _apply_revenuecat_lifecycle_state(subscription, event)
         logger.warning(f"Billing issue for user {user.id}")
 
     await capture_subscription_lifecycle_event(
@@ -422,6 +543,7 @@ async def handle_product_change(uow, user, event):
         subscription.expires_at = parse_timestamp(event.get("expiration_at_ms"))
         subscription.status = "active"
         subscription.updated_at = utc_now()
+        _apply_revenuecat_lifecycle_state(subscription, event)
         logger.info(f"User {user.id} changed to {subscription.product_id}")
 
     await capture_subscription_lifecycle_event(
@@ -435,6 +557,7 @@ async def handle_refund(uow, user, event):
     if subscription:
         subscription.status = "refunded"
         subscription.updated_at = utc_now()
+        _apply_revenuecat_lifecycle_state(subscription, event)
         logger.info(f"User {user.id} subscription refunded")
 
     await capture_subscription_lifecycle_event(user, event, "REFUND", subscription)
@@ -443,7 +566,8 @@ async def handle_refund(uow, user, event):
         {
             "mealtrack_user_id": str(user.id),
             "product_id": event.get("product_id"),
-            "subscription_id": event.get("transaction_id") or event.get("original_transaction_id"),
+            "subscription_id": event.get("transaction_id")
+            or event.get("original_transaction_id"),
             "occurred_at": utc_now().isoformat(),
         },
         event_id=event.get("id"),
@@ -469,8 +593,27 @@ async def capture_subscription_lifecycle_event(
         "subscription_status": getattr(subscription, "status", None),
         "expiration_at_ms": event.get("expiration_at_ms"),
         "purchased_at_ms": event.get("purchased_at_ms"),
-        "cancel_reason": event.get("cancel_reason"),
-        "period_type": event.get("period_type"),
+        "cancel_reason": event.get("cancel_reason")
+        or getattr(subscription, "cancel_reason", None),
+        "period_type": _normalized_period_type(event)
+        or getattr(subscription, "period_type", None),
+        "trial_expires_at_ms": _timestamp_ms(
+            getattr(subscription, "trial_expires_at", None)
+        ),
+        "days_until_expiration": _days_until(
+            parse_timestamp(event.get("expiration_at_ms"))
+            or getattr(subscription, "expires_at", None)
+        ),
+        "trial_end_discount_claimed": bool(
+            getattr(subscription, "trial_end_discount_claimed_at", None)
+        ),
+        "trial_end_discount_product_id": getattr(
+            subscription, "trial_end_discount_product_id", None
+        ),
+        "trial_end_discount_identifier": getattr(
+            subscription, "trial_end_discount_identifier", None
+        ),
+        "cancellation_email_owner": settings.CANCELLATION_EMAIL_OWNER,
         "is_sandbox": event.get("environment") == "SANDBOX",
     }
     await PostHogAdapter().capture(
@@ -540,6 +683,7 @@ async def get_or_create_subscription(uow, user, event):
             store_transaction_id=event.get("transaction_id"),
             is_sandbox=event.get("environment") == "SANDBOX",
         )
+        _apply_revenuecat_lifecycle_state(subscription, event)
         uow.session.add(subscription)
         await uow.session.flush()
 

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -17,7 +17,6 @@ from src.domain.services.email_service import EmailService
 from src.domain.utils.timezone_utils import utc_now
 from src.infra.adapters.posthog_adapter import PostHogAdapter
 from src.infra.adapters.resend_email_adapter import ResendEmailAdapter
-from src.infra.config.settings import settings
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
@@ -262,6 +261,21 @@ def _normalized_csv(value: str | None) -> set[str]:
     return {item.strip().lower() for item in value.split(",") if item.strip()}
 
 
+def _env_csv(name: str) -> set[str]:
+    return _normalized_csv(os.getenv(name, ""))
+
+
+def _cancellation_email_owner() -> str:
+    return os.getenv("CANCELLATION_EMAIL_OWNER", "posthog").strip().lower()
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _normalized_period_type(event: dict) -> str | None:
     raw = event.get("period_type")
     if not isinstance(raw, str):
@@ -286,8 +300,8 @@ def _discount_identifier_from_event(event: dict) -> str | None:
 def _is_trial_end_discount_claim(event: dict) -> bool:
     product_id = event.get("product_id")
     discount_identifier = _discount_identifier_from_event(event)
-    product_ids = _normalized_csv(settings.TRIAL_END_DISCOUNT_PRODUCT_IDS)
-    discount_identifiers = _normalized_csv(settings.TRIAL_END_DISCOUNT_IDENTIFIERS)
+    product_ids = _env_csv("TRIAL_END_DISCOUNT_PRODUCT_IDS")
+    discount_identifiers = _env_csv("TRIAL_END_DISCOUNT_IDENTIFIERS")
 
     if isinstance(product_id, str) and product_id.strip().lower() in product_ids:
         return True
@@ -332,8 +346,11 @@ def _apply_revenuecat_lifecycle_state(
 
 def _should_send_backend_cancellation_email(user) -> bool:
     """Legacy sender is disabled unless explicitly selected as the email owner."""
-    owner = (settings.CANCELLATION_EMAIL_OWNER or "").strip().lower()
-    return owner == "backend" and settings.EMAIL_ENABLED and not user.email_opt_out
+    return (
+        _cancellation_email_owner() == "backend"
+        and _env_bool("EMAIL_ENABLED")
+        and not user.email_opt_out
+    )
 
 
 def _timestamp_ms(value: datetime | None) -> int | None:
@@ -491,7 +508,7 @@ async def handle_cancellation(uow, user, event):
         logger.info(
             "Backend cancellation email skipped for user %s; owner=%s",
             user.id,
-            settings.CANCELLATION_EMAIL_OWNER,
+            _cancellation_email_owner(),
         )
 
 
@@ -613,7 +630,7 @@ async def capture_subscription_lifecycle_event(
         "trial_end_discount_identifier": getattr(
             subscription, "trial_end_discount_identifier", None
         ),
-        "cancellation_email_owner": settings.CANCELLATION_EMAIL_OWNER,
+        "cancellation_email_owner": _cancellation_email_owner(),
         "is_sandbox": event.get("environment") == "SANDBOX",
     }
     await PostHogAdapter().capture(

--- a/src/domain/ports/subscription_repository_port.py
+++ b/src/domain/ports/subscription_repository_port.py
@@ -32,7 +32,9 @@ class SubscriptionRepositoryPort(ABC):
         pass
 
     @abstractmethod
-    async def find_expiring_soon(self, days_until_expiry: int = 7) -> list[Subscription]:
+    async def find_expiring_soon(
+        self, days_until_expiry: int = 7
+    ) -> list[Subscription]:
         """Find subscriptions expiring within specified days."""
         pass
 
@@ -47,6 +49,21 @@ class SubscriptionRepositoryPort(ABC):
 
         `now` lets callers pin the reference moment for deterministic tests and
         consistent window boundaries within a single scheduler run.
+        """
+        pass
+
+    @abstractmethod
+    async def find_trial_end_offer_candidates(
+        self,
+        lookahead_days: int,
+        now: datetime | None = None,
+        fallback_trial_window_days: int = 7,
+    ) -> list[Subscription]:
+        """Trial subscriptions charging soon and still eligible for the end-trial offer.
+
+        Includes cancelled subscriptions while their access window is still active.
+        `fallback_trial_window_days` covers older rows synced before RevenueCat
+        period_type was persisted.
         """
         pass
 

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -107,6 +107,10 @@ class Settings(BaseSettings):
     RESEND_API_KEY: str | None = Field(default=None)
     EMAIL_FROM: str = Field(default="Nutree <hello@nutree.app>")
     EMAIL_ENABLED: bool = Field(default=False)
+    CANCELLATION_EMAIL_OWNER: str = Field(
+        default="posthog",
+        description="Cancellation email owner. Use 'posthog' or 'off'; 'backend' only enables the legacy webhook sender.",
+    )
 
     # External APIs & integrations
     DEEPL_API_KEY: str | None = Field(
@@ -162,6 +166,14 @@ class Settings(BaseSettings):
     )
     REVENUECAT_SECRET_API_KEY: str | None = Field(default=None)
     REVENUECAT_WEBHOOK_SECRET: str | None = Field(default=None)
+    TRIAL_END_DISCOUNT_PRODUCT_IDS: str = Field(
+        default="",
+        description="Comma-separated RevenueCat product IDs that confirm the D3/trial-end discount was claimed.",
+    )
+    TRIAL_END_DISCOUNT_IDENTIFIERS: str = Field(
+        default="",
+        description="Comma-separated RevenueCat offer/discount identifiers that confirm the D3/trial-end discount was claimed.",
+    )
     CLOUDINARY_CLOUD_NAME: str | None = Field(default=None)
     CLOUDINARY_API_KEY: str | None = Field(default=None)
     CLOUDINARY_API_SECRET: str | None = Field(default=None)
@@ -235,7 +247,8 @@ class Settings(BaseSettings):
         default="", description="Cloudflare API token with Workers AI permission"
     )
     CLOUDFLARE_AI_GATEWAY_ID: str = Field(
-        default="", description="AI Gateway ID for routing Workers AI requests (optional)"
+        default="",
+        description="AI Gateway ID for routing Workers AI requests (optional)",
     )
     CLOUDFLARE_WORKERS_AI_TEXT_MODEL: str = Field(
         default="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
@@ -249,7 +262,8 @@ class Settings(BaseSettings):
         default=True, description="Enable Workers AI JSON Mode for structured responses"
     )
     CLOUDFLARE_WORKERS_AI_TIMEOUT_SECONDS: int = Field(
-        default=60, description="HTTP timeout for Workers AI requests (thinking models need ≥60s)"
+        default=60,
+        description="HTTP timeout for Workers AI requests (thinking models need ≥60s)",
     )
     CLOUDFLARE_WORKERS_AI_VISION_ENABLED: bool = Field(
         default=True,

--- a/src/infra/database/models/subscription.py
+++ b/src/infra/database/models/subscription.py
@@ -2,7 +2,7 @@
 Subscription model for tracking user subscriptions.
 """
 
-from sqlalchemy import Column, String, DateTime, Boolean, Enum, ForeignKey, Index
+from sqlalchemy import Boolean, Column, DateTime, Enum, ForeignKey, Index, String
 from sqlalchemy.orm import relationship
 
 from src.domain.utils.timezone_utils import utc_now
@@ -47,7 +47,13 @@ class Subscription(Base, BaseMixin):
     purchased_at = Column(DateTime(timezone=True), nullable=False)
     expires_at = Column(DateTime(timezone=True), nullable=True)
     cancelled_at = Column(DateTime(timezone=True), nullable=True)
-
+    period_type = Column(String(32), nullable=True)
+    trial_started_at = Column(DateTime(timezone=True), nullable=True)
+    trial_expires_at = Column(DateTime(timezone=True), nullable=True)
+    cancel_reason = Column(String(64), nullable=True)
+    trial_end_discount_claimed_at = Column(DateTime(timezone=True), nullable=True)
+    trial_end_discount_product_id = Column(String(255), nullable=True)
+    trial_end_discount_identifier = Column(String(255), nullable=True)
 
     # Store metadata
     store_transaction_id = Column(String(255), nullable=True)
@@ -61,6 +67,13 @@ class Subscription(Base, BaseMixin):
         Index("idx_user_id_status", "user_id", "status"),
         Index("idx_expires_at", "expires_at"),
         Index("idx_revenuecat_subscriber_id", "revenuecat_subscriber_id"),
+        Index(
+            "idx_subscription_trial_offer_candidates",
+            "status",
+            "expires_at",
+            "period_type",
+            "trial_end_discount_claimed_at",
+        ),
     )
 
     def is_active(self) -> bool:

--- a/src/infra/repositories/subscription_repository_async.py
+++ b/src/infra/repositories/subscription_repository_async.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.domain.ports.subscription_repository_port import SubscriptionRepositoryPort
@@ -109,6 +109,38 @@ class AsyncSubscriptionRepository(SubscriptionRepositoryPort):
         )
         return list(result.scalars().all())
 
+    async def find_trial_end_offer_candidates(
+        self,
+        lookahead_days: int,
+        now: datetime | None = None,
+        fallback_trial_window_days: int = 7,
+    ) -> list[Subscription]:
+        """Trial users charging soon who have not confirmed the discount purchase."""
+        reference = now or utc_now()
+        upper = reference + timedelta(days=lookahead_days)
+        fallback_lower = reference - timedelta(days=fallback_trial_window_days)
+        result = await self.session.execute(
+            select(Subscription).where(
+                and_(
+                    Subscription.status.in_(["active", "cancelled"]),
+                    Subscription.expires_at > reference,
+                    Subscription.expires_at < upper,
+                    Subscription.trial_end_discount_claimed_at.is_(None),
+                    or_(
+                        func.lower(Subscription.period_type) == "trial",
+                        and_(
+                            or_(
+                                Subscription.period_type.is_(None),
+                                Subscription.period_type == "",
+                            ),
+                            Subscription.purchased_at >= fallback_lower,
+                        ),
+                    ),
+                )
+            )
+        )
+        return list(result.scalars().all())
+
     async def cancel(self, subscription_id: str, reason: str = None) -> bool:
         """Cancel a subscription."""
         subscription = await self.find_by_id(subscription_id)
@@ -116,7 +148,7 @@ class AsyncSubscriptionRepository(SubscriptionRepositoryPort):
             subscription.status = "cancelled"
             subscription.updated_at = utc_now()
             if reason:
-                subscription.cancellation_reason = reason
+                subscription.cancel_reason = reason
             await self.session.flush()
             return True
         return False

--- a/src/infra/services/cron_trial_push_service.py
+++ b/src/infra/services/cron_trial_push_service.py
@@ -51,9 +51,11 @@ class CronTrialPushService:
 
     async def _schedule_due_pushes(self, now: datetime) -> int:
         async with AsyncUnitOfWork() as uow:
-            # Active subs whose trial converts to paid within the next day.
-            subs = await uow.subscriptions.find_expiring_in_window(
-                from_days=0, to_days=_LOOKAHEAD_DAYS, now=now
+            # Trial users whose access converts to paid soon and who have not
+            # confirmed the trial-end discount purchase. Cancelled trials remain
+            # eligible while access is still active.
+            subs = await uow.subscriptions.find_trial_end_offer_candidates(
+                lookahead_days=_LOOKAHEAD_DAYS, now=now
             )
             if not subs:
                 return 0
@@ -187,6 +189,7 @@ class CronTrialPushService:
                 "calories_consumed": 0,
                 "gender": (pref or {}).get("gender", "male"),
                 "language_code": (pref or {}).get("language", "en"),
+                "campaign": "trial_end_discount",
             },
             "created_at": utc_now(),
             "expires_at": scheduled_utc + timedelta(days=2),

--- a/tests/fixtures/fakes/fake_subscription_repository.py
+++ b/tests/fixtures/fakes/fake_subscription_repository.py
@@ -65,6 +65,32 @@ class FakeSubscriptionRepository(SubscriptionRepositoryPort):
             and lower <= sub.expires_at < upper
         ]
 
+    async def find_trial_end_offer_candidates(
+        self,
+        lookahead_days: int,
+        now: datetime | None = None,
+        fallback_trial_window_days: int = 7,
+    ) -> list[Subscription]:
+        """Trial users charging soon who have not claimed the trial-end offer."""
+        reference = now or datetime.now()
+        upper = reference + timedelta(days=lookahead_days)
+        fallback_lower = reference - timedelta(days=fallback_trial_window_days)
+        return [
+            sub
+            for sub in self._subscriptions.values()
+            if sub.status in ("active", "cancelled")
+            and sub.expires_at is not None
+            and reference < sub.expires_at < upper
+            and getattr(sub, "trial_end_discount_claimed_at", None) is None
+            and (
+                getattr(sub, "period_type", None) == "trial"
+                or (
+                    not getattr(sub, "period_type", None)
+                    and getattr(sub, "purchased_at", fallback_lower) >= fallback_lower
+                )
+            )
+        ]
+
     async def cancel(self, subscription_id: str, reason: str = None) -> bool:
         """Cancel a subscription."""
         if subscription_id in self._subscriptions:

--- a/tests/unit/api/routes/test_webhooks_cancellation_email.py
+++ b/tests/unit/api/routes/test_webhooks_cancellation_email.py
@@ -1,12 +1,12 @@
 """Tests for cancellation email in RevenueCat webhook."""
 
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.api.routes.v1.webhooks import handle_cancellation
 from src.domain.ports.email_service_port import EmailResult
-from src.infra.config.settings import settings
 
 
 @pytest.fixture
@@ -60,8 +60,10 @@ async def test_cancellation_sends_legacy_backend_email_when_explicitly_enabled(
     event = {"app_user_id": "rc_123", "product_id": "premium_monthly"}
 
     with (
-        patch.object(settings, "CANCELLATION_EMAIL_OWNER", "backend"),
-        patch.object(settings, "EMAIL_ENABLED", True),
+        patch.dict(
+            os.environ,
+            {"CANCELLATION_EMAIL_OWNER": "backend", "EMAIL_ENABLED": "true"},
+        ),
         patch(
             "src.api.routes.v1.webhooks._get_email_service",
             return_value=mock_email_service,
@@ -80,8 +82,10 @@ async def test_cancellation_skips_email_if_opted_out(
     event = {"app_user_id": "rc_123", "product_id": "premium_monthly"}
 
     with (
-        patch.object(settings, "CANCELLATION_EMAIL_OWNER", "backend"),
-        patch.object(settings, "EMAIL_ENABLED", True),
+        patch.dict(
+            os.environ,
+            {"CANCELLATION_EMAIL_OWNER": "backend", "EMAIL_ENABLED": "true"},
+        ),
         patch(
             "src.api.routes.v1.webhooks._get_email_service",
             return_value=mock_email_service,

--- a/tests/unit/api/routes/test_webhooks_cancellation_email.py
+++ b/tests/unit/api/routes/test_webhooks_cancellation_email.py
@@ -6,12 +6,15 @@ import pytest
 
 from src.api.routes.v1.webhooks import handle_cancellation
 from src.domain.ports.email_service_port import EmailResult
+from src.infra.config.settings import settings
 
 
 @pytest.fixture
 def mock_email_service():
     service = AsyncMock()
-    service.send_cancellation_email.return_value = EmailResult(success=True, message_id="msg_123")
+    service.send_cancellation_email.return_value = EmailResult(
+        success=True, message_id="msg_123"
+    )
     return service
 
 
@@ -36,7 +39,9 @@ def mock_uow():
 
 
 @pytest.mark.asyncio
-async def test_cancellation_sends_email(mock_uow, mock_user, mock_email_service):
+async def test_cancellation_skips_backend_email_by_default(
+    mock_uow, mock_user, mock_email_service
+):
     event = {"app_user_id": "rc_123", "product_id": "premium_monthly"}
 
     with patch(
@@ -45,17 +50,42 @@ async def test_cancellation_sends_email(mock_uow, mock_user, mock_email_service)
     ):
         await handle_cancellation(mock_uow, mock_user, event)
 
+        mock_email_service.send_cancellation_email.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_sends_legacy_backend_email_when_explicitly_enabled(
+    mock_uow, mock_user, mock_email_service
+):
+    event = {"app_user_id": "rc_123", "product_id": "premium_monthly"}
+
+    with (
+        patch.object(settings, "CANCELLATION_EMAIL_OWNER", "backend"),
+        patch.object(settings, "EMAIL_ENABLED", True),
+        patch(
+            "src.api.routes.v1.webhooks._get_email_service",
+            return_value=mock_email_service,
+        ),
+    ):
+        await handle_cancellation(mock_uow, mock_user, event)
+
         mock_email_service.send_cancellation_email.assert_called_once_with(mock_user)
 
 
 @pytest.mark.asyncio
-async def test_cancellation_skips_email_if_opted_out(mock_uow, mock_user, mock_email_service):
+async def test_cancellation_skips_email_if_opted_out(
+    mock_uow, mock_user, mock_email_service
+):
     mock_user.email_opt_out = True
     event = {"app_user_id": "rc_123", "product_id": "premium_monthly"}
 
-    with patch(
-        "src.api.routes.v1.webhooks._get_email_service",
-        return_value=mock_email_service,
+    with (
+        patch.object(settings, "CANCELLATION_EMAIL_OWNER", "backend"),
+        patch.object(settings, "EMAIL_ENABLED", True),
+        patch(
+            "src.api.routes.v1.webhooks._get_email_service",
+            return_value=mock_email_service,
+        ),
     ):
         await handle_cancellation(mock_uow, mock_user, event)
 

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -1,6 +1,7 @@
 """
 Unit tests for RevenueCat webhook handler.
 """
+
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +20,7 @@ from src.api.routes.v1.webhooks import (
     parse_timestamp,
     revenuecat_webhook,
 )
+from src.infra.config.settings import settings
 
 
 class TestWebhookHelpers:
@@ -88,7 +90,7 @@ class TestWebhookHandler:
                 "environment": "PRODUCTION",
                 "purchased_at_ms": 1696800000000,
                 "expiration_at_ms": 1699478400000,
-                "transaction_id": "1000000123456789"
+                "transaction_id": "1000000123456789",
             }
         }
 
@@ -97,8 +99,8 @@ class TestWebhookHandler:
         mock_request.json.return_value = webhook_event
 
         # Set a valid webhook secret for the test
-        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
-            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+        with patch("src.api.routes.v1.webhooks.os.getenv", return_value="test_secret"):
+            with patch("src.api.routes.v1.webhooks.AsyncUnitOfWork") as mock_uow_class:
                 mock_uow = MagicMock()
                 mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
                 mock_uow.__aexit__ = AsyncMock(return_value=False)
@@ -118,8 +120,14 @@ class TestWebhookHandler:
                 mock_uow.session.execute.return_value = mock_result
 
                 # Mock no existing subscription (async)
-                with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=None):
-                    result = await revenuecat_webhook(mock_request, authorization="test_secret")
+                with patch(
+                    "src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ):
+                    result = await revenuecat_webhook(
+                        mock_request, authorization="test_secret"
+                    )
 
                 assert result == {"status": "success"}
                 # commit/rollback are owned by the AsyncUnitOfWork context manager, not called explicitly
@@ -134,8 +142,8 @@ class TestWebhookHandler:
         mock_request.json.return_value = webhook_event
 
         # Set a valid webhook secret for the test
-        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
-            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+        with patch("src.api.routes.v1.webhooks.os.getenv", return_value="test_secret"):
+            with patch("src.api.routes.v1.webhooks.AsyncUnitOfWork") as mock_uow_class:
                 mock_uow = MagicMock()
                 mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
                 mock_uow.__aexit__ = AsyncMock(return_value=False)
@@ -155,7 +163,9 @@ class TestWebhookHandler:
 
                 # Mock subscriptions repository (fallback lookup path)
                 mock_uow.subscriptions = MagicMock()
-                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(
+                    return_value=None
+                )
 
                 with caplog.at_level("ERROR"):
                     with pytest.raises(HTTPException) as exc_info:
@@ -179,20 +189,24 @@ class TestWebhookHandler:
             }
         }
 
-        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
-            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+        with patch("src.api.routes.v1.webhooks.os.getenv", return_value="test_secret"):
+            with patch("src.api.routes.v1.webhooks.AsyncUnitOfWork") as mock_uow_class:
                 mock_uow = MagicMock()
                 mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
                 mock_uow.__aexit__ = AsyncMock(return_value=False)
                 mock_uow.subscriptions = MagicMock()
-                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(
+                    return_value=None
+                )
                 mock_uow.session.execute = AsyncMock()
                 mock_result = MagicMock()
                 mock_result.scalars.return_value.first.return_value = None
                 mock_uow.session.execute.return_value = mock_result
                 mock_uow_class.return_value = mock_uow
 
-                result = await revenuecat_webhook(mock_request, authorization="test_secret")
+                result = await revenuecat_webhook(
+                    mock_request, authorization="test_secret"
+                )
 
                 assert result == {"status": "ignored", "reason": "user_not_found"}
 
@@ -225,16 +239,20 @@ class TestWebhookHandler:
             }
         }
 
-        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
-            with patch('src.api.routes.v1.webhooks.AsyncUnitOfWork') as mock_uow_class:
+        with patch("src.api.routes.v1.webhooks.os.getenv", return_value="test_secret"):
+            with patch("src.api.routes.v1.webhooks.AsyncUnitOfWork") as mock_uow_class:
                 mock_uow = MagicMock()
                 mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
                 mock_uow.__aexit__ = AsyncMock(return_value=False)
                 mock_uow.subscriptions = MagicMock()
-                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=None)
+                mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(
+                    return_value=None
+                )
                 mock_uow_class.return_value = mock_uow
 
-                result = await revenuecat_webhook(mock_request, authorization="test_secret")
+                result = await revenuecat_webhook(
+                    mock_request, authorization="test_secret"
+                )
 
                 assert result == {"status": "success"}
 
@@ -243,7 +261,7 @@ class TestWebhookHandler:
         mock_request.json.side_effect = Exception("Invalid JSON")
 
         # Set a valid webhook secret for the test
-        with patch('src.api.routes.v1.webhooks.os.getenv', return_value="test_secret"):
+        with patch("src.api.routes.v1.webhooks.os.getenv", return_value="test_secret"):
             with pytest.raises(HTTPException) as exc_info:
                 await revenuecat_webhook(mock_request, authorization="test_secret")
 
@@ -254,7 +272,7 @@ class TestWebhookHandler:
         """Test webhook authorization check."""
         mock_request.json.return_value = webhook_event
 
-        with patch('src.api.routes.v1.webhooks.os.getenv') as mock_getenv:
+        with patch("src.api.routes.v1.webhooks.os.getenv") as mock_getenv:
             mock_getenv.return_value = "secret_token"
 
             # Test with wrong authorization
@@ -274,12 +292,21 @@ class TestWebhookHandler:
             "purchased_at_ms": 1696800000000,
             "expiration_at_ms": 1699478400000,
             "transaction_id": "123456",
-            "environment": "PRODUCTION"
+            "environment": "PRODUCTION",
         }
 
         # Mock no existing subscription (async) and referral credit side effect
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=None), \
-             patch('src.api.routes.v1.webhooks._credit_referral_on_purchase', new_callable=AsyncMock):
+        with (
+            patch(
+                "src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "src.api.routes.v1.webhooks._credit_referral_on_purchase",
+                new_callable=AsyncMock,
+            ),
+        ):
             await handle_purchase(mock_uow, user, event)
 
         # Verify subscription was added
@@ -289,17 +316,85 @@ class TestWebhookHandler:
         assert added_subscription.product_id == "premium_monthly"
         assert added_subscription.status == "active"
 
+    async def test_handle_purchase_persists_trial_lifecycle_fields(self, mock_uow):
+        """Trial metadata is persisted for D3 push and winback eligibility."""
+        user = MagicMock(id="user_123")
+        event = {
+            "app_user_id": "user_123",
+            "product_id": "premium_monthly",
+            "store": "APP_STORE",
+            "period_type": "TRIAL",
+            "purchased_at_ms": 1696800000000,
+            "expiration_at_ms": 1699478400000,
+            "transaction_id": "123456",
+            "environment": "PRODUCTION",
+        }
+
+        with (
+            patch(
+                "src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "src.api.routes.v1.webhooks._credit_referral_on_purchase",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await handle_purchase(mock_uow, user, event)
+
+        added_subscription = mock_uow.session.add.call_args[0][0]
+        assert added_subscription.period_type == "trial"
+        assert added_subscription.trial_started_at is not None
+        assert added_subscription.trial_expires_at is not None
+
+    async def test_handle_renewal_marks_trial_end_discount_claim(self, mock_uow):
+        """Configured discounted product IDs confirm the offer was claimed."""
+        user = MagicMock(id="user_123")
+        subscription = MagicMock()
+        subscription.trial_started_at = None
+        event = {
+            "app_user_id": "user_123",
+            "product_id": "nutree_trial_end_discount_yearly",
+            "discount_identifier": "trial-end-d3",
+            "period_type": "NORMAL",
+            "purchased_at_ms": 1696800000000,
+            "expiration_at_ms": 1699478400000,
+        }
+
+        with (
+            patch.object(
+                settings,
+                "TRIAL_END_DISCOUNT_PRODUCT_IDS",
+                "nutree_trial_end_discount_yearly",
+            ),
+            patch(
+                "src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id",
+                new_callable=AsyncMock,
+                return_value=subscription,
+            ),
+        ):
+            await handle_renewal(mock_uow, user, event)
+
+        assert subscription.trial_end_discount_claimed_at is not None
+        assert (
+            subscription.trial_end_discount_product_id
+            == "nutree_trial_end_discount_yearly"
+        )
+        assert subscription.trial_end_discount_identifier == "trial-end-d3"
+
     async def test_handle_renewal(self, mock_uow):
         """Test handling renewal event."""
         user = MagicMock(id="user_123")
         subscription = MagicMock()
-        event = {
-            "app_user_id": "user_123",
-            "expiration_at_ms": 1699478400000
-        }
+        event = {"app_user_id": "user_123", "expiration_at_ms": 1699478400000}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id', new_callable=AsyncMock, return_value=subscription):
+        with patch(
+            "src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id",
+            new_callable=AsyncMock,
+            return_value=subscription,
+        ):
             await handle_renewal(mock_uow, user, event)
 
         assert subscription.status == "active"
@@ -312,7 +407,11 @@ class TestWebhookHandler:
         event = {"app_user_id": "user_123"}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_or_create_subscription', new_callable=AsyncMock, return_value=subscription):
+        with patch(
+            "src.api.routes.v1.webhooks.get_or_create_subscription",
+            new_callable=AsyncMock,
+            return_value=subscription,
+        ):
             await handle_cancellation(mock_uow, user, event)
 
         assert subscription.status == "cancelled"
@@ -325,7 +424,11 @@ class TestWebhookHandler:
         event = {"app_user_id": "user_123"}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_or_create_subscription', new_callable=AsyncMock, return_value=subscription):
+        with patch(
+            "src.api.routes.v1.webhooks.get_or_create_subscription",
+            new_callable=AsyncMock,
+            return_value=subscription,
+        ):
             await handle_expiration(mock_uow, user, event)
 
         assert subscription.status == "expired"
@@ -337,7 +440,11 @@ class TestWebhookHandler:
         event = {"app_user_id": "user_123"}
 
         # Mock existing subscription (async)
-        with patch('src.api.routes.v1.webhooks.get_or_create_subscription', new_callable=AsyncMock, return_value=subscription):
+        with patch(
+            "src.api.routes.v1.webhooks.get_or_create_subscription",
+            new_callable=AsyncMock,
+            return_value=subscription,
+        ):
             await handle_billing_issue(mock_uow, user, event)
 
         assert subscription.status == "billing_issue"
@@ -350,7 +457,9 @@ class TestWebhookHandler:
             "transferred_to": ["firebase_uid_123", "$RCAnonymousID:new"],
         }
         mock_uow.subscriptions = MagicMock()
-        mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(return_value=subscription)
+        mock_uow.subscriptions.find_by_revenuecat_id = AsyncMock(
+            return_value=subscription
+        )
 
         await handle_transfer(mock_uow, event)
 

--- a/tests/unit/api/test_webhook_handler.py
+++ b/tests/unit/api/test_webhook_handler.py
@@ -2,6 +2,7 @@
 Unit tests for RevenueCat webhook handler.
 """
 
+import os
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,7 +21,6 @@ from src.api.routes.v1.webhooks import (
     parse_timestamp,
     revenuecat_webhook,
 )
-from src.infra.config.settings import settings
 
 
 class TestWebhookHelpers:
@@ -363,10 +363,13 @@ class TestWebhookHandler:
         }
 
         with (
-            patch.object(
-                settings,
-                "TRIAL_END_DISCOUNT_PRODUCT_IDS",
-                "nutree_trial_end_discount_yearly",
+            patch.dict(
+                os.environ,
+                {
+                    "TRIAL_END_DISCOUNT_PRODUCT_IDS": (
+                        "nutree_trial_end_discount_yearly"
+                    )
+                },
             ),
             patch(
                 "src.api.routes.v1.webhooks.get_subscription_by_revenuecat_id",

--- a/tests/unit/domain/ports/test_async_repository_contracts.py
+++ b/tests/unit/domain/ports/test_async_repository_contracts.py
@@ -60,6 +60,7 @@ def test_repository_ports_are_async_contracts():
             "find_active_by_user_id",
             "find_expiring_soon",
             "find_expiring_in_window",
+            "find_trial_end_offer_candidates",
             "cancel",
             "reactivate",
             "update_payment_status",

--- a/tests/unit/infra/repositories/test_subscription_repository_async.py
+++ b/tests/unit/infra/repositories/test_subscription_repository_async.py
@@ -67,3 +67,21 @@ async def test_find_expiring_soon_returns_active_future_rows():
     assert "subscriptions.status" in compiled
     assert "subscriptions.expires_at <= " in compiled
     assert "subscriptions.expires_at > " in compiled
+
+
+@pytest.mark.asyncio
+async def test_find_trial_end_offer_candidates_allows_cancelled_unexpired_trials():
+    rows = [MagicMock(id="sub-trial")]
+    session = _AsyncSession(rows)
+    repo = AsyncSubscriptionRepository(session)
+    now = datetime(2026, 6, 9, tzinfo=UTC)
+
+    result = await repo.find_trial_end_offer_candidates(lookahead_days=1, now=now)
+
+    assert result == rows
+    compiled = str(session.statement)
+    assert "subscriptions.status IN" in compiled
+    assert "subscriptions.expires_at > " in compiled
+    assert "subscriptions.expires_at < " in compiled
+    assert "trial_end_discount_claimed_at IS NULL" in compiled
+    assert "lower(subscriptions.period_type)" in compiled

--- a/tests/unit/infra/services/test_cron_trial_push_service.py
+++ b/tests/unit/infra/services/test_cron_trial_push_service.py
@@ -24,7 +24,7 @@ def _make_sub(user_id: str, expires_at: datetime, status: str = "active"):
 def _patch_uow_with_subs(subs):
     """Build an async context-manager mock wired to return `subs`."""
     uow_cm = MagicMock()
-    uow_cm.subscriptions.find_expiring_in_window = AsyncMock(return_value=subs)
+    uow_cm.subscriptions.find_trial_end_offer_candidates = AsyncMock(return_value=subs)
     uow_cm.session = MagicMock()
     uow_cm.session.execute = AsyncMock(return_value=MagicMock(rowcount=len(subs)))
     uow_cm.session.flush = AsyncMock()
@@ -43,23 +43,29 @@ async def test_schedules_row_for_active_expiring_sub_with_token():
 
     uow_ctx, _uow = _patch_uow_with_subs([sub])
 
-    with patch(
-        "src.infra.services.cron_trial_push_service.AsyncUnitOfWork",
-        return_value=uow_ctx,
-    ), patch.object(
-        CronTrialPushService,
-        "_fetch_prefs",
-        AsyncMock(return_value={
-            user_id: {
-                "language": "en",
-                "timezone": "Asia/Ho_Chi_Minh",
-                "gender": "male",
-            }
-        }),
-    ), patch.object(
-        CronTrialPushService,
-        "_fetch_fcm_tokens",
-        AsyncMock(return_value={user_id: ["tok1", "tok2"]}),
+    with (
+        patch(
+            "src.infra.services.cron_trial_push_service.AsyncUnitOfWork",
+            return_value=uow_ctx,
+        ),
+        patch.object(
+            CronTrialPushService,
+            "_fetch_prefs",
+            AsyncMock(
+                return_value={
+                    user_id: {
+                        "language": "en",
+                        "timezone": "Asia/Ho_Chi_Minh",
+                        "gender": "male",
+                    }
+                }
+            ),
+        ),
+        patch.object(
+            CronTrialPushService,
+            "_fetch_fcm_tokens",
+            AsyncMock(return_value={user_id: ["tok1", "tok2"]}),
+        ),
     ):
         n = await svc.check_and_schedule_pushes(NOW_UTC)
         assert n >= 1
@@ -73,23 +79,29 @@ async def test_skips_user_without_fcm_token():
 
     uow_ctx, _uow = _patch_uow_with_subs([sub])
 
-    with patch(
-        "src.infra.services.cron_trial_push_service.AsyncUnitOfWork",
-        return_value=uow_ctx,
-    ), patch.object(
-        CronTrialPushService,
-        "_fetch_prefs",
-        AsyncMock(return_value={
-            user_id: {
-                "language": "en",
-                "timezone": "UTC",
-                "gender": "male",
-            }
-        }),
-    ), patch.object(
-        CronTrialPushService,
-        "_fetch_fcm_tokens",
-        AsyncMock(return_value={}),  # no tokens
+    with (
+        patch(
+            "src.infra.services.cron_trial_push_service.AsyncUnitOfWork",
+            return_value=uow_ctx,
+        ),
+        patch.object(
+            CronTrialPushService,
+            "_fetch_prefs",
+            AsyncMock(
+                return_value={
+                    user_id: {
+                        "language": "en",
+                        "timezone": "UTC",
+                        "gender": "male",
+                    }
+                }
+            ),
+        ),
+        patch.object(
+            CronTrialPushService,
+            "_fetch_fcm_tokens",
+            AsyncMock(return_value={}),  # no tokens
+        ),
     ):
         n = await svc.check_and_schedule_pushes(NOW_UTC)
         assert n == 0
@@ -117,7 +129,7 @@ async def test_runs_single_schedule_pass():
 
 @pytest.mark.asyncio
 async def test_queries_next_day_charge_window():
-    """Subs charging within the next day are considered (from_days=0, to_days=1)."""
+    """Trial-end offer candidates charging within the next day are considered."""
     svc = CronTrialPushService()
     uow_ctx, uow = _patch_uow_with_subs([])
     with patch(
@@ -125,8 +137,8 @@ async def test_queries_next_day_charge_window():
         return_value=uow_ctx,
     ):
         await svc.check_and_schedule_pushes(NOW_UTC)
-    uow.subscriptions.find_expiring_in_window.assert_awaited_once_with(
-        from_days=0, to_days=1, now=NOW_UTC
+    uow.subscriptions.find_trial_end_offer_candidates.assert_awaited_once_with(
+        lookahead_days=1, now=NOW_UTC
     )
 
 
@@ -140,7 +152,9 @@ async def test_language_resolution_falls_back_to_users_language_code():
     row.timezone = "Asia/Ho_Chi_Minh"
     row.gender = "female"
     row.language_code = "vi"
-    session.execute = AsyncMock(return_value=MagicMock(fetchall=MagicMock(return_value=[row])))
+    session.execute = AsyncMock(
+        return_value=MagicMock(fetchall=MagicMock(return_value=[row]))
+    )
 
     out = await CronTrialPushService._fetch_prefs(session, ["u1"])
     assert out["u1"]["language"] == "vi"
@@ -155,7 +169,9 @@ async def test_language_resolution_pref_overrides_user():
     row.timezone = "UTC"
     row.gender = "male"
     row.language_code = "vi"
-    session.execute = AsyncMock(return_value=MagicMock(fetchall=MagicMock(return_value=[row])))
+    session.execute = AsyncMock(
+        return_value=MagicMock(fetchall=MagicMock(return_value=[row]))
+    )
 
     out = await CronTrialPushService._fetch_prefs(session, ["u1"])
     assert out["u1"]["language"] == "en"
@@ -170,7 +186,9 @@ async def test_language_resolution_unknown_falls_back_to_en():
     row.timezone = "UTC"
     row.gender = "male"
     row.language_code = "de"
-    session.execute = AsyncMock(return_value=MagicMock(fetchall=MagicMock(return_value=[row])))
+    session.execute = AsyncMock(
+        return_value=MagicMock(fetchall=MagicMock(return_value=[row]))
+    )
 
     out = await CronTrialPushService._fetch_prefs(session, ["u1"])
     assert out["u1"]["language"] == "en"
@@ -198,6 +216,7 @@ def test_build_row_schedules_two_hours_before_charge():
     assert row["context"]["language_code"] == "vi"
     assert row["context"]["gender"] == "female"
     assert row["context"]["fcm_tokens"] == ["tok1"]
+    assert row["context"]["campaign"] == "trial_end_discount"
     assert row["expires_at"] == row["scheduled_for_utc"] + timedelta(days=2)
 
 


### PR DESCRIPTION
## Summary
- persist RevenueCat trial, cancellation, and trial-end discount claim state on subscriptions
- expand trial push eligibility to active and cancelled-but-unexpired trials that have not claimed the discount
- gate the legacy backend cancellation email sender so PostHog Workflows can own winback email
- document rollout/ownership and add plan artifacts

## Test plan
- [x] uv run ruff check touched backend files
- [x] uv run pytest tests/unit/infra/services/test_cron_trial_push_service.py tests/unit/infra/repositories/test_subscription_repository_async.py tests/unit/domain/ports/test_async_repository_contracts.py tests/unit/api/routes/test_webhooks_cancellation_email.py tests/unit/api/test_webhook_handler.py -q
- [x] push hook full unit suite: 1812 passed

## Rollout notes
- Set TRIAL_END_DISCOUNT_PRODUCT_IDS and/or TRIAL_END_DISCOUNT_IDENTIFIERS before enabling campaign targeting.
- Keep CANCELLATION_EMAIL_OWNER=posthog unless explicitly rolling back to backend email.
- PostHog Workflow/channel setup and RevenueCat sandbox QA remain external launch gates.