### PR TITLE
docs: refresh food label scan docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A sophisticated FastAPI-based microservice for meal tracking and nutritional ana
 
 ## 🚀 Features
 
-- **AI-Powered Meal Analysis**: Vision-based food recognition with 6 analysis strategies and provider fallback routing.
-- **26 Endpoint Route Modules**: 85 endpoint decorators covering meals, users, profiles, chat, notifications, meal plans, suggestions, activities, ingredients, webhooks, and support routes.
+- **AI-Powered Meal Analysis**: Vision-based food recognition with 6 meal strategies, food-label image analysis, and provider fallback routing.
+- **26 Endpoint Route Modules**: 88 endpoint decorators covering meals, users, profiles, chat, notifications, meal plans, suggestions, activities, ingredients, webhooks, and support routes.
 - **CQRS Architecture**: Commands, queries, events, and handlers wired through a PyMediator singleton event bus.
 - **Intelligent Planning**: AI-generated weekly plans with dietary preferences, cooking time constraints, and ingredient-based generation.
 - **Vector Search**: Pinecone semantic search with 1024-dim embeddings (llama-text-embed-v2).
@@ -42,10 +42,10 @@ A sophisticated FastAPI-based microservice for meal tracking and nutritional ana
 
 Follows a **4-Layer Clean Architecture** with **CQRS** and **Event-Driven Design**:
 
-1. **API Layer** (91 files, 10,624 LOC): 26 endpoint route modules, 85 endpoint decorators, schemas, middleware, dependencies, and API mappers.
-2. **Application Layer** (207 files, 11,192 LOC): CQRS command/query/event handlers and orchestration services.
-3. **Domain Layer** (166 files, 16,283 LOC): entities, services, ports, policies, and bounded contexts.
-4. **Infrastructure Layer** (154 files, 15,134 LOC): database models, repositories, external adapters, cache, observability, and event bus implementation.
+1. **API Layer** (91 files, 11,323 LOC): 26 endpoint route modules, 88 endpoint decorators, schemas, middleware, dependencies, and API mappers.
+2. **Application Layer** (207 files, 11,333 LOC): CQRS command/query/event handlers and orchestration services.
+3. **Domain Layer** (174 files, 17,397 LOC): entities, services, ports, policies, and bounded contexts.
+4. **Infrastructure Layer** (154 files, 15,337 LOC): database models, repositories, external adapters, cache, observability, and event bus implementation.
 
 ## 🚦 Getting Started
 

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,11 +1,11 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** July 2, 2026
+**Last Updated:** July 5, 2026
 **Base URL:** `http://localhost:8000` (dev) or deployed host
 **API Docs:** `/docs` (Swagger UI)
 **Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
 Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
-**Surface:** 28 route files, 27 router registrations, 26 endpoint-bearing route modules, and 85 endpoint decorators.
+**Surface:** 28 route files, 27 router registrations, 26 endpoint-bearing route modules, and 88 endpoint decorators.
 
 ---
 
@@ -48,12 +48,13 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | DELETE | `/v1/meals/{meal_id}` | Delete meal (soft delete) |
 | PUT | `/v1/meals/{meal_id}/ingredients` | Update meal ingredients |
 
-### Food Label OCR Contract
+### Food Label Image Contract
 
-- `/v1/meals/food-label/scan-by-url` requires `ocr_text_lines` from native client OCR.
-- The backend parses OCR text deterministically and does not send food-label images to AI analysis.
-- Missing OCR text, sparse text, missing fields, and conflicting values fail cleanly without AI fallback.
-- The backend remains source of truth for validation and derives calories from macros; clients must not calculate label nutrition.
+- `/v1/meals/food-label/scan-by-url` accepts a Cloudinary `image_url`/`image_id` pair plus optional `label_crop_image_url`/`label_crop_image_id` and `crop_metadata`.
+- The backend downloads image bytes and sends the label crop, or the full image when no crop is supplied, through `FoodLabelImageAnalysisStrategy`.
+- AI output is validated against `FoodLabelNutritionResponse` before mapping to `Nutrition` and `food_label_metadata`.
+- Failed label reads return controlled validation errors and do not persist meals.
+- The backend remains source of truth for validation and calorie presentation; clients must not calculate label nutrition.
 
 ---
 

--- a/docs/beverage-scan.md
+++ b/docs/beverage-scan.md
@@ -30,9 +30,11 @@ UploadMealImageImmediatelyHandler or ScanByUrlCommandHandler
   6. Invalidate meal caches
 ```
 
-Food-label scans do not use this image-AI flow. Clients upload through the
-signed Cloudinary flow, run native OCR, then call
-`/v1/meals/food-label/scan-by-url` with `ocr_text_lines`.
+Food-label scans use a separate image-AI flow. Clients upload through the signed
+Cloudinary flow, optionally crop the nutrition panel, then call
+`/v1/meals/food-label/scan-by-url` with the full image URL and optional
+`label_crop_image_url` plus crop metadata. The handler analyzes the crop when
+present and persists the result with `source="food_label"`.
 
 Meal scan must not create `hydration_entries`.
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,7 +1,7 @@
 # Backend Code Standards — Python Style & Conventions
 
-**Last Updated:** June 27, 2026
-**Scope:** All code in `src/` (627 Python files, 53,972 LOC)
+**Last Updated:** July 5, 2026
+**Scope:** All code in `src/` (635 Python files, 56,132 LOC)
 **Applies To:** Typing, naming, imports, code organization, error handling
 
 ---

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,6 +1,6 @@
 # Backend Codebase Summary
 
-**Generated:** June 27, 2026
+**Generated:** July 5, 2026
 **Status:** Production-ready snapshot of the live backend codebase
 **Runtime:** FastAPI 0.136.3 on Python 3.13.2 with async SQLAlchemy 2.0
 
@@ -10,19 +10,19 @@
 
 | Metric | Value |
 |--------|-------|
-| Source files | 627 Python files in `src/` |
-| Source LOC | 53,972 LOC in `src/` |
-| Test files | 306 Python files in `tests/` |
+| Source files | 635 Python files in `src/` |
+| Source LOC | 56,132 LOC in `src/` |
+| Test files | 312 Python files in `tests/` |
 | Collected tests | 1,600+ collected tests |
 | API router files | 28 route files under `src/api/routes/`; 26 contain endpoint decorators |
-| API endpoints | 85 endpoint decorators under `src/api/routes/` |
-| CQRS command files | 37 |
-| CQRS query files | 34 |
-| CQRS event files | 10 |
-| CQRS handler files | 75 |
-| Domain service files | 46 |
-| Port files | 25 |
-| Database model files | 39 |
+| API endpoints | 88 endpoint decorators under `src/api/routes/` |
+| CQRS command files | 50 |
+| CQRS query files | 52 |
+| CQRS event files | 14 |
+| CQRS handler files | 86 |
+| Domain service files | 60 |
+| Port files | 27 |
+| Database model files | 48 |
 | ORM table declarations | 39 |
 
 ---
@@ -31,10 +31,10 @@
 
 | Layer | Files | LOC | Notes |
 |-------|-------|-----|-------|
-| API | 91 | 10,624 | Routes, middleware, schemas, dependency wiring, and API mappers |
-| Application | 207 | 11,192 | Commands, queries, handlers, and orchestration services |
-| Domain | 166 | 16,283 | Entities, services, ports, policies, and bounded contexts |
-| Infrastructure | 154 | 15,134 | Database, cache, adapters, observability, and service integrations |
+| API | 91 | 11,323 | Routes, middleware, schemas, dependency wiring, and API mappers |
+| Application | 207 | 11,333 | Commands, queries, handlers, and orchestration services |
+| Domain | 174 | 17,397 | Entities, services, ports, policies, and bounded contexts |
+| Infrastructure | 154 | 15,337 | Database, cache, adapters, observability, and service integrations |
 
 ---
 
@@ -42,7 +42,7 @@
 
 The current HTTP surface includes:
 
-- Meal logging and analysis: image upload, upload-token, scan-by-url, manual meals, parse-text, streak, weekly budget, and daily macros.
+- Meal logging and analysis: image upload, upload-token, scan-by-url, food-label scan-by-url, manual meals, parse-text, streak, weekly budget, and daily macros.
 - User and profile management: Firebase sync, onboarding completion, metrics, TDEE, language, timezone, and account deletion.
 - Discovery and planning: meal suggestions discover, recipes, and save.
 - Nutrition and activity tracking: nutrition bulk/presence, activities daily/bulk, hydration, movement, and the journey progress snapshot.
@@ -69,13 +69,17 @@ The current HTTP surface includes:
 | `src/app/queries/` | 52 | Read-operation query packages |
 | `src/app/handlers/` | 86 | CQRS handler packages |
 | `src/domain/model/` | 63 | Domain entities and value objects |
-| `src/domain/services/` | 54 | Domain services and policies |
+| `src/domain/services/` | 60 | Domain services and policies |
 | `src/infra/database/models/` | 48 | ORM model packages and table declarations |
 | `src/infra/repositories/` | 23 | Data access adapters |
 | `src/infra/services/` | 27 | Infrastructure services and AI providers |
-| `tests/` | 306 | Unit, architecture, migration, and explicit integration tests |
+| `tests/` | 312 | Unit, architecture, migration, and explicit integration tests |
 
 ---
+
+## Recent Features (July 2026)
+
+- **Food-Label Image Scan:** `/v1/meals/food-label/scan-by-url` now analyzes Cloudinary-hosted nutrition-label images directly, preferring an optional label crop and crop metadata. `FoodLabelImageAnalysisStrategy` reads multilingual nutrition panels into the strict `FoodLabelNutritionResponse` contract; failures do not persist meals.
 
 ## Recent Features (June 2026)
 

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,6 +1,6 @@
 # Backend External Services Integration
 
-**Last Updated:** June 27, 2026
+**Last Updated:** July 5, 2026
 **Services:** Firebase, Cloudinary, OpenAI, Cloudflare Workers AI, RevenueCat, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, Brave Search, Pexels, Unsplash, Resend, Google Imagen, Pollinations, nutree-affiliate
 **Failure handling:** Optional integrations degrade when safe. Firebase Auth and the primary DB fail fast. Redis optional caches degrade by bypassing cache; any Redis-backed required state must be documented and health-checked separately.
 
@@ -75,6 +75,7 @@ Logs emitted: `[AI-ATTEMPT]`, `[AI-FALLBACK-SUCCESS]`, `[AI-ATTEMPT-FAILED]`. Ne
 
 ### Vision AI (Meal Analysis)
 - 6 analysis strategies: basic, portion-aware, ingredient-aware, weight-aware, user-context, combined
+- Food-label scan strategy: reads Cloudinary-hosted Nutrition Facts labels, preferring an optional cropped label image and validating output through `FoodLabelNutritionResponse`
 - JSON parsing with multiple fallbacks: direct, markdown extraction, regex, truncation recovery
 - Safety detection for blocked responses
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -1,14 +1,14 @@
 # MealTrack Backend - Project Overview & Product Development Requirements
 
-**Version:** 0.6.6
-**Last Updated:** June 27, 2026
-**Status:** Production-ready. 627 Python files in `src/`, 53,972 LOC in `src/`, 306 Python files in `tests/`, and 1,600+ collected tests. Latest verified changes: OpenAI-first AI routing, journey progress seed, upload-token smoke coverage, and pydantic-settings/CI alignment.
+**Version:** 0.6.7
+**Last Updated:** July 5, 2026
+**Status:** Production-ready. 635 Python files in `src/`, 56,132 LOC in `src/`, 312 Python files in `tests/`, and 1,600+ collected tests. Latest verified changes: food-label image scan contract, OpenAI-first AI routing, journey progress seed, upload-token smoke coverage, and pydantic-settings/CI alignment.
 
 ---
 
 ## Executive Summary
 
-MealTrack Backend is a FastAPI-based service for meal tracking and nutritional analysis. It implements Clean Architecture with CQRS across 4 layers, while `src/` also includes bootstrap, cron, and observability modules outside the layer directories. The current API surface spans 28 route files, 26 endpoint-bearing route modules, and 85 endpoint decorators; the test suite is unit-biased by default and exceeds 1,600 collected tests.
+MealTrack Backend is a FastAPI-based service for meal tracking and nutritional analysis. It implements Clean Architecture with CQRS across 4 layers, while `src/` also includes bootstrap, cron, and observability modules outside the layer directories. The current API surface spans 28 route files, 26 endpoint-bearing route modules, and 88 endpoint decorators; the test suite is unit-biased by default and exceeds 1,600 collected tests.
 
 ---
 
@@ -30,11 +30,12 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 ### 1. AI-Powered Meal Analysis
 - 6 analysis strategies: basic, portion-aware, ingredient-aware, weight-aware, user-context-aware, combined.
 - Multi-food detection in single image with confidence scoring.
+- Nutrition Facts label analysis via `/v1/meals/food-label/scan-by-url`, optional label crop, crop metadata, and strict `FoodLabelNutritionResponse` validation.
 - OpenAI is the default provider; configured Cloudflare Workers AI can take routed text purposes first and vision purposes as fallback.
 - Returns results in <3 seconds through the meal state machine (PROCESSING → ANALYZING → READY/FAILED).
 
-### 2. RESTful API (85 endpoint decorators across 26 endpoint route modules)
-- **Meals**: image/analyze, manual, parse-text, streak, weekly/daily-breakdown, weekly/budget, daily/macros, /{id} (GET/DELETE), ingredients (PUT).
+### 2. RESTful API (88 endpoint decorators across 26 endpoint route modules)
+- **Meals**: image/analyze, upload-token, scan-by-url, food-label/scan-by-url, manual, parse-text, streak, weekly/daily-breakdown, weekly/budget, daily/macros, /{id} (GET/DELETE), ingredients (PUT).
 - **User Profiles**: create, metrics (GET/POST), TDEE, custom-macros.
 - **Users**: sync, Firebase UID lookups, metrics, timezone, language, delete.
 - **Meal Suggestions**: discover (6 meals + images), recipes, save.
@@ -119,6 +120,7 @@ Empower users to understand their nutrition through effortless, AI-driven tracki
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 0.6.7 | Jul 5, 2026 | Updated docs for food-label image scan-by-url: optional label crop URL and crop metadata, direct nutrition-label image analysis, strict `FoodLabelNutritionResponse` validation, and refreshed codebase/API metrics. |
 | 0.6.6 | Jun 27, 2026 | Documentation refresh for current runtime versions, current codebase metrics, OpenAI-first AI routing, and updated test/CI defaults. |
 | 0.6.5 | Jun 13, 2026 | Added validation retry orchestration for structured AI nutrition output, with exactly one repair attempt for meal image scan and text parse flows, controlled `AIOutputValidationError` handling, preserved ingredient-recognition's unstructured contract, and kept calorie divergence checks anchored to backend-derived macro calories. |
 | 0.6.4 | Jun 13, 2026 | Added canonical AI nutrition contracts for image and text flows, rejected impossible over-limit food quantities at validation time, preserved current text-parse macro compatibility, and removed silent invalid-food filtering from the legacy parser. |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,13 +1,19 @@
 # MealTrack Backend - Project Roadmap
 
-**Version:** 0.6.6
-**Last Updated:** June 27, 2026
-**Status:** Production-ready. 627 source files in `src/`, 53,972 LOC in `src/`, 306 Python test files, and 1,600+ collected tests. Default `pytest` is unit-biased because integration tests are ignored by config.
+**Version:** 0.6.7
+**Last Updated:** July 5, 2026
+**Status:** Production-ready. 635 source files in `src/`, 56,132 LOC in `src/`, 312 Python test files, and 1,600+ collected tests. Default `pytest` is unit-biased because integration tests are ignored by config.
 **Architecture**: 4-Layer Clean Architecture + CQRS + Event-Driven with PyMediator singleton registry + Sentry monitoring.
 
 ---
 
 ## Completed Phases
+
+### July 2026: Food-Label Image Scan
+- [x] `/v1/meals/food-label/scan-by-url` analyzes Nutrition Facts label images directly from Cloudinary bytes.
+- [x] Optional `label_crop_image_url` and crop metadata let mobile send a nutrition-panel crop while retaining the original image record.
+- [x] `FoodLabelImageAnalysisStrategy` handles multilingual labels and returns the strict `FoodLabelNutritionResponse` contract.
+- [x] Failed label reads do not persist meals; successful scans persist READY `Meal(source="food_label")` rows and invalidate meal caches without hydration side effects.
 
 ### June 2026: Python 3.13 and Dependency Standardization
 - [x] Upgraded runtime, Docker, CI, and documented backend baseline to Python 3.13.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,9 +1,9 @@
 # Backend System Architecture Overview
 
-**Last Updated:** June 27, 2026
+**Last Updated:** July 5, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
-**Codebase:** 627 Python files, 53,972 LOC in `src/`
+**Codebase:** 635 Python files, 56,132 LOC in `src/`
 
 ---
 
@@ -21,7 +21,7 @@
 └────────────────────────┬────────────────────────────────────┘
                          │ Domain Services
 ┌────────────────────────▼────────────────────────────────────┐
-│                Domain Layer (166 files)                      │
+│                Domain Layer (174 files)                      │
 │  Business Logic │ Domain Models │ Port Interfaces            │
 └────────────────────────┬────────────────────────────────────┘
                          │ Port Implementations
@@ -37,11 +37,11 @@
 
 | Layer | Files | LOC | Key Contents |
 |-------|-------|-----|-------------|
-| API | 91 | 10,624 | 28 route files, 26 endpoint route modules, 85 endpoint decorators, schemas, middleware, dependencies |
-| App | 207 | 11,192 | 37 command files, 34 query files, 10 event files, 75 handler files |
-| Domain | 166 | 16,283 | Meal, nutrition, user, hydration, movement, progress, notification, planning, referral-facing policies |
-| Infra | 154 | 15,134 | PostgreSQL/pgvector, Redis, PyMediator, external adapters, observability, push/email services |
-| **Total** | **618** | **53,233** | Layer directories only; `src/` also has bootstrap, cron, and observability modules |
+| API | 91 | 11,323 | 28 route files, 26 endpoint route modules, 88 endpoint decorators, schemas, middleware, dependencies |
+| App | 207 | 11,333 | 50 command files, 52 query files, 14 event files, 86 handler files |
+| Domain | 174 | 17,397 | Meal, nutrition, user, hydration, movement, progress, notification, planning, referral-facing policies |
+| Infra | 154 | 15,337 | PostgreSQL/pgvector, Redis, PyMediator, external adapters, observability, push/email services |
+| **Total** | **626** | **55,390** | Layer directories only; `src/` also has bootstrap, cron, and observability modules |
 
 **Layer rule:** Domain has ZERO external dependencies. See `cqrs-guide.md` for handler patterns.
 
@@ -115,6 +115,16 @@ Architecture guardrails enforced by `tests/unit/architecture/test_logging_owners
 5. Handler returns Meal immediately to API (synchronous response to client)
 6. `EventBus.publish()` → `MealAnalysisEventHandler` (background)
 7. Background: calls `VisionAIService` through the provider stack, parses nutrition, updates Meal to READY
+
+## Data Flow Example: Food-Label Scan By URL
+
+1. `POST /v1/meals/food-label/scan-by-url` receives Cloudinary image identifiers, optional label-crop identifiers, and crop metadata.
+2. Route validates Cloudinary URLs and creates `ScanByUrlCommand(scan_mode="food_label")`.
+3. `ScanByUrlCommandHandler` downloads the full image bytes; if a label crop is supplied, it downloads and analyzes the crop bytes.
+4. Handler calls `VisionAIService.analyze_with_strategy(..., FoodLabelImageAnalysisStrategy)`.
+5. Infrastructure validates provider output against `FoodLabelNutritionResponse`.
+6. `VisionResponseParser` maps validated label data into `Nutrition` and `food_label_metadata`.
+7. Handler persists a READY `Meal(source="food_label")`, invalidates meal caches, and does not create hydration side effects.
 
 ---
 

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -1,8 +1,8 @@
 # Backend Testing Standards
 
-**Last Updated:** June 27, 2026
+**Last Updated:** July 5, 2026
 **Coverage Target:** CI gate 65% for unit coverage; docs target 70%+ overall, 100% critical paths, 80%+ new features
-**Suite Size:** 306 Python files in `tests/`; latest collection reaches 1,600+ tests
+**Suite Size:** 312 Python files in `tests/`; latest collection reaches 1,600+ tests
 
 ---
 


### PR DESCRIPTION
## Summary
- Update backend docs for the current food-label image scan-by-url contract, including optional label crop handling and `FoodLabelNutritionResponse` validation
- Refresh codebase, API, layer, and test metrics across README and evergreen docs
- Remove stale native-OCR-only wording from food-label scan docs

## Related issues
- None found via `gh issue list --search "food label docs"`

## Test plan
- [x] Searched edited docs for stale OCR and old metric wording
- [x] Checked docs line counts against size guidance
- [x] Ran staged secret scan; only placeholder/header terms matched, no secret values
- [ ] `node $HOME/.claude/scripts/validate-docs.cjs docs/` timed out after 90s with no output