### PR TITLE
feat(food-label): add hybrid OCR parser

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -34,7 +34,6 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/meals/image/analyze` | Analyze meal from image (immediate upload) |
-| POST | `/v1/meals/food-label/analyze` | Deprecated; returns 410 |
 | GET | `/v1/meals/upload-token` | Create signed direct-upload token |
 | POST | `/v1/meals/scan-by-url` | Analyze meal from an existing image URL |
 | POST | `/v1/meals/food-label/scan-by-url` | Analyze Nutrition Facts label from an existing image URL |

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -34,7 +34,7 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/meals/image/analyze` | Analyze meal from image (immediate upload) |
-| POST | `/v1/meals/food-label/analyze` | Analyze Nutrition Facts label from image upload |
+| POST | `/v1/meals/food-label/analyze` | Deprecated; returns 410 |
 | GET | `/v1/meals/upload-token` | Create signed direct-upload token |
 | POST | `/v1/meals/scan-by-url` | Analyze meal from an existing image URL |
 | POST | `/v1/meals/food-label/scan-by-url` | Analyze Nutrition Facts label from an existing image URL |
@@ -51,9 +51,9 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 
 ### Food Label OCR Contract
 
-- `/v1/meals/food-label/scan-by-url` accepts optional `ocr_text_lines` from native client OCR.
-- When `FOOD_LABEL_OCR_FIRST_ENABLED=true`, the backend attempts deterministic parsing before AI image analysis.
-- OCR parse failures, sparse text, missing fields, and conflicting values fall back to the existing AI image path.
+- `/v1/meals/food-label/scan-by-url` requires `ocr_text_lines` from native client OCR.
+- The backend parses OCR text deterministically and does not send food-label images to AI analysis.
+- Missing OCR text, sparse text, missing fields, and conflicting values fail cleanly without AI fallback.
 - The backend remains source of truth for validation and derives calories from macros; clients must not calculate label nutrition.
 
 ---

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,6 +1,6 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** June 27, 2026
+**Last Updated:** July 2, 2026
 **Base URL:** `http://localhost:8000` (dev) or deployed host
 **API Docs:** `/docs` (Swagger UI)
 **Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
@@ -34,8 +34,10 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/meals/image/analyze` | Analyze meal from image (immediate upload) |
+| POST | `/v1/meals/food-label/analyze` | Analyze Nutrition Facts label from image upload |
 | GET | `/v1/meals/upload-token` | Create signed direct-upload token |
 | POST | `/v1/meals/scan-by-url` | Analyze meal from an existing image URL |
+| POST | `/v1/meals/food-label/scan-by-url` | Analyze Nutrition Facts label from an existing image URL |
 | POST | `/v1/meals/manual` | Create meal from USDA foods |
 | POST | `/v1/meals/parse-text` | Parse meal from text description |
 | POST | `/v1/meals/parse-text/guest-trial` | One-shot guest text parse trial |
@@ -46,6 +48,13 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | GET | `/v1/meals/{meal_id}` | Get meal details |
 | DELETE | `/v1/meals/{meal_id}` | Delete meal (soft delete) |
 | PUT | `/v1/meals/{meal_id}/ingredients` | Update meal ingredients |
+
+### Food Label OCR Contract
+
+- `/v1/meals/food-label/scan-by-url` accepts optional `ocr_text_lines` from native client OCR.
+- When `FOOD_LABEL_OCR_FIRST_ENABLED=true`, the backend attempts deterministic parsing before AI image analysis.
+- OCR parse failures, sparse text, missing fields, and conflicting values fall back to the existing AI image path.
+- The backend remains source of truth for validation and derives calories from macros; clients must not calculate label nutrition.
 
 ---
 

--- a/docs/beverage-scan.md
+++ b/docs/beverage-scan.md
@@ -23,14 +23,16 @@ Mobile → POST /v1/meals/image/analyze or /v1/meals/scan-by-url
          ↓
 UploadMealImageImmediatelyHandler or ScanByUrlCommandHandler
   1. Get image bytes (multipart upload or Cloudinary URL download)
-  2. For `scan_mode="food_label"`, call `VisionAIService.analyze_food_label(...)`
-     and persist `Meal(source="food_label")`
-  3. Otherwise call `VisionAIService.analyze(...)`
-  4. Validate `is_food`
-  5. Parse normal nutrition foods
-  6. Persist `Meal(source="scanner")`
-  7. Invalidate meal caches
+  2. Call `VisionAIService.analyze(...)`
+  3. Validate `is_food`
+  4. Parse normal nutrition foods
+  5. Persist `Meal(source="scanner")`
+  6. Invalidate meal caches
 ```
+
+Food-label scans do not use this image-AI flow. Clients upload through the
+signed Cloudinary flow, run native OCR, then call
+`/v1/meals/food-label/scan-by-url` with `ocr_text_lines`.
 
 Meal scan must not create `hydration_entries`.
 

--- a/src/api/routes/v1/meal_scan_by_url.py
+++ b/src/api/routes/v1/meal_scan_by_url.py
@@ -34,6 +34,7 @@ class FoodLabelScanByUrlRequest(BaseModel):
     image_url: str
     image_id: str
     target_date: str | None = None
+    ocr_text_lines: list[str] | None = None
 
 
 def _validate_cloudinary_url(image_url: str, image_id: str) -> None:
@@ -75,6 +76,7 @@ async def _scan_by_url(
     target_date: str | None,
     user_description: str | None,
     scan_mode: str,
+    ocr_text_lines: list[str] | None = None,
 ) -> DetailedMealResponse:
     _validate_cloudinary_url(image_url, image_id)
 
@@ -93,6 +95,7 @@ async def _scan_by_url(
         target_date=parsed_target_date,
         language=language,
         scan_mode=scan_mode,
+        ocr_text_lines=ocr_text_lines,
     )
 
     try:
@@ -179,6 +182,7 @@ async def scan_food_label_by_url(
             target_date=body.target_date,
             user_description=None,
             scan_mode="food_label",
+            ocr_text_lines=body.ocr_text_lines,
             event_bus=event_bus,
         )
     except ValidationException:

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -259,38 +259,6 @@ async def analyze_meal_image_immediate(
         raise handle_exception(e) from e
 
 
-@router.post(
-    "/food-label/analyze",
-    status_code=status.HTTP_410_GONE,
-)
-@limiter.limit("10/minute")
-async def analyze_food_label_image_immediate(
-    request: Request,
-    file: UploadFile = File(...),
-    user_id: str = Depends(get_current_user_id),
-    target_date: str | None = Query(
-        None, description="Target date in YYYY-MM-DD format for meal association"
-    ),
-    event_bus: EventBus = Depends(get_configured_event_bus),
-    image_store=Depends(get_image_store),
-    cache_service: CachePort | None = Depends(get_cache_service),
-    task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
-    ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
-):
-    """Deprecated food-label image analysis endpoint."""
-    raise HTTPException(
-        status_code=status.HTTP_410_GONE,
-        detail={
-            "message": (
-                "Food-label scans require client OCR text. "
-                "Upload the image with /v1/meals/upload-token, then call "
-                "/v1/meals/food-label/scan-by-url with ocr_text_lines."
-            ),
-            "error_code": "FOOD_LABEL_IMAGE_ANALYSIS_DEPRECATED",
-        },
-    )
-
-
 @router.post("/manual", response_model=ManualMealCreationResponse)
 async def create_manual_meal(
     request: Request,

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -216,7 +216,7 @@ async def analyze_meal_image_immediate(
     ),
     scan_mode: str = Query(
         "scanner",
-        description="scanner for meal photos. Use /food-label/analyze for Nutrition Facts labels.",
+        description="scanner for meal photos. Use /food-label/scan-by-url with OCR text for Nutrition Facts labels.",
     ),
     event_bus: EventBus = Depends(get_configured_event_bus),
     image_store=Depends(get_image_store),
@@ -233,7 +233,10 @@ async def analyze_meal_image_immediate(
     try:
         if scan_mode != "scanner":
             raise ValidationException(
-                message="Use /v1/meals/food-label/analyze for Nutrition Facts labels.",
+                message=(
+                    "Use /v1/meals/food-label/scan-by-url with OCR text "
+                    "for Nutrition Facts labels."
+                ),
                 error_code="INVALID_SCAN_MODE",
                 details={"scan_mode": scan_mode},
             )
@@ -258,8 +261,7 @@ async def analyze_meal_image_immediate(
 
 @router.post(
     "/food-label/analyze",
-    status_code=status.HTTP_200_OK,
-    response_model=DetailedMealResponse,
+    status_code=status.HTTP_410_GONE,
 )
 @limiter.limit("10/minute")
 async def analyze_food_label_image_immediate(
@@ -275,23 +277,18 @@ async def analyze_food_label_image_immediate(
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
 ):
-    """Analyze a packaged-food Nutrition Facts label."""
-    try:
-        return await _analyze_uploaded_image(
-            request=request,
-            file=file,
-            user_id=user_id,
-            target_date=target_date,
-            user_description=None,
-            scan_mode="food_label",
-            event_bus=event_bus,
-            image_store=image_store,
-            cache_service=cache_service,
-            task_manager=task_manager,
-            ai_manager=ai_manager,
-        )
-    except Exception as e:
-        raise handle_exception(e) from e
+    """Deprecated food-label image analysis endpoint."""
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail={
+            "message": (
+                "Food-label scans require client OCR text. "
+                "Upload the image with /v1/meals/upload-token, then call "
+                "/v1/meals/food-label/scan-by-url with ocr_text_lines."
+            ),
+            "error_code": "FOOD_LABEL_IMAGE_ANALYSIS_DEPRECATED",
+        },
+    )
 
 
 @router.post("/manual", response_model=ManualMealCreationResponse)

--- a/src/app/commands/meal/scan_by_url_command.py
+++ b/src/app/commands/meal/scan_by_url_command.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Optional
 
 from src.app.events.base import Command
 
@@ -14,7 +13,8 @@ class ScanByUrlCommand(Command):
     user_id: str
     image_url: str
     public_id: str
-    user_description: Optional[str] = None
-    target_date: Optional[date] = None
+    user_description: str | None = None
+    target_date: date | None = None
     language: str = "en"
     scan_mode: str = "scanner"
+    ocr_text_lines: list[str] | None = None

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -33,7 +33,6 @@ from src.domain.utils.timezone_utils import (
     noon_utc_for_date,
     utc_now,
 )
-from src.infra.config.settings import get_settings
 from src.observability import capture_message, distribution_metric, increment_metric
 
 logger = logging.getLogger(__name__)
@@ -142,39 +141,36 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
             # Vision analysis via bytes path (never sends URL to the AI provider)
             if command.scan_mode == "food_label":
                 ocr_started = time.time()
-                ocr_enabled = get_settings().FOOD_LABEL_OCR_FIRST_ENABLED
-                has_ocr_text = bool(command.ocr_text_lines)
-                if ocr_enabled and has_ocr_text:
-                    self._record_ocr_metric("food_label_ocr.attempt")
-                    ocr_result = self.food_label_ocr_parser.parse(
-                        command.ocr_text_lines
-                    )
-                    elapsed_ms = (time.time() - ocr_started) * 1000
-                    if ocr_result.succeeded:
-                        self._record_ocr_metric(
-                            "food_label_ocr.success",
-                            elapsed_ms=elapsed_ms,
-                        )
-                        self._record_ocr_metric("food_label_ocr.ai_avoided")
-                        vision_result = {"structured_data": ocr_result.structured_data}
-                    else:
-                        reason = ",".join(ocr_result.failure_reasons[:3])
-                        self._record_ocr_metric(
-                            "food_label_ocr.fallback_to_ai",
-                            reason=reason or "unknown",
-                            elapsed_ms=elapsed_ms,
-                        )
-                        vision_result = await self.vision_service.analyze_food_label(
-                            image_bytes
-                        )
-                else:
+                if not command.ocr_text_lines:
                     self._record_ocr_metric(
-                        "food_label_ocr.skipped",
-                        reason="disabled" if not ocr_enabled else "no_ocr_text",
+                        "food_label_ocr.rejected",
+                        reason="no_ocr_text",
                     )
-                    vision_result = await self.vision_service.analyze_food_label(
-                        image_bytes
+                    raise ValueError(
+                        "Nutrition Facts label text could not be read. "
+                        "Please retake the label photo and try again."
                     )
+
+                self._record_ocr_metric("food_label_ocr.attempt")
+                ocr_result = self.food_label_ocr_parser.parse(command.ocr_text_lines)
+                elapsed_ms = (time.time() - ocr_started) * 1000
+                if not ocr_result.succeeded:
+                    reason = ",".join(ocr_result.failure_reasons[:3])
+                    self._record_ocr_metric(
+                        "food_label_ocr.failure",
+                        reason=reason or "unknown",
+                        elapsed_ms=elapsed_ms,
+                    )
+                    raise ValueError(
+                        "Nutrition Facts label could not be parsed from OCR text. "
+                        "Please retake the label photo and try again."
+                    )
+
+                self._record_ocr_metric(
+                    "food_label_ocr.success",
+                    elapsed_ms=elapsed_ms,
+                )
+                vision_result = {"structured_data": ocr_result.structured_data}
             elif command.user_description:
                 from src.domain.strategies.meal_analysis_strategy import (
                     AnalysisStrategyFactory,

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -19,6 +19,7 @@ from src.domain.parsers.vision_response_parser import (
 )
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
+from src.domain.services.food_label_ocr_parser import FoodLabelOcrParser
 from src.domain.services.meal_analysis.deepl_meal_translation_service import (
     DeepLMealTranslationService,
 )
@@ -32,7 +33,8 @@ from src.domain.utils.timezone_utils import (
     noon_utc_for_date,
     utc_now,
 )
-from src.observability import capture_message
+from src.infra.config.settings import get_settings
+from src.observability import capture_message, distribution_metric, increment_metric
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         gpt_parser: GPTResponseParser = None,
         meal_translation_service: DeepLMealTranslationService | None = None,
         cache_invalidation: CacheInvalidationService | None = None,
+        food_label_ocr_parser: FoodLabelOcrParser | None = None,
     ):
         self.uow = uow
         self.event_bus = event_bus
@@ -56,6 +59,26 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         self.gpt_parser = gpt_parser
         self.meal_translation_service = meal_translation_service
         self.cache_invalidation = cache_invalidation
+        self.food_label_ocr_parser = food_label_ocr_parser or FoodLabelOcrParser()
+
+    def _record_ocr_metric(
+        self,
+        name: str,
+        *,
+        reason: str | None = None,
+        elapsed_ms: float | None = None,
+    ) -> None:
+        attributes = {"component": "food_label_ocr"}
+        if reason:
+            attributes["reason"] = reason
+        increment_metric(name, attributes=attributes)
+        if elapsed_ms is not None:
+            distribution_metric(
+                "food_label_ocr.parse_latency_ms",
+                elapsed_ms,
+                unit="millisecond",
+                attributes=attributes,
+            )
 
     def _capture_rejected_scan(
         self,
@@ -118,9 +141,40 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
 
             # Vision analysis via bytes path (never sends URL to the AI provider)
             if command.scan_mode == "food_label":
-                vision_result = await self.vision_service.analyze_food_label(
-                    image_bytes
-                )
+                ocr_started = time.time()
+                ocr_enabled = get_settings().FOOD_LABEL_OCR_FIRST_ENABLED
+                has_ocr_text = bool(command.ocr_text_lines)
+                if ocr_enabled and has_ocr_text:
+                    self._record_ocr_metric("food_label_ocr.attempt")
+                    ocr_result = self.food_label_ocr_parser.parse(
+                        command.ocr_text_lines
+                    )
+                    elapsed_ms = (time.time() - ocr_started) * 1000
+                    if ocr_result.succeeded:
+                        self._record_ocr_metric(
+                            "food_label_ocr.success",
+                            elapsed_ms=elapsed_ms,
+                        )
+                        self._record_ocr_metric("food_label_ocr.ai_avoided")
+                        vision_result = {"structured_data": ocr_result.structured_data}
+                    else:
+                        reason = ",".join(ocr_result.failure_reasons[:3])
+                        self._record_ocr_metric(
+                            "food_label_ocr.fallback_to_ai",
+                            reason=reason or "unknown",
+                            elapsed_ms=elapsed_ms,
+                        )
+                        vision_result = await self.vision_service.analyze_food_label(
+                            image_bytes
+                        )
+                else:
+                    self._record_ocr_metric(
+                        "food_label_ocr.skipped",
+                        reason="disabled" if not ocr_enabled else "no_ocr_text",
+                    )
+                    vision_result = await self.vision_service.analyze_food_label(
+                        image_bytes
+                    )
             elif command.user_description:
                 from src.domain.strategies.meal_analysis_strategy import (
                     AnalysisStrategyFactory,

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 from src.app.commands.meal import UploadMealImageImmediatelyCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.cache_invalidation_service import CacheInvalidationService
-from src.domain.constants import MealDefaults
 from src.domain.exceptions.ai_exceptions import AIVisionError, AIVisionFailureKind
 from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_projection import MealProjection
@@ -78,15 +77,6 @@ class UploadMealImageImmediatelyHandler(
 
         for attempt in range(1, max_attempts + 1):
             try:
-                if command.scan_mode == "food_label":
-                    logger.info(
-                        f"[PHASE-1-START] meal={meal_id} | "
-                        f"food label analysis | attempt={attempt}/{max_attempts}"
-                    )
-                    return await self.vision_service.analyze_food_label(
-                        command.file_contents
-                    )
-
                 if command.user_description:
                     from src.domain.strategies.meal_analysis_strategy import (
                         AnalysisStrategyFactory,
@@ -229,61 +219,6 @@ class UploadMealImageImmediatelyHandler(
             f"[ANALYSIS-COMPLETE] image_id={image_id} | elapsed={analysis_elapsed:.2f}s"
         )
 
-        if command.scan_mode == "food_label":
-            nutrition = self.gpt_parser.parse_food_label_to_nutrition(analysis_result)
-            label_metadata = self.gpt_parser.parse_food_label_metadata(analysis_result)
-            if not label_metadata.get("is_food_label", True):
-                raise ValueError(
-                    "Nutrition Facts label could not be read. "
-                    "Please retake the label photo and try again."
-                )
-
-            async with self.uow as uow:
-                user_timezone = await uow.users.get_user_timezone(command.user_id)
-                if not user_timezone or not is_valid_timezone(user_timezone):
-                    user_timezone = "UTC"
-
-                now = utc_now()
-                meal_date = command.target_date if command.target_date else now.date()
-                if command.target_date and command.target_date != now.date():
-                    meal_datetime = noon_utc_for_date(meal_date, user_timezone)
-                else:
-                    meal_datetime = now
-
-                zone_info = get_zone_info(user_timezone)
-                local_datetime = meal_datetime.astimezone(zone_info)
-                meal_type = determine_meal_type_from_timestamp(local_datetime)
-
-                meal = Meal(
-                    meal_id=str(uuid4()),
-                    user_id=command.user_id,
-                    status=MealStatus.READY,
-                    created_at=meal_datetime,
-                    meal_type=meal_type,
-                    image=MealImage(
-                        image_id=image_id,
-                        format="jpeg" if "jpeg" in command.content_type else "png",
-                        size_bytes=len(command.file_contents),
-                        url=image_url,
-                    ),
-                    source="food_label",
-                    dish_name=MealDefaults.UNNAMED_FOOD_NAME,
-                    ready_at=utc_now(),
-                    raw_gpt_json=self.gpt_parser.extract_raw_json(analysis_result),
-                    food_label_metadata=label_metadata,
-                    nutrition=nutrition,
-                )
-
-                saved_meal = await uow.meals.save(meal)
-                await uow.commit()
-
-            if self.cache_invalidation:
-                await self.cache_invalidation.after_meal_write(
-                    command.user_id, meal_date
-                )
-
-            return saved_meal
-
         # Step 5: Parse nutrition and validate food detected.
         if not self.gpt_parser.parse_is_food(analysis_result):
             self._capture_rejected_scan(
@@ -399,6 +334,12 @@ class UploadMealImageImmediatelyHandler(
 
     async def handle(self, command: UploadMealImageImmediatelyCommand) -> Meal:
         """Handle immediate meal image upload and analysis."""
+        if command.scan_mode == "food_label":
+            raise ValueError(
+                "Food-label scans require client OCR text. "
+                "Use /v1/meals/food-label/scan-by-url."
+            )
+
         if not all([self.image_store, self.vision_service, self.gpt_parser]):
             raise RuntimeError("Required dependencies not configured")
 

--- a/src/domain/model/ai/model_purpose.py
+++ b/src/domain/model/ai/model_purpose.py
@@ -5,7 +5,6 @@ from enum import Enum
 
 class ModelPurpose(Enum):
     MEAL_SCAN = "meal_scan"
-    FOOD_LABEL_SCAN = "food_label_scan"
     INGREDIENT_SCAN = "ingredient_scan"
     PARSE_TEXT = "parse_text"
     BARCODE = "barcode"

--- a/src/domain/ports/vision_ai_service_port.py
+++ b/src/domain/ports/vision_ai_service_port.py
@@ -32,19 +32,6 @@ class VisionAIServicePort(ABC):
         pass
 
     @abstractmethod
-    async def analyze_food_label(self, image_bytes: bytes) -> dict[str, Any]:
-        """
-        Analyze a packaged food Nutrition Facts label image.
-
-        Args:
-            image_bytes: The raw bytes of the image to analyze
-
-        Returns:
-            JSON-compatible dictionary with the raw AI response
-        """
-        pass
-
-    @abstractmethod
     async def analyze_by_url_with_strategy(
         self, image_url: str, strategy: MealAnalysisStrategy
     ) -> dict[str, Any]:

--- a/src/domain/services/food_label_ocr_parser.py
+++ b/src/domain/services/food_label_ocr_parser.py
@@ -1,0 +1,194 @@
+"""Deterministic parser for OCR text from Nutrition Facts labels."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class FoodLabelOcrParseResult:
+    structured_data: dict | None = None
+    failure_reasons: list[str] = field(default_factory=list)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.structured_data is not None and not self.failure_reasons
+
+
+class FoodLabelOcrParser:
+    """Parse common US Nutrition Facts OCR lines into the food-label contract."""
+
+    _NUMBER = r"(\d+(?:\.\d+)?)"
+    _MACRO_ALIASES = {
+        "fat_g": ("total fat", "fat"),
+        "carbs_g": ("total carbohydrate", "total carb", "carbohydrate"),
+        "fiber_g": ("dietary fiber", "fiber"),
+        "sugar_g": ("total sugars", "sugars", "sugar"),
+        "protein_g": ("protein",),
+    }
+
+    def parse(self, ocr_lines: list[str] | None) -> FoodLabelOcrParseResult:
+        lines = self._clean_lines(ocr_lines)
+        if len(lines) < 4:
+            return FoodLabelOcrParseResult(failure_reasons=["ocr_text_too_sparse"])
+
+        reasons: list[str] = []
+        serving_size = self._parse_serving_size(lines)
+        if not serving_size:
+            reasons.append("missing_serving_size")
+
+        servings_per_package = self._parse_servings_per_package(lines)
+        if servings_per_package is None:
+            reasons.append("missing_servings_per_package")
+
+        macros, macro_reasons = self._parse_macros(lines)
+        reasons.extend(macro_reasons)
+
+        label_calories = self._parse_calories(lines)
+        if label_calories is not None and not self._calories_match_macros(
+            label_calories, macros
+        ):
+            reasons.append("conflicting_label_calories")
+
+        if reasons:
+            return FoodLabelOcrParseResult(failure_reasons=reasons)
+
+        product_name = self._parse_product_name(lines)
+        return FoodLabelOcrParseResult(
+            structured_data={
+                "is_food_label": True,
+                "product_name": product_name or "Scanned Food Label",
+                "brand": None,
+                "serving_size": serving_size,
+                "servings_per_package": servings_per_package,
+                "label_calories_per_serving": label_calories,
+                "macros_per_serving": macros,
+                "confidence": 0.88,
+                "label_notes": ["Parsed from OCR text."],
+            }
+        )
+
+    def _clean_lines(self, ocr_lines: list[str] | None) -> list[str]:
+        if not ocr_lines:
+            return []
+        cleaned: list[str] = []
+        for line in ocr_lines:
+            text = re.sub(r"\s+", " ", str(line)).strip()
+            if text:
+                cleaned.append(text)
+        return cleaned[:80]
+
+    def _parse_serving_size(self, lines: list[str]) -> dict | None:
+        for line in lines:
+            lower = line.lower()
+            if "serving size" not in lower:
+                continue
+            grams = self._first_number_before_unit(line, "g")
+            if grams is None:
+                continue
+            display = line.split(":", 1)[-1].strip()
+            display = re.sub(r"(?i)^serving size\s*", "", display).strip()
+            return {"display_text": display or f"{grams:g}g", "grams": grams}
+        return None
+
+    def _parse_servings_per_package(self, lines: list[str]) -> float | None:
+        patterns = (
+            rf"(?:about\s+)?{self._NUMBER}\s+servings?\s+per\s+(?:container|package)",
+            rf"servings?\s+per\s+(?:container|package)\s*(?:about\s*)?{self._NUMBER}",
+        )
+        for line in lines:
+            lower = line.lower()
+            for pattern in patterns:
+                match = re.search(pattern, lower)
+                if match:
+                    return float(match.group(1))
+        return None
+
+    def _parse_macros(self, lines: list[str]) -> tuple[dict, list[str]]:
+        macros: dict[str, float] = {}
+        reasons: list[str] = []
+        for field_name, aliases in self._MACRO_ALIASES.items():
+            values = [
+                value
+                for line in lines
+                if (value := self._parse_macro_line(line, aliases)) is not None
+            ]
+            if not values:
+                if field_name in {"fiber_g", "sugar_g"}:
+                    macros[field_name] = 0.0
+                else:
+                    reasons.append(f"missing_{field_name}")
+                continue
+            if self._has_conflict(values):
+                reasons.append(f"conflicting_{field_name}")
+                continue
+            macros[field_name] = values[0]
+        return macros, reasons
+
+    def _parse_macro_line(self, line: str, aliases: tuple[str, ...]) -> float | None:
+        lower = line.lower()
+        if not any(alias in lower for alias in aliases):
+            return None
+        if "calories from fat" in lower:
+            return None
+        match = re.search(r"(?:less than\s*)?(\d+(?:\.\d+)?)\s*g\b", lower)
+        if not match:
+            return None
+        value = float(match.group(1))
+        if "less than" in lower:
+            return min(value, 0.5)
+        return value
+
+    def _parse_calories(self, lines: list[str]) -> float | None:
+        for line in lines:
+            lower = line.lower()
+            if "calories from fat" in lower or "calorie diet" in lower:
+                continue
+            match = re.search(rf"\bcalories\b\s*{self._NUMBER}", lower)
+            if match:
+                return float(match.group(1))
+        return None
+
+    def _calories_match_macros(self, label_calories: float, macros: dict) -> bool:
+        if not {"protein_g", "carbs_g", "fat_g"}.issubset(macros):
+            return True
+        fiber = float(macros.get("fiber_g", 0.0))
+        net_carbs = max(0.0, float(macros["carbs_g"]) - fiber)
+        derived = (
+            float(macros["protein_g"]) * 4
+            + net_carbs * 4
+            + fiber * 2
+            + float(macros["fat_g"]) * 9
+        )
+        tolerance = max(50.0, label_calories * 0.35)
+        return abs(label_calories - derived) <= tolerance
+
+    def _parse_product_name(self, lines: list[str]) -> str | None:
+        skip_terms = (
+            "nutrition facts",
+            "serving",
+            "amount per",
+            "calories",
+            "daily value",
+            "total fat",
+            "sodium",
+            "carbohydrate",
+            "fiber",
+            "sugar",
+        )
+        for line in lines[:6]:
+            lower = line.lower()
+            if not any(term in lower for term in skip_terms) and len(line) <= 80:
+                return line
+        return None
+
+    def _first_number_before_unit(self, text: str, unit: str) -> float | None:
+        match = re.search(rf"{self._NUMBER}\s*{re.escape(unit)}\b", text.lower())
+        return float(match.group(1)) if match else None
+
+    def _has_conflict(self, values: list[float]) -> bool:
+        if len(values) < 2:
+            return False
+        first = values[0]
+        return any(abs(value - first) > max(0.5, first * 0.15) for value in values[1:])

--- a/src/domain/services/prompts/system_prompts.py
+++ b/src/domain/services/prompts/system_prompts.py
@@ -247,40 +247,6 @@ WORKED EXAMPLE 2 — Coca-Cola 330ml can:
 
 Return ONLY valid JSON matching the structure above."""
 
-    FOOD_LABEL_ANALYSIS = """You are a nutrition-label extraction assistant. Analyze the image as a packaged food Nutrition Facts label and return structured data as JSON only. No markdown, no prose.
-
-RESPONSE FORMAT — return exactly this structure:
-{
-  "is_food_label": true,
-  "product_name": "Product name in English if visible, otherwise concise packaged food name",
-  "brand": "Brand name if visible, otherwise null",
-  "serving_size": {"display_text": "2/3 cup (55g)", "grams": 55.0},
-  "servings_per_package": 8.0,
-  "label_calories_per_serving": 230.0,
-  "macros_per_serving": {
-    "protein_g": 3.0,
-    "carbs_g": 37.0,
-    "fat_g": 8.0,
-    "fiber_g": 4.0,
-    "sugar_g": 12.0
-  },
-  "confidence": 0.92,
-  "label_notes": ["Includes 10g added sugars"]
-}
-
-RULES:
-- Only extract values that belong to one serving on the visible Nutrition Facts label.
-- serving_size.grams is required. Convert ounces to grams when grams are not printed.
-- servings_per_package is required. Use the printed "servings per container/package" value.
-- macros_per_serving values are grams per serving. Total carbohydrate maps to carbs_g, total fat maps to fat_g, dietary fiber maps to fiber_g, total sugars maps to sugar_g, protein maps to protein_g.
-- label_calories_per_serving is optional label metadata. The backend will derive logged calories from macros, so do not alter macros to force calories to match.
-- label_notes should stay concise. Include important assumptions, discrepancies, or label-specific caveats.
-- If the product or brand is not visible, infer a concise generic product_name from the label context and set brand to null.
-- Do not extract ingredients. Ingredients are hidden unless confidently read by a separate ingredient flow.
-- If no Nutrition Facts label is visible, set "is_food_label": false and still return the same keys with conservative values only when the serving size and macros are readable.
-
-Return ONLY valid JSON matching the structure above."""
-
     # Supported language codes (ISO 639-1)
     SUPPORTED_LANGUAGES = {"en", "vi", "es", "fr", "de", "ja", "zh"}
 

--- a/src/domain/strategies/meal_analysis_strategy.py
+++ b/src/domain/strategies/meal_analysis_strategy.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from src.domain.services.prompts.system_prompts import SystemPrompts
 
@@ -51,7 +51,7 @@ class BasicAnalysisStrategy(MealAnalysisStrategy):
     Basic meal analysis strategy without additional context.
     """
 
-    def __init__(self, optimized_prompt_enabled: Optional[bool] = None):
+    def __init__(self, optimized_prompt_enabled: bool | None = None):
         if optimized_prompt_enabled is None:
             optimized_prompt_enabled = True
         self.optimized_prompt_enabled = bool(optimized_prompt_enabled)
@@ -95,7 +95,7 @@ class IngredientAwareAnalysisStrategy(MealAnalysisStrategy):
     Ingredient-aware meal analysis strategy.
     """
 
-    def __init__(self, ingredients: List[Dict[str, Any]]):
+    def __init__(self, ingredients: list[dict[str, Any]]):
         self.ingredients = ingredients
         logger.info(
             f"Created IngredientAwareAnalysisStrategy with {len(ingredients)} ingredients"
@@ -160,19 +160,6 @@ class IngredientIdentificationStrategy(MealAnalysisStrategy):
         return "IngredientIdentification"
 
 
-class FoodLabelAnalysisStrategy(MealAnalysisStrategy):
-    """Strategy for extracting packaged food Nutrition Facts labels."""
-
-    def get_analysis_prompt(self) -> str:
-        return SystemPrompts.FOOD_LABEL_ANALYSIS
-
-    def get_user_message(self) -> str:
-        return "Extract the visible Nutrition Facts label for one serving:"
-
-    def get_strategy_name(self) -> str:
-        return "FoodLabelAnalysis"
-
-
 class UserContextAwareAnalysisStrategy(MealAnalysisStrategy):
     """
     Analysis strategy that incorporates user-provided context.
@@ -212,7 +199,7 @@ class AnalysisStrategyFactory:
 
     @staticmethod
     def create_basic_strategy(
-        optimized_prompt_enabled: Optional[bool] = None,
+        optimized_prompt_enabled: bool | None = None,
     ) -> MealAnalysisStrategy:
         """Create a basic analysis strategy."""
         return BasicAnalysisStrategy(optimized_prompt_enabled=optimized_prompt_enabled)
@@ -224,7 +211,7 @@ class AnalysisStrategyFactory:
 
     @staticmethod
     def create_ingredient_strategy(
-        ingredients: List[Dict[str, Any]],
+        ingredients: list[dict[str, Any]],
     ) -> MealAnalysisStrategy:
         """Create an ingredient-aware analysis strategy."""
         return IngredientAwareAnalysisStrategy(ingredients)
@@ -240,11 +227,6 @@ class AnalysisStrategyFactory:
         return IngredientIdentificationStrategy()
 
     @staticmethod
-    def create_food_label_strategy() -> MealAnalysisStrategy:
-        """Create a packaged food-label extraction strategy."""
-        return FoodLabelAnalysisStrategy()
-
-    @staticmethod
     def create_user_context_strategy(user_description: str) -> MealAnalysisStrategy:
         """Create a user-context-aware analysis strategy.
 
@@ -258,9 +240,9 @@ class AnalysisStrategyFactory:
 
     @staticmethod
     def create_combined_strategy(
-        portion_size: Optional[float] = None,
-        unit: Optional[str] = None,
-        ingredients: Optional[List[Dict[str, Any]]] = None,
+        portion_size: float | None = None,
+        unit: str | None = None,
+        ingredients: list[dict[str, Any]] | None = None,
     ) -> MealAnalysisStrategy:
         """
         Create a combined strategy with both portion and ingredient context.

--- a/src/infra/adapters/vision_ai_service.py
+++ b/src/infra/adapters/vision_ai_service.py
@@ -12,17 +12,13 @@ from src.domain.exceptions.ai_exceptions import (
     AIOutputValidationError,
     AIUnavailableError,
 )
-from src.domain.model.ai.nutrition_contracts import (
-    FoodLabelNutritionResponse,
-    VisionNutritionResponse,
-)
+from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
 from src.domain.ports.vision_ai_service_port import VisionAIServicePort
 from src.domain.services.ai_output_validation_service import (
     validate_ai_output,
 )
 from src.domain.strategies.meal_analysis_strategy import (
     AnalysisStrategyFactory,
-    FoodLabelAnalysisStrategy,
     IngredientIdentificationStrategy,
     MealAnalysisStrategy,
 )
@@ -36,7 +32,6 @@ MAX_URL_IMAGE_BYTES = 5 * 1024 * 1024
 URL_FETCH_TIMEOUT_SECONDS = 10
 ALLOWED_URL_IMAGE_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
 VISION_VALIDATION_PURPOSE = "meal_scan"
-FOOD_LABEL_VALIDATION_PURPOSE = "food_label_scan"
 
 
 class VisionAIService(VisionAIServicePort):
@@ -104,21 +99,9 @@ class VisionAIService(VisionAIServicePort):
             return await self._analyze_without_nutrition_contract(image_bytes, strategy)
 
         try:
-            schema = (
-                FoodLabelNutritionResponse
-                if isinstance(strategy, FoodLabelAnalysisStrategy)
-                else VisionNutritionResponse
-            )
-            validation_purpose = (
-                FOOD_LABEL_VALIDATION_PURPOSE
-                if isinstance(strategy, FoodLabelAnalysisStrategy)
-                else VISION_VALIDATION_PURPOSE
-            )
-            model_purpose = (
-                ModelPurpose.FOOD_LABEL_SCAN
-                if isinstance(strategy, FoodLabelAnalysisStrategy)
-                else ModelPurpose.MEAL_SCAN
-            )
+            schema = VisionNutritionResponse
+            validation_purpose = VISION_VALIDATION_PURPOSE
+            model_purpose = ModelPurpose.MEAL_SCAN
             result = await self._ai_manager.generate_with_vision(
                 purpose=model_purpose,
                 prompt=strategy.get_user_message(),
@@ -243,11 +226,6 @@ class VisionAIService(VisionAIServicePort):
         strategy = AnalysisStrategyFactory.create_basic_strategy(
             optimized_prompt_enabled=self._optimized_prompt_enabled
         )
-        return await self.analyze_with_strategy(image_bytes, strategy)
-
-    async def analyze_food_label(self, image_bytes: bytes) -> dict[str, Any]:
-        """Analyze a packaged food Nutrition Facts label image."""
-        strategy = AnalysisStrategyFactory.create_food_label_strategy()
         return await self.analyze_with_strategy(image_bytes, strategy)
 
     async def analyze_with_portion_context(

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -268,6 +268,10 @@ class Settings(BaseSettings):
     MEAL_ANALYZE_MAX_OUTPUT_TOKENS: int = Field(
         default=MEAL_ANALYZE_DEFAULT_MAX_OUTPUT_TOKENS
     )
+    FOOD_LABEL_OCR_FIRST_ENABLED: bool = Field(
+        default=False,
+        description="Enable deterministic OCR-first parsing for food-label scans",
+    )
 
     # Affiliate integration
     AFFILIATE_INTEGRATION_ENABLED: bool = Field(

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -260,7 +260,7 @@ class Settings(BaseSettings):
         description="Workers AI model for image analysis (must support vision input)",
     )
     CLOUDFLARE_WORKERS_AI_VISION_PURPOSES: str = Field(
-        default="meal_scan,food_label_scan,ingredient_scan",
+        default="meal_scan,ingredient_scan",
         description="Comma-separated ModelPurpose values where Workers AI vision is included in routing",
     )
     # Meal analysis settings
@@ -268,11 +268,6 @@ class Settings(BaseSettings):
     MEAL_ANALYZE_MAX_OUTPUT_TOKENS: int = Field(
         default=MEAL_ANALYZE_DEFAULT_MAX_OUTPUT_TOKENS
     )
-    FOOD_LABEL_OCR_FIRST_ENABLED: bool = Field(
-        default=False,
-        description="Enable deterministic OCR-first parsing for food-label scans",
-    )
-
     # Affiliate integration
     AFFILIATE_INTEGRATION_ENABLED: bool = Field(
         default=False,

--- a/src/infra/services/ai/ai_model_manager.py
+++ b/src/infra/services/ai/ai_model_manager.py
@@ -31,7 +31,6 @@ TEXT_PURPOSES: set[ModelPurpose] = {
 }
 VISION_PURPOSES: set[ModelPurpose] = {
     ModelPurpose.MEAL_SCAN,
-    ModelPurpose.FOOD_LABEL_SCAN,
     ModelPurpose.INGREDIENT_SCAN,
 }
 
@@ -40,9 +39,6 @@ FALLBACK_CHAINS: dict[ModelPurpose, list[str]] = {
     # VISION TASKS: OpenAI primary, optional provider routes append as fallback
     # ==========================================================================
     ModelPurpose.MEAL_SCAN: [
-        DEFAULT_OPENAI_MODEL,
-    ],
-    ModelPurpose.FOOD_LABEL_SCAN: [
         DEFAULT_OPENAI_MODEL,
     ],
     ModelPurpose.INGREDIENT_SCAN: [

--- a/tests/fixtures/mock_adapters/mock_vision_ai_service.py
+++ b/tests/fixtures/mock_adapters/mock_vision_ai_service.py
@@ -18,10 +18,6 @@ class MockVisionAIService(VisionAIServicePort):
         """Return mock analysis result."""
         return self.mock_response
 
-    async def analyze_food_label(self, image_bytes: bytes) -> Dict[str, Any]:
-        """Return mock food-label analysis result."""
-        return self.mock_response
-
     async def analyze_by_url_with_strategy(
         self, image_url: str, strategy: MealAnalysisStrategy
     ) -> Dict[str, Any]:

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -217,6 +217,7 @@ def test_scan_by_url_non_food_returns_not_food_image(client: TestClient):
     payload = {
         "image_url": "https://res.cloudinary.com/test/image/upload/v123/mealtrack/abc.jpg",
         "image_id": "abc",
+        "ocr_text_lines": ["Nutrition Facts", "Protein 12g"],
     }
     r = client.post("/v1/meals/scan-by-url", json=payload)
 
@@ -247,6 +248,7 @@ def test_food_label_scan_by_url_uses_food_label_mode(client: TestClient):
     class _FoodLabelBus:
         async def send(self, msg):
             assert msg.scan_mode == "food_label"
+            assert msg.ocr_text_lines == ["Nutrition Facts", "Protein 12g"]
             return Meal(
                 meal_id=str(uuid4()),
                 user_id=str(uuid4()),
@@ -286,6 +288,7 @@ def test_food_label_scan_by_url_uses_food_label_mode(client: TestClient):
     payload = {
         "image_url": "https://res.cloudinary.com/test/image/upload/v123/mealtrack/abc.jpg",
         "image_id": "abc",
+        "ocr_text_lines": ["Nutrition Facts", "Protein 12g"],
     }
     r = client.post("/v1/meals/food-label/scan-by-url", json=payload)
 

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -83,60 +83,13 @@ def test_meals_analyze_rejects_food_label_mode(client: TestClient):
     assert r.json()["detail"]["error_code"] == "INVALID_SCAN_MODE"
 
 
-def test_food_label_analyze_uses_food_label_mode(client: TestClient):
-    from datetime import datetime
-    from uuid import uuid4
-
-    from src.api.dependencies.event_bus import get_configured_event_bus
-    from src.domain.model.meal import Meal, MealImage, MealStatus
-    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
-
-    class _FoodLabelBus:
-        async def send(self, msg):
-            assert msg.scan_mode == "food_label"
-            return Meal(
-                meal_id=str(uuid4()),
-                user_id=str(uuid4()),
-                status=MealStatus.READY,
-                created_at=datetime(2026, 7, 2, 12, 0),
-                ready_at=datetime(2026, 7, 2, 12, 0),
-                image=MealImage(
-                    image_id=str(uuid4()),
-                    format="jpeg",
-                    size_bytes=3,
-                    url="https://example.com/label.jpg",
-                ),
-                dish_name="Unnamed Food",
-                source="food_label",
-                food_label_metadata={
-                    "product_name": "Protein Bar",
-                    "serving_size": {"display_text": "1 bar (55g)", "grams": 55},
-                    "servings_per_package": 8,
-                    "confidence": 0.92,
-                },
-                nutrition=Nutrition(
-                    macros=Macros(protein=3, carbs=37, fat=8),
-                    food_items=[
-                        FoodItem(
-                            id="label-item",
-                            name="Protein Bar",
-                            quantity=55,
-                            unit="g",
-                            macros=Macros(protein=3, carbs=37, fat=8),
-                        )
-                    ],
-                ),
-            )
-
-    client.app.dependency_overrides[get_configured_event_bus] = lambda: _FoodLabelBus()
-
+def test_food_label_analyze_is_deprecated(client: TestClient):
     r = client.post(
         "/v1/meals/food-label/analyze",
         files={"file": ("x.jpg", b"abc", "image/jpeg")},
     )
-    assert r.status_code == 200
-    assert r.json()["source"] == "food_label"
-    assert r.json()["food_label_metadata"]["servings_per_package"] == 8
+    assert r.status_code == 410
+    assert r.json()["detail"]["error_code"] == "FOOD_LABEL_IMAGE_ANALYSIS_DEPRECATED"
 
 
 def test_meals_analyze_rejects_invalid_target_date(client: TestClient):

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -83,15 +83,6 @@ def test_meals_analyze_rejects_food_label_mode(client: TestClient):
     assert r.json()["detail"]["error_code"] == "INVALID_SCAN_MODE"
 
 
-def test_food_label_analyze_is_deprecated(client: TestClient):
-    r = client.post(
-        "/v1/meals/food-label/analyze",
-        files={"file": ("x.jpg", b"abc", "image/jpeg")},
-    )
-    assert r.status_code == 410
-    assert r.json()["detail"]["error_code"] == "FOOD_LABEL_IMAGE_ANALYSIS_DEPRECATED"
-
-
 def test_meals_analyze_rejects_invalid_target_date(client: TestClient):
     r = client.post(
         "/v1/meals/image/analyze?target_date=2024-99-99",

--- a/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
+++ b/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
@@ -35,7 +35,6 @@ def _make_handler(vision_analyze_mock, max_attempts: int = 3):
 
     vision_service = Mock()
     vision_service.analyze = vision_analyze_mock
-    vision_service.analyze_food_label = AsyncMock()
 
     handler = UploadMealImageImmediatelyHandler(
         uow=Mock(),
@@ -146,88 +145,14 @@ class TestVisionRetryRouting:
         assert analyze_mock.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_food_label_mode_uses_label_analyzer(self):
-        """Food-label scans route through the label-specific analyzer."""
+    async def test_food_label_mode_is_rejected_by_immediate_upload(self):
+        """Food-label scans require OCR text through the scan-by-url endpoint."""
         analyze_mock = AsyncMock()
         handler = _make_handler(analyze_mock, max_attempts=3)
         command = _make_command()
         command.scan_mode = "food_label"
-        handler.vision_service.analyze_food_label = AsyncMock(
-            return_value={"is_food_label": True}
-        )
 
-        result = await handler._run_vision_analysis(command, meal_id="meal-abc")
+        with pytest.raises(ValueError, match="require client OCR text"):
+            await handler.handle(command)
 
-        assert result == {"is_food_label": True}
-        handler.vision_service.analyze_food_label.assert_awaited_once_with(
-            command.file_contents
-        )
         analyze_mock.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_food_label_parallel_upload_persists_ready_label_meal(self):
-        from src.app.handlers.command_handlers.upload_meal_image_immediately_command_handler import (
-            UploadMealImageImmediatelyHandler,
-        )
-        from src.domain.model.nutrition import FoodItem, Macros, Nutrition
-
-        command = _make_command()
-        command.scan_mode = "food_label"
-        uow = _make_uow()
-        image_store = Mock()
-        image_store.save_async = AsyncMock(return_value="https://cdn.test/label.jpg")
-        vision_service = Mock()
-        vision_service.analyze_food_label = AsyncMock(
-            return_value={"is_food_label": True, "product_name": "Protein Bar"}
-        )
-        parser = Mock()
-        parser.parse_food_label_to_nutrition.return_value = Nutrition(
-            macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
-            food_items=[
-                FoodItem(
-                    id="label-item",
-                    name="Protein Bar",
-                    quantity=55,
-                    unit="g",
-                    macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
-                    is_custom=True,
-                )
-            ],
-        )
-        label_metadata = {
-            "is_food_label": True,
-            "product_name": "Protein Bar",
-            "serving_size": {"display_text": "1 bar (55g)", "grams": 55},
-            "servings_per_package": 8,
-            "confidence": 0.92,
-        }
-        parser.parse_food_label_metadata.return_value = label_metadata
-        parser.extract_raw_json.return_value = '{"product_name":"Protein Bar"}'
-        parser.parse_is_food = Mock()
-        cache = Mock()
-        cache.after_meal_write = AsyncMock()
-
-        handler = UploadMealImageImmediatelyHandler(
-            uow=uow,
-            event_bus=Mock(),
-            image_store=image_store,
-            vision_service=vision_service,
-            gpt_parser=parser,
-            fast_path_policy=_make_fast_path_policy(),
-            cache_invalidation=cache,
-        )
-
-        meal = await handler._handle_parallel_upload(command)
-
-        assert meal.status.value == "READY"
-        assert meal.source == "food_label"
-        assert meal.dish_name == "Unnamed Food"
-        assert meal.emoji is None
-        assert meal.food_label_metadata == label_metadata
-        assert meal.nutrition.food_items[0].quantity == 55
-        uow.meals.save.assert_awaited_once()
-        saved_meal = uow.meals.save.await_args.args[0]
-        assert saved_meal.food_label_metadata == label_metadata
-        cache.after_meal_write.assert_awaited_once()
-        parser.parse_is_food.assert_not_called()
-        parser.parse_food_label_name.assert_not_called()

--- a/tests/unit/domain/services/test_food_label_ocr_parser.py
+++ b/tests/unit/domain/services/test_food_label_ocr_parser.py
@@ -1,0 +1,80 @@
+"""Tests for deterministic Nutrition Facts OCR parsing."""
+
+import pytest
+
+from src.domain.services.food_label_ocr_parser import FoodLabelOcrParser
+
+
+def _clean_label_lines() -> list[str]:
+    return [
+        "ACME Protein Bar",
+        "Nutrition Facts",
+        "8 servings per container",
+        "Serving size 1 bar (55g)",
+        "Calories 210",
+        "Total Fat 7g",
+        "Total Carbohydrate 24g",
+        "Dietary Fiber 5g",
+        "Total Sugars 8g",
+        "Protein 12g",
+    ]
+
+
+def test_parse_clean_us_label_succeeds():
+    result = FoodLabelOcrParser().parse(_clean_label_lines())
+
+    assert result.succeeded is True
+    data = result.structured_data
+    assert data is not None
+    assert data["product_name"] == "ACME Protein Bar"
+    assert data["serving_size"]["grams"] == pytest.approx(55)
+    assert data["servings_per_package"] == pytest.approx(8)
+    assert data["macros_per_serving"]["protein_g"] == pytest.approx(12)
+    assert data["label_calories_per_serving"] == pytest.approx(210)
+
+
+def test_parse_missing_required_macro_fails():
+    lines = [
+        line for line in _clean_label_lines() if not line.startswith("Protein")
+    ]
+
+    result = FoodLabelOcrParser().parse(lines)
+
+    assert result.succeeded is False
+    assert "missing_protein_g" in result.failure_reasons
+
+
+def test_parse_conflicting_macro_values_fails():
+    result = FoodLabelOcrParser().parse(
+        [*_clean_label_lines(), "Total Fat 20g"]
+    )
+
+    assert result.succeeded is False
+    assert "conflicting_fat_g" in result.failure_reasons
+
+
+def test_parse_sparse_ocr_text_fails():
+    result = FoodLabelOcrParser().parse(["Nutrition Facts", "Calories 120"])
+
+    assert result.succeeded is False
+    assert result.failure_reasons == ["ocr_text_too_sparse"]
+
+
+def test_parse_conflicting_label_calories_fails():
+    lines = [
+        "ACME Protein Bar",
+        "Nutrition Facts",
+        "8 servings per container",
+        "Serving size 1 bar (55g)",
+        "Calories 900",
+        "Total Fat 7g",
+        "Total Carbohydrate 24g",
+        "Dietary Fiber 5g",
+        "Total Sugars 8g",
+        "Protein 12g",
+    ]
+
+    result = FoodLabelOcrParser().parse(lines)
+
+    assert result.succeeded is False
+    assert "conflicting_label_calories" in result.failure_reasons

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -119,72 +119,32 @@ async def test_scan_by_url_packaged_beverage_creates_standard_meal(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_scan_by_url_food_label_creates_ready_meal(monkeypatch):
-    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
-
+async def test_scan_by_url_food_label_requires_ocr_text(monkeypatch):
     _install_fake_image_download(monkeypatch)
     uow = _make_uow()
-    cache = MagicMock()
-    cache.after_meal_write = AsyncMock()
     handler = ScanByUrlCommandHandler(
         uow=uow,
         event_bus=MagicMock(),
         vision_service=MagicMock(),
         gpt_parser=MagicMock(),
-        cache_invalidation=cache,
     )
-    handler.vision_service.analyze_food_label = AsyncMock(
-        return_value={"is_food_label": True, "product_name": "Protein Bar"}
-    )
-    handler.gpt_parser.parse_food_label_to_nutrition.return_value = Nutrition(
-        macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
-        food_items=[
-            FoodItem(
-                id="label-item",
-                name="Protein Bar",
-                quantity=55,
-                unit="g",
-                macros=Macros(protein=10, carbs=20, fat=5, fiber=4, sugar=8),
-                is_custom=True,
+
+    with pytest.raises(ValueError, match="label text could not be read"):
+        await handler.handle(
+            ScanByUrlCommand(
+                user_id=_USER_ID,
+                image_url=_IMAGE_URL,
+                public_id="mealtrack/00000000-0000-0000-0000-000000000002",
+                scan_mode="food_label",
             )
-        ],
-    )
-    handler.gpt_parser.parse_food_label_metadata.return_value = {"is_food_label": True}
-    handler.gpt_parser.extract_raw_json.return_value = '{"product_name":"Protein Bar"}'
-    handler.gpt_parser.parse_is_food = MagicMock()
-
-    result = await handler.handle(
-        ScanByUrlCommand(
-            user_id=_USER_ID,
-            image_url=_IMAGE_URL,
-            public_id="mealtrack/00000000-0000-0000-0000-000000000002",
-            scan_mode="food_label",
         )
-    )
 
-    handler.vision_service.analyze_food_label.assert_awaited_once_with(
-        b"fake-image-bytes"
-    )
-    uow.meals.save.assert_awaited_once()
-    handler.gpt_parser.parse_is_food.assert_not_called()
-    cache.after_meal_write.assert_awaited_once()
-    assert result.source == "food_label"
-    assert result.dish_name == "Unnamed Food"
-    assert result.emoji is None
-    assert result.nutrition.food_items[0].quantity == 55
-    handler.gpt_parser.parse_food_label_name.assert_not_called()
+    uow.meals.save.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_scan_by_url_food_label_uses_ocr_when_enabled(monkeypatch):
-    from src.app.handlers.command_handlers import scan_by_url_command_handler as module
-
+async def test_scan_by_url_food_label_uses_ocr_only(monkeypatch):
     _install_fake_image_download(monkeypatch)
-    monkeypatch.setattr(
-        module,
-        "get_settings",
-        lambda: type("Settings", (), {"FOOD_LABEL_OCR_FIRST_ENABLED": True})(),
-    )
     uow = _make_uow()
     cache = MagicMock()
     cache.after_meal_write = AsyncMock()
@@ -196,7 +156,6 @@ async def test_scan_by_url_food_label_uses_ocr_when_enabled(monkeypatch):
         cache_invalidation=cache,
         food_label_ocr_parser=FoodLabelOcrParser(),
     )
-    handler.vision_service.analyze_food_label = AsyncMock()
 
     result = await handler.handle(
         ScanByUrlCommand(
@@ -219,23 +178,14 @@ async def test_scan_by_url_food_label_uses_ocr_when_enabled(monkeypatch):
         )
     )
 
-    handler.vision_service.analyze_food_label.assert_not_awaited()
     assert result.source == "food_label"
     assert result.food_label_metadata["product_name"] == "ACME Protein Bar"
     assert result.nutrition.food_items[0].quantity == pytest.approx(55)
 
 
 @pytest.mark.asyncio
-async def test_scan_by_url_food_label_falls_back_to_ai_on_ocr_failure(monkeypatch):
-    from src.app.handlers.command_handlers import scan_by_url_command_handler as module
-    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
-
+async def test_scan_by_url_food_label_ocr_failure_does_not_call_ai(monkeypatch):
     _install_fake_image_download(monkeypatch)
-    monkeypatch.setattr(
-        module,
-        "get_settings",
-        lambda: type("Settings", (), {"FOOD_LABEL_OCR_FIRST_ENABLED": True})(),
-    )
     uow = _make_uow()
     handler = ScanByUrlCommandHandler(
         uow=uow,
@@ -243,35 +193,16 @@ async def test_scan_by_url_food_label_falls_back_to_ai_on_ocr_failure(monkeypatc
         vision_service=MagicMock(),
         gpt_parser=MagicMock(),
     )
-    handler.vision_service.analyze_food_label = AsyncMock(
-        return_value={"is_food_label": True, "product_name": "Fallback Bar"}
-    )
-    handler.gpt_parser.parse_food_label_to_nutrition.return_value = Nutrition(
-        macros=Macros(protein=10, carbs=20, fat=5),
-        food_items=[
-            FoodItem(
-                id="fallback-item",
-                name="Fallback Bar",
-                quantity=55,
-                unit="g",
-                macros=Macros(protein=10, carbs=20, fat=5),
-                is_custom=True,
+
+    with pytest.raises(ValueError, match="could not be parsed"):
+        await handler.handle(
+            ScanByUrlCommand(
+                user_id=_USER_ID,
+                image_url=_IMAGE_URL,
+                public_id="mealtrack/00000000-0000-0000-0000-000000000004",
+                scan_mode="food_label",
+                ocr_text_lines=["Nutrition Facts", "Calories 120"],
             )
-        ],
-    )
-    handler.gpt_parser.parse_food_label_metadata.return_value = {"is_food_label": True}
-    handler.gpt_parser.extract_raw_json.return_value = "{}"
-
-    await handler.handle(
-        ScanByUrlCommand(
-            user_id=_USER_ID,
-            image_url=_IMAGE_URL,
-            public_id="mealtrack/00000000-0000-0000-0000-000000000004",
-            scan_mode="food_label",
-            ocr_text_lines=["Nutrition Facts", "Calories 120"],
         )
-    )
 
-    handler.vision_service.analyze_food_label.assert_awaited_once_with(
-        b"fake-image-bytes"
-    )
+    uow.meals.save.assert_not_awaited()

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -9,6 +9,7 @@ from src.app.handlers.command_handlers.scan_by_url_command_handler import (
     ScanByUrlCommandHandler,
 )
 from src.domain.parsers.vision_response_parser import VisionResponseParser
+from src.domain.services.food_label_ocr_parser import FoodLabelOcrParser
 
 _IMAGE_URL = "https://res.cloudinary.com/test/image/upload/v1/mealtrack/drink.jpg"
 _PUBLIC_ID = "mealtrack/1325c7ca-e012-4df3-b0b4-55bfaeb55eb0"
@@ -172,3 +173,105 @@ async def test_scan_by_url_food_label_creates_ready_meal(monkeypatch):
     assert result.emoji is None
     assert result.nutrition.food_items[0].quantity == 55
     handler.gpt_parser.parse_food_label_name.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_by_url_food_label_uses_ocr_when_enabled(monkeypatch):
+    from src.app.handlers.command_handlers import scan_by_url_command_handler as module
+
+    _install_fake_image_download(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "get_settings",
+        lambda: type("Settings", (), {"FOOD_LABEL_OCR_FIRST_ENABLED": True})(),
+    )
+    uow = _make_uow()
+    cache = MagicMock()
+    cache.after_meal_write = AsyncMock()
+    handler = ScanByUrlCommandHandler(
+        uow=uow,
+        event_bus=MagicMock(),
+        vision_service=MagicMock(),
+        gpt_parser=VisionResponseParser(),
+        cache_invalidation=cache,
+        food_label_ocr_parser=FoodLabelOcrParser(),
+    )
+    handler.vision_service.analyze_food_label = AsyncMock()
+
+    result = await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id="mealtrack/00000000-0000-0000-0000-000000000003",
+            scan_mode="food_label",
+            ocr_text_lines=[
+                "ACME Protein Bar",
+                "Nutrition Facts",
+                "8 servings per container",
+                "Serving size 1 bar (55g)",
+                "Calories 210",
+                "Total Fat 7g",
+                "Total Carbohydrate 24g",
+                "Dietary Fiber 5g",
+                "Total Sugars 8g",
+                "Protein 12g",
+            ],
+        )
+    )
+
+    handler.vision_service.analyze_food_label.assert_not_awaited()
+    assert result.source == "food_label"
+    assert result.food_label_metadata["product_name"] == "ACME Protein Bar"
+    assert result.nutrition.food_items[0].quantity == pytest.approx(55)
+
+
+@pytest.mark.asyncio
+async def test_scan_by_url_food_label_falls_back_to_ai_on_ocr_failure(monkeypatch):
+    from src.app.handlers.command_handlers import scan_by_url_command_handler as module
+    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+
+    _install_fake_image_download(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "get_settings",
+        lambda: type("Settings", (), {"FOOD_LABEL_OCR_FIRST_ENABLED": True})(),
+    )
+    uow = _make_uow()
+    handler = ScanByUrlCommandHandler(
+        uow=uow,
+        event_bus=MagicMock(),
+        vision_service=MagicMock(),
+        gpt_parser=MagicMock(),
+    )
+    handler.vision_service.analyze_food_label = AsyncMock(
+        return_value={"is_food_label": True, "product_name": "Fallback Bar"}
+    )
+    handler.gpt_parser.parse_food_label_to_nutrition.return_value = Nutrition(
+        macros=Macros(protein=10, carbs=20, fat=5),
+        food_items=[
+            FoodItem(
+                id="fallback-item",
+                name="Fallback Bar",
+                quantity=55,
+                unit="g",
+                macros=Macros(protein=10, carbs=20, fat=5),
+                is_custom=True,
+            )
+        ],
+    )
+    handler.gpt_parser.parse_food_label_metadata.return_value = {"is_food_label": True}
+    handler.gpt_parser.extract_raw_json.return_value = "{}"
+
+    await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id="mealtrack/00000000-0000-0000-0000-000000000004",
+            scan_mode="food_label",
+            ocr_text_lines=["Nutrition Facts", "Calories 120"],
+        )
+    )
+
+    handler.vision_service.analyze_food_label.assert_awaited_once_with(
+        b"fake-image-bytes"
+    )

--- a/tests/unit/infra/adapters/test_vision_ai_service.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service.py
@@ -151,29 +151,6 @@ async def test_analyze_with_strategy_allows_max_token_override():
 
 
 @pytest.mark.asyncio
-async def test_analyze_food_label_uses_food_label_schema():
-    service = _make_service(
-        response={
-            "product_name": "Cereal",
-            "serving_size": {"display_text": "55g", "grams": 55},
-            "servings_per_package": 8,
-            "macros_per_serving": {"protein_g": 3, "carbs_g": 37, "fat_g": 8},
-            "confidence": 0.91,
-        }
-    )
-
-    image = _make_jpeg(400, 300)
-    await service.analyze_food_label(image)
-
-    from src.domain.model.ai.nutrition_contracts import FoodLabelNutritionResponse
-
-    call_kwargs = service._ai_manager.generate_with_vision.call_args.kwargs
-    assert call_kwargs["purpose"].value == "food_label_scan"
-    assert call_kwargs["schema"] is FoodLabelNutritionResponse
-    assert "Nutrition Facts label" in call_kwargs["system_message"]
-
-
-@pytest.mark.asyncio
 async def test_analyze_by_url_passes_meal_analyze_max_tokens():
     """URL analysis must fetch bytes and pass the meal-analysis token budget."""
     service = _make_service()

--- a/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
+++ b/tests/unit/infra/services/ai/test_ai_vision_failure_routing.py
@@ -56,9 +56,7 @@ def _fake_settings_with_cf_text_and_vision():
     )
     settings.CLOUDFLARE_WORKERS_AI_VISION_ENABLED = True
     settings.CLOUDFLARE_WORKERS_AI_VISION_MODEL = "cf-vision-model"
-    settings.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = (
-        "meal_scan,food_label_scan,ingredient_scan"
-    )
+    settings.CLOUDFLARE_WORKERS_AI_VISION_PURPOSES = "meal_scan,ingredient_scan"
     return settings
 
 
@@ -126,7 +124,6 @@ def test_image_scan_purposes_prefer_openai_and_fallback_to_cf(mock_circuit_break
 
     for purpose in {
         ModelPurpose.MEAL_SCAN,
-        ModelPurpose.FOOD_LABEL_SCAN,
         ModelPurpose.INGREDIENT_SCAN,
     }:
         assert manager.get_fallback_chain(purpose)[:2] == [


### PR DESCRIPTION
## Summary
- Add optional `ocr_text_lines` to food-label scan-by-url requests.
- Add feature-flagged deterministic Nutrition Facts OCR parsing before AI image fallback.
- Add OCR metrics and parser/handler/route tests.

## Verification
- `.venv/bin/python -m ruff check src/domain/services/food_label_ocr_parser.py src/api/routes/v1/meal_scan_by_url.py src/app/commands/meal/scan_by_url_command.py src/app/handlers/command_handlers/scan_by_url_command_handler.py tests/unit/domain/services/test_food_label_ocr_parser.py tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py tests/unit/api/test_app_smoke_routes.py`
- `.venv/bin/python -m pytest tests/unit/domain/services/test_food_label_ocr_parser.py tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py tests/unit/api/test_app_smoke_routes.py -q`

Jira: NM-168