### PR TITLE
feat(meals): attach saved photos

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -8,6 +8,7 @@ from src.app.commands.ingredient import RecognizeIngredientCommand
 # Import all commands
 from src.app.commands.meal import (
     AddCustomIngredientCommand,
+    AttachMealPhotoCommand,
     DeleteMealCommand,
     EditMealCommand,
     ScanByUrlCommand,
@@ -58,6 +59,7 @@ from src.app.commands.weight import (
 # Saved suggestion handlers
 from src.app.handlers.command_handlers import (
     AddCustomIngredientCommandHandler,
+    AttachMealPhotoCommandHandler,
     CompleteOnboardingCommandHandler,
     CreateManualMealCommandHandler,
     DeleteFcmTokenCommandHandler,
@@ -357,6 +359,14 @@ def get_configured_event_bus() -> EventBus:
     event_bus.register_handler(
         AddCustomIngredientCommand,
         AddCustomIngredientCommandHandler(
+            uow=AsyncUnitOfWork(),
+            cache_invalidation=cache_invalidation_service,
+        ),
+    )
+
+    event_bus.register_handler(
+        AttachMealPhotoCommand,
+        AttachMealPhotoCommandHandler(
             uow=AsyncUnitOfWork(),
             cache_invalidation=cache_invalidation_service,
         ),

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -7,6 +7,7 @@ import logging
 import time
 import uuid
 from datetime import datetime
+from urllib.parse import urlparse
 
 from fastapi import (
     APIRouter,
@@ -35,6 +36,7 @@ from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
 from src.api.schemas.progress_schemas import DailyBreakdownResponse, StreakResponse
 from src.api.schemas.request.meal_requests import (
+    AttachMealPhotoRequest,
     CreateManualMealFromFoodsRequest,
     EditMealIngredientsRequest,
     ParseMealTextRequest,
@@ -58,6 +60,7 @@ from src.api.services.guest_parse_quota import (
     validate_install_id,
 )
 from src.app.commands.meal import CustomNutritionData, EditMealCommand, FoodItemChange
+from src.app.commands.meal.attach_meal_photo_command import AttachMealPhotoCommand
 from src.app.commands.meal.create_manual_meal_command import (
     CreateManualMealCommand,
     CustomNutrition,
@@ -132,6 +135,14 @@ def _parsed_food_item_to_response(item) -> ParsedFoodItem:
         fdc_id=item.fdc_id,
         allowed_units=getattr(item, "allowed_units", None) or [],
     )
+
+
+def _validate_uploaded_meal_photo_url(image_url: str, image_id: str) -> None:
+    parsed = urlparse(image_url)
+    if parsed.scheme != "https" or parsed.netloc != "res.cloudinary.com":
+        raise ValidationException("image_url must be a Cloudinary secure URL")
+    if image_id not in parsed.path:
+        raise ValidationException("image_id does not match image_url")
 
 
 async def _analyze_uploaded_image(
@@ -403,9 +414,7 @@ async def parse_meal_text(
         )
         app_response = await event_bus.send(command)
 
-        api_items = [
-            _parsed_food_item_to_response(item) for item in app_response.items
-        ]
+        api_items = [_parsed_food_item_to_response(item) for item in app_response.items]
         total_calories = sum(i.calories for i in api_items)
 
         return ParseMealTextResponse(
@@ -839,6 +848,30 @@ async def update_meal_ingredients(
         ai_manager=ai_manager,
     )
     return result
+
+
+@router.put("/{meal_id}/photo", response_model=None)
+async def attach_meal_photo(
+    meal_id: str,
+    payload: AttachMealPhotoRequest,
+    user_id: str = Depends(get_current_user_id),
+    event_bus: EventBus = Depends(get_configured_event_bus),
+):
+    """
+    Attach an already-uploaded meal photo to an existing meal.
+
+    Requires authentication - users can only modify their own meals.
+    """
+    _validate_uploaded_meal_photo_url(payload.image_url, payload.image_id)
+    command = AttachMealPhotoCommand(
+        meal_id=meal_id,
+        user_id=user_id,
+        image_id=payload.image_id,
+        image_url=payload.image_url,
+        image_format=payload.image_format,
+        size_bytes=payload.size_bytes,
+    )
+    return await event_bus.send(command)
 
 
 @router.get("/weekly/budget", response_model=WeeklyBudgetResponse)

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -392,6 +392,24 @@ class EditMealIngredientsRequest(BaseModel):
         }
 
 
+class AttachMealPhotoRequest(BaseModel):
+    """Request DTO for attaching an uploaded image to a meal."""
+
+    image_id: str = Field(..., description="Cloudinary upload image UUID")
+    image_url: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Cloudinary secure URL returned after upload",
+    )
+    image_format: Literal["jpeg", "png"] = Field(
+        "jpeg", description="Uploaded image format"
+    )
+    size_bytes: int = Field(
+        ..., gt=0, le=8 * 1024 * 1024, description="Uploaded image size in bytes"
+    )
+
+
 class AddCustomIngredientRequest(BaseModel):
     """Request DTO for adding custom ingredient to meal."""
 

--- a/src/app/commands/meal/__init__.py
+++ b/src/app/commands/meal/__init__.py
@@ -2,12 +2,13 @@
 Meal commands.
 """
 
+from .attach_meal_photo_command import AttachMealPhotoCommand
 from .delete_meal_command import DeleteMealCommand
 from .edit_meal_command import (
-    EditMealCommand,
     AddCustomIngredientCommand,
-    FoodItemChange,
     CustomNutritionData,
+    EditMealCommand,
+    FoodItemChange,
 )
 from .scan_by_url_command import ScanByUrlCommand
 from .upload_meal_image_immediately_command import UploadMealImageImmediatelyCommand
@@ -20,4 +21,5 @@ __all__ = [
     "FoodItemChange",
     "CustomNutritionData",
     "DeleteMealCommand",
+    "AttachMealPhotoCommand",
 ]

--- a/src/app/commands/meal/attach_meal_photo_command.py
+++ b/src/app/commands/meal/attach_meal_photo_command.py
@@ -1,0 +1,17 @@
+"""Command to attach an uploaded photo to an existing meal."""
+
+from dataclasses import dataclass
+
+from src.app.events.base import Command
+
+
+@dataclass
+class AttachMealPhotoCommand(Command):
+    """Attach already-uploaded meal image metadata to a meal."""
+
+    meal_id: str
+    user_id: str
+    image_id: str
+    image_url: str
+    image_format: str
+    size_bytes: int

--- a/src/app/handlers/command_handlers/__init__.py
+++ b/src/app/handlers/command_handlers/__init__.py
@@ -4,24 +4,32 @@ Each handler is in its own file for better maintainability.
 """
 
 from .add_custom_ingredient_command_handler import AddCustomIngredientCommandHandler
-from .scan_by_url_command_handler import ScanByUrlCommandHandler
+from .attach_meal_photo_command_handler import AttachMealPhotoCommandHandler
 from .complete_onboarding_command_handler import CompleteOnboardingCommandHandler
 
 # Standalone handlers (already individual files)
 from .create_manual_meal_command_handler import CreateManualMealCommandHandler
-from .parse_meal_text_handler import ParseMealTextHandler
 from .delete_fcm_token_command_handler import DeleteFcmTokenCommandHandler
+from .delete_hydration_entry_command_handler import DeleteHydrationEntryCommandHandler
 from .delete_meal_command_handler import DeleteMealCommandHandler
+from .delete_movement_entry_command_handler import DeleteMovementEntryCommandHandler
 from .delete_user_command_handler import DeleteUserCommandHandler
 
 # Meal handlers (already extracted)
 from .edit_meal_command_handler import EditMealCommandHandler
+from .log_caloric_drink_command_handler import LogCaloricDrinkCommandHandler
 
+# Hydration handlers
+from .log_hydration_command_handler import LogHydrationCommandHandler
+
+# Movement handlers
+from .log_movement_command_handler import LogMovementCommandHandler
 from .meal_suggestion import (
     DiscoverMealsCommandHandler,
     GenerateMealRecipesCommandHandler,
     SaveMealSuggestionCommandHandler,
 )
+from .parse_meal_text_handler import ParseMealTextHandler
 
 # Ingredient handlers
 from .recognize_ingredient_command_handler import RecognizeIngredientCommandHandler
@@ -31,12 +39,18 @@ from .register_fcm_token_command_handler import RegisterFcmTokenCommandHandler
 
 # User handlers (newly extracted)
 from .save_user_onboarding_command_handler import SaveUserOnboardingCommandHandler
+from .saved_suggestion import (
+    DeleteSavedSuggestionCommandHandler,
+    SaveSuggestionCommandHandler,
+)
+from .scan_by_url_command_handler import ScanByUrlCommandHandler
 from .sync_user_command_handler import SyncUserCommandHandler
+from .update_custom_macros_command_handler import UpdateCustomMacrosCommandHandler
+from .update_language_command_handler import UpdateLanguageCommandHandler
+from .update_movement_entry_command_handler import UpdateMovementEntryCommandHandler
 from .update_notification_preferences_command_handler import (
     UpdateNotificationPreferencesCommandHandler,
 )
-from .update_custom_macros_command_handler import UpdateCustomMacrosCommandHandler
-from .update_language_command_handler import UpdateLanguageCommandHandler
 from .update_timezone_command_handler import UpdateTimezoneCommandHandler
 from .update_user_last_accessed_command_handler import (
     UpdateUserLastAccessedCommandHandler,
@@ -45,25 +59,12 @@ from .update_user_metrics_command_handler import UpdateUserMetricsCommandHandler
 from .upload_meal_image_immediately_command_handler import (
     UploadMealImageImmediatelyHandler,
 )
-from .saved_suggestion import (
-    SaveSuggestionCommandHandler,
-    DeleteSavedSuggestionCommandHandler,
-)
-
-# Hydration handlers
-from .log_hydration_command_handler import LogHydrationCommandHandler
-from .log_caloric_drink_command_handler import LogCaloricDrinkCommandHandler
-from .delete_hydration_entry_command_handler import DeleteHydrationEntryCommandHandler
-
-# Movement handlers
-from .log_movement_command_handler import LogMovementCommandHandler
-from .delete_movement_entry_command_handler import DeleteMovementEntryCommandHandler
-from .update_movement_entry_command_handler import UpdateMovementEntryCommandHandler
 
 __all__ = [
     # Meal handlers
     "EditMealCommandHandler",
     "AddCustomIngredientCommandHandler",
+    "AttachMealPhotoCommandHandler",
     "DeleteMealCommandHandler",
     # User handlers
     "SaveUserOnboardingCommandHandler",

--- a/src/app/handlers/command_handlers/attach_meal_photo_command_handler.py
+++ b/src/app/handlers/command_handlers/attach_meal_photo_command_handler.py
@@ -1,0 +1,73 @@
+"""Handler for attaching uploaded meal photos."""
+
+from typing import Any
+
+from src.api.exceptions import (
+    AuthorizationException,
+    ResourceNotFoundException,
+    ValidationException,
+)
+from src.app.commands.meal import AttachMealPhotoCommand
+from src.app.events.base import EventHandler, handles
+from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.domain.model.meal import MealImage, MealStatus
+from src.domain.model.meal_projection import MealProjection
+from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
+from src.domain.utils.timezone_utils import utc_now
+
+
+@handles(AttachMealPhotoCommand)
+class AttachMealPhotoCommandHandler(
+    EventHandler[AttachMealPhotoCommand, dict[str, Any]]
+):
+    """Attach a validated uploaded photo to a meal owned by the user."""
+
+    def __init__(
+        self,
+        uow: AsyncUnitOfWorkPort,
+        cache_invalidation: CacheInvalidationService | None = None,
+    ):
+        self.uow = uow
+        self.cache_invalidation = cache_invalidation
+
+    async def handle(self, command: AttachMealPhotoCommand) -> dict[str, Any]:
+        async with self.uow as uow:
+            try:
+                meal = await uow.meals.find_by_id(
+                    command.meal_id, projection=MealProjection.FULL
+                )
+                if not meal:
+                    raise ResourceNotFoundException("Meal not found")
+                if meal.user_id != command.user_id:
+                    raise AuthorizationException(
+                        "You do not have permission to modify this meal"
+                    )
+                if meal.status != MealStatus.READY:
+                    raise ValidationException(
+                        "Meal must be in READY status to attach a photo"
+                    )
+
+                image = MealImage(
+                    image_id=command.image_id,
+                    format=command.image_format,
+                    size_bytes=command.size_bytes,
+                    url=command.image_url,
+                )
+                updated_meal = meal.with_image(image)
+                saved_meal = await uow.meals.save(updated_meal)
+                await uow.commit()
+
+                if self.cache_invalidation:
+                    meal_date = (saved_meal.created_at or utc_now()).date()
+                    await self.cache_invalidation.after_meal_write(
+                        saved_meal.user_id, meal_date
+                    )
+
+                return {
+                    "success": True,
+                    "meal_id": saved_meal.meal_id,
+                    "image_url": saved_meal.image.url if saved_meal.image else None,
+                }
+            except Exception:
+                await uow.rollback()
+                raise

--- a/src/domain/model/meal/meal.py
+++ b/src/domain/model/meal/meal.py
@@ -251,6 +251,31 @@ class Meal:
             **self._recipe_fields(),
         )
 
+    def with_image(self, image: MealImage) -> "Meal":
+        """Return the meal with updated image metadata."""
+        return Meal(
+            meal_id=self.meal_id,
+            user_id=self.user_id,
+            status=self.status,
+            created_at=self.created_at,
+            image=image,
+            dish_name=self.dish_name,
+            nutrition=self.nutrition,
+            ready_at=self.ready_at,
+            error_message=self.error_message,
+            raw_gpt_json=self.raw_gpt_json,
+            food_label_metadata=self.food_label_metadata,
+            updated_at=utc_now(),
+            last_edited_at=self.last_edited_at,
+            edit_count=self.edit_count,
+            is_manually_edited=self.is_manually_edited,
+            meal_type=self.meal_type,
+            translations=self.translations,
+            source=self.source,
+            quantity=self.quantity,
+            **self._recipe_fields(),
+        )
+
     def mark_inactive(self) -> "Meal":
         """Mark meal as INACTIVE (soft delete)."""
         return Meal(

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -114,16 +114,21 @@ class AsyncMealRepository(MealRepositoryPort):
                 meal.instructions
             )
 
-            # Update image URL if changed (parallel upload sets URL after initial save)
-            if meal.image and meal.image.url:
+            # Update image association/URL if changed.
+            if meal.image:
                 img_result = await self.session.execute(
                     select(MealImageORM).where(
                         MealImageORM.image_id == meal.image.image_id
                     )
                 )
                 existing_image = img_result.scalars().first()
-                if existing_image and existing_image.url != meal.image.url:
-                    existing_image.url = meal.image.url
+                if existing_image:
+                    if existing_image.url != meal.image.url:
+                        existing_image.url = meal.image.url
+                else:
+                    self.session.add(meal_image_domain_to_orm(meal.image))
+                    await self.session.flush()
+                existing_meal.image_id = str(meal.image.image_id)
 
             if meal.nutrition:
                 if not existing_meal.nutrition:

--- a/tests/unit/handlers/command_handlers/test_attach_meal_photo_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_attach_meal_photo_command_handler.py
@@ -1,0 +1,98 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.api.exceptions import AuthorizationException
+from src.app.commands.meal import AttachMealPhotoCommand
+from src.app.handlers.command_handlers.attach_meal_photo_command_handler import (
+    AttachMealPhotoCommandHandler,
+)
+from src.domain.model.meal import Meal, MealImage
+from src.domain.model.nutrition import Macros, Nutrition
+
+
+def _ready_meal(user_id: str) -> Meal:
+    meal = Meal.create_new_processing(
+        user_id=user_id,
+        image=MealImage(
+            image_id=str(uuid4()),
+            format="jpeg",
+            size_bytes=1000,
+            url="https://example.com/original.jpg",
+        ),
+    )
+    return meal.mark_ready(
+        nutrition=Nutrition(macros=Macros(protein=20, carbs=30, fat=10)),
+        dish_name="Rice bowl",
+    )
+
+
+def _uow_for(meal: Meal):
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    uow.meals.find_by_id = AsyncMock(return_value=meal)
+    uow.meals.save = AsyncMock(side_effect=lambda saved: saved)
+    uow.commit = AsyncMock()
+    uow.rollback = AsyncMock()
+    return uow
+
+
+@pytest.mark.asyncio
+async def test_attach_meal_photo_updates_owned_meal_image():
+    user_id = str(uuid4())
+    meal = _ready_meal(user_id)
+    uow = _uow_for(meal)
+    cache = MagicMock()
+    cache.after_meal_write = AsyncMock()
+    image_id = str(uuid4())
+    image_url = f"https://res.cloudinary.com/demo/image/upload/mealtrack/{image_id}.jpg"
+
+    handler = AttachMealPhotoCommandHandler(uow=uow, cache_invalidation=cache)
+
+    result = await handler.handle(
+        AttachMealPhotoCommand(
+            meal_id=meal.meal_id,
+            user_id=user_id,
+            image_id=image_id,
+            image_url=image_url,
+            image_format="jpeg",
+            size_bytes=2048,
+        )
+    )
+
+    saved_meal = uow.meals.save.await_args.args[0]
+    assert result["success"] is True
+    assert result["meal_id"] == meal.meal_id
+    assert result["image_url"] == image_url
+    assert saved_meal.image.image_id == image_id
+    assert saved_meal.image.url == image_url
+    assert saved_meal.nutrition == meal.nutrition
+    uow.commit.assert_awaited_once()
+    cache.after_meal_write.assert_awaited_once_with(
+        user_id, saved_meal.created_at.date()
+    )
+
+
+@pytest.mark.asyncio
+async def test_attach_meal_photo_rejects_wrong_owner():
+    meal = _ready_meal(str(uuid4()))
+    uow = _uow_for(meal)
+    handler = AttachMealPhotoCommandHandler(uow=uow)
+
+    with pytest.raises(AuthorizationException):
+        await handler.handle(
+            AttachMealPhotoCommand(
+                meal_id=meal.meal_id,
+                user_id=str(uuid4()),
+                image_id=str(uuid4()),
+                image_url="https://res.cloudinary.com/demo/image/upload/mealtrack/photo.jpg",
+                image_format="jpeg",
+                size_bytes=2048,
+            )
+        )
+
+    uow.meals.save.assert_not_awaited()
+    uow.commit.assert_not_awaited()
+    uow.rollback.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add `PUT /v1/meals/{meal_id}/photo` to attach an already-uploaded Cloudinary image to an owned meal
- Validate Cloudinary URL/image id, meal ownership, and READY status before persistence
- Update meal image association in the async repository and invalidate meal caches
- Add handler unit coverage for successful attach and wrong-owner rejection

## Jira
- https://nutreeai.atlassian.net/browse/NM-153

## Test plan
- [x] `uv run ruff check --ignore UP045 ...`
- [x] `uv run pytest tests/unit/handlers/command_handlers/test_attach_meal_photo_command_handler.py`
- [x] `python3 -m compileall ...`