### PR TITLE
feat(meals): expose food allowed units

### DIFF
--- a/migrations/versions/20260705000001_add_allowed_units_to_food_item.py
+++ b/migrations/versions/20260705000001_add_allowed_units_to_food_item.py
@@ -1,0 +1,35 @@
+"""Add allowed unit options to food items.
+
+Revision ID: 20260705000001
+Revises: 20260702000001
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260705000001"
+down_revision = "20260702000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "food_item",
+        "unit",
+        existing_type=sa.String(length=50),
+        type_=sa.String(length=120),
+        existing_nullable=False,
+    )
+    op.add_column("food_item", sa.Column("allowed_units", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("food_item", "allowed_units")
+    op.alter_column(
+        "food_item",
+        "unit",
+        existing_type=sa.String(length=120),
+        type_=sa.String(length=50),
+        existing_nullable=False,
+    )

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -178,6 +178,7 @@ class MealMapper:
                         custom_nutrition=custom_nutrition_dto,
                         fdc_id=getattr(item, "fdc_id", None),
                         is_custom=getattr(item, "is_custom", False),
+                        allowed_units=getattr(item, "allowed_units", None) or [],
                     )
                     food_items.append(food_item_dto)
 
@@ -467,6 +468,7 @@ class MealMapper:
             confidence=item_dict.get("confidence", 1.0),
             fdc_id=item_dict.get("fdc_id"),
             is_custom=item_dict.get("is_custom", False),
+            allowed_units=item_dict.get("allowed_units") or None,
         )
 
     @staticmethod

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -45,7 +45,10 @@ from src.api.schemas.response import (
     MealValueInsightsStatusResponse,
 )
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
-from src.api.schemas.response.meal_responses import ParseMealTextResponse
+from src.api.schemas.response.meal_responses import (
+    ParsedFoodItem,
+    ParseMealTextResponse,
+)
 from src.api.schemas.response.weekly_budget_response import WeeklyBudgetResponse
 from src.api.services.guest_parse_quota import (
     GuestParseQuotaService,
@@ -72,6 +75,7 @@ from src.app.queries.meal import (
     GetMealByIdQuery,
     GetStreakQuery,
 )
+from src.domain.model.nutrition.macros import Macros as MacrosModel
 from src.domain.ports.cache_port import CachePort
 from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.services.meal_value_insight_service import MealValueInsightService
@@ -108,6 +112,26 @@ def _parse_target_date(target_date: str | None):
             error_code="INVALID_DATE_FORMAT",
             details={"date": target_date},
         ) from e
+
+
+def _parsed_food_item_to_response(item) -> ParsedFoodItem:
+    return ParsedFoodItem(
+        name=item.name,
+        quantity=item.quantity,
+        unit=item.unit,
+        calories=MacrosModel(
+            protein=item.protein,
+            carbs=item.carbs,
+            fat=item.fat,
+            fiber=item.fiber if hasattr(item, "fiber") and item.fiber else 0.0,
+        ).total_calories,
+        protein=item.protein,
+        carbs=item.carbs,
+        fat=item.fat,
+        data_source=item.data_source,
+        fdc_id=item.fdc_id,
+        allowed_units=getattr(item, "allowed_units", None) or [],
+    )
 
 
 async def _analyze_uploaded_image(
@@ -379,28 +403,8 @@ async def parse_meal_text(
         )
         app_response = await event_bus.send(command)
 
-        # Map app DTO to API response DTO
-        from src.api.schemas.response.meal_responses import ParsedFoodItem
-        from src.domain.model.nutrition.macros import Macros as MacrosModel
-
         api_items = [
-            ParsedFoodItem(
-                name=item.name,
-                quantity=item.quantity,
-                unit=item.unit,
-                calories=MacrosModel(
-                    protein=item.protein,
-                    carbs=item.carbs,
-                    fat=item.fat,
-                    fiber=item.fiber if hasattr(item, "fiber") and item.fiber else 0.0,
-                ).total_calories,
-                protein=item.protein,
-                carbs=item.carbs,
-                fat=item.fat,
-                data_source=item.data_source,
-                fdc_id=item.fdc_id,
-            )
-            for item in app_response.items
+            _parsed_food_item_to_response(item) for item in app_response.items
         ]
         total_calories = sum(i.calories for i in api_items)
 
@@ -479,28 +483,7 @@ async def parse_meal_text_guest_trial(
 
     await quota.mark_completed(id_hash)
 
-    from src.api.schemas.response.meal_responses import ParsedFoodItem
-    from src.domain.model.nutrition.macros import Macros as MacrosModel
-
-    api_items = [
-        ParsedFoodItem(
-            name=item.name,
-            quantity=item.quantity,
-            unit=item.unit,
-            calories=MacrosModel(
-                protein=item.protein,
-                carbs=item.carbs,
-                fat=item.fat,
-                fiber=item.fiber if hasattr(item, "fiber") and item.fiber else 0.0,
-            ).total_calories,
-            protein=item.protein,
-            carbs=item.carbs,
-            fat=item.fat,
-            data_source=item.data_source,
-            fdc_id=item.fdc_id,
-        )
-        for item in app_response.items
-    ]
+    api_items = [_parsed_food_item_to_response(item) for item in app_response.items]
     total_calories = sum(i.calories for i in api_items)
 
     return ParseMealTextResponse(

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -294,6 +294,7 @@ async def create_manual_meal(
                     quantity=i.quantity,
                     unit=i.unit,
                     custom_nutrition=custom_nutrition,
+                    allowed_units=[unit.model_dump() for unit in i.allowed_units],
                 )
             )
 
@@ -829,6 +830,9 @@ async def update_meal_ingredients(
                 quantity=change_request.quantity,
                 unit=change_request.unit,
                 custom_nutrition=custom_nutrition,
+                allowed_units=[
+                    unit.model_dump() for unit in change_request.allowed_units
+                ],
             )
         )
 

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -185,6 +185,14 @@ class ManualMealCustomNutritionRequest(BaseModel):
         )
 
 
+class ServingUnitRequest(BaseModel):
+    """Food-specific serving conversion option."""
+
+    unit: str = Field(..., min_length=1, max_length=120)
+    gram_weight: float = Field(..., gt=0)
+    description: str = Field("", max_length=200)
+
+
 class ManualMealItemRequest(BaseModel):
     """Single selected food item with portion to create a manual meal.
 
@@ -204,7 +212,11 @@ class ManualMealItemRequest(BaseModel):
         ..., gt=0, description="Amount relative to serving unit (e.g., grams)"
     )
     unit: str = Field(
-        "g", min_length=1, max_length=64, description="Unit, default grams"
+        "g", min_length=1, max_length=120, description="Unit, default grams"
+    )
+    allowed_units: list[ServingUnitRequest] = Field(
+        default_factory=list,
+        description="Food-specific units allowed for editing this ingredient",
     )
     custom_nutrition: Optional[ManualMealCustomNutritionRequest] = Field(
         None,
@@ -268,7 +280,11 @@ class FoodItemChangeRequest(BaseModel):
         None, gt=0, le=10000, description="Quantity amount"
     )
     unit: Optional[str] = Field(
-        None, min_length=1, max_length=20, description="Unit of measurement"
+        None, min_length=1, max_length=120, description="Unit of measurement"
+    )
+    allowed_units: list[ServingUnitRequest] = Field(
+        default_factory=list,
+        description="Food-specific units allowed for editing this ingredient",
     )
     custom_nutrition: Optional["CustomNutritionRequest"] = Field(
         None, description="Custom nutrition data for non-USDA ingredients"

--- a/src/api/schemas/response/barcode_product_response.py
+++ b/src/api/schemas/response/barcode_product_response.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from src.api.schemas.response.meal_responses import ServingUnitResponse
+
 
 class BarcodeProductResponse(BaseModel):
     """Response DTO for barcode product lookup."""
@@ -35,6 +37,10 @@ class BarcodeProductResponse(BaseModel):
     )
     is_estimate: bool = Field(
         False, description="True when macros are AI-estimated, user should verify"
+    )
+    allowed_units: list[ServingUnitResponse] = Field(
+        default_factory=list,
+        description="Food-specific serving conversion options",
     )
 
     model_config = {"from_attributes": True}

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -143,6 +143,14 @@ class FoodLabelMetadataResponse(BaseModel):
     label_notes: list[str] = Field(default_factory=list)
 
 
+class ServingUnitResponse(BaseModel):
+    """Food-specific serving conversion option."""
+
+    unit: str = Field(..., description="Unit token used for save/edit requests")
+    gram_weight: float = Field(..., gt=0, description="Gram weight for one unit")
+    description: str = Field("", description="User-facing serving description")
+
+
 class MealValueBulletResponse(BaseModel):
     """Short meal-level value insight."""
 
@@ -215,6 +223,10 @@ class FoodItemResponse(BaseModel):
     )
     fdc_id: int | None = Field(None, description="USDA FDC ID if available")
     is_custom: bool = Field(False, description="Whether this is a custom ingredient")
+    allowed_units: list[ServingUnitResponse] = Field(
+        default_factory=list,
+        description="Allowed unit options for this food item",
+    )
 
 
 class SimpleMealResponse(BaseModel):

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -35,6 +35,14 @@ class ValueInsightCategoryEnum(StrEnum):
 # Translation Response DTOs
 
 
+class ServingUnitResponse(BaseModel):
+    """Food-specific serving conversion option."""
+
+    unit: str = Field(..., description="Unit token used for save/edit requests")
+    gram_weight: float = Field(..., gt=0, description="Gram weight for one unit")
+    description: str = Field("", description="User-facing serving description")
+
+
 class ParsedFoodItem(BaseModel):
     """Response DTO for a single parsed food item."""
 
@@ -51,6 +59,10 @@ class ParsedFoodItem(BaseModel):
         None, description="Data source: usda, fatsecret, or ai_estimate"
     )
     fdc_id: int | None = Field(None, description="USDA FDC ID when available")
+    allowed_units: list[ServingUnitResponse] = Field(
+        default_factory=list,
+        description="Allowed unit options for this food item",
+    )
 
 
 class ParseMealTextResponse(BaseModel):
@@ -141,14 +153,6 @@ class FoodLabelMetadataResponse(BaseModel):
     label_calories_per_serving: float | None = Field(None, ge=0)
     confidence: float = Field(..., ge=0, le=1)
     label_notes: list[str] = Field(default_factory=list)
-
-
-class ServingUnitResponse(BaseModel):
-    """Food-specific serving conversion option."""
-
-    unit: str = Field(..., description="Unit token used for save/edit requests")
-    gram_weight: float = Field(..., gt=0, description="Gram weight for one unit")
-    description: str = Field("", description="User-facing serving description")
 
 
 class MealValueBulletResponse(BaseModel):

--- a/src/app/commands/meal/create_manual_meal_command.py
+++ b/src/app/commands/meal/create_manual_meal_command.py
@@ -4,7 +4,7 @@ Command to create a manual meal from a list of USDA FDC items or custom foods wi
 
 from dataclasses import dataclass
 from datetime import date
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from src.app.events.base import Command
 
@@ -30,6 +30,7 @@ class ManualMealItem:
     quantity: float = 1.0  # in grams or unit-specified grams base
     unit: str = "g"  # unit name, e.g., "g"
     custom_nutrition: Optional[CustomNutrition] = None
+    allowed_units: Optional[List[dict[str, Any]]] = None
 
 
 @dataclass

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -126,6 +126,7 @@ class ParseMealTextHandler(
                 fat=item.get("fat", 0),
                 data_source=item.get("data_source"),
                 fdc_id=item.get("fdc_id"),
+                allowed_units=item.get("allowed_units") or [],
             )
             for item in enhanced_items
         ]

--- a/src/app/schemas/meal_schemas.py
+++ b/src/app/schemas/meal_schemas.py
@@ -4,7 +4,7 @@ Domain-agnostic - used by handlers, mapped to API DTOs at the presentation layer
 """
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any
 
 
 @dataclass
@@ -17,16 +17,17 @@ class ParsedFoodItemDto:
     protein: float
     carbs: float
     fat: float
-    data_source: Optional[str] = None
-    fdc_id: Optional[int] = None
+    data_source: str | None = None
+    fdc_id: int | None = None
+    allowed_units: list[dict[str, Any]] | None = None
 
 
 @dataclass
 class ParseMealTextResponseDto:
     """DTO for parse meal text command response (app layer)."""
 
-    items: List[ParsedFoodItemDto]
+    items: list[ParsedFoodItemDto]
     total_protein: float
     total_carbs: float
     total_fat: float
-    emoji: Optional[str] = None
+    emoji: str | None = None

--- a/src/domain/model/meal/food_item_change.py
+++ b/src/domain/model/meal/food_item_change.py
@@ -4,7 +4,7 @@ Used when editing meals to add, update, or remove food items.
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 
 @dataclass
@@ -18,6 +18,7 @@ class FoodItemChange:
     quantity: Optional[float] = None
     unit: Optional[str] = None
     custom_nutrition: Optional["CustomNutritionData"] = None
+    allowed_units: Optional[list[dict[str, Any]]] = None
 
 
 @dataclass

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from .macros import Macros
 from .micros import Micros
@@ -19,6 +20,7 @@ class FoodItem:
     confidence: float = 1.0  # 0.0-1.0 confidence score from AI or lookup
     fdc_id: int | None = None  # USDA FDC ID if available
     is_custom: bool = False  # Whether this is a custom ingredient
+    allowed_units: list[dict[str, Any]] | None = None
 
     def __post_init__(self):
         """Validate invariants."""
@@ -34,8 +36,8 @@ class FoodItem:
             raise ValueError(f"Confidence must be between 0 and 1: {self.confidence}")
         if not self.unit or not self.unit.strip():
             raise ValueError("Unit cannot be empty")
-        if len(self.unit) > 50:
-            raise ValueError(f"Unit too long (max 50 chars): {len(self.unit)}")
+        if len(self.unit) > 120:
+            raise ValueError(f"Unit too long (max 120 chars): {len(self.unit)}")
 
     @property
     def calories(self) -> float:
@@ -58,6 +60,8 @@ class FoodItem:
             result["micros"] = self.micros.to_dict()
         if self.fdc_id:
             result["fdc_id"] = self.fdc_id
+        if self.allowed_units:
+            result["allowed_units"] = self.allowed_units
         return result
 
 

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -443,6 +443,7 @@ class NutritionCalculationService:
                     micros=None,
                     confidence=1.0,
                     fdc_id=getattr(item, "fdc_id", None),
+                    allowed_units=getattr(item, "allowed_units", None),
                 )
             )
 

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -101,6 +101,7 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 confidence=0.8,
                 fdc_id=existing_item.fdc_id,
                 is_custom=True,
+                allowed_units=change.allowed_units or existing_item.allowed_units,
             )
             logger.info(
                 f"Updated food item with custom nutrition: {existing_item.name}"
@@ -134,6 +135,7 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     confidence=0.9,
                     fdc_id=existing_item.fdc_id,
                     is_custom=existing_item.is_custom,
+                    allowed_units=change.allowed_units or existing_item.allowed_units,
                 )
                 logger.info(f"Updated food item with unit change: {existing_item.name}")
             else:
@@ -192,6 +194,7 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             confidence=existing_item.confidence,
             fdc_id=existing_item.fdc_id,
             is_custom=existing_item.is_custom,
+            allowed_units=change.allowed_units or existing_item.allowed_units,
         )
         logger.info(f"Updated food item with scaling: {existing_item.name}")
 
@@ -223,6 +226,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                 quantity,
                 unit,
                 change.custom_nutrition,
+                change.allowed_units,
             )
             food_items_dict[new_item_id] = food_item
             logger.info(f"Added custom food item: {change.name}")
@@ -248,6 +252,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                     confidence=0.9,
                     fdc_id=change.fdc_id,
                     is_custom=False,
+                    allowed_units=change.allowed_units,
                 )
                 logger.info(f"Added food item from nutrition service: {change.name}")
                 return
@@ -265,10 +270,17 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             confidence=0.3,
             fdc_id=change.fdc_id,
             is_custom=True,
+            allowed_units=change.allowed_units,
         )
 
     def _create_from_custom_nutrition(
-        self, item_id: str, name: str, quantity: float, unit: str, custom_nutrition
+        self,
+        item_id: str,
+        name: str,
+        quantity: float,
+        unit: str,
+        custom_nutrition,
+        allowed_units=None,
     ) -> FoodItem:
         """Create food item from custom nutrition data."""
         quantity_grams = convert_quantity_to_grams(quantity, unit, name)
@@ -290,6 +302,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             confidence=0.8,
             fdc_id=None,
             is_custom=True,
+            allowed_units=allowed_units,
         )
 
 

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -3,12 +3,12 @@ fatsecret API HTTP client.
 Provides product lookup by barcode and food search using OAuth 2.0.
 """
 
-from typing import Dict, Any, Optional, List
 import asyncio
-import logging
-import time
 import base64
+import logging
 import re
+import time
+from typing import Any
 
 import httpx
 
@@ -41,9 +41,9 @@ class FatSecretService:
     def __init__(self, client_id: str, client_secret: str):
         self.client_id = client_id
         self.client_secret = client_secret
-        self._access_token: Optional[str] = None
+        self._access_token: str | None = None
         self._token_expires_at: float = 0
-        self._client: Optional[httpx.AsyncClient] = None
+        self._client: httpx.AsyncClient | None = None
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client."""
@@ -57,7 +57,7 @@ class FatSecretService:
             await self._client.aclose()
             self._client = None
 
-    async def _get_access_token(self) -> Optional[str]:
+    async def _get_access_token(self) -> str | None:
         """Get OAuth 2.0 access token, refreshing if needed."""
         # Check if token is still valid (with 60s buffer)
         if self._access_token and time.time() < self._token_expires_at - 60:
@@ -100,9 +100,9 @@ class FatSecretService:
         self,
         method: str,
         endpoint: str = "",
-        params: Optional[Dict] = None,
+        params: dict | None = None,
         base_url: str = FATSECRET_API_BASE,
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """Make authenticated API request."""
         token = await self._get_access_token()
         if not token:
@@ -111,7 +111,7 @@ class FatSecretService:
         url = base_url if not endpoint else f"{base_url}/{endpoint}"
         headers = {
             "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
         }
 
         try:
@@ -119,7 +119,7 @@ class FatSecretService:
             if method.upper() == "GET":
                 response = await client.get(url, headers=headers, params=params)
             else:
-                response = await client.post(url, headers=headers, json=params)
+                response = await client.post(url, headers=headers, data=params)
 
             if response.status_code != 200:
                 logger.warning(
@@ -127,7 +127,14 @@ class FatSecretService:
                 )
                 return None
 
-            return response.json()
+            try:
+                return response.json()
+            except ValueError:
+                logger.warning(
+                    "fatsecret API returned non-JSON response: %s",
+                    response.text[:200],
+                )
+                return None
         except httpx.HTTPError as e:
             logger.warning(f"fatsecret request error: {e}")
             return None
@@ -137,7 +144,7 @@ class FatSecretService:
         barcode: str,
         region: str = "US",
         language: str = "en",
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Fetch product by barcode from fatsecret."""
         # Validate barcode format
         if not BARCODE_PATTERN.match(barcode):
@@ -185,7 +192,7 @@ class FatSecretService:
         max_results: int = 10,
         region: str = "US",
         language: str = "en",
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Search foods by query string with nutrition data."""
         try:
             params = {
@@ -225,7 +232,7 @@ class FatSecretService:
 
             # Process each food, fetching detailed nutrition concurrently to
             # avoid N+1 sequential round trips (one food.get per search result).
-            async def _process(food: Dict) -> Dict:
+            async def _process(food: dict) -> dict:
                 food_id = food.get("food_id")
                 mapped = self._map_search_result(food)
 
@@ -260,7 +267,7 @@ class FatSecretService:
             logger.warning(f"fatsecret search error for query '{query}': {e}")
             return []
 
-    def _extract_serving_units(self, food: Dict) -> List[Dict]:
+    def _extract_serving_units(self, food: dict) -> list[dict]:
         """Extract all serving units from fatsecret food details."""
         servings = food.get("servings", {}).get("serving", [])
         if not servings:
@@ -289,7 +296,7 @@ class FatSecretService:
 
         return units or self._default_allowed_units()
 
-    def _select_per_100g_serving(self, food: Dict[str, Any]) -> Optional[Dict]:
+    def _select_per_100g_serving(self, food: dict[str, Any]) -> dict | None:
         servings = food.get("servings", {}).get("serving", [])
         if isinstance(servings, dict):
             servings = [servings]
@@ -303,7 +310,7 @@ class FatSecretService:
                 return serving
         return servings[0] if isinstance(servings[0], dict) else None
 
-    def _extract_nutrition_from_details(self, food: Dict[str, Any]) -> Dict[str, Any]:
+    def _extract_nutrition_from_details(self, food: dict[str, Any]) -> dict[str, Any]:
         """Extract per-100g nutrition from fatsecret food details."""
         serving = self._select_per_100g_serving(food)
 
@@ -326,11 +333,11 @@ class FatSecretService:
             "allowed_units": self._extract_serving_units(food),
         }
 
-    def _default_allowed_units(self) -> List[Dict]:
+    def _default_allowed_units(self) -> list[dict]:
         """Return default allowed units when none are provided."""
         return [{"unit": "g", "gram_weight": 100.0, "description": "100 g"}]
 
-    def _map_product(self, food: Dict[str, Any], barcode: str) -> Dict[str, Any]:
+    def _map_product(self, food: dict[str, Any], barcode: str) -> dict[str, Any]:
         """Map fatsecret response to clean dict."""
         serving = self._select_per_100g_serving(food)
         if not isinstance(serving, dict):
@@ -365,7 +372,7 @@ class FatSecretService:
             "allowed_units": self._extract_serving_units(food),
         }
 
-    def _calc_per_100g(self, value: Any, metric_amount: float) -> Optional[float]:
+    def _calc_per_100g(self, value: Any, metric_amount: float) -> float | None:
         """Calculate nutrition value per 100g using metric_serving_amount."""
         if value is None:
             return None
@@ -376,7 +383,7 @@ class FatSecretService:
             return None
         return (raw_value / metric_amount) * 100
 
-    def _map_search_result(self, food: Dict[str, Any]) -> Dict[str, Any]:
+    def _map_search_result(self, food: dict[str, Any]) -> dict[str, Any]:
         """Map fatsecret search result to clean dict."""
         return {
             "description": food.get("food_name", ""),
@@ -389,7 +396,7 @@ class FatSecretService:
             "allowed_units": self._default_allowed_units(),  # Will be enriched with details
         }
 
-    def _safe_float(self, value: Any) -> Optional[float]:
+    def _safe_float(self, value: Any) -> float | None:
         """Safely convert value to float."""
         if value is None:
             return None
@@ -399,7 +406,7 @@ class FatSecretService:
             return None
 
 
-_fat_secret_service: Optional[FatSecretService] = None
+_fat_secret_service: FatSecretService | None = None
 
 
 def get_fat_secret_service() -> FatSecretService:

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 # fatsecret API endpoints
 FATSECRET_TOKEN_URL = "https://oauth.fatsecret.com/connect/token"
-FATSECRET_API_BASE = "https://platform.fatsecret.com/rest/v1"
+FATSECRET_API_BASE = "https://platform.fatsecret.com/rest/server.api"
 
 # Barcode validation pattern (8-14 digits)
 BARCODE_PATTERN = re.compile(r"^\d{8,14}$")
@@ -97,14 +97,18 @@ class FatSecretService:
             return None
 
     async def _api_request(
-        self, method: str, endpoint: str, params: Optional[Dict] = None
+        self,
+        method: str,
+        endpoint: str = "",
+        params: Optional[Dict] = None,
+        base_url: str = FATSECRET_API_BASE,
     ) -> Optional[Dict]:
         """Make authenticated API request."""
         token = await self._get_access_token()
         if not token:
             return None
 
-        url = f"{FATSECRET_API_BASE}/{endpoint}"
+        url = base_url if not endpoint else f"{base_url}/{endpoint}"
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
@@ -149,7 +153,7 @@ class FatSecretService:
                 "region": region,
                 "language": language,
             }
-            result = await self._api_request("GET", "", params)
+            result = await self._api_request("POST", params=params)
             if not result:
                 return None
 
@@ -159,13 +163,14 @@ class FatSecretService:
 
             # Get food details
             detail_params = {
-                "method": "food.get",
+                "method": "food.get.v5",
                 "food_id": food_id,
                 "format": "json",
                 "region": region,
                 "language": language,
+                "flag_default_serving": "true",
             }
-            food_details = await self._api_request("GET", "", detail_params)
+            food_details = await self._api_request("POST", params=detail_params)
             if not food_details:
                 return None
 
@@ -184,15 +189,16 @@ class FatSecretService:
         """Search foods by query string with nutrition data."""
         try:
             params = {
-                "method": "foods.search",
+                "method": "foods.search.v5",
                 "search_expression": query,
                 "max_results": max_results,
                 "page_number": 0,
                 "format": "json",
                 "region": region,
                 "language": language,
+                "flag_default_serving": "true",
             }
-            result = await self._api_request("GET", "", params)
+            result = await self._api_request("POST", params=params)
             if not result:
                 return []
 
@@ -227,13 +233,16 @@ class FatSecretService:
                 if food_id:
                     try:
                         detail_params = {
-                            "method": "food.get",
+                            "method": "food.get.v5",
                             "food_id": food_id,
                             "format": "json",
                             "region": region,
                             "language": language,
+                            "flag_default_serving": "true",
                         }
-                        details = await self._api_request("GET", "", detail_params)
+                        details = await self._api_request(
+                            "POST", params=detail_params
+                        )
                         if details:
                             # Handle both response formats for food.get
                             food_data = details.get("food", details)
@@ -255,16 +264,21 @@ class FatSecretService:
         """Extract all serving units from fatsecret food details."""
         servings = food.get("servings", {}).get("serving", [])
         if not servings:
-            return []
+            return self._default_allowed_units()
 
         if isinstance(servings, dict):
             servings = [servings]
 
         units = []
+        seen = set()
         for s in servings:
             unit = s.get("measurement_description")
             gram_weight = self._safe_float(s.get("metric_serving_amount"))
             if unit and gram_weight and gram_weight > 0:
+                unit_key = unit.lower().strip()
+                if unit_key in seen:
+                    continue
+                seen.add(unit_key)
                 units.append(
                     {
                         "unit": unit,
@@ -273,20 +287,25 @@ class FatSecretService:
                     }
                 )
 
-        # Always include "g" as base unit
-        if not any(u["unit"].lower() == "g" for u in units):
-            units.insert(0, {"unit": "g", "gram_weight": 1.0, "description": "1 g"})
+        return units or self._default_allowed_units()
 
-        return units
+    def _select_per_100g_serving(self, food: Dict[str, Any]) -> Optional[Dict]:
+        servings = food.get("servings", {}).get("serving", [])
+        if isinstance(servings, dict):
+            servings = [servings]
+        if not isinstance(servings, list) or not servings:
+            return None
+
+        for serving in servings:
+            metric_amount = self._safe_float(serving.get("metric_serving_amount"))
+            measurement = str(serving.get("measurement_description") or "").lower()
+            if measurement == "g" and metric_amount == 100:
+                return serving
+        return servings[0] if isinstance(servings[0], dict) else None
 
     def _extract_nutrition_from_details(self, food: Dict[str, Any]) -> Dict[str, Any]:
         """Extract per-100g nutrition from fatsecret food details."""
-        servings = food.get("servings", {}).get("serving", [])
-        serving = None
-        if isinstance(servings, list) and servings:
-            serving = servings[0]
-        elif isinstance(servings, dict):
-            serving = servings
+        serving = self._select_per_100g_serving(food)
 
         if not isinstance(serving, dict):
             return {"allowed_units": self._default_allowed_units()}
@@ -309,16 +328,11 @@ class FatSecretService:
 
     def _default_allowed_units(self) -> List[Dict]:
         """Return default allowed units when none are provided."""
-        return [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
+        return [{"unit": "g", "gram_weight": 100.0, "description": "100 g"}]
 
     def _map_product(self, food: Dict[str, Any], barcode: str) -> Dict[str, Any]:
         """Map fatsecret response to clean dict."""
-        servings = food.get("servings", {}).get("serving", [])
-        serving = None
-        if isinstance(servings, list) and servings:
-            serving = servings[0]
-        elif isinstance(servings, dict):
-            serving = servings
+        serving = self._select_per_100g_serving(food)
         if not isinstance(serving, dict):
             return {
                 "name": food.get("food_name", ""),

--- a/src/infra/database/models/nutrition/food_item.py
+++ b/src/infra/database/models/nutrition/food_item.py
@@ -2,7 +2,7 @@
 Food item model for individual food components within a meal.
 """
 
-from sqlalchemy import Column, String, Float, Integer, ForeignKey, Boolean
+from sqlalchemy import Column, String, Float, Integer, ForeignKey, Boolean, JSON
 from sqlalchemy.orm import relationship
 
 from src.infra.database.base import Base
@@ -16,8 +16,9 @@ class FoodItemORM(Base, PrimaryEntityMixin):
 
     name = Column(String(255), nullable=False)
     quantity = Column(Float, nullable=False)
-    unit = Column(String(50), nullable=False)
+    unit = Column(String(120), nullable=False)
     confidence = Column(Float, nullable=True)
+    allowed_units = Column(JSON, nullable=True)
 
     # Edit support fields
     fdc_id = Column(

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -72,6 +72,7 @@ def food_item_orm_to_domain(orm: FoodItemORM) -> DomainFoodItem:
         confidence=orm.confidence,
         fdc_id=orm.fdc_id,
         is_custom=orm.is_custom,
+        allowed_units=orm.allowed_units,
     )
 
 
@@ -207,6 +208,7 @@ def food_item_domain_to_orm(domain: DomainFoodItem, nutrition_id=None) -> FoodIt
         nutrition_id=nutrition_id,
         fdc_id=getattr(domain, "fdc_id", None),
         is_custom=getattr(domain, "is_custom", False),
+        allowed_units=getattr(domain, "allowed_units", None),
     )
     if hasattr(domain, "id") and domain.id:
         item.id = str(domain.id)

--- a/tests/unit/api/test_guest_parse_trial.py
+++ b/tests/unit/api/test_guest_parse_trial.py
@@ -36,6 +36,10 @@ class _Item:
     fiber = 0.0
     data_source = "ai_estimate"
     fdc_id = None
+    allowed_units = [
+        {"unit": "piece", "gram_weight": 50.0, "description": "1 piece"},
+        {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
+    ]
 
 
 class _Resp:
@@ -125,6 +129,10 @@ def test_guest_parse_success(monkeypatch, client: TestClient):
     assert "emoji" in body
     assert len(body["items"]) == 1
     assert body["items"][0]["name"] == "egg"
+    assert body["items"][0]["allowed_units"] == [
+        {"unit": "piece", "gram_weight": 50.0, "description": "1 piece"},
+        {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
+    ]
 
     quota_svc.reserve.assert_awaited_once_with("install-abc123")
     quota_svc.mark_completed.assert_awaited_once_with("abc123hash")
@@ -235,3 +243,7 @@ def test_authenticated_parse_text_unchanged(monkeypatch, client: TestClient):
     body = r.json()
     assert "items" in body
     assert len(body["items"]) == 1
+    assert body["items"][0]["allowed_units"] == [
+        {"unit": "piece", "gram_weight": 50.0, "description": "1 piece"},
+        {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
+    ]

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -42,6 +42,38 @@ class TestFoodItemChangeRequest:
         # Derived: 10*4 + 20*4 + 8*9 = 192
         assert request.custom_nutrition.calories_per_100g == 192.0
 
+    def test_valid_add_request_with_allowed_units(self):
+        """Test preserving food-specific unit options."""
+        request = FoodItemChangeRequest(
+            action="add",
+            name="Chicken Breast",
+            quantity=100.0,
+            unit="g",
+            allowed_units=[
+                {
+                    "unit": "g",
+                    "gram_weight": 100.0,
+                    "description": "100 g",
+                },
+                {
+                    "unit": "small breast (yield after cooking, bone removed)",
+                    "gram_weight": 84.0,
+                    "description": "1/2 small (yield after cooking, bone removed)",
+                },
+                {
+                    "unit": "cup, cooked, diced",
+                    "gram_weight": 135.0,
+                    "description": "1 cup cooked, diced",
+                },
+            ],
+        )
+
+        assert len(request.allowed_units) == 3
+        assert request.allowed_units[0].unit == "g"
+        assert request.allowed_units[0].description == "100 g"
+        assert request.allowed_units[1].unit.startswith("small breast")
+        assert request.allowed_units[2].unit == "cup, cooked, diced"
+
     def test_valid_update_request(self):
         """Test valid update request."""
         # Arrange & Act
@@ -132,7 +164,7 @@ class TestFoodItemChangeRequest:
                 action="add",
                 name="Test Food",
                 quantity=100.0,
-                unit="a" * 21,  # Over 20 character limit
+                unit="a" * 121,  # Over 120 character limit
             )
 
 

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -57,6 +57,27 @@ class _HighCalorieFatSecretService:
         return [{"food_name": "Pho concentrate"}]
 
 
+class _AllowedUnitsFatSecretService:
+    async def search_foods(self, *args, **kwargs):
+        return [
+            {
+                "food_name": "Chicken Breast",
+                "allowed_units": [
+                    {
+                        "unit": "g",
+                        "gram_weight": 100.0,
+                        "description": "100 g",
+                    },
+                    {
+                        "unit": "cup, cooked, diced",
+                        "gram_weight": 135.0,
+                        "description": "1 cup cooked, diced",
+                    },
+                ],
+            }
+        ]
+
+
 @pytest.mark.asyncio
 async def test_parse_text_unit_stays_compatible_with_prompt_manual_save():
     meal_generation_service = _FakeMealGenerationService()
@@ -98,6 +119,61 @@ async def test_parse_text_unit_stays_compatible_with_prompt_manual_save():
     }
 
     assert CreateManualMealFromFoodsRequest.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_parse_text_preserves_fatsecret_allowed_units(monkeypatch):
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Chicken breast",
+                        "quantity": 100,
+                        "unit": "g",
+                        "english_unit": "g",
+                        "protein": 31,
+                        "carbs": 0,
+                        "fat": 3.6,
+                    }
+                ]
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.parse_meal_text_handler."
+        "parse_fatsecret_nutrition",
+        lambda _food: {"calories": 165, "protein": 31, "carbs": 0, "fat": 3.6},
+    )
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.parse_meal_text_handler."
+        "scale_per_100g_nutrition",
+        lambda *args, **kwargs: {
+            "calories": 165,
+            "protein": 31,
+            "carbs": 0,
+            "fat": 3.6,
+        },
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_AllowedUnitsFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="100g chicken breast", user_id="user-1", language="en")
+    )
+    item = response.items[0]
+
+    assert item.data_source == "fatsecret"
+    assert item.allowed_units == [
+        {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
+        {
+            "unit": "cup, cooked, diced",
+            "gram_weight": 135.0,
+            "description": "1 cup cooked, diced",
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -5,6 +5,25 @@ import pytest
 from src.infra.adapters.fat_secret_service import FatSecretService
 
 
+class _Response:
+    status_code = 200
+    text = '{"ok": true}'
+
+    def json(self):
+        return {"ok": True}
+
+
+class _Client:
+    is_closed = False
+
+    def __init__(self):
+        self.post_calls = []
+
+    async def post(self, *args, **kwargs):
+        self.post_calls.append((args, kwargs))
+        return _Response()
+
+
 @pytest.mark.unit
 def test_fatsecret_serving_units_preserve_fatsecret_order():
     service = FatSecretService("client", "secret")
@@ -70,6 +89,26 @@ def test_fatsecret_nutrition_prefers_100g_serving():
     assert nutrition["carbs_100g"] == 66.67
     assert nutrition["fat_100g"] == 6.67
     assert nutrition["allowed_units"][0]["description"] == "1 cup"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fatsecret_api_request_posts_form_params():
+    service = FatSecretService("client", "secret")
+    service._get_access_token = AsyncMock(return_value="token")
+    client = _Client()
+    service._client = client
+
+    result = await service._api_request(
+        "POST",
+        params={"method": "foods.search.v5", "format": "json"},
+    )
+
+    assert result == {"ok": True}
+    _, kwargs = client.post_calls[0]
+    assert kwargs["data"] == {"method": "foods.search.v5", "format": "json"}
+    assert "json" not in kwargs
+    assert kwargs["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
 
 @pytest.mark.unit

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -1,0 +1,168 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.adapters.fat_secret_service import FatSecretService
+
+
+@pytest.mark.unit
+def test_fatsecret_serving_units_preserve_fatsecret_order():
+    service = FatSecretService("client", "secret")
+    food = {
+        "servings": {
+            "serving": [
+                {
+                    "measurement_description": "serving",
+                    "metric_serving_amount": "30.000",
+                    "serving_description": "1 cup",
+                },
+                {
+                    "measurement_description": "g",
+                    "metric_serving_amount": "100.000",
+                    "serving_description": "100 g",
+                },
+            ]
+        }
+    }
+
+    units = service._extract_serving_units(food)
+
+    assert units[0] == {
+        "unit": "serving",
+        "gram_weight": 30.0,
+        "description": "1 cup",
+    }
+    assert units[1] == {"unit": "g", "gram_weight": 100.0, "description": "100 g"}
+
+
+@pytest.mark.unit
+def test_fatsecret_nutrition_prefers_100g_serving():
+    service = FatSecretService("client", "secret")
+    food = {
+        "servings": {
+            "serving": [
+                {
+                    "measurement_description": "serving",
+                    "metric_serving_amount": "30.000",
+                    "serving_description": "1 cup",
+                    "calories": "100",
+                    "protein": "3",
+                    "carbohydrate": "20",
+                    "fat": "2",
+                },
+                {
+                    "measurement_description": "g",
+                    "metric_serving_amount": "100.000",
+                    "serving_description": "100 g",
+                    "calories": "333",
+                    "protein": "10",
+                    "carbohydrate": "66.67",
+                    "fat": "6.67",
+                },
+            ]
+        }
+    }
+
+    nutrition = service._extract_nutrition_from_details(food)
+
+    assert nutrition["calories_100g"] == 333.0
+    assert nutrition["protein_100g"] == 10.0
+    assert nutrition["carbs_100g"] == 66.67
+    assert nutrition["fat_100g"] == 6.67
+    assert nutrition["allowed_units"][0]["description"] == "1 cup"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fatsecret_search_uses_v5_methods():
+    service = FatSecretService("client", "secret")
+    service._api_request = AsyncMock(
+        side_effect=[
+            {
+                "foods_search": {
+                    "results": {
+                        "food": [
+                            {
+                                "food_id": "50953",
+                                "food_name": "Whole Grain Cheerios",
+                                "brand_name": "General Mills",
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "food": {
+                    "food_id": "50953",
+                    "food_name": "Whole Grain Cheerios",
+                    "servings": {
+                        "serving": {
+                            "measurement_description": "g",
+                            "metric_serving_amount": "100.000",
+                            "serving_description": "100 g",
+                            "calories": "333",
+                            "protein": "10",
+                            "carbohydrate": "66.67",
+                            "fat": "6.67",
+                        }
+                    },
+                }
+            },
+        ]
+    )
+
+    results = await service.search_foods("cheerios", max_results=1)
+
+    search_call = service._api_request.call_args_list[0]
+    detail_call = service._api_request.call_args_list[1]
+    search_params = search_call.kwargs["params"]
+    detail_params = detail_call.kwargs["params"]
+    assert search_call.args[0] == "POST"
+    assert detail_call.args[0] == "POST"
+    assert search_params["method"] == "foods.search.v5"
+    assert search_params["flag_default_serving"] == "true"
+    assert detail_params["method"] == "food.get.v5"
+    assert results[0]["allowed_units"][0]["gram_weight"] == 100.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fatsecret_barcode_lookup_uses_method_based_endpoint():
+    service = FatSecretService("client", "secret")
+    service._api_request = AsyncMock(
+        side_effect=[
+            {"food_id": "50953"},
+            {
+                "food": {
+                    "food_id": "50953",
+                    "food_name": "Whole Grain Cheerios",
+                    "servings": {
+                        "serving": {
+                            "measurement_description": "g",
+                            "metric_serving_amount": "100.000",
+                            "serving_description": "100 g",
+                            "calories": "333",
+                            "protein": "10",
+                            "carbohydrate": "66.67",
+                            "fat": "6.67",
+                        }
+                    },
+                }
+            },
+        ]
+    )
+
+    result = await service.get_product("12345678")
+
+    barcode_call = service._api_request.call_args_list[0]
+    detail_call = service._api_request.call_args_list[1]
+    detail_params = detail_call.kwargs["params"]
+    assert barcode_call.args[0] == "POST"
+    assert barcode_call.kwargs["params"]["method"] == "food.find_id_for_barcode"
+    assert detail_call.args[0] == "POST"
+    assert detail_params["method"] == "food.get.v5"
+    assert result["allowed_units"][0] == {
+        "unit": "g",
+        "gram_weight": 100.0,
+        "description": "100 g",
+    }


### PR DESCRIPTION
## Summary
- Persist and return food-specific allowed_units across meal APIs, barcode responses, and manual meal edit requests
- Update FatSecret v5 adapter mapping to extract serving units and default 100 g correctly
- Use allowed_units during backend nutrition conversion while preserving gram base behavior

## Validation
- .venv/bin/python -m compileall src
- .venv/bin/python -m py_compile migrations/versions/20260705000001_add_allowed_units_to_food_item.py
- .venv/bin/pytest tests/unit/api/test_meal_edit_requests.py tests/unit/api/test_small_v1_routers.py tests/unit/infra/adapters/test_fat_secret_service.py -q