### PR TITLE
feat(barcode): normalize serving units

### DIFF
--- a/src/domain/parsers/vision_response_parser.py
+++ b/src/domain/parsers/vision_response_parser.py
@@ -104,6 +104,22 @@ class VisionResponseParser:
                 micros=None,
                 confidence=min(max(0.0, float(canonical.confidence)), 1.0),
                 is_custom=True,
+                allowed_units=[
+                    {
+                        "unit": "serving",
+                        "gram_weight": float(canonical.serving_size.grams),
+                        "description": (
+                            f"1 serving ({canonical.serving_size.display_text})"
+                        ),
+                    },
+                    {
+                        "unit": "package",
+                        "gram_weight": float(canonical.serving_size.grams)
+                        * float(canonical.servings_per_package),
+                        "description": "1 package",
+                    },
+                    {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+                ],
             )
             return Nutrition(
                 macros=macros,
@@ -207,6 +223,9 @@ class VisionResponseParser:
                     macros=macros,
                     micros=None,
                     confidence=min(max(0.0, float(food_data.confidence)), 1.0),
+                    allowed_units=[
+                        {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
+                    ],
                 )
             )
 

--- a/src/domain/services/food_mapping_service.py
+++ b/src/domain/services/food_mapping_service.py
@@ -213,7 +213,39 @@ class FoodMappingService(FoodMappingServicePort):
             "provider_source": "usda_fdc",
             "is_verified": True,
             "is_estimate": False,
+            "allowed_units": self._barcode_allowed_units(
+                item, serving_size, serving_unit
+            ),
         }
+
+    def _barcode_allowed_units(
+        self,
+        item: dict[str, Any],
+        serving_size: Any,
+        serving_unit: Any,
+    ) -> list[dict[str, Any]]:
+        if item.get("foodPortions"):
+            return self._parse_usda_portions(item.get("foodPortions"))
+        if not serving_size:
+            return DEFAULT_ALLOWED_UNITS
+        try:
+            grams = float(serving_size)
+        except (TypeError, ValueError):
+            return DEFAULT_ALLOWED_UNITS
+        if grams <= 0 or str(serving_unit or "").lower() not in {
+            "g",
+            "gram",
+            "grams",
+        }:
+            return DEFAULT_ALLOWED_UNITS
+        return [
+            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            {
+                "unit": "serving",
+                "gram_weight": grams,
+                "description": f"1 serving ({serving_size} {serving_unit})",
+            },
+        ]
 
     def map_food_details(self, details: dict[str, Any]) -> dict[str, Any]:
         macros = self._extract_macros(details.get("foodNutrients") or [])

--- a/src/infra/adapters/open_food_facts_service.py
+++ b/src/infra/adapters/open_food_facts_service.py
@@ -94,9 +94,37 @@ class OpenFoodFactsService:
             "protein_100g": self._safe_float(nutriments.get("proteins_100g")),
             "carbs_100g": self._safe_float(nutriments.get("carbohydrates_100g")),
             "fat_100g": self._safe_float(nutriments.get("fat_100g")),
+            "fiber_100g": self._safe_float(nutriments.get("fiber_100g")),
+            "sugar_100g": self._safe_float(nutriments.get("sugars_100g")),
             "serving_size": serving_size,
+            "allowed_units": self._allowed_units(serving_size),
             "image_url": image_url,
         }
+
+    def _allowed_units(self, serving_size: Optional[str]) -> list[dict[str, Any]]:
+        units = [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
+        grams = self._serving_grams(serving_size)
+        if grams:
+            units.append(
+                {
+                    "unit": "serving",
+                    "gram_weight": grams,
+                    "description": f"1 serving ({serving_size or f'{grams:g} g'})",
+                }
+            )
+        return units
+
+    def _serving_grams(self, serving_size: Optional[str]) -> Optional[float]:
+        if not serving_size:
+            return None
+        match = re.search(
+            r"(\d+(?:[.,]\d+)?)\s*(g|gram|grams|ml|milliliter)",
+            serving_size,
+            re.I,
+        )
+        if not match:
+            return None
+        return self._safe_float(match.group(1).replace(",", "."))
 
     def _safe_float(self, value: Any) -> Optional[float]:
         """Safely convert value to float."""

--- a/src/infra/repositories/food_reference_projection.py
+++ b/src/infra/repositories/food_reference_projection.py
@@ -48,6 +48,7 @@ def food_reference_model_to_dict(model: FoodReferenceModel) -> dict[str, Any]:
         "fiber_100g": model.fiber_100g,
         "sugar_100g": model.sugar_100g,
         "serving_sizes": food_reference_serving_sizes_to_dict(model),
+        "allowed_units": food_reference_allowed_units_to_dict(model),
         "density": model.density,
         "serving_size": model.serving_size,
         "extra_nutrients": food_reference_nutrients_to_dict(model),
@@ -66,13 +67,15 @@ def build_food_reference_serving_rows(
     for idx, item in enumerate(raw):
         if not isinstance(item, dict):
             continue
-        name = str(item.get("name") or item.get("label") or "").strip()
+        name = str(
+            item.get("name") or item.get("label") or item.get("unit") or ""
+        ).strip()
         if not name:
             continue
         rows.append(
             FoodReferenceServingSizeModel(
                 name=name[:100],
-                grams=as_optional_float(item.get("grams")),
+                grams=as_optional_float(item.get("grams") or item.get("gram_weight")),
                 milliliters=as_optional_float(
                     item.get("milliliters") or item.get("ml")
                 ),
@@ -119,6 +122,49 @@ def food_reference_serving_sizes_to_dict(model: FoodReferenceModel) -> Any:
         }
         for row in rows
     ]
+
+
+def food_reference_allowed_units_to_dict(
+    model: FoodReferenceModel,
+) -> list[dict[str, Any]]:
+    raw_rows = getattr(model, "serving_size_rows", None)
+    if raw_rows:
+        units = [
+            {
+                "unit": row.name,
+                "gram_weight": row.grams,
+                "description": row.name,
+            }
+            for row in raw_rows
+            if row.grams is not None and row.grams > 0
+        ]
+    else:
+        units = _legacy_serving_sizes_to_allowed_units(model.serving_sizes)
+    if not any(unit["unit"].lower() == "g" for unit in units):
+        units.insert(0, {"unit": "g", "gram_weight": 1.0, "description": "1 g"})
+    return units
+
+
+def _legacy_serving_sizes_to_allowed_units(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    units: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = str(
+            item.get("name") or item.get("label") or item.get("unit") or ""
+        ).strip()
+        grams = as_optional_float(item.get("grams") or item.get("gram_weight"))
+        if name and grams is not None and grams > 0:
+            units.append(
+                {
+                    "unit": name,
+                    "gram_weight": grams,
+                    "description": item.get("description") or name,
+                }
+            )
+    return units
 
 
 def food_reference_nutrients_to_dict(model: FoodReferenceModel) -> Any:

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -95,7 +95,7 @@ class AsyncFoodReferenceRepository:
             "fiber_100g": data.get("fiber_100g", 0),
             "sugar_100g": data.get("sugar_100g", 0),
             "serving_size": data.get("serving_size"),
-            "serving_sizes": data.get("serving_sizes"),
+            "serving_sizes": data.get("serving_sizes") or data.get("allowed_units"),
             "image_url": data.get("image_url"),
             "source": data.get("source", "fatsecret"),
             "is_verified": data.get("is_verified", False),
@@ -237,7 +237,7 @@ class AsyncFoodReferenceRepository:
         model: FoodReferenceModel,
         data: dict[str, Any],
     ) -> None:
-        serving_sizes = data.get("serving_sizes")
+        serving_sizes = data.get("serving_sizes") or data.get("allowed_units")
         extra_nutrients = data.get("extra_nutrients")
         if serving_sizes is not None:
             model.serving_size_rows = build_food_reference_serving_rows(serving_sizes)

--- a/tests/unit/domain/services/test_food_mapping_service.py
+++ b/tests/unit/domain/services/test_food_mapping_service.py
@@ -32,4 +32,7 @@ def test_map_fdc_barcode_product_returns_flat_barcode_shape():
     assert result["sugar_100g"] == 18
     assert result["source"] == "usda_fdc"
     assert result["is_verified"] is True
-
+    assert result["allowed_units"] == [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+        {"unit": "serving", "gram_weight": 30.0, "description": "1 serving (30 g)"},
+    ]

--- a/tests/unit/infra/repositories/test_food_reference_projection.py
+++ b/tests/unit/infra/repositories/test_food_reference_projection.py
@@ -4,6 +4,7 @@ from src.infra.database.models.food_reference_nutrient import (
     FoodReferenceNutrientModel,
 )
 from src.infra.repositories.food_reference_projection import (
+    build_food_reference_serving_rows,
     food_reference_model_to_dict,
 )
 
@@ -73,3 +74,17 @@ def test_food_reference_nutrient_projection_preserves_legacy_object_shape():
         "unit": "mg",
         "source": "old",
     }
+
+
+def test_food_reference_projection_returns_allowed_units_from_serving_rows():
+    model = _make_food_reference_model("spinach")
+    model.serving_size_rows = build_food_reference_serving_rows(
+        [{"unit": "serving", "gram_weight": 85}]
+    )
+
+    result = food_reference_model_to_dict(model)
+
+    assert result["allowed_units"] == [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+        {"unit": "serving", "gram_weight": 85.0, "description": "serving"},
+    ]


### PR DESCRIPTION
## Summary
- Return allowed units from food-label and barcode provider flows
- Preserve barcode serving units through food reference cache projection
- Add focused tests for USDA barcode units and cached allowed unit projection

## Test plan
- [x] python3 -m py_compile src/domain/parsers/vision_response_parser.py src/domain/services/food_mapping_service.py src/infra/adapters/open_food_facts_service.py src/infra/repositories/food_reference_projection.py src/infra/repositories/food_reference_repository_async.py
- [x] uv run pytest tests/unit/domain/services/test_food_mapping_service.py tests/unit/infra/repositories/test_food_reference_projection.py tests/unit/infra/repositories/test_food_reference_repository_async.py tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py

Related issues: none found by GitHub issue search.