### PR TITLE
fix(observability): prepare reliable write foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Monorepo submodule. 4-layer Clean + CQRS + PyMediator event bus.
 | Item | Value |
 |------|-------|
 | **Framework** | FastAPI 0.115+ / Python 3.13 |
-| **Database** | MySQL 8.0 + SQLAlchemy 2.0 |
+| **Database** | PostgreSQL (Neon) + SQLAlchemy 2.0 |
 | **Migrations** | Alembic |
 | **Event Bus** | PyMediator (singleton) |
 | **AI** | Google Gemini (multi-model) |
@@ -36,9 +36,9 @@ black src/ tests/ && flake8 src/ && mypy src/ && pytest
 - Domain layer has ZERO external dependencies
 
 **Event Bus**: PyMediator with singleton registry pattern (see `docs/cqrs-guide.md`)
-- Commands emit events (don't return data)
+- Commands may return typed domain entities, DTOs, or explicit outcomes to their route/application caller; commands still own writes and must not be invoked handler-to-handler.
 - Queries return immediately
-- Events processed asynchronously
+- Events are side-effect-only and return no result; they are processed asynchronously.
 
 **Calories = Derived from Macros** (non-negotiable)
 - Backend is source of truth: `P*4 + (C-fiber)*4 + fiber*2 + F*9`

--- a/docs/cqrs-guide.md
+++ b/docs/cqrs-guide.md
@@ -25,7 +25,7 @@ Each layer has ZERO knowledge of layers above it. Domain layer is completely ind
 
 ## Commands (Write Operations)
 
-Named with imperative verbs. Validated in `__post_init__()`. Return domain entity or None.
+Named with imperative verbs. Validated in `__post_init__()`. A command handler may return a typed domain entity, DTO, or explicit outcome to its route/application caller; this is the command result boundary, not an event response. Commands do not call other handlers directly, and repositories flush while the owning UoW commits or rolls back.
 
 ```python
 @dataclass
@@ -158,6 +158,8 @@ async with AsyncUnitOfWork() as uow:
 | Single responsibility: one use case per command/query | Commands, Queries |
 | Validation in `__post_init__()` | Commands |
 | Never change state | Queries, Events |
+| May return typed result to caller | Commands, Queries |
+| Side-effect-only; return `None` | Events |
 | Always async | All handlers |
 | Fire-and-forget (no wait) | Events |
 

--- a/plans/260714-reliable-write-contract-backend/phase-00-authority-and-pre-route-redaction.md
+++ b/plans/260714-reliable-write-contract-backend/phase-00-authority-and-pre-route-redaction.md
@@ -1,0 +1,77 @@
+---
+phase: 0
+title: "Authority and Pre-route Redaction"
+status: in-progress
+priority: P1
+dependencies: []
+effort: "2-3 engineering days"
+---
+
+# Phase 0: Authority and Pre-route Redaction
+
+## Overview
+
+Correct repository authority and remove sensitive data before any reliable-write
+migration, lookup route, or capability API can deploy. This is a hard prerequisite
+for Phase 1, not rollout work.
+
+## Review Status — 2026-07-15
+
+Authority, strict PostgreSQL marker registration, and the provider redaction
+foundation are implemented and focused tests pass. This phase remains incomplete:
+generic string `path` telemetry is still accepted, and the planned exception,
+provider-neutral observability, and real-PostgreSQL SQL sentinel suites do not
+yet exist. Phase 1 and Phase 2 remain blocked.
+
+## Requirements
+
+- `AGENTS.md` names PostgreSQL/Neon and permits typed command results while
+  retaining side-effect-only asynchronous events and the fiber-aware calorie rule.
+- `docs/cqrs-guide.md` defines the typed command-result/UoW boundary: no
+  handler-to-handler dispatch and no route-owned commit.
+- Pre-routing/completion logs use only method/request class and FastAPI route
+  template (or fixed `unmatched`), never a resolved URL/path, query, identity,
+  body, or exception/database text.
+- Sentry/metrics/event-bus/SQL observability are allowlist boundaries; SQL spans
+  retain only fixed operation/table metadata or are dropped.
+- Generic path telemetry is removed. A path-like value is accepted only when it
+  originates from a trusted FastAPI route-template resolver; otherwise omit it
+  or emit fixed `unmatched`. Resolved Firebase UIDs and other non-UUID dynamic
+  segments must fail the same sentinels as UUIDs.
+
+## Related Code Files
+
+- Modify: `AGENTS.md`, `docs/cqrs-guide.md`.
+- Modify: `src/api/middleware/request_logger.py`, `src/api/exception_handlers.py`,
+  `src/infra/event_bus/pymediator_event_bus.py`, `src/observability.py`,
+  `src/infra/monitoring/sentry.py`.
+- Create: `tests/unit/api/middleware/test_reliable_write_request_redaction.py`,
+  `tests/unit/api/test_reliable_write_exception_redaction.py`,
+  `tests/unit/infra/monitoring/test_reliable_write_observability.py`,
+  `tests/unit/infra/monitoring/test_reliable_write_sentry_redaction.py`, and
+  `tests/integration/infra/test_reliable_write_sql_redaction.py`.
+
+## Implementation Steps
+
+1. Add sentinel tests first for UID, operation/entity IDs, resolved lookup path,
+   fingerprint, URL/code/weight, SQL bind value, and exception text.
+2. Replace resolved route data with a shared trusted route-template helper;
+   apply it in request middleware and exception handling with an `unmatched`
+   fallback. Remove the generic string `path` allowlist from provider-neutral
+   observability and Sentry connectors.
+3. Restrict event-bus and provider payloads to class/stage/outcome/version,
+   bounded count, and duration. Remove user context, breadcrumbs/body/header/query
+   capture, exception values, and SQL values.
+4. Add the missing exception-handler, provider-observability, and SQL redaction
+   suites listed above, then run unit and real-PostgreSQL sentinel tests. A
+   sentinel occurrence in a log,
+   metric, Sentry event/transaction/span, or SQL payload blocks Phase 1.
+
+## Success Criteria
+
+- [x] Authority documents match the current PostgreSQL and typed-command runtime.
+- [ ] All sentinel redaction tests pass, including SQL and event-bus paths.
+- [ ] Generic path telemetry is absent or validated as a trusted FastAPI route
+  template; dynamic non-UUID path segments cannot reach any connector.
+- [ ] No reliable-write migration, lookup, or API route is deployed before this
+  phase completes.

--- a/plans/260714-reliable-write-contract-backend/phase-01-contract-and-migration-foundation.md
+++ b/plans/260714-reliable-write-contract-backend/phase-01-contract-and-migration-foundation.md
@@ -1,0 +1,288 @@
+---
+phase: 1
+title: "Contract and Migration Foundation"
+status: pending
+priority: P1
+dependencies: [0]
+effort: "3-5 engineering days"
+---
+
+# Phase 1: Contract and Migration Foundation
+
+## Overview
+
+After Phase 0 corrects instruction authority and makes telemetry redaction safe, create
+normalized PostgreSQL persistence, pure domain/app contracts, an RFC 8785
+fingerprint, durable effects, and UoW repository seams. No production action is
+enabled.
+
+## Context Links
+
+- `docs/system-architecture.md`, `docs/cqrs-guide.md`, `docs/standards/db-api.md`
+- `src/infra/database/uow_async.py`
+- `src/domain/ports/async_unit_of_work_port.py`
+- `migrations/versions/20260702000001_add_food_label_metadata_to_meal.py`
+
+## Prerequisite Gate
+
+Phase 0 is a hard dependency. It corrects the PostgreSQL/CQRS authority and lands
+sentinel-tested pre-route redaction before this migration, lookup, or API code can
+be deployed. A raw resolved lookup path must never reach a log or telemetry sink.
+
+### Readiness Decision — 2026-07-15
+
+**Rejected / do not start.** No reliable-write migration, model, executor,
+manifest, lookup API, or operation-aware route may be implemented or deployed
+until Phase 0 completes and the corrected canonical-input and legacy-weight
+contracts below receive renewed independent approval. The global-only false
+capability model, authority/pytest rules, and migration marker ownership are
+resolved and do not require redesign.
+
+## Contract
+
+`client_operation_id` is a lowercase hyphenated RFC 4122 UUIDv4. For a
+contract-aware write, `Idempotency-Key` and the body/form field are both required
+and normalize to the same UUID. Neither field is authentication.
+
+The server computes, never trusts, fingerprint contract `rw-fp-v1`:
+
+```text
+sha256(UTF8("rw-fp-v1\n" + action + "\n") || RFC8785(effective_input))
+```
+
+`effective_input` is a typed, post-Pydantic-validation envelope containing only
+behavior-affecting fields: contract/action, method, route template, normalized
+path parameters, typed query arrays, behavior headers, and the action body or
+multipart digest. It excludes operation identity, auth, tracing, ignored legacy
+calories, and response-only defaults. Per-action fixture metadata declares every
+included field, omitted-vs-null/default expansion, ordered-vs-set array, and
+sanitization rule; a field not declared is rejected from the fingerprint input.
+
+RFC 8785/JCS is normative, including UTF-16 property ordering and ECMAScript
+binary64 number serialization. Strings preserve Unicode code points unless an
+action schema explicitly normalizes human text to NFC before JCS. Reject NaN and
+infinities before reservation; map `-0` to `0`; represent money/weight/domain
+decimals as schema-versioned canonical decimal strings, not host-language float.
+UUIDs use lowercase hyphenated form. Datetimes require an offset and normalize
+to exactly six fractional digits plus `Z`, preserving microseconds without
+rounding/truncation. Scalar query fields reject repeats; repeatable arrays retain
+order unless their action declaration marks them set-valued, then sort after
+normalization. Media type is lowercase type/subtype with lowercase, sorted
+behavioral parameters; multipart boundary is excluded. Multipart scans include
+SHA-256 of bytes, normalized media type, URL/crop parameters, sanitized text,
+resolved language, and behavior headers; raw bytes/URLs are never persisted.
+
+Shared fixtures live at `tests/fixtures/reliable_write/v1/fingerprint.json` and
+`../mobile/test/fixtures/reliable_write/v1/fingerprint.json` and must be byte-for-
+byte identical in source control. They cover Unicode normalization/escaping,
+UTF-16 key order, integer/binary64/`-0`/Decimal/exponent forms, omitted/null/
+default, timezone offsets/microseconds, repeated query rules, media parameters,
+path IDs, sanitized text, language/behavior headers, target date/timezone,
+URL/crop, multipart bytes/type, and UUID case. Python and Dart tests must produce
+the fixture's canonical UTF-8 hex and SHA-256.
+
+The v1 effective-input declarations are fixed as follows; every optional default
+is expanded to its validated effective value, explicit null remains null only
+where the domain distinguishes it, and unlisted transport metadata is excluded:
+
+| Action | Included typed effective inputs |
+|---|---|
+| `meal.manual.create` | resolved target date/timezone, meal type/source, NFC dish/emoji, resolved `Accept-Language` used by the durable value-insight effect, and ordered items with nullable USDA `fdc_id`, nullable NFC `name`, normalized quantity/unit, and all custom nutrition fields (protein/carbs/fat/fiber/sugar); legacy client calories excluded |
+| `meal.suggestion.create` | suggestion ID, NFC name/description/cuisine/origin/emoji, meal type/date, resolved target timezone/language, top-level protein/carbs/fat, portion multiplier/cook time, ordered ingredients (name/amount/unit/macros including fiber), ordered instructions, normalized image URL SHA-256, provider/source identity and persisted download-location/public-ID digests; legacy client calories excluded |
+| `meal.image.create` | file SHA-256, normalized media type, resolved target date/timezone/language, sanitized description, crop/options, and every persisted provider-affecting upload/analyzer option (provider name/model/version, public-ID/location digest, scan mode) |
+| `meal.url.create` | URL SHA-256, public-ID/download-location digests, crop metadata/options, resolved target date/timezone/language, sanitized description, provider name/model/version, and validated transport `scan_mode="scanner"` normalized to canonical enum value `scanner` before fingerprinting and command dispatch |
+| `meal.food_label.create` | URL SHA-256, public-ID/download-location digests, label-crop URL/public-ID digests and crop metadata/options, resolved target date/timezone/language, sanitized description, provider name/model/version, and scan mode `food_label` |
+| `meal.ingredients.update` | lowercase meal UUID path, NFC `dish_name` (including explicit null), `created_at` normalized to six-digit UTC (including explicit null), normalized `meal_type` (including explicit null), resolved language/timezone, and ordered normalized ingredient edits with every persisted field (action, IDs/source identifiers, name, quantity/unit, macros including fiber) |
+| `meal.delete` | lowercase meal UUID path only |
+| `weight.create` | client ID, canonical Decimal weight, six-digit UTC instant |
+| `weight.sync` | ordered items of client ID, canonical Decimal weight, six-digit UTC instant |
+| `weight.delete` | lowercase weight-entry UUID path only |
+| `onboarding.complete` | verified Firebase UID path digest and effective completion state/version |
+| `promo.redeem` | NFC/case-normalized promo-code HMAC only |
+| `referral.apply` | NFC/case-normalized referral-code HMAC, normalized integer `discount_applied`, and uppercase ISO currency; provider resolution is execution output, not client input |
+
+Language/timezone/profile defaults are resolved before reservation and included;
+changes on a later call therefore conflict rather than silently changing the
+response. URL/code/path values appear only in the in-memory canonical input or
+as HMAC/SHA-256 digests and are never copied to logs or the operation row.
+
+Uniqueness is `(user_id, action, client_operation_id)`. Stable actions are
+`meal.manual.create`, `meal.suggestion.create`, `meal.image.create`, `meal.url.create`,
+`meal.food_label.create`, `meal.ingredients.update`, `meal.delete`,
+`weight.create`, `weight.sync`, `weight.delete`, `onboarding.complete`,
+`promo.redeem`, and `referral.apply`.
+
+## Data Model and Transaction Rules
+
+Create `reliable_write_operations` with UUID primary key, user FK `CASCADE`,
+action, client operation UUID, fingerprint, state, lease token/expiry, result
+contract/schema/status/entity ID/canonical date, immutable JSONB exact response,
+safe terminal error code, retention expiry, scrubbed-at, and timestamps. Add:
+
+- unique constraint on user/action/client operation;
+- lookup index on user/action/client operation;
+- cleanup index on state/retention expiry;
+- checks for state and 64-character lowercase SHA-256; fingerprint may be null
+  only after the row enters `expired` during privacy scrubbing.
+
+JSONB is a documented immutable response-snapshot exception under
+`docs/standards/db-api.md`; never store request bodies. The v1 snapshot is capped
+at 256 KiB, contains the exact logical JSON response and stable safe headers
+(excluding the computed `Idempotency-Replayed` marker), and is created before
+commit; exceeding the cap rolls back the mutation. Field order,
+whitespace, compression, and transport-generated headers are not contractual,
+but parsed JSON, status, content type, and allowlisted response headers are.
+Default active retention is 30 days. At expiry, scrub response/fingerprint and
+retain a seven-day
+`expired` tombstone, then delete. Account deletion cascades immediately.
+
+Create `reliable_write_effects` with operation/user FKs `CASCADE`, effect type,
+opaque target key, minimal immutable JSONB payload, `pending|processing|sent|
+permanent_failure`, attempt/DB-time lease fields, and unique
+`(operation_id,effect_type,target_key)`. Required external/domain effects and
+repairable projection/cache effects are inserted in the mutation UoW. Consumers
+claim with `FOR UPDATE SKIP LOCKED`, pass the effect UUID as downstream
+idempotency identity where the provider supports it, and retry with bounded
+backoff. Delivery is at-least-once; a provider without idempotency may observe a
+repeat after delivery-before-mark crash, but the local effect row is unique and
+no mutation repeats. Replay may signal dispatch
+of only an already-recorded pending effect; it never inserts an effect or reruns
+the mutation. Effect failure after commit cannot change an operation from
+committed to failed. Required effects exhaust into `permanent_failure`, page the
+owner, and are retained for manual replay/acknowledgement; repairable projection
+effects may be rebuilt from the canonical entity but keep the same unique key.
+
+Create dedicated `reliable_write_capabilities`, owned solely by this migration,
+with action PK, compiled contract version, `enabled=false`, `ever_enabled=false`,
+updated-at, and revision. This table, not the existing feature-flag service/cache,
+is the manifest/kill-switch source. It has no cohort/allowlist column: v1 admission
+is global per action/environment. Create `reliable_write_migration_markers` with
+primary key `migration_revision`, fixed schema checksum, and `installed_at`; the
+migration inserts this marker only after all owned objects and false rows validate
+in the same transaction. Create `referral_attributions` with unique
+`referred_user_id`, source type, normalized code HMAC, nullable internal referral
+and affiliate references, and timestamps; Phase 5 specifies its use.
+
+### Executable Reservation and Lease Fence
+
+1. Reservation transaction uses `INSERT ... ON CONFLICT DO NOTHING RETURNING`.
+   The insert winner owns a random lease token. A loser reads the row in a new
+   transaction: fingerprint mismatch conflicts; committed/permanent/expired are
+   terminal; a DB-time-live pending lease returns in-progress.
+2. A stale pending row is claimed only by
+   `UPDATE ... SET lease_token=:new, lease_expires_at=db_now()+:ttl WHERE id=:id
+   AND state='pending' AND fingerprint=:fp AND lease_token=:old AND
+   lease_expires_at<=db_now() RETURNING ...`. No returned row means re-read.
+3. Long provider/AI work renews with a token/fingerprint/state CAS using DB time.
+   Flag disable blocks new reservations/reclaims but an already-live owner may
+   renew and finish; disabled stale work is never resumed.
+4. Immediately before invoking the domain mutation, the action UoW runs
+   `SELECT ... FOR UPDATE` with user/action/operation/fingerprint/token/state and
+   `lease_expires_at>db_now()`. Missing/deleted/account-cascaded or changed rows
+   abort before the callback. The row lock is held through mutation, effect
+   inserts, response snapshot, and finalization; finalization repeats the token/
+   state predicate. Thus an expired old worker cannot enter the mutation after a
+   new owner claims it.
+
+## Related Code Files
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/domain/model/reliable_write/reliable_write_operation.py` | Pure state/value types |
+| Create | `src/domain/ports/reliable_write_operation_repository_port.py` | Async repository contract |
+| Create | `src/app/services/reliable_write/fingerprint.py` | Canonicalization + SHA-256 |
+| Create | `src/app/services/reliable_write/executor.py` | Reserve/claim/replay/finalize policy |
+| Create | `src/infra/database/models/reliable_write_operation.py` | SQLAlchemy model |
+| Create | `src/infra/database/models/reliable_write_effect.py` | Durable effect/outbox model |
+| Create | `src/infra/database/models/reliable_write_capability.py` | Dedicated kill switch model |
+| Create | `src/infra/database/models/reliable_write_migration_marker.py` | Revision ownership/checksum marker |
+| Create | `src/infra/database/models/referral/referral_attribution.py` | User-unique internal/affiliate claim |
+| Create | `src/infra/repositories/reliable_write_operation_repository_async.py` | Lock/CAS/persist adapter |
+| Create | `src/infra/repositories/reliable_write_effect_repository_async.py` | Effect claim/finalize adapter |
+| Create | `src/infra/repositories/reliable_write_capability_repository_async.py` | Manifest/admin adapter |
+| Modify | `src/infra/repositories/referral_repository.py` | Attribution claim operations |
+| Modify | `src/domain/ports/async_unit_of_work_port.py` | Typed operation repository port |
+| Modify | `src/infra/database/uow_async.py` | Instantiate repository per fresh UoW |
+| Modify | `src/infra/database/models/__init__.py` | Register model for Alembic |
+| Create | `migrations/versions/20260714000001_add_reliable_write_contract.py` | PostgreSQL expand schema + false capabilities |
+| Create | `tests/migrations/test_reliable_write_operations_migration.py` | `@pytest.mark.postgres` upgrade/downgrade/schema/marker-retry tests |
+| Create | `tests/unit/app/services/reliable_write/test_fingerprint.py` | Canonical fixtures |
+| Create | `tests/unit/app/services/reliable_write/test_executor.py` | State/concurrency policy |
+| Create | `tests/integration/infra/repositories/test_reliable_write_operation_repository_async.py` | DB locks/constraints |
+| Modify | `tests/unit/infra/database/test_model_registry_metadata.py` | Registry assertion |
+
+## Implementation Steps
+
+1. Complete the instruction/redaction prerequisite gates. Before service code,
+   write byte-identical Python/Dart RFC 8785 fixtures that prove every declared
+   input changes the fingerprint, including manual `fdc_id`/`name`/
+   `Accept-Language`, suggestion top-level macros, and URL `scanner` mode.
+2. Add domain types and repository port. Keep SQLAlchemy/FastAPI imports out.
+3. Add ORM model and import it through the central registry.
+4. Generate a PostgreSQL migration from the rechecked head. It creates all owned
+   tables/checks/indexes and exactly the registry actions as false capability rows,
+   then atomically inserts marker revision `20260714000001` with a fixed schema
+   checksum. On retry, a matching marker plus exact expected schema/false rows is
+   a no-op; a missing marker with any owned object, checksum mismatch, or unexpected
+   capability data aborts. It never adopts or overwrites preexisting data. Do not
+   backfill legacy writes.
+5. Downgrade acquires the same transaction-scoped PostgreSQL advisory lock,
+   verifies this revision's marker/checksum, and aborts if any capability has
+   `ever_enabled=true` or if any operation, effect, or attribution row exists.
+   Only a provably unused install drops owned rows/tables. Application rollback
+   is otherwise forward-only.
+6. Implement the exact insert/loser/CAS/`FOR UPDATE` fence above plus finalization,
+   expiry scrub, and delete. Repository flushes; UoW alone commits.
+7. Implement executor policy. It accepts the action UoW for domain+result
+   atomicity and never invokes one handler from another.
+8. Add architecture tests banning API/infra imports from new domain/app code and
+   manual `commit()` in the new repository/service.
+9. Decorate every real-PostgreSQL migration/repository test with the registered
+   strict `@pytest.mark.postgres`; keep non-database contract tests unmarked.
+
+## Test Scenario Matrix
+
+| Scenario | Expected |
+|---|---|
+| Same user/action/key/fingerprint | One owner; later call replays |
+| Same key, different body | 409 conflict; callback not called |
+| Same key, different action/user | Independent operation |
+| Crash after reservation | Pending then stale-lease recovery |
+| Lease expires during AI; new owner claims | Old token cannot enter mutation; one mutation |
+| Account deleted while provider runs | Fence sees no row; no mutation/effect |
+| Crash inside action transaction | Mutation and result both rollback |
+| Crash after mutation/effect flush before commit | Mutation/result/effects all rollback |
+| Expiry | Descriptor scrub -> tombstone -> delete |
+
+## Verification Commands
+
+```bash
+uv run pytest tests/unit/app/services/reliable_write tests/integration/infra/repositories/test_reliable_write_operation_repository_async.py -o addopts=""
+uv run pytest tests/migrations/test_reliable_write_operations_migration.py tests/migrations/test_alembic_revision_graph.py -m postgres
+uv run alembic heads
+uv run alembic upgrade head
+uv run alembic downgrade 20260702000001
+uv run alembic upgrade head
+```
+
+## Success Criteria
+
+- [ ] Python and Dart fixtures enumerate every included action field, including
+  referral discount/currency; manual item `fdc_id`/`name` and resolved
+  `Accept-Language`; suggestion top-level protein/carbs/fat; all meal edit fields;
+  URL `scanner` normalization; and every scan/suggestion persisted and
+  provider-affecting field, with a changed-field conflict case for each.
+- [ ] Concurrent duplicates cannot both execute the mutation callback.
+- [ ] Domain mutation, exact response, and required effect rows share one UoW.
+- [ ] Real PostgreSQL tests cover first upgrade, interrupted/retry behavior,
+  marker/checksum/object collision aborts, guarded downgrade, schema/indexes/checks,
+  data-present abort, and one Alembic head.
+- [ ] Every seeded action capability is false and `ever_enabled=false`.
+
+## Risks and Security
+
+Reservation and action transactions create a recoverable pending window by
+design. Lease claims use DB time and compare-and-swap, not process clocks.
+Operation IDs and hashes are high-cardinality private metadata: never log or use
+as metric labels. Exact response snapshots are private user data, exist only for
+replay/reconciliation, are size/retention bounded, and inherit user-row deletion.

--- a/plans/260714-reliable-write-contract-backend/phase-02-capability-and-reconciliation-api.md
+++ b/plans/260714-reliable-write-contract-backend/phase-02-capability-and-reconciliation-api.md
@@ -1,0 +1,166 @@
+---
+phase: 2
+title: "Capability and Reconciliation API"
+status: pending
+priority: P1
+dependencies: [0, 1]
+effort: "2-3 engineering days"
+---
+
+# Phase 2: Capability and Reconciliation API
+
+## Overview
+
+Expose authenticated, versioned capability negotiation and operation lookup.
+The manifest is a code allowlist gated by the dedicated capability table from
+Phase 1. Missing, stale, unknown, or error states disable operation-aware writes;
+lookup remains available even when every write is killed.
+
+## Prerequisite Gate — 2026-07-15
+
+**Blocked / do not start or deploy.** Phase 2 begins only after Phase 0 sentinel
+completion, corrected Phase 1 canonical/weight contracts, and renewed independent
+foundation approval. Approval still seeds every capability false with
+`ever_enabled=false`; it does not authorize deployment or enablement.
+
+## API Contract
+
+`GET /v1/write-capabilities` returns:
+
+```json
+{
+  "manifest_version": 1,
+  "generated_at": "...Z",
+  "expires_at": "...Z",
+  "ttl_seconds": 30,
+  "idempotency_retention_seconds": 2592000,
+  "actions": [{
+    "action": "meal.manual.create",
+    "method": "POST",
+    "route_template": "/v1/meals/manual",
+    "contract_version": 1,
+    "enabled": false,
+    "operation_id_transport": "header_and_body",
+    "lookup_route_template": "/v1/write-operations/{action}/{client_operation_id}"
+  }]
+}
+```
+
+The registry contains a separate entry for `meal.suggestion.create` mapped to
+`POST /v1/meal-suggestions/save`. Every registry action has exactly one database
+row and every row starts false.
+
+Use `Cache-Control: private, max-age=30` and `Vary: Authorization`. No stale
+grace. A dedicated in-process immutable snapshot has a monotonic 30-second hard
+TTL and is never backed by `FeatureFlagService` or the existing 600-second cache
+(`src/domain/cache/cache_keys.py`). A process may serve an enabled value only
+while that snapshot is unexpired; on expiry, DB/cache/read error fails closed as
+503/all-disabled. Dedicated admin update code writes `enabled`, permanently ORs
+`ever_enabled`, increments revision, and invalidates its local snapshot; other
+processes converge within 30 seconds. Cross-process tests use two independent
+cache instances and DB time. Capability is checked before reservation, upload,
+AI, or other external work. Flag-off is admission-only for a currently live
+lease, blocks new reservation/reclaim, and never disables lookup.
+
+`GET /v1/write-operations/{action}/{client_operation_id}` validates allowlisted
+action and UUIDv4, scopes by authenticated internal user ID, and returns 200 for
+a well-formed lookup:
+
+```json
+{
+  "action": "weight.sync",
+  "client_operation_id": "...",
+  "status": "committed",
+  "entity_id": null,
+  "canonical_date": null,
+  "response_contract_version": 1,
+  "http_status": 200,
+  "response_body": {"results": []},
+  "error_code": null,
+  "retention_expires_at": "...Z",
+  "retry_after_seconds": null
+}
+```
+
+The lookup HTTP status is 200 for every valid owner-scoped state. `notFound`
+never discloses another user's operation and has all response/retention fields
+null. `pending` has null response fields and `retry_after_seconds` in `1..30`;
+the mutation response is exactly
+`{"code":"OPERATION_IN_PROGRESS","status":"pending","retry_after_seconds":n}`
+plus matching `Retry-After`. `expired` exposes only status and tombstone expiry.
+`committed` returns the frozen response status/body. `permanentFailure` returns
+the frozen safe 4xx status/body and allowlisted error code, never raw exception
+text. All five shapes are versioned shared fixtures.
+
+Lookup does not consult the capability flag. It validates auth, compiled action,
+UUID, and owner, then reads operation state. Tombstone deletion becomes
+`notFound`; clients may resend only when their locally persisted creation time is
+within the manifest's advertised 30-day idempotency retention. Otherwise they
+surface reconciliation-required and do not auto-retry.
+
+## CQRS and Files
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/app/queries/reliable_write/get_write_capabilities_query.py` | Manifest query |
+| Create | `src/app/queries/reliable_write/get_write_operation_query.py` | Reconciliation query |
+| Create | `src/app/handlers/query_handlers/reliable_write/get_write_capabilities_query_handler.py` | Manifest assembly |
+| Create | `src/app/handlers/query_handlers/reliable_write/get_write_operation_query_handler.py` | Owner lookup |
+| Create | `src/app/services/reliable_write/capability_registry.py` | Allowlist + capability names |
+| Create | `src/app/services/reliable_write/capability_snapshot.py` | Dedicated 30s fail-closed cache |
+| Create | `src/api/routes/v1/reliable_writes.py` | Authenticated GET routes |
+| Create | `src/api/routes/v1/admin_reliable_writes.py` | Authenticated admin kill-switch update |
+| Create | `src/api/schemas/response/reliable_write_responses.py` | Versioned responses |
+| Modify | `src/api/dependencies/event_bus.py` | Register query handlers |
+| Modify | `src/api/main.py` | Register router |
+| Create | `tests/unit/app/handlers/query_handlers/reliable_write/test_capabilities.py` | Fail-closed tests |
+| Create | `tests/unit/app/handlers/query_handlers/reliable_write/test_operation_lookup.py` | Ownership/status tests |
+| Create | `tests/unit/api/test_reliable_write_routes.py` | Auth/schema/cache headers |
+
+## Implementation Steps
+
+1. Write route schema snapshots and unauthenticated 401 tests first.
+2. Implement a static action registry including suggestion. Route templates,
+   methods, contract versions, lookup path, and capability names never come from
+   request data. Add an equality guardrail among registry, migration rows,
+   manifest fixtures, lookup allowlist, routes, and integration fixtures.
+3. Read only the dedicated capability table in one query. Capability is
+   `compiled_support AND database_enabled`; either false disables it. Implement
+   the 30-second snapshot and admin revision invalidation without generic flags.
+4. Add read-only queries and handlers with injected fresh UoWs.
+5. Register handlers only at the event-bus composition root.
+6. Return route templates, not resolved IDs/URLs. Add private cache headers.
+7. With two process-like caches, toggle one action off and observe admission
+   disabled within 30 seconds while lookup of an existing operation still works.
+
+## Compatibility Matrix
+
+| Client / backend | Behavior |
+|---|---|
+| Old client / new backend | Ignores new GET routes; legacy writes unchanged |
+| New client / old backend | Manifest 404/invalid => `neverAutoRetry` |
+| New/new, flag off | One-attempt legacy flow; no operation fields; lookup still available |
+| New/new, flag on | Header+body contract; lookup before resend |
+| Cached manifest expired | Disabled until fresh manifest succeeds |
+
+## Verification Commands
+
+```bash
+uv run pytest tests/unit/app/handlers/query_handlers/reliable_write tests/unit/api/test_reliable_write_routes.py
+uv run ruff check src/app/services/reliable_write src/app/queries/reliable_write src/app/handlers/query_handlers/reliable_write src/api/routes/v1/reliable_writes.py
+```
+
+## Success Criteria
+
+- [ ] Manifest is authenticated, versioned, allowlisted, TTL-bound, and private.
+- [ ] Missing capability, DB error, stale manifest, and unknown version fail closed.
+- [ ] Lookup cannot enumerate another user's operations.
+- [ ] Suggestion exists in registry, migration, manifest, lookup, route, tests,
+  and rollout with its own false capability.
+- [ ] Every status schema has a backward-compatible JSON fixture.
+
+## Risks and Security
+
+The generic `/v1/feature-flags/` endpoint is not the mobile contract. Never
+include admin metadata, user identifiers, cross-owner operation existence, or
+raw terminal error details.

--- a/plans/260714-reliable-write-contract-backend/phase-03-meal-write-integration.md
+++ b/plans/260714-reliable-write-contract-backend/phase-03-meal-write-integration.md
@@ -1,0 +1,167 @@
+---
+phase: 3
+title: "Meal Write Integration"
+status: pending
+priority: P1
+dependencies: [0, 1, 2]
+effort: "5-8 engineering days"
+---
+
+# Phase 3: Meal Write Integration
+
+## Overview
+
+Integrate reliable writes into every requested meal action while preserving the
+legacy no-operation request path. All action flags remain off through this phase.
+
+## Current Flow Inventory
+
+| Route | Command -> handler | Persistence/tests |
+|---|---|---|
+| `POST /v1/meals/manual` | `CreateManualMealCommand` -> `CreateManualMealCommandHandler` | `AsyncMealRepository`; `test_create_manual_meal_command_handler.py`, `test_meals_api.py`, `test_manual_meal_with_target_date.py` |
+| `POST /v1/meal-suggestions/save` | `SaveMealSuggestionCommand` -> `SaveMealSuggestionCommandHandler` | `AsyncMealRepository`; `test_meal_suggestions_routes.py`, `test_meal_suggestion_cqrs_handlers.py` |
+| `POST /v1/meals/image/analyze` | `UploadMealImageImmediatelyCommand` -> `UploadMealImageImmediatelyHandler` | Cloudinary + AI + meal UoW; `tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py`, `tests/unit/infra/database/test_uow_meal_suggestion_boundary.py` |
+| `POST /v1/meals/scan-by-url` | `ScanByUrlCommand` -> `ScanByUrlCommandHandler` | AI + meal UoW; app-smoke, food-guard, beverage-routing tests |
+| `POST /v1/meals/food-label/scan-by-url` | same command with `scan_mode=food_label` | same handler/repository/tests |
+| `PUT /v1/meals/{meal_id}/ingredients` | `EditMealCommand` -> `EditMealCommandHandler` | `AsyncMealRepository`; edit handler/API tests |
+| `DELETE /v1/meals/{meal_id}` | `DeleteMealCommand` -> `DeleteMealCommandHandler` | `src/infra/repositories/meal_repository_async.py` and `src/infra/repositories/hydration_repository_async.py`; `tests/unit/handlers/command_handlers/test_meal_delete_command_handlers.py`, `tests/integration/test_meal_edit_api.py` |
+
+The registry/action for the suggestion row is exactly
+`meal.suggestion.create`; it has its own false capability and never aliases
+`meal.manual.create`.
+
+## Request and Replay Contract
+
+- JSON requests add optional `client_operation_id: UUID4`; multipart image adds
+  an optional form field. Routes also accept `Idempotency-Key`.
+- Both absent: exact legacy behavior. One present, invalid, or mismatch: 400.
+  Both present while action flag is off: `409 WRITE_CAPABILITY_DISABLED` before
+  upload, AI, DB, cache, translation, or background work.
+- Exact replay contract `rw-response-v1` is selected: same key/fingerprint
+  returns the stored first-call status, content type, echoed key, and
+  `application/json` body with parsed-JSON equality. The transport-only
+  `Idempotency-Replayed` header is false on first response and true on replay and
+  is not part of the frozen snapshot. A replay never rehydrates the
+  entity and never adds a fresher translation, insight, timestamp, or detail.
+  Wire whitespace/key order/compression/date headers are outside the contract.
+- For operation-aware meal writes, the handler constructs an application-owned,
+  JSON-compatible frozen DTO from the canonical persisted meal inside the action
+  UoW; it does not import API schemas. The API response model is a contract-tested
+  mirror and the route returns the frozen body without post-commit requery.
+  Optional projections (translation and value insights) are
+  deterministically `null`/absent according to the versioned fixture on the
+  first response as well as replay; legacy calls retain today's projection
+  timing. The serialized, schema-validated body (maximum 256 KiB), status, and
+  safe headers finalize in the same transaction. Serialization/cap failure
+  rolls back the meal. The API returns only that frozen DTO.
+- Shared `rw-response-v1` fixtures pin manual, suggestion, image, URL,
+  food-label, edit, and delete first/replay pairs in both repositories. Mobile
+  approval of these exact logical JSON fixtures is an enablement gate, not an
+  unresolved backend implementation choice.
+- Add response headers `Idempotency-Key` and `Idempotency-Replayed: true|false`
+  only for operation-aware calls. Existing response fields and status codes stay.
+- Required and repairable effects are recorded exactly once in
+  `reliable_write_effects` in the mutation UoW. Required: Unsplash download
+  tracking and integration/domain-event publication. Repairable projection:
+  cache invalidation, translation, and value-insight generation. A committed
+  operation is successful even while these effects are pending.
+
+For op-aware multipart upload, derive Cloudinary public ID from a server-secret
+HMAC of user/action/operation rather than a random second ID. Never expose or log
+the HMAC input. This makes external upload overwrite/retry deterministic while
+the meal row remains protected by the operation record. Legacy uploads stay as-is.
+
+## Calories and Canonical Inputs
+
+The operation fingerprint uses effective validated inputs, not ignored client
+metadata. Suggestion `calories` remains accepted for old clients but is excluded
+from authoritative persistence and fingerprinting. Add optional `fiber` defaults
+to suggestion/ingredient schemas; calculate through domain `Macros.calories`:
+`P*4 + (C-fiber)*4 + fiber*2 + F*9`. Manual custom nutrition continues using its
+existing fiber-aware backend calculation. API response calories come from the
+saved domain nutrition only.
+
+## Related Code Files
+
+| Action | Paths |
+|---|---|
+| Create | `src/api/dependencies/reliable_write.py`, `src/api/schemas/request/reliable_write_requests.py` |
+| Create | `src/app/dto/reliable_write_result.py` | Typed frozen v1 HTTP response snapshot |
+| Modify routes | `src/api/routes/v1/meals.py`, `meal_scan_by_url.py`, `meal_suggestions.py` |
+| Modify schemas | `src/api/schemas/request/meal_requests.py`, `meal_suggestion_requests.py`; response meal/suggestion schemas only for optional operation metadata if mobile needs body access |
+| Modify commands | `src/app/commands/meal/create_manual_meal_command.py`, `upload_meal_image_immediately_command.py`, `scan_by_url_command.py`, `edit_meal_command.py`, `delete_meal_command.py`; `src/app/commands/meal_suggestion/save_meal_suggestion_command.py` |
+| Modify handlers | `src/app/handlers/command_handlers/create_manual_meal_command_handler.py`, `upload_meal_image_immediately_command_handler.py`, `scan_by_url_command_handler.py`, `edit_meal_command_handler.py`, `delete_meal_command_handler.py`, `meal_suggestion/save_meal_suggestion_command_handler.py` |
+| Modify composition | `src/api/dependencies/event_bus.py` |
+| Existing repo/model/migration | `src/infra/repositories/meal_repository_async.py`, `src/infra/repositories/hydration_repository_async.py`, `src/infra/database/models/meal/meal.py`, `migrations/versions/20260702000001_add_food_label_metadata_to_meal.py` |
+| Create effects | `src/cron/reliable_write_effects.py`, `src/infra/services/reliable_write_effect_dispatch_service.py` |
+| New tests | `tests/unit/api/test_reliable_meal_write_routes.py`, `tests/integration/api/test_reliable_meal_writes.py` |
+| Extend tests | `tests/integration/api/test_meals_api.py`, `tests/integration/test_manual_meal_with_target_date.py`, `tests/integration/test_meal_edit_api.py`, `tests/unit/api/test_meal_suggestions_routes.py`, `tests/unit/api/test_app_smoke_routes.py`, and listed handler suites |
+
+## Implementation Steps
+
+1. Add red route tests for absent/partial/mismatch/disabled/enabled contracts.
+2. Build request contexts at the API boundary after Pydantic validation. Include
+   path IDs, query/form fields, language-affecting inputs, and file hash.
+3. Add optional reliable context to each command. Action constants stay in code;
+   clients cannot choose action.
+4. Reserve before Cloudinary/AI on scans and renew long leases. At the mutation
+   fence, use one action UoW for meal, effect rows, and exact v1 response. Remove
+   explicit handler commits; UoW alone commits.
+5. For manual/suggestion/edit/delete, execute mutation, effect insertion, response
+   serialization, and finalization under the same UoW. Replay only returns the
+   snapshot and offers pending recorded effects to the dispatcher.
+6. Store the exact response body because replay requires it; classify it as
+   private user data with user-cascade, retention scrub, 256 KiB check, no logs,
+   and no analytics/Sentry attachment. Never store request/AI payloads.
+7. Preserve existing response schemas/statuses. Operation-aware v1 may only add
+   the documented headers; its deterministic null projection fields are pinned.
+8. Implement idempotent effect consumers. Each consumer uses the effect UUID as
+   its downstream idempotency key where supported, marks success in a separate
+   UoW, and can repair after process crash. Provider calls are never made while
+   holding the operation DB lock. Cache/projection/provider failure after commit
+   cannot produce a mutation 5xx or change the frozen response.
+9. Replace touched logs containing raw user/meal/image/body data with action,
+   outcome, replay boolean, bounded latency, and error class.
+
+## Test Scenario Matrix
+
+| Scenario | Expected |
+|---|---|
+| Duplicate manual/suggestion create | Same frozen body; one meal/effect set |
+| Timeout after meal commit | Lookup committed; replay returns same entity |
+| Same operation, changed target date/item | 409; original unchanged |
+| Duplicate scan while first pending | No second AI/upload; pending response |
+| Scan crash after upload | Deterministic asset reuse; no duplicate meal |
+| Crash after commit before effect dispatch | Replay/cron repairs pending effects; no mutation rerun |
+| Effect delivery succeeds then mark crashes | One local effect; retry uses provider key or documented at-least-once delivery |
+| Replayed edit | Original frozen response; edit count increments once |
+| Replayed/already-missing delete | Same success ACK; no repeated events |
+| Fiber present | Calories use backend fiber-aware formula |
+| Legacy request | Existing snapshots/status/body unchanged |
+
+## Verification Commands
+
+```bash
+uv run pytest tests/unit/api/test_reliable_meal_write_routes.py tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py tests/unit/api/test_meal_suggestions_routes.py tests/unit/api/test_app_smoke_routes.py
+uv run pytest tests/integration/api/test_reliable_meal_writes.py -o addopts="" -m integration
+uv run pytest tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py tests/unit/handlers/command_handlers/test_meal_delete_command_handlers.py
+```
+
+## Success Criteria
+
+- [ ] Every listed meal action has disabled, first-call, duplicate, conflict,
+  pending, timeout-after-commit, and owner-isolation coverage.
+- [ ] Scan external work cannot run twice for a live identical operation.
+- [ ] First/replay parsed JSON and status match shared `rw-response-v1` fixtures;
+  no entity rehydration occurs.
+- [ ] Faults at every effect insert/commit/dispatch/mark boundary are recoverable.
+- [ ] Legacy route responses remain compatible.
+- [ ] All persisted/displayed calories derive from saved macros.
+
+## Risks and Security
+
+Scans span non-transactional providers. Durable reservation plus deterministic
+asset identity bounds duplicate side effects; the DB still owns canonical meal
+identity. The bounded private response snapshot necessarily contains existing
+response fields, but raw food/image/user-description data must not appear in
+operation metadata, effect keys, logs, metrics, traces, Sentry, or analytics.

--- a/plans/260714-reliable-write-contract-backend/phase-04-weight-write-integration.md
+++ b/plans/260714-reliable-write-contract-backend/phase-04-weight-write-integration.md
@@ -1,0 +1,222 @@
+---
+phase: 4
+title: "Weight Write Integration"
+status: pending
+priority: P1
+dependencies: [0, 1, 2]
+effort: "4-6 engineering days"
+---
+
+# Phase 4: Weight Write Integration
+
+## Overview
+
+Give single create, batch sync, and delete stable operation identity and exact
+per-item reconciliation. Preserve legacy response fields and keep flags off
+until the product gate on single-write timestamp semantics is approved.
+
+## Current Flow and Gap
+
+- Routes: `src/api/routes/v1/weight_entries.py`.
+- Commands/handlers: add, sync, delete under `src/app/commands/weight/` and
+  `src/app/handlers/command_handlers/`.
+- Repository/model: `weight_repository_async.py`, `WeightEntryORM` with unique
+  `(user_id, recorded_at)`.
+- Migration origin: `057_add_weight_entries_table.py`; timezone correction:
+  `20260503113601_fix_datetime_timezone_columns_batch.py`.
+- Current single add generates a UUID and plain-inserts; batch generates UUIDs,
+  upserts by timestamp, and returns only count/message. Current handlers create
+  concrete UoWs and call `commit()` manually. There is no focused weight handler,
+  repository-upsert, route-contract, or batch-outcome suite.
+
+## Selected Versioned Weight Contract
+
+New optional request fields remain ignored by legacy clients:
+
+- single item schema adds optional `client_id`/`client_operation_id`, but both
+  `client_id: UUID4` and operation ID are required when the header is present;
+- sync item: required `client_id: UUID4` when top-level operation is present;
+- sync request: top-level `client_operation_id`;
+- delete: body `client_operation_id` is required only for operation-aware delete
+  (retain path ID and accept an optional JSON body); header must match.
+
+Preserve single response `id`, `weight_kg`, `recorded_at`, `created_at`, message.
+Add `client_id`, `server_id`, `canonical_weight_kg`,
+`canonical_recorded_at`, and `outcome`. Preserve batch `synced_count` and message;
+add ordered `results`:
+
+```json
+{"client_id":"...","server_id":"...","canonical_weight_kg":"72.400",
+ "canonical_recorded_at":"2026-07-14T08:09:10.123456Z",
+ "outcome":"created|updated|duplicate|rejected","error_code":null}
+```
+
+V1 selects **partial item acceptance with one atomic persistence transaction for
+all accepted items**. Envelope/structural failures (invalid operation/header,
+invalid UUID/datetime JSON type, over 100 items, repeated `client_id`, or repeated
+canonical instant) return terminal 422 and write nothing. After structural
+parsing, each item is independently domain-validated in input order. Invalid
+weight/range or policy time returns `rejected`, `server_id=null`, both canonical
+fields null, and exactly one allowlisted code
+`WEIGHT_OUT_OF_RANGE|RECORDED_AT_OUT_OF_RANGE`; it creates no row. Accepted
+items return `created|updated|duplicate` with non-null server/canonical fields.
+Unexpected DB failure rolls back every accepted item and the operation remains
+retryable; it is never converted into item rejection.
+
+The HTTP status for any structurally valid batch is 200, including all-rejected.
+`synced_count` is the count of `created+updated+duplicate`, not input count;
+`rejected_count` is explicit; `results` has exactly one row per input in the same
+order. The frozen operation response/lookup stores all outcomes and counts, and
+replay returns them unchanged. Response message is a stable fixture-derived v1
+string, not an input-dependent free-form error.
+
+Require timezone-aware input and normalize to UTC as exactly
+`YYYY-MM-DDTHH:MM:SS.ffffffZ`. Preserve microseconds with no rounding or
+truncation; offset-equivalent instants collide. Database/session precision must
+round-trip six digits. Canonical weight is a versioned fixed-scale decimal
+string returned from the persisted NUMERIC row, never a binary float or echoed
+before DB validation.
+
+## PostgreSQL NUMERIC Expand Migration
+
+Before reliable weight admission, add a migration chained from the rechecked
+Alembic head that creates nullable, unbounded `weight_kg_numeric NUMERIC` beside
+legacy `weight_kg FLOAT`, not an in-place type change. Unbounded NUMERIC is
+required so the expand migration does not reject current accepted positive
+floats above 999.999 kg or below 0.001 kg. Map it in `WeightEntryORM` as
+`Numeric(asdecimal=True)` and map the operation-aware domain boundary with
+`Decimal`.
+
+Legacy behavior remains authoritative while capabilities are false: legacy
+requests keep accepting every value the current `float > 0` schema/storage path
+accepts and retain their existing response semantics. Legacy writes always write
+the FLOAT column and also write the exact finite `Decimal(str(weight_kg))` to
+NUMERIC when representable; a legacy value that cannot be represented in NUMERIC
+leaves the nullable column null and is reported by a count-only migration audit,
+never rejected or coerced. Backfill applies the same rule to existing rows. Legacy
+reads continue using FLOAT, so nullable or higher-precision NUMERIC data cannot
+change old-client behavior.
+
+Only operation-aware admission applies the v1 finite 0.001..999.999 kg domain
+range and `ROUND_HALF_UP` quantization to 0.001 kg; accepted operation-aware
+writes dual-write the canonical NUMERIC value and its FLOAT mirror. These checks
+remain unreachable while the action capability is false. Reliable reads require
+a non-null NUMERIC value and return its fixed three-decimal representation; they
+never reinterpret a legacy-only null as operation-aware success.
+
+A later contract migration may constrain scale, make NUMERIC non-null, or retire
+FLOAT only after a full audit proves all legacy-only rows are compatible and
+legacy request support has an independently approved migration path. Downgrade is
+permitted only when no reliable weight operation is committed and every non-null
+NUMERIC value round-trips to its FLOAT mirror under the applicable legacy or v1
+policy; otherwise it aborts. Real PostgreSQL tests cover positive legacy values
+above 999.999 and below 0.001, exact backfill, nullable fallback, legacy and v1
+dual-write paths, half-step v1 rounding, downgrade guards, and Decimal round-trip.
+
+## Single-Create Upsert Decision and Enablement Gate
+
+V1 is selected: operation-aware `weight.create` invokes the exact same
+same-UTC-instant repository upsert/classification as one-item sync. It returns
+`created`, `duplicate`, or `updated` and never plain-inserts into the unique
+constraint. Legacy create retains its existing conflict behavior. Product/mobile
+approval of this intentional split and its shared fixtures is required before
+`weight.create` can turn on; no implementation choice remains open. Batch/delete
+also remain false until partial-result and tombstone fixtures pass.
+
+## Repository Algorithm
+
+For each accepted canonical timestamp in a bounded batch (maximum 100), inside a
+single UoW that also finalizes the exact response:
+
+1. `INSERT ... ON CONFLICT DO NOTHING RETURNING id`.
+2. If inserted, outcome `created`.
+3. Otherwise `SELECT ... FOR UPDATE` existing row. Equal value => `duplicate`;
+   changed value => update and `updated`.
+4. Return the existing/inserted server ID and canonical DB values.
+
+This avoids unreliable `xmax` inspection and classifies concurrent inserts
+correctly. The operation snapshot stores the ordered result array in the same
+UoW transaction. Single create calls this algorithm once. Delete stores the exact
+success ACK and canonical server ID; replay returns it even though the row is
+gone. Repository methods flush only and never commit.
+
+## Related Code Files
+
+| Action | Paths |
+|---|---|
+| Modify schemas | `src/api/schemas/request/weight_entry_requests.py`, `response/weight_entry_responses.py` |
+| Modify route | `src/api/routes/v1/weight_entries.py` |
+| Modify commands | `src/app/commands/weight/add_weight_entry_command.py`, `sync_weight_entries_command.py`, `delete_weight_entry_command.py` |
+| Modify handlers | `src/app/handlers/command_handlers/add_weight_entry_command_handler.py`, `sync_weight_entries_command_handler.py`, `delete_weight_entry_command_handler.py`; inject `AsyncUnitOfWorkPort` |
+| Modify domain | `src/domain/model/weight/weight_entry.py`; add typed upsert outcome DTO |
+| Modify repository/model | `src/infra/repositories/weight_repository_async.py`, `src/infra/database/models/weight_entry.py`, `src/infra/mappers/weight_entry_mapper.py` |
+| Create migration | `migrations/versions/<head>_expand_weight_kg_numeric.py` | Nullable unbounded PostgreSQL `NUMERIC` expand/backfill/dual-write guard; tests are `@pytest.mark.postgres` |
+| Existing migrations | `migrations/versions/057_add_weight_entries_table.py`, `migrations/versions/20260503113601_fix_datetime_timezone_columns_batch.py` |
+| Modify composition | `src/api/dependencies/event_bus.py` supplies fresh UoWs |
+| Create tests | `tests/unit/api/test_reliable_weight_routes.py`, `tests/unit/handlers/command_handlers/test_reliable_weight_handlers.py` |
+| Create integration | `tests/integration/infra/repositories/test_weight_repository_reliable_upsert.py`, `tests/integration/api/test_reliable_weight_writes.py` |
+
+## Implementation Steps
+
+1. Pin old request/response snapshots before adding fields.
+2. Add and verify the nullable unbounded NUMERIC expand migration and ORM/mapper
+   Decimal boundary before reliable route work; pin full positive-float legacy
+   compatibility plus v1 conversion/rounding/fallback/downgrade tests.
+3. Add two-tier structural/envelope and per-item domain validators, fixed-scale
+   Decimal output, exact UTC serializer, batch bounds, and duplicate checks.
+4. Refactor handlers to injected UoW ports; no concrete UoW or manual commit.
+5. Implement typed repository outcome algorithm and map ordered client IDs.
+6. Wrap create/sync/delete mutation + exact response snapshot in the reliable executor.
+7. Ensure a batch retry returns the stored full ordered mapping, including
+   rejected rows, without validators causing new upserts or mutations.
+7. Keep list pagination unchanged; generic operation lookup is authoritative for
+   ambiguous writes, while list remains a projection/repair source.
+
+## Test Scenario Matrix
+
+| Scenario | Expected |
+|---|---|
+| New timestamp | created + new server ID |
+| Same instant/offset, same value | duplicate + existing server ID |
+| Same instant, changed value | updated + existing server ID |
+| Mixed batch | Ordered per-client independent outcomes |
+| Valid plus out-of-range items | 200 partial; rejected null IDs; accepted persist atomically |
+| All items rejected | 200, synced_count 0, one rejected result per input |
+| Duplicate client ID/timestamp in batch | 422; zero writes |
+| `+07:00` vs `Z` same microsecond | Same DB key/server ID; no precision loss |
+| Legacy float `72.4005` | `72.401` by fixed `ROUND_HALF_UP`; NUMERIC and mirror/read mapping agree |
+| Legacy float above `999.999` | Accepted unchanged by legacy path; exact NUMERIC mirror when representable |
+| Legacy positive float below `0.001` | Accepted unchanged by legacy path; no v1 range policy leaks into legacy admission |
+| NUMERIC downgrade with mismatch or reliable operation | Abort; no precision/data loss |
+| Batch retry | Same mapping; zero repository mutations |
+| Timeout after commit/restart | Lookup restores mapping |
+| Delete replay | Stable success ACK/server ID |
+| Cross-user server ID/delete | 404/403-equivalent without disclosure |
+
+## Verification Commands
+
+```bash
+uv run pytest tests/unit/api/test_reliable_weight_routes.py tests/unit/handlers/command_handlers/test_reliable_weight_handlers.py
+uv run pytest tests/integration/infra/repositories/test_weight_repository_reliable_upsert.py tests/integration/api/test_reliable_weight_writes.py -o addopts="" -m integration
+uv run pytest tests/migrations/test_weight_kg_numeric_migration.py -m postgres
+```
+
+## Success Criteria
+
+- [ ] Every input maps to exactly one client ID/outcome; accepted rows have
+  server/canonical values and rejected rows have null values plus safe code.
+- [ ] Single and batch operation-aware upsert semantics match the selected v1
+  fixtures; product/mobile approval gates enablement only.
+- [ ] Persisted/replayed UTC and Decimal strings match Python/Dart fixtures.
+- [ ] Nullable unbounded PostgreSQL NUMERIC expand/backfill/dual-write/downgrade
+  behavior preserves all current legacy positive-float writes and the ORM mapping
+  passes real-database compatibility tests before weight admission.
+- [ ] Legacy request/response snapshots pass unchanged.
+- [ ] Retry and lookup return the same ordered mapping.
+
+## Risks and Security
+
+Weight is sensitive health data. Do not log, metric-label, or copy values,
+timestamps, IDs, operation keys, or result arrays outside the authenticated
+response and private operation row. Telemetry uses action, outcome, count, and
+bounded duration only.

--- a/plans/260714-reliable-write-contract-backend/phase-05-onboarding-promo-and-referral-decisions.md
+++ b/plans/260714-reliable-write-contract-backend/phase-05-onboarding-promo-and-referral-decisions.md
@@ -1,0 +1,149 @@
+---
+phase: 5
+title: "Onboarding Promo and Referral Decisions"
+status: pending
+priority: P1
+dependencies: [0, 1, 2]
+effort: "3-5 engineering days plus product approval"
+---
+
+# Phase 5: Onboarding, Promo, and Referral Decisions
+
+## Overview
+
+Make purchase-finalization writes convergent while preserving legacy calls.
+This phase records product choices explicitly; every unresolved choice defaults
+to capability disabled and no automatic retry.
+
+## Current Evidence
+
+| Action | Current implementation | Existing guard/gap |
+|---|---|---|
+| Onboarding complete | `PUT /v1/users/firebase/{firebase_uid}/onboarding/complete`; `CompleteOnboardingCommandHandler` | Set-if-false; repeat returns `updated=false`; handler creates concrete UoW; no operation result test |
+| Promo redeem | `POST /v1/promo-codes/redeem`; direct `RedeemPromoCodeCommandHandler` | Row lock + unique promo/user; repeat returns 422 instead of original success |
+| Referral apply | `POST /v1/referrals/apply`; direct `ApplyReferralCodeCommandHandler` | Internal conversion is user-unique, but affiliate path only has an outbox row; two affiliate codes can both enqueue |
+| Referral payout | `POST /v1/referrals/payout` | Only pending-status guard; no operation lookup; excluded |
+| Referral my-code | write-on-read GET | Lazy random code creation; excluded |
+
+Promo/referral routes currently instantiate handlers directly instead of using
+the configured PyMediator singleton. Refactor them through commands registered at
+`src/api/dependencies/event_bus.py`; handlers receive injected fresh UoWs.
+
+## Proposed Decisions and Safe Defaults
+
+| Decision needing approval | Proposed v1 contract | Fail-closed default |
+|---|---|---|
+| Onboarding repeat | Operation-aware request returns stored result; a new operation after already complete returns 200 `already_completed` | Flag off; legacy set-if-false only |
+| Promo same code/user, new operation | 200 success with `outcome=already_redeemed`; never increments usage twice | Flag off; preserve current 422 legacy behavior |
+| Referral same user/code/source, new operation | 200 success with `outcome=already_applied`; no second conversion/outbox event | Flag off; preserve current 400 legacy behavior |
+| Referral same user, different code or internal/affiliate source | 409 `REFERRAL_ALREADY_ASSIGNED`; the first attribution/benefit is immutable | Flag off; no automatic retry |
+| Affiliate validation unavailable | Leave operation pending/retryable only through lookup + explicit application retry; never fall through to a different benefit | Capability off until fault tests pass |
+| Payout idempotency/status | Separate future contract with payout ID and status route | Not advertised; always `neverAutoRetry` |
+| Lazy my-code creation | Separate concurrency-safe create/read decision | Not advertised as a safe GET |
+
+Approval owners: product owns benefit semantics and attribution immutability;
+backend owns transaction/error/status contracts; mobile owns UX and retry enablement.
+No flag turns on until all three accept fixtures.
+
+## Request and Response Compatibility
+
+- Onboarding adds an optional request model in
+  `src/api/schemas/request/user_requests.py` containing `client_operation_id`;
+  its response model is in `src/api/schemas/response/user_responses.py`. No-body
+  old calls remain valid. The route resolves both
+  verified Firebase path ownership and internal user ID for operation scoping.
+- Promo/referral existing request bodies add optional `client_operation_id`.
+  Referral fingerprint fixtures include the normalized `discount_applied` integer
+  and uppercase `currency`; changing either with the same operation ID conflicts.
+- All require matching `Idempotency-Key` when operation-aware.
+- Preserve existing fields and statuses for legacy requests. Operation-aware
+  responses add `client_operation_id`, `outcome`, and `replayed`; old decoders
+  may ignore additions. Duplicate same-operation returns original status/body.
+- Generic operation lookup is the reconciliation/status route. It returns only
+  safe outcome metadata, never raw promo/referral code or Firebase UID.
+
+## Related Code Files
+
+| Area | Paths |
+|---|---|
+| Onboarding route/schema | `src/api/routes/v1/users.py`, `src/api/schemas/request/user_requests.py`, `src/api/schemas/response/user_responses.py` |
+| Onboarding command/handler | `src/app/commands/user/complete_onboarding_command.py`, `src/app/handlers/command_handlers/complete_onboarding_command_handler.py` |
+| Promo route/command/handler | `src/api/routes/v1/promo_codes.py`, `src/app/commands/promo_code/redeem_promo_code_command.py`, `src/app/handlers/command_handlers/promo_code/redeem_promo_code_handler.py` |
+| Promo repository/models | `src/infra/repositories/promo_code_repository.py`, `src/infra/database/models/promo_code/promo_code.py`, `src/infra/database/models/promo_code/promo_code_redemption.py` |
+| Referral route/command/handler | `src/api/routes/v1/referrals.py`, `src/app/commands/referral/apply_referral_code_command.py`, `src/app/handlers/command_handlers/referral/apply_referral_code_handler.py` |
+| Referral repository/models | `src/infra/repositories/referral_repository.py`, `src/infra/database/models/referral/referral_code.py`, `src/infra/database/models/referral/referral_conversion.py`, new `src/infra/database/models/referral/referral_attribution.py` |
+| Affiliate adapter/outbox | `src/infra/adapters/affiliate_service_adapter.py`, `src/domain/ports/affiliate_service_port.py`, `src/infra/repositories/affiliate_event_outbox_repository.py`, `src/infra/database/models/affiliate_event_outbox.py`, `src/infra/services/affiliate_outbox_dispatch_service.py`, `src/cron/affiliate_outbox.py` |
+| Composition | `src/api/dependencies/event_bus.py` |
+| Existing tests | `test_redeem_promo_code_handler.py`, `test_promo_code_repository.py`, `test_apply_affiliate_code_handler.py`, mocked route tests |
+| New tests | `tests/unit/api/test_reliable_purchase_finalization_routes.py`, `tests/integration/api/test_reliable_purchase_finalization_writes.py` |
+
+## Implementation Steps
+
+1. Pin legacy status/body behavior, then add operation-aware red tests.
+2. Convert promo/referral commands to normal CQRS `Command` types and register
+   handlers. Remove direct route handler construction.
+3. Refactor all three handlers to injected `AsyncUnitOfWorkPort`; repositories
+   flush only and UoW owns commit/rollback.
+4. Onboarding: lock/read user, apply final state if needed, insert a unique
+   operation-scoped cache-invalidation effect, and write the exact response in
+   the same UoW. The effect dispatcher invalidates after commit and repairs a
+   crash; route/handler code performs no untracked post-commit invalidation.
+5. Promo: keep promo row lock; handle unique business duplicate according to
+   operation-aware decision without incrementing `current_uses`.
+6. Referral: normalize the presented code and compute a server-keyed HMAC. For
+   internal codes, resolve the owning referral row; for affiliate codes, call
+   `AffiliateServicePort.validate_code` after reservation but outside the
+   mutation transaction. Provider timeout/unavailability leaves the operation
+   pending and performs no local claim; it never falls through to internal or a
+   different benefit.
+7. In the fenced mutation UoW, claim `referral_attributions` with unique
+   `referred_user_id`. The row stores source, code HMAC, and stable internal or
+   affiliate reference but no raw code. Same source/HMAC maps to
+   `already_applied`; any other existing row finalizes safe 409. For an internal
+   winner, insert `ReferralConversion`; for an affiliate winner, enqueue one
+   `AffiliateEventOutbox` linked by an explicit `attribution_id`/unique event key.
+   Attribution, conversion/outbox, exact response, and operation finalization
+   commit together. Outbox payload JSON is never the deduplication key.
+8. Record only outcome/business row ID in snapshots; exclude code, discount,
+   currency, Firebase UID, affiliate ID, and outbox payload.
+9. Keep payout and my-code absent from manifest and document their no-retry policy.
+
+## Test Scenario Matrix
+
+| Scenario | Expected |
+|---|---|
+| Onboarding same operation | Original `updated` result replayed |
+| Onboarding new operation after complete | Approved `already_completed` outcome |
+| Concurrent promo same code/user | One redemption/use increment |
+| Promo timeout after commit | Lookup committed; no second increment |
+| Referral same user/code | One conversion/outbox event |
+| Same operation/code, changed discount or currency | 409 fingerprint conflict; no benefit mutation |
+| Referral same user/different code | Deterministic 409, no reassignment |
+| Concurrent internal vs affiliate codes | One attribution winner; loser 409; one benefit effect |
+| Concurrent two affiliate codes | One attribution/outbox winner independent of JSON payload |
+| Same affiliate code after outbox dispatch crash | `already_applied`; idempotent linked outbox repair |
+| Affiliate adapter transient failure | No local conversion; operation not falsely committed |
+| Account switch/other user lookup | `notFound`; no benefit metadata leak |
+
+## Verification Commands
+
+```bash
+uv run pytest tests/unit/handlers/test_redeem_promo_code_handler.py tests/unit/repositories/test_promo_code_repository.py tests/unit/app/handlers/command_handlers/referral/test_apply_affiliate_code_handler.py
+uv run pytest tests/unit/api/test_reliable_purchase_finalization_routes.py
+uv run pytest tests/integration/api/test_reliable_purchase_finalization_writes.py -o addopts="" -m integration
+```
+
+## Success Criteria
+
+- [ ] Product/backend/mobile approvals are recorded against response fixtures.
+- [ ] Onboarding, promo, and referral effects commit with exact durable responses.
+- [ ] Business-key duplicates cannot increment, reassign, or enqueue twice.
+- [ ] Unique referred-user attribution spans internal and affiliate paths and is
+  enforced by PostgreSQL, not handler timing or outbox JSON.
+- [ ] Payout and lazy my-code remain explicitly unsupported.
+
+## Risks and Security
+
+Changing duplicate errors to success can affect analytics and support flows, so
+it applies only to enabled operation-aware requests until approved. Never log
+codes, discount/currency, UIDs, affiliate identity, or operation identifiers.

--- a/plans/260714-reliable-write-contract-backend/phase-06-compatibility-observability-and-rollout.md
+++ b/plans/260714-reliable-write-contract-backend/phase-06-compatibility-observability-and-rollout.md
@@ -1,0 +1,251 @@
+---
+phase: 6
+title: "Compatibility, Observability, and Rollout"
+status: pending
+priority: P1
+dependencies: [0, 2, 3, 4, 5]
+effort: "4-6 engineering days plus staged observation"
+---
+
+# Phase 6: Compatibility, Observability, and Rollout
+
+## Overview
+
+Prove failure semantics, compatibility, retention, privacy, and rollback before
+enabling one action at a time. Elapsed time alone never advances rollout.
+
+## HTTP Failure Semantics
+
+| Admission/operation state | Mutation endpoint | Lookup | Re-execute? |
+|---|---|---|---|
+| Both operation fields absent | Legacy endpoint behavior | n/a | Legacy only |
+| Partial/invalid/mismatched UUIDv4 | 400 `INVALID_IDEMPOTENCY_KEY` | `notFound` | No reservation |
+| Flag off/version unsupported, no row | 409 `WRITE_CAPABILITY_DISABLED` | `notFound` | No |
+| Flag off, existing pending row | 409 for new/reclaim; a live admitted owner may finish | `pending` + bounded `Retry-After` | Never resume stale work while off |
+| Same key, changed fingerprint | 409 `IDEMPOTENCY_KEY_REUSED` | Owner sees state without fingerprint/body | No |
+| Pending, live lease | 409 `OPERATION_IN_PROGRESS`, `Retry-After: 1..30` | `pending`, same bound | No duplicate owner |
+| Pending, stale lease, flag on | CAS reclaim or 409 race result | `pending` | One fenced owner only |
+| Committed | Exact original status + `rw-response-v1` JSON; replay true | `committed` + same frozen result | Never |
+| Permanent deterministic failure | Exact original safe 4xx/body; replay true | `permanentFailure` + safe status/code/body | Never |
+| Expired tombstone | 410 `OPERATION_EXPIRED` | `expired`, no fingerprint/result | Never; fingerprint is gone |
+| Tombstone deleted | May become new only if capability is on | `notFound` | Mobile resends only if local created-at is within advertised retention |
+| DB failure before reservation | 503 | `notFound` | Client follows retention/manifest rule |
+| Transient failure after reservation | 503 safe body | `pending` until fenced reclaim or expiry | Only fenced reclaim while flag on |
+| Response lost after commit | Transport ambiguity | `committed` exact result | Never |
+
+Authentication/authorization runs before operation lookup/reservation. Never
+convert an auth failure into a durable operation record. A server-generated 503
+after commit is forbidden; projection/effect failures do not alter the committed
+response. Transport loss remains possible and is reconciled. An expired
+duplicate is always terminal and non-reexecuting because the fingerprint has
+been privacy-scrubbed.
+
+## Full Compatibility Matrix
+
+| Mobile | Backend | Capability | Required result |
+|---|---|---|---|
+| Old | Old | n/a | Baseline |
+| Old | New | ignored | Existing bodies/statuses; no operation row; known old-client blind-retry risk is not worsened |
+| New | Old | manifest missing | Do not send operation fields or auto-retry; retain ambiguous local state |
+| New | New | flag off/stale | One attempt, legacy contract; lookup remains enabled for old operation rows |
+| New | New | flag on, v1 match | Durable operation + lookup; exact logical JSON/status replay v1 |
+| New | New | unknown manifest/action version | Fail closed; no operation send/replay |
+| Pre-migration backend process | Migrated DB | not advertised | Old process ignores table/flags; routes remain legacy |
+| New backend process | Pre-migration DB | startup/predeploy failure | Do not serve enabled manifest; deployment fails before traffic |
+
+New mobile must fetch/validate the manifest before adding body fields; old
+Pydantic servers may ignore unknown JSON fields and headers without deduping.
+Presence of accepted fields or an HTTP success never proves capability.
+
+The shared staging suite runs old mobile/new backend and new mobile/old backend,
+then new/new with each capability off/on and mobile contract v13. It verifies no
+operation fields reach old backend, lookup remains usable after kill, exact
+first/replay fixtures match, and unknown manifest/response versions fail closed.
+
+## Observability and Retention
+
+Phase 0 owns all mandatory pre-route redaction implementation and sentinel tests;
+it completes before any Phase 1 migration or route deployment. This phase only
+verifies that its redaction guarantees remain true under reliable-write fault and
+rollout scenarios.
+
+Use provider-neutral `src.observability` only. Metrics:
+
+- `reliable_write.request.count`: action, outcome (`legacy|reserved|committed|replayed|conflict|pending|disabled|permanent_failure`);
+- `reliable_write.duration_ms`: action, stage (`reserve|execute|lookup`), outcome;
+- `reliable_write.pending.count` and `oldest_age_seconds`: action only;
+- `reliable_write.expiry.count`: action, stage (`scrub|delete`).
+
+Allowed logs: route template/action, enum outcome, contract version, retry flag,
+bounded duration/count, exception class. Forbidden everywhere: raw/resolved UID,
+operation ID or suffix, fingerprint, request/response/result body, entity ID,
+meal/ingredient/image/value/timestamp, promo/referral code, token/header, URL,
+receipt, payment details, or database error text containing values.
+
+Create `src/cron/reliable_write_cleanup.py` using database time, bounded batches,
+and `SELECT ... FOR UPDATE SKIP LOCKED`. It scrubs after 30 days, retains
+seven-day expired tombstones, then deletes; effects expire only after terminal
+and their parent operation policy permits it. Each row update predicates the
+selected state/retention timestamp so replay/finalize races lose safely. Account
+deletion cascade is tested concurrently. Cleanup is rerunnable and reports
+counts only. A failure does not alter write capabilities but pages the named
+owner before storage grows unbounded.
+Provision an external Render cron command `python -m src.cron.reliable_write_cleanup`
+after the entrypoint tests pass; schedule/owner belongs in deployment docs rather
+than an in-process loop.
+
+## Tests and Fault Injection
+
+Create:
+
+- `tests/integration/api/test_reliable_write_fault_injection.py`;
+- `tests/integration/api/test_reliable_write_compatibility.py`;
+- `tests/unit/cron/test_reliable_write_cleanup.py`;
+- `tests/unit/architecture/test_reliable_write_guardrails.py`;
+- `tests/unit/infra/monitoring/test_reliable_write_observability.py`;
+- `tests/unit/api/middleware/test_reliable_write_request_redaction.py`;
+- `tests/unit/api/test_reliable_write_exception_redaction.py`;
+- `tests/unit/infra/monitoring/test_reliable_write_sentry_redaction.py`;
+- `tests/integration/infra/test_reliable_write_sql_redaction.py` (also
+  `@pytest.mark.postgres`);
+- `tests/integration/app/test_reliable_write_lease_fencing.py`;
+- `tests/integration/app/test_reliable_write_effect_repair.py`;
+- `tests/integration/app/test_reliable_write_capability_cache.py`;
+- `tests/contract/test_reliable_write_shared_fixtures.py`.
+
+Inject faults: before reservation; after reservation; before socket response;
+after external scan upload/AI; before domain flush; after domain flush/before
+commit; after commit/before response; during cache invalidation/translation/
+analytics; after effect delivery/before mark; during snapshot scrub; cleanup
+versus replay/finalize/account deletion. Run two concurrent requests on separate
+PostgreSQL sessions/process-like executors, including lease expiry while AI is
+still running and two independent capability caches, not only mocked callbacks.
+
+Architecture guardrails assert domain has no FastAPI/SQLAlchemy imports,
+repositories never commit, routes do not instantiate handlers/UoWs, every
+advertised action has route+handler+integration fixtures, and action registry
+equals migration capability inventory and shared fixtures.
+
+Versioned shared files are
+`tests/fixtures/reliable_write/v1/{manifest,lookup,mutation,weight,benefits,fingerprint}.json`
+and the identical mobile paths
+`../mobile/test/fixtures/reliable_write/v1/{manifest,lookup,mutation,weight,benefits,fingerprint}.json`.
+They cover every lookup status, first/replay/conflict/pending/expired/permanent
+mutation response, every action including suggestion, all four weight outcomes,
+partial/all-rejected batches, onboarding/promo/referral duplicate/conflict
+decisions, exact UTC/Decimal strings, and canonical fingerprint cases. CI hashes
+both copies, runs Python consumers here and Dart consumers in mobile, and fails
+on drift.
+
+Update `docs/system-architecture.md`, `docs/cqrs-guide.md`,
+`docs/database-guide.md`, `docs/api-endpoints.md`, and deployment/cron guidance
+with the final contract, retention, kill-switch, and rollback procedures.
+
+## Rollout and Rollback
+
+1. Deploy the instruction-authority corrections and mandatory route-template/
+   Sentry/event-bus/SQL redaction. Do not expose lookup before redaction tests pass.
+2. Run the real-PostgreSQL expand migration with every dedicated capability row
+   false. Verify one Alembic head, ownership marker, tables/indexes/checks, false
+   rows including suggestion, and `ever_enabled=false`; production cohort none.
+3. Deploy web code containing manifest, ungated lookup, dedicated admin kill
+   switch/cache, and **all** action integrations while every row remains false.
+4. Provision the effect dispatcher and cleanup cron, run entrypoint tests and
+   cleanup dry-run, and confirm effect backlog/expiry alerts with no user data.
+5. Run old-client/new-backend staging smoke and legacy snapshots. Then validate
+   new mobile against the shared manifest/lookup/response fixtures and full
+   old/new/new matrix, including mobile contract v13. No flag changes yet.
+6. After approvals, first enablement is global for one production action at a time
+   in order: manual meal; suggestion; URL scan;
+   food-label scan; multipart scan; meal edit/delete; weight sync/delete/create;
+   onboarding; promo; referral. Each action has its own flag.
+7. Advance only when named release owner approves numeric thresholds for
+   duplicate prevention, conflicts, pending age, 5xx, latency, and lookup rate.
+8. Kill switch: disable action row. Admission reflects off within 30 seconds;
+   clients stop new sends/reclaims, a live admitted request may finish, and stale
+   work never resumes. Existing records remain lookup-readable until retention.
+9. App rollback is forward-only: disable all rows, deploy compatible prior code,
+   and keep schema/data. Alembic downgrade is permitted only on a never-enabled,
+   entirely unused install; it acquires the migration lock and aborts if
+   `ever_enabled` or any operation/effect/attribution row exists.
+
+## Verification Commands
+
+```bash
+uv run black src/ tests/
+uv run ruff check src/ tests/
+uv run mypy src/
+uv run lint-imports
+uv run pytest tests/unit --cov=src --cov-fail-under=65
+uv run pytest tests/integration/api/test_reliable_write_fault_injection.py tests/integration/api/test_reliable_write_compatibility.py -o addopts="" -m integration
+uv run pytest tests/integration/app/test_reliable_write_lease_fencing.py tests/integration/app/test_reliable_write_effect_repair.py tests/integration/app/test_reliable_write_capability_cache.py -o addopts="" -m integration
+uv run pytest tests/contract/test_reliable_write_shared_fixtures.py
+uv run pytest tests/migrations -m postgres
+uv run alembic heads
+```
+
+From `../mobile`, run the mobile fixture/contract suite selected in its Phase 4
+and Phase 5 plan, including contract v13; CI must also compare SHA-256 for the six
+shared JSON fixture files. Run the staging matrix with capability off/on for each
+action, but keep production rows false.
+
+## Success Criteria
+
+- [ ] Compatibility matrix and every fault boundary pass.
+- [ ] No mutation can commit without same-transaction exact response and required effects.
+- [ ] Kill switch disables new sends within manifest TTL while lookup remains.
+- [ ] Observability redaction tests reject every forbidden field.
+- [ ] Rollout owner, pause authority, minimum volume, and numeric thresholds are
+  approved before any flag reaches production true.
+
+## Remaining Decision Gates
+
+- Mobile approves `rw-response-v1`: stored first-call status and exact logical
+  JSON, including deterministic null optional meal projections and no rehydrate.
+- Product/mobile approve operation-aware single same-instant weight upsert,
+  partial batch, `rejected`, fixed UTC/Decimal, and synced-count semantics.
+- Product/mobile approve onboarding `already_completed`, promo
+  `already_redeemed`, referral `already_applied`, immutable user-unique attribution
+  across internal/affiliate sources, and one-benefit behavior.
+- Name rollout owner and pause authority; approve minimum observation volume and
+  numeric duplicate/conflict/pending/5xx/latency/lookup thresholds.
+- V1 has no production cohort or allowlist. First global enablement requires the
+  named approvals; until then every action capability remains false.
+
+## Validation Log
+
+- Tier: Full (7 phases, Phase 0 through Phase 6).
+- Fact check scope: reviewer-verified current route, command, handler, repository,
+  model, migration, test, event-bus, and Alembic paths are cited; implementation
+  must recheck the head and working tree before generating a revision.
+- Flow trace: confirmed current concrete-UoW/manual-commit weight handlers,
+  post-commit scan/translation boundaries, timestamp batch upsert, onboarding
+  set-if-false, promo row lock/usage increment, referral business dedup, and
+  promo/referral route handler bypasses.
+- Contract correction: suggestion now has its own action; exact response replay,
+  partial weights, durable effects, referral attribution, JCS, lease fencing,
+  state/expiry/cache/migration behavior, and shared fixtures are selected.
+- Review status (2026-07-15): final foundation readiness remains rejected.
+  Global-only false capabilities, authority/pytest rules, and migration-marker
+  ownership are resolved. Phase 0 generic-path and missing sentinel tests,
+  exhaustive canonical declarations/fixtures, and legacy weight compatibility
+  remain open. Do not start or deploy Phase 1-2 until renewed approval.
+- Structural validation: `ck plan validate
+  plans/260714-reliable-write-contract-backend/plan.md --strict` passed on
+  2026-07-14 with all seven phase files detected and no syntax/structure warnings;
+  rerun after the 2026-07-15 readiness corrections.
+
+### Whole-Plan Consistency Sweep
+
+- Files reread: `plan.md` and Phases 0-6.
+- Decision deltas checked: UUID transport; all 13 actions including suggestion;
+  RFC 8785 typed inputs; lease token fence; exact response snapshots; durable
+  effects; state/expiry; dedicated 30-second cache; partial weight results;
+  cross-source referral attribution; PostgreSQL guards; compatibility;
+  Phase 0 prerequisite redaction; deploy order; shared fixtures; and false defaults.
+- Intentional distinctions checked: legacy versus operation-aware behavior;
+  admission kill versus ungated lookup/live-owner completion; exact logical JSON
+  versus wire bytes; partial item validation versus atomic accepted-item commit;
+  application rollback versus guarded unused-install Alembic downgrade.
+- Remaining gates are approvals/ownership values listed above. They cannot turn a
+  capability on implicitly; production cohort remains none.

--- a/plans/260714-reliable-write-contract-backend/plan.md
+++ b/plans/260714-reliable-write-contract-backend/plan.md
@@ -3,7 +3,7 @@ title: "Reliable Write Contract Backend"
 description: "Add fail-closed, capability-gated idempotency and reconciliation for critical meal, weight, onboarding, promo, and referral writes."
 status: in-progress
 priority: P1
-branch: "main"
+branch: "feature/reliable-write-foundation-prep"
 tags: [backend, api, database, reliability, critical]
 blockedBy: []
 blocks: []
@@ -30,6 +30,10 @@ migration, API, or capability enablement has started.
 
 ## Readiness Status — 2026-07-15
 
+- Delivery handoff: draft PR [#418](https://github.com/phuoctung28/mealtrack_backend/pull/418)
+  targets `delivery` from `feature/reliable-write-foundation-prep`. It contains
+  the authority/plan corrections and incomplete Phase 0 redaction groundwork;
+  it contains no Phase 1-2 migration/API or capability enablement.
 - Final foundation review: **rejected**. Phase 1 and Phase 2 must not start or
   deploy until the open canonical-input, legacy-weight-compatibility, and Phase 0
   redaction gates below pass renewed review.

--- a/plans/260714-reliable-write-contract-backend/plan.md
+++ b/plans/260714-reliable-write-contract-backend/plan.md
@@ -1,0 +1,145 @@
+---
+title: "Reliable Write Contract Backend"
+description: "Add fail-closed, capability-gated idempotency and reconciliation for critical meal, weight, onboarding, promo, and referral writes."
+status: in-progress
+priority: P1
+branch: "main"
+tags: [backend, api, database, reliability, critical]
+blockedBy: []
+blocks: []
+created: "2026-07-14T08:12:00.825Z"
+updated: "2026-07-15"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Reliable Write Contract Backend
+
+## Overview
+
+Build a reusable reliable-write contract without changing legacy client behavior.
+Operation-aware requests use UUIDv4 identity, canonical fingerprints, durable
+user/action-scoped results, reconciliation lookup, and remote kill switches.
+Requests without the contract keep current behavior; every new capability ships
+disabled until its integration and compatibility gates pass.
+
+This backend plan unblocks mobile Phase 4 and the purchase-finalization slices of
+Phase 5 in `../mobile/plans/260714-0918-reliability-architecture-remediation/`.
+Phase 0 authority and redaction implementation has started. No reliable-write
+migration, API, or capability enablement has started.
+
+## Readiness Status — 2026-07-15
+
+- Final foundation review: **rejected**. Phase 1 and Phase 2 must not start or
+  deploy until the open canonical-input, legacy-weight-compatibility, and Phase 0
+  redaction gates below pass renewed review.
+- Phase 0: in progress. PostgreSQL/CQRS authority, strict `postgres` marker, and
+  migration-marker paths are resolved. Generic path telemetry and the missing
+  exception/provider/SQL sentinel suites remain open.
+- Resolved design gates: all capability rows default false with
+  `ever_enabled=false`; v1 has no cohort/allowlist; any first enablement is a
+  separately approved global enablement for one action.
+- Open canonical declarations: manual item `fdc_id`/`name` and resolved
+  `Accept-Language`; suggestion top-level protein/carbs/fat; URL scan mode
+  `scanner` normalization and cross-repo changed-field fixtures.
+- Open weight storage policy: the expand migration must preserve every current
+  legacy positive-float write, including values above 999.999 and below 0.001.
+
+## Contract Direction
+
+- Header and body must contain the same canonical UUIDv4; partial, invalid, or
+  mismatched identity fails before mutation.
+- Database uniqueness: `(authenticated_user_id, action, client_operation_id)`.
+- Same key + same RFC 8785/JCS v1 fingerprint replays the exact stored v1 HTTP
+  status and logical JSON body; different fingerprint returns
+  `409 IDEMPOTENCY_KEY_REUSED`.
+- A durable pending reservation may precede external scan work, but the domain
+  mutation, exact response snapshot, and required effect/outbox rows are written
+  in one transaction.
+- `GET /v1/write-capabilities` is authenticated, versioned, TTL-bound, and
+  fail-closed. A dedicated capability table/cache (maximum 30-second process
+  TTL) is the remote kill switch; it never reuses the existing 600-second
+  feature-flag cache.
+- `GET /v1/write-operations/{action}/{client_operation_id}` is authenticated and
+  remains available while writes are disabled and returns
+  `pending|committed|notFound|expired|permanentFailure`.
+- Stable actions include `meal.suggestion.create`; every action flag is false.
+  V1 has no cohort targeting: first enablement, if separately approved, is global
+  for that action in production. Until then production cohort is none.
+- Backend-calculated calories remain derived from macros using
+  `P*4 + (C-fiber)*4 + fiber*2 + F*9`.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 0 | [Authority and Pre-route Redaction](./phase-00-authority-and-pre-route-redaction.md) | In Progress |
+| 1 | [Contract and Migration Foundation](./phase-01-contract-and-migration-foundation.md) | Blocked |
+| 2 | [Capability and Reconciliation API](./phase-02-capability-and-reconciliation-api.md) | Blocked |
+| 3 | [Meal Write Integration](./phase-03-meal-write-integration.md) | Pending |
+| 4 | [Weight Write Integration](./phase-04-weight-write-integration.md) | Pending |
+| 5 | [Onboarding Promo and Referral Decisions](./phase-05-onboarding-promo-and-referral-decisions.md) | Pending |
+| 6 | [Compatibility Observability and Rollout](./phase-06-compatibility-observability-and-rollout.md) | Pending |
+
+## Dependencies
+
+- Hard consumer dependency: mobile reliable-write decision record and endpoint
+  inventory under `../mobile/`; backend lands before mobile enables replay.
+- Related, not blocking: pending `260612-1046-service-initiated-bandwidth-reduction`
+  touches scan-by-URL upload flow; coordinate file ownership during implementation.
+- Current Alembic head verified as `20260702000001`; implementation must re-check.
+- Product/mobile/release gates remain explicit in Phase 6. All capability rows
+  default false; v1 has no cohort columns or per-user admission behavior.
+- Hard implementation gate: do not create or deploy reliable-write migrations,
+  manifest/lookup APIs, or operation-aware routes until Phase 0 is complete and
+  a renewed foundation review approves the corrected Phase 1 contract.
+
+## Delivery Gates
+
+1. Instruction-authority correction and telemetry/Sentry/SQL redaction tests.
+2. PostgreSQL expand migrations (reliable-write foundation and weight NUMERIC),
+   foundation, manifest, and lookup with all actions
+   false; lookup is never capability-gated.
+3. Meal, durable-effect, and exact-response replay tests.
+4. Partial weight batch and purchase-finalization convergence tests.
+5. Shared cross-repo fixtures, old/new staging matrix, fault injection, and only
+   then separately approved per-action global rollout. Cohort/allowlist rollout
+   requires a future migration, manifest contract, deterministic assignment, and
+   admission tests.
+
+## Prioritized Next Steps
+
+1. Finish Phase 0: remove generic path telemetry or accept only a trusted
+   FastAPI route template, then add and pass exception-handler,
+   provider-observability, and real-PostgreSQL SQL sentinel tests.
+2. Complete the exhaustive fingerprint inventory and paired Python/Dart fixture
+   declarations for manual, suggestion, and URL-scanner inputs.
+3. Validate the unbounded nullable NUMERIC compatibility policy against all
+   current legacy positive-float writes while keeping operation-aware validation
+   isolated behind disabled capabilities.
+4. Rerun strict plan validation and independent foundation readiness review.
+5. Only after approval, implement the disabled Phase 1 foundation and Phase 2
+   manifest/lookup. Do not deploy or enable any reliable-write capability as part
+   of that approval.
+
+## Global Success Criteria
+
+- One accepted operation creates at most one canonical entity/effect.
+- Timeout-after-commit reconciles without blind replay.
+- Old clients keep existing request/response compatibility.
+- New clients treat missing, stale, disabled, or unknown capability data as no-retry.
+- Logs/metrics exclude UID, operation ID, fingerprint, bodies, meal/image/weight
+  values, promo/referral codes, tokens, URLs, and credentials.
+- Shared versioned backend/mobile fixtures pin canonicalization, manifest,
+  lookup, replay, weight, benefit, and UTC behavior before either client enables.
+
+## Blocking Approvals (Defaults Applied)
+
+The design choices are selected in this plan so implementation is deterministic,
+but capability enablement remains blocked on: mobile acceptance of exact logical
+JSON replay v1; product/mobile acceptance of operation-aware same-instant weight
+upsert and partial-batch outcomes; product acceptance of onboarding/promo/referral
+duplicate semantics and immutable one-benefit referral attribution; a named
+release owner/pause authority; numeric rollout thresholds and minimum observation
+volume. The fail-closed defaults are all action rows false, no production
+enablement, no automatic retry, and lookup-only reconciliation.

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,10 +21,11 @@ markers =
     api: API integration tests
     unit: Unit tests (fast)
     integration: Integration tests (slow)
+    postgres: Requires a real PostgreSQL database and Alembic migration path
     performance: Performance tests
     validation: Validation and error handling tests
     slow: Slow running tests
     fast: Fast running tests
 filterwarnings =
     ignore::DeprecationWarning
-    ignore::PendingDeprecationWarning 
+    ignore::PendingDeprecationWarning

--- a/src/api/exception_handlers.py
+++ b/src/api/exception_handlers.py
@@ -11,10 +11,11 @@ prevents duplicate Sentry issues per failure event.
 
 import logging
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from src.api.exceptions import MealTrackException, create_http_exception
+from src.api.middleware.request_logger import get_route_template
 from src.domain.exceptions.ai_exceptions import AIUnavailableError
 
 logger = logging.getLogger(__name__)
@@ -40,11 +41,12 @@ async def _ai_unavailable_handler(
 ) -> JSONResponse:
     """Log degraded AI state at WARNING; return 503 without ERROR."""
     logger.warning(
-        "AI provider unavailable: %s",
+        "AI provider unavailable: error_type=%s route=%s",
         type(exc).__name__,
+        get_route_template(request),
         extra={
             "error_code": "AI_UNAVAILABLE",
-            "attempted_models": exc.attempted_models,
+            "route": get_route_template(request),
         },
     )
     return JSONResponse(
@@ -71,16 +73,15 @@ async def _unexpected_exception_handler(
     """
     request_id = getattr(getattr(request, "state", None), "request_id", None)
     logger.error(
-        "Unexpected error handling %s %s: %s",
+        "Unexpected error: method=%s route=%s error_type=%s",
         request.method,
-        request.url.path,
+        get_route_template(request),
         type(exc).__name__,
-        exc_info=True,
         extra={
             "error_type": type(exc).__name__,
             "request_id": request_id,
             "method": request.method,
-            "path": request.url.path,
+            "route": get_route_template(request),
         },
     )
     return JSONResponse(

--- a/src/api/middleware/request_logger.py
+++ b/src/api/middleware/request_logger.py
@@ -49,22 +49,15 @@ class RequestLoggerMiddleware:
             return
 
         request = Request(scope)
-        if request.url.path in self.SKIP_PATHS:
+        if scope.get("path") in self.SKIP_PATHS:
             await self.app(scope, receive, send)
             return
 
         request_id = uuid.uuid4().hex[:8]
         scope.setdefault("state", {})
         scope["state"]["request_id"] = request_id
-        set_request_context(
-            request_id=request_id,
-            method=request.method,
-            path=request.url.path,
-            user_id=self._get_user_id(request),
-        )
-
         start_time = time.time()
-        self._log_request(request, request_id)
+        self._log_request(request.method, request_id)
 
         response_logged = False
 
@@ -77,7 +70,14 @@ class RequestLoggerMiddleware:
                 headers.append("X-Response-Time", f"{elapsed:.3f}s")
                 await send(message)
                 # Log after delivery so elapsed reflects actual time-to-first-byte
-                self._log_response(request, message["status"], request_id, elapsed)
+                set_request_context(
+                    request_id=request_id,
+                    method=request.method,
+                    path=get_route_template(scope),
+                )
+                self._log_response(
+                    scope, request.method, message["status"], request_id, elapsed
+                )
                 response_logged = True
             else:
                 await send(message)
@@ -89,22 +89,23 @@ class RequestLoggerMiddleware:
             # Only log [RES-...] if http.response.start was never sent — avoids a
             # duplicate log line when the app raises mid-stream after headers went out.
             if not response_logged:
-                self._log_response(request, 500, request_id, elapsed)
-            self._log_error(request, request_id, elapsed, e)
+                set_request_context(
+                    request_id=request_id,
+                    method=request.method,
+                    path=get_route_template(scope),
+                )
+                self._log_response(scope, request.method, 500, request_id, elapsed)
+            self._log_error(scope, request.method, request_id, elapsed, e)
             raise
 
-    def _log_request(self, request: Request, request_id: str) -> None:
-        client_ip = self._get_client_ip(request)
-        user_id = self._get_user_id(request)
-        user_str = f" user={user_id}" if user_id else ""
-        logger.info(
-            f"[REQ-{request_id}] {request.method} {request.url.path}"
-            f" client={client_ip}{user_str}"
-        )
+    def _log_request(self, method: str, request_id: str) -> None:
+        """Log only pre-routing metadata; resolved paths are never safe here."""
+        logger.info("[REQ-%s] method=%s request_class=http", request_id, method)
 
     def _log_response(
         self,
-        request: Request,
+        scope: Scope,
+        method: str,
         status_code: int,
         request_id: str,
         elapsed: float,
@@ -118,13 +119,18 @@ class RequestLoggerMiddleware:
             log_level = logging.WARNING
         logger.log(
             log_level,
-            f"[RES-{request_id}] {request.method} {request.url.path}"
-            f" status={status_code} elapsed={elapsed:.3f}s",
+            "[RES-%s] method=%s route=%s status=%s elapsed=%.3fs",
+            request_id,
+            method,
+            get_route_template(scope),
+            status_code,
+            elapsed,
         )
 
     def _log_error(
         self,
-        request: Request,
+        scope: Scope,
+        method: str,
         request_id: str,
         elapsed: float,
         error: Exception,
@@ -134,23 +140,21 @@ class RequestLoggerMiddleware:
         # re-raises after calling the handler, so this path fires every time;
         # logging at WARNING avoids a duplicate ERROR/Sentry issue per request.
         logger.warning(
-            f"[ERR-{request_id}] {request.method} {request.url.path}"
-            f" elapsed={elapsed:.3f}s error={type(error).__name__}"
+            "[ERR-%s] method=%s route=%s elapsed=%.3fs error_type=%s",
+            request_id,
+            method,
+            get_route_template(scope),
+            elapsed,
+            type(error).__name__,
         )
 
-    def _get_client_ip(self, request: Request) -> str:
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        if request.client:
-            return request.client.host
-        return "unknown"
 
-    def _get_user_id(self, request: Request) -> str | None:
-        try:
-            return getattr(request.state, "user_id", None)
-        except AttributeError:
-            return None
+def get_route_template(scope: Scope | Request) -> str:
+    """Return a FastAPI route template, never an incoming resolved path."""
+    raw_scope = scope.scope if isinstance(scope, Request) else scope
+    route = raw_scope.get("route")
+    path = getattr(route, "path", None)
+    return path if isinstance(path, str) and path.startswith("/") else "unmatched"
 
 
 def get_request_id(request: Request) -> str | None:

--- a/src/infra/event_bus/pymediator_event_bus.py
+++ b/src/infra/event_bus/pymediator_event_bus.py
@@ -117,7 +117,10 @@ class PyMediatorEventBus(EventBus):
             for param in signature.parameters.values()
             if param.default is inspect.Parameter.empty
             and param.kind
-            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
         ]
         if required_params:
             return handler
@@ -132,7 +135,7 @@ class PyMediatorEventBus(EventBus):
             self._domain_event_subscribers[event_type] = []
 
         self._domain_event_subscribers[event_type].append(handler)
-        logger.debug(f"Subscribed to {event_type.__name__}")
+        logger.debug("event_bus stage=subscribed event_type=%s", event_type.__name__)
 
     async def send(self, event: Event) -> Any:
         """Send a command/query and get the result."""
@@ -160,29 +163,35 @@ class PyMediatorEventBus(EventBus):
                 isinstance(e, DomainEvent) for e in result
             ):
                 logger.debug(
-                    f"Publishing {len(result)} domain events from command result"
+                    "event_bus stage=publish_result event_type=%s", event_type.__name__
                 )
                 for domain_event in result:
                     await self.publish(domain_event)
             elif isinstance(result, dict) and "events" in result:
                 events = result.get("events", [])
                 logger.debug(
-                    f"Publishing {len(events)} domain events from command result"
+                    "event_bus stage=publish_result event_type=%s", event_type.__name__
                 )
                 for domain_event in events:
                     if isinstance(domain_event, DomainEvent):
                         await self.publish(domain_event)
             return result
 
-        except (MealTrackException, AIUnavailableError) as e:
+        except (MealTrackException, AIUnavailableError) as error:
             # Controlled application exceptions and degraded AI-provider failures
             # are converted to proper HTTP responses by the API layer. Keep this
             # at debug so routine control flow does not produce duplicate ERRORs.
-            logger.debug(f"Application exception handling {event_type.__name__}: {str(e)}")
+            logger.debug(
+                "event_bus stage=application_exception event_type=%s error_type=%s",
+                event_type.__name__,
+                type(error).__name__,
+            )
             raise
-        except Exception as e:
+        except Exception as error:
             logger.error(
-                f"Error handling {event_type.__name__}: {str(e)}", exc_info=True
+                "event_bus stage=handler_error event_type=%s error_type=%s",
+                event_type.__name__,
+                type(error).__name__,
             )
             raise
 
@@ -191,13 +200,13 @@ class PyMediatorEventBus(EventBus):
         event_type = type(event)
 
         if event_type not in self._domain_event_subscribers:
-            logger.debug(f"No subscribers for {event_type.__name__}")
+            logger.debug(
+                "event_bus stage=no_subscribers event_type=%s", event_type.__name__
+            )
             return
 
         subscribers = self._domain_event_subscribers[event_type]
-        logger.debug(
-            f"Publishing {event_type.__name__} to {len(subscribers)} subscribers"
-        )
+        logger.debug("event_bus stage=publishing event_type=%s", event_type.__name__)
 
         # Execute subscribers concurrently
         tasks = []
@@ -214,22 +223,27 @@ class PyMediatorEventBus(EventBus):
         if tasks:
             # Execute all tasks in the background (fire-and-forget)
             async def run_tasks_in_background():
-                logger.debug(f"Starting background processing for {event_type.__name__}")
+                logger.debug(
+                    "event_bus stage=background_start event_type=%s",
+                    event_type.__name__,
+                )
                 results = await asyncio.gather(*tasks, return_exceptions=True)
 
                 # Log any exceptions
-                for i, result in enumerate(results):
+                for result in results:
                     if isinstance(result, Exception):
                         logger.error(
-                            f"Subscriber {i} for {event_type.__name__} failed: {result}",
-                            exc_info=result,
+                            "event_bus stage=subscriber_error event_type=%s error_type=%s",
+                            event_type.__name__,
+                            type(result).__name__,
                         )
                 logger.debug(
-                    f"Background processing completed for {event_type.__name__}"
+                    "event_bus stage=background_complete event_type=%s",
+                    event_type.__name__,
                 )
 
             # Schedule the task to run in the background (managed lifecycle)
-            logger.debug(f"Scheduling background task for {event_type.__name__}")
+            logger.debug("event_bus stage=scheduled event_type=%s", event_type.__name__)
             self._task_manager.spawn(
                 f"event_bus:{event_type.__name__}",
                 run_tasks_in_background(),

--- a/src/infra/monitoring/sentry.py
+++ b/src/infra/monitoring/sentry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Literal, cast
 
@@ -28,6 +29,10 @@ SentryMessageLevel = Literal["fatal", "critical", "error", "warning", "info", "d
 SentryLogLevel = Literal["fatal", "error", "warning", "info", "debug", "trace"]
 _SENTRY_MESSAGE_LEVELS = {"fatal", "critical", "error", "warning", "info", "debug"}
 _SENTRY_LOG_LEVELS = {"fatal", "error", "warning", "info", "debug", "trace"}
+_SAFE_SPAN_OPERATION = re.compile(r"^[a-z][a-z0-9_.-]{0,79}$")
+_PROVIDER_FORBIDDEN_KEYS = frozenset(
+    {"user_id", "row_id", "event_id", "image_id", "image_url", "path"}
+)
 
 
 class SentryObservabilityConnector:
@@ -60,7 +65,7 @@ class SentryObservabilityConnector:
             "release": settings.SENTRY_RELEASE,
             "traces_sample_rate": settings.SENTRY_TRACES_SAMPLE_RATE,
             "profiles_sample_rate": settings.SENTRY_PROFILES_SAMPLE_RATE,
-            "send_default_pii": settings.SENTRY_SEND_PII,
+            "send_default_pii": False,
             "enable_logs": settings.SENTRY_ENABLE_LOGS,
             "enable_metrics": settings.SENTRY_ENABLE_METRICS,
             "integrations": [
@@ -69,6 +74,8 @@ class SentryObservabilityConnector:
                 SqlalchemyIntegration(),
                 LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
             ],
+            "before_send": _before_send,
+            "before_send_transaction": _before_send_transaction,
         }
         if settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE is not None:
             init_kwargs["profile_session_sample_rate"] = (
@@ -90,7 +97,9 @@ class SentryObservabilityConnector:
         if not self._can_use_sdk():
             return
 
-        self._apply_safe_context(context)
+        self._apply_safe_context(
+            {"error_type": type(error).__name__, **(context or {})}
+        )
         sentry_sdk.capture_exception(error)
 
     def capture_message(
@@ -188,15 +197,11 @@ class SentryObservabilityConnector:
         context = {
             "request_id": request_id,
             "method": method,
-            "path": path,
-            "route": path,
+            "route": _safe_route_template(path),
             "environment": settings.ENVIRONMENT,
             "release": settings.SENTRY_RELEASE,
-            "user_id": user_id,
         }
         self._apply_safe_context(context)
-        if user_id:
-            sentry_sdk.set_user({"id": user_id})
 
     def start_span(
         self,
@@ -208,10 +213,11 @@ class SentryObservabilityConnector:
         if not self._can_use_sdk():
             return nullcontext()
 
-        self._apply_safe_context(
-            {"operation": operation, **filter_safe_context(context)}
+        safe_operation = (
+            operation if _SAFE_SPAN_OPERATION.fullmatch(operation) else "operation"
         )
-        return sentry_sdk.start_span(op=operation, description=description)
+        self._apply_safe_context({"operation": safe_operation, **(context or {})})
+        return sentry_sdk.start_span(op=safe_operation, description=None)
 
     def flush(self, *, timeout: float = 5) -> None:
         if not self._can_use_sdk():
@@ -222,7 +228,11 @@ class SentryObservabilityConnector:
         return bool(self._enabled and sentry_sdk is not None)
 
     def _apply_safe_context(self, context: dict[str, Any] | None) -> None:
-        safe_context = filter_safe_context(context)
+        safe_context = {
+            key: value
+            for key, value in filter_safe_context(context).items()
+            if key not in _PROVIDER_FORBIDDEN_KEYS
+        }
         if not safe_context:
             return
 
@@ -248,3 +258,44 @@ def _normalize_log_level(level: str) -> SentryLogLevel:
     if level in _SENTRY_LOG_LEVELS:
         return cast(SentryLogLevel, level)
     return "info"
+
+
+def _safe_route_template(value: str) -> str:
+    """Accept only route templates/static routes; reject URLs and resolved paths."""
+    if not value.startswith("/") or "?" in value or "://" in value:
+        return "unmatched"
+    if re.search(r"/[0-9a-f]{8}-[0-9a-f-]{27,}(?:/|$)", value, re.IGNORECASE):
+        return "unmatched"
+    return value
+
+
+def _before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
+    """Fail closed: provider events retain classifications, never request/error data."""
+    del hint
+    contexts = event.get("contexts")
+    mealtrack = contexts.get("mealtrack") if isinstance(contexts, dict) else None
+    safe_context = {
+        key: value
+        for key, value in filter_safe_context(mealtrack).items()
+        if key not in _PROVIDER_FORBIDDEN_KEYS
+    }
+    return {
+        "level": event.get("level", "error"),
+        "logger": event.get("logger", "application"),
+        "transaction": "unmatched",
+        "contexts": {"mealtrack": safe_context} if safe_context else {},
+        "tags": filter_safe_tags(safe_context),
+    }
+
+
+def _before_send_transaction(
+    event: dict[str, Any], hint: dict[str, Any]
+) -> dict[str, Any]:
+    """Retain only HTTP route-template spans; SQL spans may expose statements/binds."""
+    del hint
+    spans: list[dict[str, Any]] = []
+    for span in event.get("spans", []):
+        if not isinstance(span, dict) or span.get("op") != "http.server":
+            continue
+        spans.append({"op": "http.server", "description": "unmatched"})
+    return {"transaction": "unmatched", "spans": spans}

--- a/src/observability.py
+++ b/src/observability.py
@@ -12,6 +12,52 @@ from src.observability_connectors import (
 
 _connector: ObservabilityConnector = NoopObservabilityConnector()
 
+# This facade is the application's privacy boundary.  These fields are bounded,
+# operational classifications only; identifiers and arbitrary values fail closed.
+_SAFE_FIELDS = frozenset(
+    {
+        "request_id",
+        "method",
+        "path",
+        "route",
+        "action",
+        "stage",
+        "outcome",
+        "version",
+        "status_code",
+        "status",
+        "component",
+        "operation",
+        "error_type",
+        "error_code",
+        "event_type",
+        "provider",
+        "ai_provider",
+        "ai_model",
+        "ai_purpose",
+        "ai_stage",
+        "failure_kind",
+        "cache_hit",
+        "attempt_count",
+        "attempt_index",
+        "elapsed_ms",
+        "duration_ms",
+        "content_len_bucket",
+    }
+)
+_SAFE_VALUE_TYPES = (str, int, float, bool)
+
+
+def _safe_fields(values: dict[str, Any] | None) -> dict[str, Any]:
+    """Drop non-allowlisted, complex, and potentially identifying telemetry."""
+    if not values:
+        return {}
+    return {
+        key: value
+        for key, value in values.items()
+        if key in _SAFE_FIELDS and isinstance(value, _SAFE_VALUE_TYPES)
+    }
+
 
 def get_observability_connector() -> ObservabilityConnector:
     """Return the process-wide observability connector."""
@@ -47,7 +93,9 @@ def capture_exception(
     context: dict[str, Any] | None = None,
 ) -> None:
     """Capture an unexpected exception through the active connector."""
-    get_observability_connector().capture_exception(error, context=context)
+    safe_context = _safe_fields(context)
+    safe_context["error_type"] = type(error).__name__
+    get_observability_connector().capture_exception(error, context=safe_context)
 
 
 def capture_message(
@@ -60,7 +108,7 @@ def capture_message(
     get_observability_connector().capture_message(
         message,
         level=level,
-        context=context,
+        context=_safe_fields(context),
     )
 
 
@@ -74,7 +122,7 @@ def log_event(
     get_observability_connector().log_event(
         level,
         message,
-        attributes=attributes,
+        attributes=_safe_fields(attributes),
     )
 
 
@@ -90,7 +138,7 @@ def increment_metric(
         name,
         value,
         unit=unit,
-        attributes=attributes,
+        attributes=_safe_fields(attributes),
     )
 
 
@@ -106,7 +154,7 @@ def gauge_metric(
         name,
         value,
         unit=unit,
-        attributes=attributes,
+        attributes=_safe_fields(attributes),
     )
 
 
@@ -122,7 +170,7 @@ def distribution_metric(
         name,
         value,
         unit=unit,
-        attributes=attributes,
+        attributes=_safe_fields(attributes),
     )
 
 
@@ -138,7 +186,6 @@ def set_request_context(
         request_id=request_id,
         method=method,
         path=path,
-        user_id=user_id,
     )
 
 
@@ -152,7 +199,7 @@ def start_span(
     return get_observability_connector().start_span(
         operation=operation,
         description=description,
-        context=context,
+        context=_safe_fields(context) if context else None,
     )
 
 

--- a/tests/unit/api/middleware/test_reliable_write_request_redaction.py
+++ b/tests/unit/api/middleware/test_reliable_write_request_redaction.py
@@ -1,0 +1,95 @@
+"""Sentinel tests for route-template request observability."""
+
+import logging
+from contextlib import nullcontext
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.exception_handlers import register_exception_handlers
+from src.api.middleware.request_logger import RequestLoggerMiddleware
+from src.observability import (
+    reset_observability_connector_for_test,
+    set_observability_connector_for_test,
+)
+
+
+class _RecordingConnector:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def set_request_context(self, **kwargs):
+        self.calls.append(("request_context", kwargs))
+
+    def __getattr__(self, _name):
+        return lambda *args, **kwargs: nullcontext()
+
+
+def teardown_function() -> None:
+    reset_observability_connector_for_test()
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestLoggerMiddleware)
+    register_exception_handlers(app)
+
+    @app.get("/v1/operations/{operation_id}")
+    def lookup(operation_id: str):
+        return {"operation_id": operation_id}
+
+    @app.get("/v1/fail/{operation_id}")
+    def failure(operation_id: str):
+        raise RuntimeError(f"sql bind sentinel={operation_id} uid=uid-sentinel")
+
+    return app
+
+
+def test_success_logs_and_context_never_contain_resolved_path_or_uid(caplog):
+    connector = _RecordingConnector()
+    set_observability_connector_for_test(connector)
+    sentinel_id = "operation-sentinel-123"
+    client = TestClient(_app(), raise_server_exceptions=False)
+
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            f"/v1/operations/{sentinel_id}?fingerprint=query-sentinel",
+            headers={"Authorization": "Bearer token-sentinel", "X-UID": "uid-sentinel"},
+        )
+
+    assert response.status_code == 200
+    rendered = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.name.startswith("src.api.")
+    )
+    assert sentinel_id not in rendered
+    assert "query-sentinel" not in rendered
+    assert "uid-sentinel" not in rendered
+    assert "/v1/operations/{operation_id}" in rendered
+    context = connector.calls[-1][1]
+    assert context["path"] == "/v1/operations/{operation_id}"
+    assert "user_id" not in context
+
+
+def test_failure_logs_never_contain_exception_text_or_resolved_path(caplog):
+    sentinel_id = "operation-sentinel-456"
+    client = TestClient(_app(), raise_server_exceptions=False)
+
+    with caplog.at_level(logging.DEBUG):
+        response = client.get(f"/v1/fail/{sentinel_id}?weight=weight-sentinel")
+
+    assert response.status_code == 500
+    rendered = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.name.startswith("src.api.")
+    )
+    for forbidden in (
+        sentinel_id,
+        "weight-sentinel",
+        "sql bind sentinel",
+        "uid-sentinel",
+    ):
+        assert forbidden not in rendered
+    assert "/v1/fail/{operation_id}" in rendered

--- a/tests/unit/api/middleware/test_request_logger.py
+++ b/tests/unit/api/middleware/test_request_logger.py
@@ -88,7 +88,7 @@ class TestRequestLogging:
 
         # Check log contains request info
         assert any("[REQ-" in record.message for record in caplog.records)
-        assert any("GET /test" in record.message for record in caplog.records)
+        assert any("method=GET" in record.message for record in caplog.records)
 
     def test_logs_response(self, client, caplog):
         """Should log response details."""
@@ -142,9 +142,9 @@ class TestErrorLogging:
 
         err_logs = [r for r in caplog.records if "[ERR-" in r.message]
         assert len(err_logs) >= 1
-        assert all(r.levelname == "WARNING" for r in err_logs), (
-            "[ERR-...] middleware log must be WARNING, not ERROR"
-        )
+        assert all(
+            r.levelname == "WARNING" for r in err_logs
+        ), "[ERR-...] middleware log must be WARNING, not ERROR"
 
     @pytest.mark.parametrize("status_code", [400, 401, 403, 404])
     def test_expected_client_errors_log_at_info(self, app, caplog, status_code):

--- a/tests/unit/infra/monitoring/test_observability_facade.py
+++ b/tests/unit/infra/monitoring/test_observability_facade.py
@@ -84,7 +84,11 @@ def test_facade_delegates_to_configured_connector():
 
     assert connector.calls == [
         ("initialize",),
-        ("capture_exception", error, {"component": "cron"}),
+        (
+            "capture_exception",
+            error,
+            {"component": "cron", "error_type": "RuntimeError"},
+        ),
         ("capture_message", "hello", "error", {"operation": "send"}),
         ("log_event", "info", "cron started", {"component": "cron"}),
         ("increment_metric", "cron.started", 1.0, None, {"component": "cron"}),
@@ -118,6 +122,33 @@ def test_cache_hit_is_safe_observability_attribute_and_tag():
         "cache_hit": "true",
     }
     assert filter_safe_tags(attributes)["cache_hit"] == "true"
+
+
+def test_facade_drops_sentinel_identifiers_and_payloads_from_metrics():
+    connector = RecordingConnector()
+    set_observability_connector_for_test(connector)
+
+    increment_metric(
+        "reliable_write.request.count",
+        attributes={
+            "action": "manual_meal",
+            "outcome": "committed",
+            "operation_id": "operation-sentinel",
+            "entity_id": "entity-sentinel",
+            "fingerprint": "fingerprint-sentinel",
+            "payload": {"weight": "weight-sentinel"},
+        },
+    )
+
+    assert connector.calls == [
+        (
+            "increment_metric",
+            "reliable_write.request.count",
+            1.0,
+            None,
+            {"action": "manual_meal", "outcome": "committed"},
+        )
+    ]
 
 
 def test_meal_scan_rejection_image_context_is_safe_but_not_tagged():

--- a/tests/unit/infra/monitoring/test_reliable_write_sentry_redaction.py
+++ b/tests/unit/infra/monitoring/test_reliable_write_sentry_redaction.py
@@ -1,0 +1,68 @@
+"""Sentinel tests for provider payload redaction."""
+
+from unittest.mock import MagicMock
+
+from src.infra.monitoring.sentry import SentryObservabilityConnector
+
+
+def test_sentry_hooks_scrub_request_exception_sql_and_breadcrumb_sentinels(monkeypatch):
+    sdk = MagicMock()
+    monkeypatch.setattr("src.infra.monitoring.sentry.sentry_sdk", sdk)
+    monkeypatch.setattr("src.infra.monitoring.sentry.settings.SENTRY_DSN", "dsn")
+
+    connector = SentryObservabilityConnector()
+    connector.initialize()
+    hooks = sdk.init.call_args.kwargs
+    event = {
+        "request": {
+            "url": "https://host/v1/operations/op-sentinel?key=query-sentinel",
+            "data": "body-sentinel",
+        },
+        "exception": {"values": [{"value": "SQL bind sql-sentinel uid-sentinel"}]},
+        "breadcrumbs": {
+            "values": [
+                {"message": "breadcrumb-sentinel", "data": {"sql": "sql-sentinel"}}
+            ]
+        },
+        "contexts": {
+            "trace": {"op": "http.server", "description": "/v1/operations/op-sentinel"}
+        },
+    }
+
+    scrubbed = hooks["before_send"](event, {})
+    rendered = repr(scrubbed)
+    for forbidden in (
+        "op-sentinel",
+        "query-sentinel",
+        "body-sentinel",
+        "sql-sentinel",
+        "uid-sentinel",
+        "breadcrumb-sentinel",
+    ):
+        assert forbidden not in rendered
+
+
+def test_sentry_transaction_hook_drops_sql_span_and_templates_http_span(monkeypatch):
+    sdk = MagicMock()
+    monkeypatch.setattr("src.infra.monitoring.sentry.sentry_sdk", sdk)
+    monkeypatch.setattr("src.infra.monitoring.sentry.settings.SENTRY_DSN", "dsn")
+    connector = SentryObservabilityConnector()
+    connector.initialize()
+    hook = sdk.init.call_args.kwargs["before_send_transaction"]
+
+    event = {
+        "transaction": "/v1/operations/op-sentinel",
+        "spans": [
+            {"op": "http.server", "description": "/v1/operations/op-sentinel"},
+            {
+                "op": "db.sql.query",
+                "description": "SELECT * FROM users WHERE id = :uid",
+                "data": {"db.params": "sql-sentinel"},
+            },
+        ],
+    }
+    scrubbed = hook(event, {})
+    assert scrubbed is not None
+    assert scrubbed["transaction"] == "unmatched"
+    assert len(scrubbed["spans"]) == 1
+    assert scrubbed["spans"][0]["description"] == "unmatched"

--- a/tests/unit/infra/monitoring/test_sentry_connector.py
+++ b/tests/unit/infra/monitoring/test_sentry_connector.py
@@ -167,8 +167,6 @@ def test_capture_message_applies_only_safe_context(monkeypatch):
     safe_context = mock_sdk.set_context.call_args.args[1]
     assert safe_context == {
         "component": "affiliate_outbox",
-        "row_id": "row-1",
-        "event_id": "evt-1",
         "event_type": "signup",
     }
     assert "payload" not in safe_context
@@ -192,10 +190,10 @@ def test_request_context_sets_safe_context_and_user(monkeypatch):
     safe_context = mock_sdk.set_context.call_args.args[1]
     assert safe_context["request_id"] == "abc12345"
     assert safe_context["method"] == "GET"
-    assert safe_context["path"] == "/v1/meals"
+    assert safe_context["route"] == "/v1/meals"
     assert safe_context["environment"] == "test"
     assert safe_context["release"] == "rel-1"
-    mock_sdk.set_user.assert_called_once_with({"id": "user-1"})
+    mock_sdk.set_user.assert_not_called()
 
 
 def test_start_span_returns_noop_when_disabled(monkeypatch):

--- a/tests/unit/infra/test_pymediator_event_bus.py
+++ b/tests/unit/infra/test_pymediator_event_bus.py
@@ -62,7 +62,8 @@ async def test_expected_application_exception_is_not_logged_as_error(caplog):
     ]
     assert any(
         record.levelno == logging.DEBUG
-        and "Application exception handling _MissingMealQuery" in record.message
+        and "stage=application_exception" in record.message
+        and "event_type=_MissingMealQuery" in record.message
         for record in caplog.records
     )
 
@@ -86,7 +87,8 @@ async def test_ai_unavailable_exception_is_not_logged_as_error(caplog):
     ]
     assert any(
         record.levelno == logging.DEBUG
-        and "Application exception handling _AIUnavailableQuery" in record.message
+        and "stage=application_exception" in record.message
+        and "event_type=_AIUnavailableQuery" in record.message
         for record in caplog.records
     )
 
@@ -101,10 +103,14 @@ async def test_unexpected_exception_is_logged_as_error(caplog):
         logger="src.infra.event_bus.pymediator_event_bus",
     ):
         with pytest.raises(RuntimeError):
-            await bus.send(_CrashingQuery(name="test"))
+            await bus.send(_CrashingQuery(name="operation-sentinel uid-sentinel"))
 
     assert any(
         record.levelno == logging.ERROR
-        and "Error handling _CrashingQuery" in record.message
+        and "stage=handler_error" in record.message
+        and "event_type=_CrashingQuery" in record.message
         for record in caplog.records
     )
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "operation-sentinel" not in rendered
+    assert "uid-sentinel" not in rendered


### PR DESCRIPTION
## Summary
- correct backend PostgreSQL/CQRS authority and document the seven-phase reliable-write plan
- add Phase 0 pre-route logging, event-bus, observability, and Sentry redaction groundwork
- register the PostgreSQL pytest marker and merge the latest `delivery` into this feature branch

## Safety status
- Phase 0 is incomplete and this PR is intentionally draft
- Phase 1-2 reliable-write migrations and APIs were rejected by readiness review and are absent
- all reliable-write capabilities remain false; this PR does not enable, deploy, or roll out any action

## Open gates
- make canonical fingerprint declarations exhaustive: manual item `fdc_id`/`name`, `Accept-Language`, suggestion top-level macros, and scanner normalization; then add cross-repo Python/Dart fixtures
- replace the incompatible `NUMERIC(6,3)` policy with a representation and admission/backfill policy that preserves all positive legacy Float values
- remove generic dynamic path telemetry or validate only trusted FastAPI route templates, including non-UUID identifiers
- add the planned exception-redaction, provider-neutral observability, and PostgreSQL/SQL sentinel tests before Phase 0 can pass

## Validation
- [x] merged `origin/delivery` normally with no conflicts
- [x] `uv run ruff check` on changed production and test files
- [x] 45 focused middleware, event-bus, observability, and Sentry tests passed
- [x] `ck plan validate plans/260714-reliable-write-contract-backend --strict` (7 phases, 0 errors, 0 warnings)
- [x] `git diff --check origin/delivery...HEAD`
- [x] staged/range secret scan reviewed; only SQL bind-variable names matched
- [ ] complete Phase 0 redaction and sentinel coverage
- [ ] receive renewed foundation readiness approval before any Phase 1-2 work

Related issues: none found.