### PR TITLE
perf(meal-recommendation): reduce recommendation hydration

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -101,6 +101,22 @@ Dev mode: `X-Dev-User-Id` header (requires `DEV_MODE=true`)
 | POST | `/v1/meal-suggestions/recipes` | Generate recipe batch |
 | POST | `/v1/meal-suggestions/save` | Save a meal suggestion |
 
+## Meal Recommendations
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/meal-recommendations/three-day` | Create or replay a 3-day catalog plan; returns compact selected-slot summaries only |
+| GET | `/v1/meal-recommendations/{plan_id}` | Read the owner-scoped compact plan summary |
+| GET | `/v1/meal-recommendations/{plan_id}/slots/{slot_id}` | Read one hydrated selected slot with alternatives |
+| POST | `/v1/meal-recommendations/{plan_id}/slots/{slot_id}/swap` | Swap a slot and return the changed-slot detail response |
+| POST | `/v1/meal-recommendations/{plan_id}/slots/{slot_id}/log` | Log the selected recommendation and return the changed-slot detail response |
+
+### Meal Recommendation Contract
+
+- `create` and `get` return the compact summary contract: selected slots only, with no slot-level ingredients, alternatives, or scores in the plan payload.
+- Slot detail hydrates exactly one selected slot plus its alternatives. Mutation responses reuse the same changed-slot shape so clients can patch cached plans in place.
+- Recommendation analytics are scheduled through `BackgroundTaskManager` when the dependency is available; the route falls back to inline capture when it is not.
+
 ---
 
 ## Saved Suggestions

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,6 +1,6 @@
 # Backend Codebase Summary
 
-**Generated:** July 5, 2026
+**Generated:** July 19, 2026
 **Status:** Production-ready snapshot of the live backend codebase
 **Runtime:** FastAPI 0.136.3 on Python 3.13.2 with async SQLAlchemy 2.0
 
@@ -10,20 +10,20 @@
 
 | Metric | Value |
 |--------|-------|
-| Source files | 635 Python files in `src/` |
-| Source LOC | 56,132 LOC in `src/` |
-| Test files | 312 Python files in `tests/` |
+| Source files | 693 Python files in `src/` |
+| Source LOC | 62,521 LOC in `src/` |
+| Test files | 337 Python files in `tests/` |
 | Collected tests | 1,600+ collected tests |
-| API router files | 28 route files under `src/api/routes/`; 26 contain endpoint decorators |
-| API endpoints | 88 endpoint decorators under `src/api/routes/` |
-| CQRS command files | 50 |
-| CQRS query files | 52 |
-| CQRS event files | 14 |
-| CQRS handler files | 86 |
-| Domain service files | 60 |
-| Port files | 27 |
-| Database model files | 48 |
-| ORM table declarations | 39 |
+| API router files | 30 route files under `src/api/routes/`; 27 contain endpoint decorators |
+| API endpoints | 94 endpoint decorators under `src/api/routes/` |
+| CQRS command files | 56 |
+| CQRS query files | 55 |
+| CQRS event files | 25 |
+| CQRS handler files | 94 |
+| Domain service files | 68 |
+| Port files | 31 |
+| Database model files | 51 |
+| ORM table declarations | 41 |
 
 ---
 
@@ -31,10 +31,10 @@
 
 | Layer | Files | LOC | Notes |
 |-------|-------|-----|-------|
-| API | 91 | 11,323 | Routes, middleware, schemas, dependency wiring, and API mappers |
-| Application | 207 | 11,333 | Commands, queries, handlers, and orchestration services |
-| Domain | 174 | 17,397 | Entities, services, ports, policies, and bounded contexts |
-| Infrastructure | 154 | 15,337 | Database, cache, adapters, observability, and service integrations |
+| API | 95 | 12,072 | Routes, middleware, schemas, dependency wiring, and API mappers |
+| Application | 238 | 13,901 | Commands, queries, handlers, and orchestration services |
+| Domain | 190 | 18,933 | Entities, services, ports, policies, and bounded contexts |
+| Infrastructure | 161 | 16,873 | Database, cache, adapters, observability, and service integrations |
 
 ---
 
@@ -63,17 +63,23 @@ The current HTTP surface includes:
 
 | Directory | Files | Purpose |
 |-----------|-------|---------|
-| `src/api/routes/v1/` | 25 | Versioned REST route modules |
-| `src/api/schemas/` | 35 | Pydantic DTOs |
-| `src/app/commands/` | 50 | Write-operation command packages |
-| `src/app/queries/` | 52 | Read-operation query packages |
-| `src/app/handlers/` | 86 | CQRS handler packages |
-| `src/domain/model/` | 63 | Domain entities and value objects |
-| `src/domain/services/` | 60 | Domain services and policies |
-| `src/infra/database/models/` | 48 | ORM model packages and table declarations |
-| `src/infra/repositories/` | 23 | Data access adapters |
+| `src/api/routes/v1/` | 27 | Versioned REST route modules |
+| `src/api/schemas/` | 36 | Pydantic DTOs |
+| `src/app/commands/` | 56 | Write-operation command packages |
+| `src/app/queries/` | 55 | Read-operation query packages |
+| `src/app/handlers/` | 94 | CQRS handler packages |
+| `src/domain/model/` | 66 | Domain entities and value objects |
+| `src/domain/services/` | 68 | Domain services and policies |
+| `src/infra/database/models/` | 51 | ORM model packages and table declarations |
+| `src/infra/repositories/` | 25 | Data access adapters |
 | `src/infra/services/` | 27 | Infrastructure services and AI providers |
-| `tests/` | 312 | Unit, architecture, migration, and explicit integration tests |
+| `tests/` | 337 | Unit, architecture, migration, and explicit integration tests |
+
+---
+
+## Recent Characterization Work
+
+- **Meal Recommendation Performance Redesign:** `/v1/meal-recommendations/three-day` and `GET /v1/meal-recommendations/{plan_id}` now return compact selected-slot summaries; `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` hydrates one slot plus alternatives; swap/log return changed-slot detail responses; catalog meals use a process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback.
 
 ---
 
@@ -84,14 +90,14 @@ The current HTTP surface includes:
 ## Recent Features (June 2026)
 
 - **Canonical AI Nutrition Contracts + Validation Retry:** `src/domain/model/ai/nutrition_contracts.py` defines image and text nutrition contracts with bounded food counts, strict quantity validation, and backend-calorie authority; invalid structured meal image/text output now retries exactly once before a controlled `AIOutputValidationError`, while ingredient recognition keeps its unstructured `{name, confidence, category}` contract and the legacy parser no longer silently drops invalid AI food items.
-- **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry pushes at T-2d and T-1d; notifications rescheduled on timezone changes; cron push (`src/cron/push.py`) precomputes notification rows, schedules trial-expiry rows, dispatches due rows through database row claiming, and cleans expired rows
-- **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; PostHog lifecycle mirroring
-- **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` — fire-and-forget async capture; enabled by `POSTHOG_API_KEY`
-- **Parallel Recipe Generator:** `src/domain/services/meal_suggestion/parallel_recipe_generator.py` with per-recipe attempt logic in `recipe_attempt_builder.py`; 3-phase pipeline: name generation → parallel recipe generation → translation
-- **Cron Lifecycle Email Service:** `src/cron/email.py` runs re-engagement and trial-expiry lifecycle emails via `CronLifecycleEmailService`
-- **Configurable Referral Commission:** `REFERRAL_COMMISSIONS` env var (JSON dict, per-currency, default 2 USD)
-- **Variable-Length Referral Codes:** 3–15 character codes
-- **AI Handshake Guest Trial Quota (Postgres):** `src/api/services/guest_parse_quota.py` + table `ai_handshake_guest_trial_quotas`; enforces one-shot AI trial per guest install HMAC hash using Postgres row-level locking (INSERT+conflict → SELECT FOR UPDATE); Redis not required for this endpoint.
+- **Notification / Push Overhaul:** Platform-specific payload builders (`src/infra/services/push/`); Android high-priority FCM, APNs Time Sensitive with `interruption-level` in payload body; trial-expiry pushes at T-2d and T-1d; notifications rescheduled on timezone changes; cron push (`src/cron/push.py`) precomputes notification rows, schedules trial-expiry rows, dispatches due rows through database row claiming, and cleans expired rows.
+- **RevenueCat Webhook Expansion:** Full lifecycle coverage (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER); referral credit/revoke on purchase/refund; PostHog lifecycle mirroring.
+- **PostHog Analytics Adapter:** `src/infra/adapters/posthog_adapter.py` - fire-and-forget async capture; enabled by `POSTHOG_API_KEY`.
+- **Parallel Recipe Generator:** `src/domain/services/meal_suggestion/parallel_recipe_generator.py` with per-recipe attempt logic in `recipe_attempt_builder.py`; 3-phase pipeline: name generation → parallel recipe generation → translation.
+- **Cron Lifecycle Email Service:** `src/cron/email.py` runs re-engagement and trial-expiry lifecycle emails via `CronLifecycleEmailService`.
+- **Configurable Referral Commission:** `REFERRAL_COMMISSIONS` env var (JSON dict, per-currency, default 2 USD).
+- **Variable-Length Referral Codes:** 3–15 character codes.
+- **AI Handshake Guest Trial Quota (Postgres):** `src/api/services/guest_parse_quota.py` + table `ai_handshake_guest_trial_quotas`; enforces one-shot AI trial per guest install HMAC hash using Postgres row-level locking (INSERT+conflict -> SELECT FOR UPDATE); Redis not required for this endpoint.
 
 ---
 

--- a/docs/meal-recommendation-mobile-handoff.md
+++ b/docs/meal-recommendation-mobile-handoff.md
@@ -12,6 +12,8 @@ The feature recommends 3 meals per day for 3 continuous days:
 
 The backend does not call an LLM at recommendation time. It uses a curated `meal_catalog`, computes nutrition from `food_reference` ingredients, ranks catalog meals deterministically, and stores a durable plan.
 
+The current mobile contract is compact by default: plan reads return selected slots only, while slot-detail and mutation responses hydrate one slot at a time for local cache patching.
+
 ## Backend Engine
 
 Algorithm: `catalog_deterministic_v1`
@@ -36,12 +38,13 @@ On app open or recommendation screen entry:
 
 1. Call `POST /v1/meal-recommendations/three-day`.
 2. Use a stable `Idempotency-Key` for the current auto-generation attempt.
-3. Render returned 3-day plan.
+3. Cache the returned compact plan summary by `plan_id` and render the selected slots immediately.
 4. Let user:
    - view meal details
    - swap a slot
    - log a recommended meal
-5. Re-read the plan with `GET /v1/meal-recommendations/{plan_id}` when needed.
+5. Fetch `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` when the user drills into a slot or needs alternatives.
+6. Merge swap/log responses back into the cached plan instead of reloading the full plan.
 
 ## API Contracts
 
@@ -70,6 +73,11 @@ Behavior:
 GET /v1/meal-recommendations/{plan_id}
 Authorization: Bearer <firebase-jwt>
 ```
+
+Behavior:
+
+- Returns the compact plan summary for the owner-scoped plan.
+- The response includes selected slots only. Slot ingredients, alternatives, and scores are omitted from the summary payload.
 
 ### Swap Slot
 
@@ -108,87 +116,20 @@ Authorization: Bearer <firebase-jwt>
 
 Behavior:
 
-- Materializes the selected catalog meal as a normal meal.
+- Materializes the selected catalog meal as a normal meal using the already loaded selected catalog projection.
 - Preserves ingredient `food_reference_id`.
 - Marks the recommendation slot as logged.
 - Safe to retry with the same `request_id`.
 
 ## Response Shape
 
-The recommendation response is display-complete. Each selected slot and alternative includes renderable catalog meal details.
+The plan summary is compact:
 
-```json
-{
-  "id": "plan-id",
-  "status": "active",
-  "timezone": "America/Los_Angeles",
-  "start_date": "2026-07-17",
-  "daily_calories": 2000,
-  "algorithm_version": "catalog_deterministic_v1",
-  "allergy_evaluated": false,
-  "slots": [
-    {
-      "id": "slot-id",
-      "slot_date": "2026-07-17",
-      "day_index": 0,
-      "meal_type": "breakfast",
-      "catalog_meal_id": "catalog-meal-id",
-      "catalog_meal": {
-        "id": "catalog-meal-id",
-        "name": "Teriyaki Chicken Rice",
-        "cuisine": "japanese",
-        "description": "Display copy",
-        "image_url": "https://...",
-        "calories": 640,
-        "macros": {
-          "protein_g": 38.5,
-          "carbs_g": 72.1,
-          "fat_g": 18.3,
-          "fiber_g": 4.2,
-          "sugar_g": 8.1
-        },
-        "ingredients": [
-          {
-            "food_reference_id": 123,
-            "display_name": "Chicken breast",
-            "quantity": 120,
-            "unit": "g"
-          }
-        ]
-      },
-      "target_calories": 500,
-      "score": 0.94,
-      "position": 0,
-      "selection_version": 1,
-      "logged_meal_id": null,
-      "alternatives": [
-        {
-          "id": "candidate-id",
-          "catalog_meal_id": "alternative-catalog-meal-id",
-          "catalog_meal": {
-            "id": "alternative-catalog-meal-id",
-            "name": "Chicken Rice Bowl",
-            "cuisine": "vietnamese",
-            "description": "Display copy",
-            "image_url": "https://...",
-            "calories": 590,
-            "macros": {
-              "protein_g": 34.2,
-              "carbs_g": 68.0,
-              "fat_g": 16.5,
-              "fiber_g": 3.8,
-              "sugar_g": 5.4
-            },
-            "ingredients": []
-          },
-          "score": 0.91,
-          "candidate_rank": 1
-        }
-      ]
-    }
-  ]
-}
-```
+- plan metadata: `id`, `status`, `timezone`, `start_date`, `daily_calories`, `algorithm_version`, `allergy_evaluated`
+- slot summary: `id`, `slot_date`, `day_index`, `meal_type`, `catalog_meal_id`, compact `catalog_meal`, `target_calories`, `position`, `selection_version`, `logged_meal_id`
+- omitted from plan summary: `score`, `alternatives`, and `catalog_meal.ingredients`
+
+Use `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` for the hydrated selected slot payload when the user needs details or alternatives.
 
 ## Error Handling
 
@@ -207,9 +148,9 @@ Ready:
 - Catalog importer exists.
 - Catalog nutrition is computed from ingredients and `food_reference`.
 - Deterministic 3-day recommendation engine exists.
-- Create, get, swap, and log endpoints exist.
+- Create, get, slot-detail, swap, and log endpoints exist.
 - Operation idempotency exists.
-- Recommendation responses include renderable selected and alternative meal details.
+- Recommendation read paths now use the compact/delta contract for mobile cache patching.
 - Focused backend tests pass.
 
 Environment prerequisites:
@@ -222,9 +163,9 @@ Environment prerequisites:
 Mobile can start:
 
 - screen structure for 3-day plan
-- local state model for plan/slot/alternative/logged state
+- local state model for compact plan + hydrated slot detail state
 - API client methods
 - idempotency key generation
 - swap/log retry behavior
 - loading/error/empty states
-- rendering selected meal cards and alternative cards from embedded `catalog_meal`
+- rendering selected meal cards from summary data and alternative cards from hydrated slot detail

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -9,6 +9,14 @@
 
 ## Completed Phases
 
+### July 2026: Meal Recommendation Performance Redesign
+- [x] `POST /v1/meal-recommendations/three-day` and `GET /v1/meal-recommendations/{plan_id}` now return compact selected-slot summaries instead of full hydrated plans.
+- [x] `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` returns one hydrated selected slot plus alternatives for drill-down.
+- [x] `swap` and `log` return changed-slot detail responses so clients can patch the cached plan in place.
+- [x] Recommendation analytics schedule through `BackgroundTaskManager` when available.
+- [x] Catalog meals use a process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback.
+- [x] Meal-history affinity now uses aggregate linked ingredient buckets, and logged recommended meals reuse the loaded selected catalog projection without fabricating an image.
+
 ### July 2026: Food-Label Image Scan
 - [x] `/v1/meals/food-label/scan-by-url` analyzes Nutrition Facts label images directly from Cloudinary bytes.
 - [x] Optional `label_crop_image_url` and crop metadata let mobile send a nutrition-panel crop while retaining the original image record.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -131,6 +131,14 @@ downloading Cloudinary bytes. Graph nodes must not import provider SDKs,
 6. `VisionResponseParser` maps validated label data into `Nutrition` and `food_label_metadata`.
 7. Handler persists a READY `Meal(source="food_label")`, invalidates meal caches, and does not create hydration side effects.
 
+## Data Flow Example: Meal Recommendation Plan
+
+1. `POST /v1/meal-recommendations/three-day` resolves timezone and daily calories, then builds or replays a durable recommendation plan.
+2. The plan-level response is compact: it includes only the selected slots. Slot ingredients, alternatives, and scores stay out of the summary payload.
+3. `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` hydrates one selected slot and its alternatives when the client needs drill-down data.
+4. `swap` and `log` return the changed-slot detail shape so the mobile client can patch its cached plan without reloading everything.
+5. Recommendation analytics are scheduled through `BackgroundTaskManager` when available. Catalog meals are read from the process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback. Meal-history affinity is projected from aggregate linked ingredient buckets instead of loading the full meal graph, and logging a recommended meal reuses the already loaded selected catalog projection without fabricating image data.
+
 ---
 
 ## Affiliate System Boundary

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-01-baseline-and-contract-characterization.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-01-baseline-and-contract-characterization.md
@@ -1,0 +1,79 @@
+---
+phase: 1
+title: "Baseline And Contract Characterization"
+status: completed
+priority: P1
+effort: "1-2d"
+dependencies: []
+mode: tdd
+---
+
+# Phase 1: Baseline And Contract Characterization
+
+## Overview
+
+Freeze current deterministic behavior, owner/idempotency guarantees, query/hydration cost, and reproducible performance evidence before changing architecture.
+
+## Context Links
+
+- [Approved brainstorm](../reports/brainstorm-260720-0205-recommendation-performance-redesign.md)
+- `src/domain/services/meal_recommendation/three_day_plan_optimizer.py`
+- `src/api/routes/v1/meal_recommendations.py`
+- `src/infra/repositories/meal_recommendation_plan_repository_async.py`
+
+## Requirements
+
+- Characterize exact selected and alternative IDs for normal, affinity, tolerance-fallback, and reversed-input cases.
+- Record response bytes, SQL count, rows hydrated, catalog refresh count, and stage timings without making noisy wall-clock values unit-test gates.
+- Preserve owner scope, idempotency, operation replay, and recommendation semantics; the unreleased response shape is only a before/after measurement baseline.
+
+## File Inventory
+
+| Action | Files |
+|---|---|
+| Extend | `tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py` |
+| Extend | `tests/unit/api/test_meal_recommendations_route.py` |
+| Add | `tests/unit/api/test_meal_recommendation_http_contract.py` |
+| Add | `scripts/testing/benchmark_meal_recommendation_performance.py` |
+| Evidence | `plans/reports/meal-recommendation-performance-baseline.json` |
+
+## Tests Before
+
+1. Add golden fixtures with exact 9 selected and 45 alternative IDs, scores/rounding, sparse catalog, and shuffled input.
+2. Add instrumented fake repositories/scorers for catalog, history, persistence, serialization, and analytics call counts.
+3. Record current JSON/OpenAPI size and fields for before/after comparison while locking mutation replay behavior.
+4. Add an explicit benchmark with fixed 180/1,000/5,000 catalogs, 10 warmups, at least 50 samples, `perf_counter_ns`, and runner metadata.
+5. Use `asyncio.Event`, not sleeps, to characterize the current analytics wait.
+
+## Refactor
+
+No production behavior changes. Only test seams and repeatable evidence collection are allowed.
+
+## Tests After And Regression Gate
+
+```bash
+.venv/bin/python3 -m pytest -q tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py tests/unit/api/test_meal_recommendations_route.py tests/unit/api/test_meal_recommendation_http_contract.py
+.venv/bin/python3 scripts/testing/benchmark_meal_recommendation_performance.py --catalog-sizes 180,1000,5000 --output plans/reports/meal-recommendation-performance-baseline.json
+```
+
+## Success Criteria
+
+- [x] Golden outputs cover selection, alternatives, fallback, affinity, and input-order stability.
+- [x] Owner scope, idempotency replay, and recommendation semantics are locked.
+- [x] Baseline reports response bytes, SQL count, hydrated rows, p50/p95, and runner metadata.
+- [x] Unit CI uses deterministic counts and shapes, not fragile absolute timings.
+
+## Completion Evidence
+
+- Added deterministic optimizer goldens for normal and affinity-weighted plans.
+- Added HTTP contract characterization for current full-plan payload, OpenAPI fields, and synchronous analytics wait.
+- Added synthetic benchmark evidence at `plans/reports/meal-recommendation-performance-baseline.json`.
+- Verified with the Phase 1 pytest gate, benchmark script, and focused ruff check.
+
+## Risks And Security
+
+Use synthetic fixtures only. Redact DSNs and tokens from benchmark evidence.
+
+## Next Steps
+
+Use these goldens as the non-negotiable regression gate for phases 2-5.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-02-nonblocking-observability-and-summary-contract.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-02-nonblocking-observability-and-summary-contract.md
@@ -1,0 +1,89 @@
+---
+phase: 2
+title: "Nonblocking Observability And Summary Contract"
+status: completed
+priority: P1
+effort: "2d"
+dependencies: [1]
+mode: tdd
+---
+
+# Phase 2: Nonblocking Observability And Summary Contract
+
+## Overview
+
+Remove PostHog network waits from HTTP latency and replace the unreleased full-plan response with one compact plan contract plus owner-scoped lazy slot detail.
+
+## Requirements
+
+- Create and get return plan metadata and nine selected slot summaries: IDs, date/type, meal identity/name/cuisine/image, backend-derived calories/macros, selection version, and logged meal ID.
+- Summary omits description, ingredients, scores, and alternatives.
+- `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` returns one fully hydrated selected meal and that slot's alternatives.
+- Create and idempotent replay must not hydrate the 54-candidate graph.
+- Analytics runs through `BackgroundTaskManager`; failures never change endpoint status.
+- Stage metrics cover target, idempotency, snapshot, affinity, ranking, persistence, hydration, serialization, and analytics enqueue.
+
+## File Inventory
+
+| Action | Files |
+|---|---|
+| Modify | `src/api/routes/v1/meal_recommendations.py`, `meal_recommendation_route_support.py` |
+| Modify | `src/api/schemas/response/meal_recommendation_responses.py` |
+| Modify | meal recommendation query/handler exports and `meal_recommendation_plan_repository_port.py` |
+| Modify | `src/infra/repositories/meal_recommendation_plan_repository_async.py` |
+| Modify | `src/api/base_dependencies.py`, task-manager and API lifecycle composition |
+| Modify | `src/app/services/meal_recommendation_analytics_service.py`, `src/infra/adapters/posthog_adapter.py` |
+| Extend | route, HTTP-contract, analytics-service, and background-task-manager tests |
+| Add if client reuse is implemented | `tests/unit/infra/adapters/test_posthog_adapter.py` |
+
+## Function And Interface Checklist
+
+- Add repository `get_summary(...)` and `get_slot_detail(...)`; never call `_rows_to_plan()` for them.
+- Add lightweight creation replay metadata/projection so replay returns the compact plan directly.
+- Replace `to_response(...)` with compact-plan and slot-detail serializers.
+- Snapshot a bounded privacy-safe analytics payload and schedule one background task.
+- Reuse one lifecycle-managed PostHog client and close it at shutdown.
+
+## Tests Before
+
+1. Create/get expose one compact response contract in HTTP and OpenAPI.
+2. Compact response contains nine slots, no ingredients/alternatives, and is <35% of the phase-1 payload.
+3. Slot detail is owner-scoped/404-safe and hydrates only one slot.
+4. Create/replay performs no full-plan hydration.
+5. A blocked analytics adapter cannot block HTTP completion; background failure cannot change success.
+6. Metric tests inject a clock and assert low-cardinality labels/counts, not milliseconds.
+
+## Refactor
+
+1. Replace the unreleased full-plan DTO with compact plan and slot-detail DTOs.
+2. Add compact repository/query projections with owner-anchor authorization.
+3. Schedule analytics using the process-wide task manager, never raw `asyncio.create_task`.
+4. Batch route events into one task and add stage metrics without IDs.
+
+## Tests After And Regression Gate
+
+```bash
+.venv/bin/python3 -m pytest -q tests/unit/api/test_meal_recommendations_route.py tests/unit/api/test_meal_recommendation_http_contract.py tests/unit/app/services/test_meal_recommendation_analytics_service.py tests/unit/infra/event_bus/test_background_task_manager.py
+```
+
+## Success Criteria
+
+- [x] Create/get expose only the compact plan contract.
+- [x] Summary/detail query only required rows and enforce owner scope.
+- [x] PostHog latency/failure is outside the HTTP critical path.
+- [x] Stage metrics explain create/read time without high-cardinality labels.
+
+## Completion Evidence
+
+- Added compact plan and slot-detail response models.
+- Added owner-scoped summary/detail repository projections and query handler wiring.
+- Routed recommendation analytics through `BackgroundTaskManager` when available.
+- Verified with focused API, handler, repository, analytics, and HTTP-contract tests.
+
+## Risks And Security
+
+Do not place domain objects or sessions in background tasks. Snapshot only sanitized scalar analytics fields before the UoW closes.
+
+## Next Steps
+
+Wire the compact contract into Flutter after target-slot mutation support is complete.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-03-process-local-catalog-snapshot-and-ranking.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-03-process-local-catalog-snapshot-and-ranking.md
@@ -1,0 +1,98 @@
+---
+phase: 3
+title: "Process-Local Catalog Snapshot And Ranking"
+status: completed
+priority: P1
+effort: "2-3d"
+dependencies: [1]
+mode: tdd
+---
+
+# Phase 3: Process-Local Catalog Snapshot And Ranking
+
+## Overview
+
+Compile active catalog meals once per process/revision and replace repeated full-catalog ranking passes with deterministic ranked pools.
+
+## Requirements
+
+- Cache a frozen tuple of fully resolved `CatalogMeal`, revision, expiry, and refresh time in one process-scoped service.
+- Default TTL 300 seconds; expiry runs a lightweight revision query before any hydration.
+- One async lock plus double-check prevents refresh stampedes.
+- Revision covers active catalog count/max `meal_catalog.updated_at` and max linked `food_reference.updated_at`; serving-size updates must advance the parent timestamp.
+- Read revision before/after hydration and retry once if import changed concurrently.
+- Cold failure returns typed catalog-unavailable; warm refresh failure serves last good data and retries after 30 seconds with a metric.
+- No Redis recommendation-result cache.
+- Rank once per meal type/target, then deterministically partition unique winners and five alternatives per slot.
+- A newly persisted plan returns the already-built immutable projection after flush instead of reloading 54 rows and catalog relationship trees.
+
+## File Inventory
+
+| Action | Files |
+|---|---|
+| Add | `src/app/services/catalog_meal_snapshot_service.py` |
+| Modify | `src/domain/ports/catalog_recipe_repository_port.py` |
+| Modify | `src/infra/repositories/catalog_recipe_repository_async.py` |
+| Modify | `src/infra/repositories/meal_recommendation_plan_repository_async.py` |
+| Modify | create recommendation handler, `src/api/dependencies/event_bus.py`, settings |
+| Modify | scoring, optimizer, and alternative-selection domain services |
+| Add | `tests/unit/app/services/test_catalog_meal_snapshot_service.py` |
+| Extend | catalog repository, event-bus singleton, deterministic optimizer tests |
+
+## Function And Interface Checklist
+
+- `CatalogMealRepositoryPort.get_active_catalog_revision()` returns an immutable comparable value.
+- `CatalogMealSnapshotService.get_snapshot(uow)` exposes an immutable tuple and no mutation API.
+- Event-bus composition injects one shared snapshot service into copied create handlers.
+- Scoring builds immutable pools keyed by meal type/target.
+- Keep `ALGORITHM_VERSION` only if every phase-1 golden remains exact.
+
+## Tests Before
+
+1. Cold hydrates once; warm executes zero catalog SQL.
+2. Twenty concurrent cold callers produce one load; cancelled waiter does not poison refresh.
+3. Unchanged revision reuses; changed revision refreshes; mid-load change retries once.
+4. Cold failure fails closed; warm refresh failure serves last good and records age/retry metrics.
+5. Returned snapshot is immutable.
+6. Counting scorer proves one score per eligible meal/type-target.
+7. Optimizer matches all phase-1 goldens for normal, affinity, fallback, and shuffled input.
+8. Fresh persistence performs no `_load_batch()` after flush; conflict/replay behavior remains correct.
+
+## Refactor
+
+1. Add revision query without ORM relationship hydration.
+2. Implement single-flight snapshot lifecycle with an injected monotonic clock.
+3. Compose one service per API process.
+4. Extract ranked pools and partition winners first, then alternatives excluding all winners.
+5. Preserve formula, rounding, and `(-score, catalog_meal.id)` tie break.
+6. Return the in-memory immutable compact plan after successful flush; keep compact projection reads for replay/conflict paths.
+
+## Tests After And Regression Gate
+
+```bash
+.venv/bin/python3 -m pytest -q tests/unit/app/services/test_catalog_meal_snapshot_service.py tests/unit/infra/repositories/test_catalog_recipe_repository_async.py tests/unit/api/test_event_bus_dependency_singletons.py tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py
+```
+
+## Success Criteria
+
+- [x] Warm generation performs no catalog hydration or nutrition conversion.
+- [x] Fresh generation performs no post-save full-plan reload.
+- [x] Concurrent refreshes hydrate once and never expose partial state.
+- [x] 180/1,000/5,000 catalogs show linear scoring-call growth.
+- [x] Output stays golden-identical or deliberately bumps algorithm version with evidence.
+
+## Completion Evidence
+
+- Added process-local catalog snapshot service with revision checks, TTL, lock, and last-good fallback.
+- Added active catalog revision query.
+- Injected one snapshot service into configured recommendation creation handlers.
+- Changed fresh persistence to return the in-memory plan after flush.
+- Reworked optimizer to partition selected slots and alternatives from ranked pools while preserving goldens.
+
+## Risks And Security
+
+Never key the snapshot by user. Importer and canonical nutrition tests must prove revision timestamps advance.
+
+## Next Steps
+
+Combine the warm snapshot with aggregate affinity.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-04-aggregate-affinity-and-fast-generation.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-04-aggregate-affinity-and-fast-generation.md
@@ -1,0 +1,87 @@
+---
+phase: 4
+title: "Aggregate Affinity And Fast Generation"
+status: completed
+priority: P1
+effort: "2d"
+dependencies: [1, 3]
+mode: tdd
+---
+
+# Phase 4: Aggregate Affinity And Fast Generation
+
+## Overview
+
+Replace hydration of up to 5,000 historical meals and food-item objects with one owner-scoped aggregate query while preserving affinity semantics.
+
+## Requirements
+
+- Query only canonical `food_reference_id`, local age-day bucket, and capped effective quantity for the prior 90 days.
+- Preserve owner/status filters, `coalesce(ready_at, created_at)`, timezone boundaries, unlinked exclusion, per-item 500 g cap, recency decay, and confidence.
+- SQL aggregates evidence; `IngredientAffinityService` continues to own scoring policy.
+- Do not add indexes until representative `EXPLAIN ANALYZE` proves one is missing.
+
+## File Inventory
+
+| Action | Files |
+|---|---|
+| Modify | `src/domain/ports/meal_repository_port.py` |
+| Modify | `src/infra/repositories/meal_repository_async.py` |
+| Modify | `src/app/services/meal_recommendation_history_projector.py` |
+| Modify | `src/domain/services/meal_recommendation/ingredient_affinity_service.py` |
+| Modify | create recommendation handler stage instrumentation |
+| Extend | `tests/unit/app/services/test_meal_recommendation_history_projector.py`, `tests/integration/infra/repositories/test_meal_repository_async.py` |
+| Add | `tests/unit/infra/repositories/test_meal_repository_history_aggregate.py` |
+| Conditional | one timestamped Alembic index migration only with query-plan evidence |
+
+## Function And Interface Checklist
+
+- Add immutable `IngredientHistoryBucket(food_reference_id, age_days, capped_grams)`.
+- Add `MealRepositoryPort.aggregate_linked_ingredient_history(...)`.
+- Change `MealRecommendationHistoryProjector.build_affinity(...)` to buckets and remove `find_by_date_range(... limit=5000)`.
+- Keep affinity service pure/deterministic.
+
+## Tests Before
+
+1. Bucket output produces the same profile as the phase-1 event characterization.
+2. Cover UTC/non-UTC boundaries, `ready_at` fallback, empty/unlinked history, deleted/inactive meals, per-item cap before bucket aggregation, and owner isolation.
+3. Assert query projection never hydrates Meal/Nutrition/FoodItem trees.
+4. Record representative 90-day `EXPLAIN ANALYZE`.
+5. Handler proves warm create uses one affinity query and zero date-range calls.
+
+## Refactor
+
+1. Define the bucket at the domain boundary.
+2. Implement grouped SQL with timezone-safe age buckets and cap before `SUM`.
+3. Adapt projector without changing current `now` semantics.
+4. Remove obsolete `_HISTORY_LIMIT`.
+5. Add a concurrent index only with before/after evidence and rollback SQL.
+
+## Tests After And Regression Gate
+
+```bash
+.venv/bin/python3 -m pytest -q tests/unit/app/services/test_meal_recommendation_history_projector.py tests/unit/infra/repositories/test_meal_repository_history_aggregate.py tests/integration/infra/repositories/test_meal_repository_async.py tests/unit/app/handlers/test_meal_recommendation_handlers.py
+```
+
+## Success Criteria
+
+- [x] Generation performs one bounded aggregate query and hydrates no historical meal graph.
+- [x] Affinity matches phase-1 characterization at timezone/recency boundaries.
+- [ ] Warm generation meets <500 ms staging p95 with zero full-catalog SQL.
+- [x] Any index has before/after query-plan evidence.
+
+## Completion Evidence
+
+- Added `IngredientHistoryBucket` and bucket-based affinity projection.
+- Added `aggregate_linked_ingredient_history(...)` to the meal repository port and async repository.
+- Updated recommendation history projector to use the aggregate method instead of `find_by_date_range`.
+- Local deterministic and synthetic benchmark gates passed; staging p95 evidence still needs a pinned/staging runner.
+- No index migration was added because no representative staging query-plan evidence showed one was needed.
+
+## Risks And Security
+
+Owner filtering happens inside SQL. Never emit user food IDs in metrics or benchmark artifacts.
+
+## Next Steps
+
+Optimize swap/log so mutations do not undo generation/read gains.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-05-targeted-mutations-and-delta-responses.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-05-targeted-mutations-and-delta-responses.md
@@ -1,0 +1,89 @@
+---
+phase: 5
+title: "Targeted Mutations And Delta Responses"
+status: completed
+priority: P1
+effort: "2-3d"
+dependencies: [1, 2]
+mode: tdd
+---
+
+# Phase 5: Targeted Mutations And Delta Responses
+
+## Overview
+
+Lock, hydrate, mutate, and return only the requested slot for swap/log while retaining operation replay.
+
+## Requirements
+
+- SQL includes owner-anchor authorization, `batch_id`, and `slot_id`, locking at most that slot's six candidates.
+- Preserve optimistic versioning, historical replay, fingerprint conflicts, duplicate-log prevention, and same-UoW state changes.
+- Swap/log return plan ID and one fully hydrated changed slot; they never reload the full plan.
+- Pass the already-loaded selected catalog meal to materialization; remove the fake one-byte image and allow `Meal.image=None`.
+
+## File Inventory
+
+| Action | Files |
+|---|---|
+| Modify | recommendation domain model for a typed slot mutation result |
+| Modify | `src/domain/ports/meal_recommendation_plan_repository_port.py` |
+| Modify | `src/infra/repositories/meal_recommendation_plan_repository_async.py` |
+| Modify | swap/log handlers and `recommended_meal_materialization_service.py` |
+| Modify | recommendation route/support serializers |
+| Extend | plan-repository, handler, materialization, and route tests |
+| Add | `tests/integration/infra/repositories/test_meal_recommendation_slot_concurrency.py` |
+
+## Function And Interface Checklist
+
+- Add `MealRecommendationSlotMutationResult` with plan/slot IDs, selected meal, version, logged meal ID, and target-slot alternatives.
+- Replace full-batch mutation loaders with owner-scoped `_load_slot_for_update(...)`.
+- Operation replay returns the same stored delta as the first request.
+- Materializer accepts the selected catalog projection and makes no catalog lookup.
+- `to_slot_mutation_response(...)` serializes one slot and is the only mutation response.
+
+## Tests Before
+
+1. SQL/integration tests prove owner anchor, batch/slot predicates, `FOR UPDATE`, and <=6 rows.
+2. Same request replays same delta; different fingerprint conflicts; stale/logged conflicts remain.
+3. Concurrent swaps leave one selected; competing logs create one normal meal; unrelated slots are not locked.
+4. Warm delta mutation performs replay lookup plus one slot lock and no batch reload.
+5. Materialization uses supplied meal, backend calorie logic, and no fake image.
+6. HTTP/OpenAPI contract contains one changed slot and no full-plan mutation response.
+
+## Refactor
+
+1. Separate slot mutation projection from full-plan projection.
+2. Authorize through an owner-scoped anchor subquery before locking.
+3. Persist sufficient operation result data for equivalent replay using the existing four tables.
+4. Return typed mutation results directly from the route.
+5. Remove placeholder image persistence.
+
+## Tests After And Regression Gate
+
+```bash
+.venv/bin/python3 -m pytest -q tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/app/services/test_recommended_meal_materialization_service.py tests/unit/api/test_meal_recommendations_route.py tests/integration/infra/repositories/test_meal_recommendation_slot_concurrency.py
+```
+
+## Success Criteria
+
+- [x] Swap/log lock and hydrate one owner-scoped slot only.
+- [x] Delta responses never reload or serialize the other eight slots.
+- [x] Swap/log expose only the changed-slot contract.
+- [x] Log creates one normal meal with no fabricated image.
+- [ ] Swap/log delta meet <300 ms staging p95.
+
+## Completion Evidence
+
+- Added typed slot mutation results and changed swap/log routes to return one slot detail response.
+- Added owner-anchored slot lock path for swap/log instead of full-batch mutation hydration.
+- Updated materialization to use the selected hydrated catalog projection and keep `Meal.image` unset.
+- Focused route, handler, repository, and materialization tests pass.
+- Staging p95 remains a rollout gate for Phase 7.
+
+## Risks And Security
+
+Never trust `plan_id` alone. Prove locks on PostgreSQL; compiled-SQL tests cannot prove concurrency.
+
+## Next Steps
+
+Update Flutter against this final changed-slot contract.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-06-mobile-stale-while-revalidate.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-06-mobile-stale-while-revalidate.md
@@ -1,0 +1,98 @@
+---
+phase: 6
+title: "Mobile Stale-While-Revalidate"
+status: completed
+priority: P1
+effort: "2-3d"
+dependencies: [2, 5]
+mode: tdd
+---
+
+# Phase 6: Mobile Stale-While-Revalidate
+
+## Overview
+
+Render the last user-scoped plan summary immediately, refresh in the background, load detail on demand, and patch target slots from deltas.
+
+## Requirements
+
+- Cache `{schema_version, user_scope, cached_at, plan}` in SharedPreferences; no secrets.
+- Return valid cache synchronously and show `isRefreshing`, not blank `isLoading`.
+- Remove corrupt, unknown-version, wrong-user, or expired-plan cache; offline refresh preserves valid cache.
+- No-cache behavior keeps existing loading/error behavior.
+- Create/get consume the compact plan contract; swap/log consume the changed-slot contract; details/alternatives load lazily.
+- Late refresh cannot overwrite a newer mutation.
+- Pending request IDs survive failure and clear only after delta application plus cache persistence.
+
+## File Inventory
+
+All paths are under `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai`.
+
+| Action | Files |
+|---|---|
+| Modify | `lib/core/network/api_service.dart` and generated Retrofit output |
+| Modify | recommendation API models and generated Freezed/JSON output |
+| Modify | remote data source and mapper |
+| Add | `lib/features/meal_recommendation/data/datasources/meal_recommendation_cache_data_source.dart` |
+| Modify | domain repository and repository implementation |
+| Modify | `application/providers/meal_recommendation_controller.dart` |
+| Modify | detail screen, alternatives sheet, and slot-card providers/widgets |
+| Extend | repository, controller, detail, alternatives, and plan-deck tests |
+
+## Function And Interface Checklist
+
+- Repository separates cached read, remote refresh, lazy detail, and delta mutations.
+- Controller state separates initial loading, refresh, and per-slot mutation.
+- Delta patch verifies plan/slot/version and replaces exactly one slot.
+- Cache validates schema and user scope before domain mapping.
+- Generate Retrofit/Freezed output only after handwritten contract tests fail as expected.
+
+## Tests Before
+
+1. Valid payload round-trips; corrupt/version/wrong-user/expired entries are discarded.
+2. First state contains cached plan and begins refresh without blanking content.
+3. Success replaces only older cache; failure preserves it; 404 clears stale cache and regenerates.
+4. Delta patches exactly one slot and preserves the other eight.
+5. Late refresh cannot undo a completed mutation.
+6. Failed mutation keeps prior plan/request ID; success clears ID after cache write.
+7. Lazy detail/alternatives show local loading/retry without blanking home.
+
+## Refactor
+
+1. Replace current models with compact-plan, changed-slot, and slot-detail models/mappings.
+2. Extract typed cache serialization.
+3. Bootstrap cache, then remote refresh.
+4. Add a state generation/version guard around refresh/mutations.
+5. Patch one slot; preserve full meal data for logged-meal projection.
+6. Load ingredients/alternatives only when opened.
+
+## Tests After And Regression Gate
+
+```bash
+/Users/alexnguyen/flutter/bin/flutter test test/features/meal_recommendation/data/repositories/meal_recommendation_repository_impl_test.dart test/features/meal_recommendation/application/providers/meal_recommendation_controller_test.dart test/features/meal_recommendation/presentation/widgets/recommended_meal_alternatives_sheet_test.dart test/features/meal_recommendation/presentation/widgets/recommended_meal_plan_deck_test.dart
+/Users/alexnguyen/flutter/bin/dart analyze lib/features/meal_recommendation test/features/meal_recommendation
+```
+
+## Success Criteria
+
+- [x] Returning users see cached recommendations before network completes.
+- [x] Offline/slow refresh does not blank a valid plan.
+- [x] Detail and alternatives load only on demand.
+- [x] Swap/log patch one slot and preserve idempotent retry.
+- [x] Generated code, focused tests, and analysis are clean.
+
+## Completion Evidence
+
+- Added slot-detail API model and Retrofit methods for compact/detail/delta contracts.
+- Added user-scoped SharedPreferences plan cache and synchronous cached-plan read.
+- Controller now renders cached plan while refreshing and patches exactly one slot from swap/log responses.
+- Regenerated Freezed/JSON/Retrofit output.
+- Focused Dart analysis and meal recommendation controller/widget tests pass.
+
+## Risks And Security
+
+Clear user-scoped cache on logout/account switch. Cached meals are display data, never authorization or calorie authority.
+
+## Next Steps
+
+Ship backend and mobile as one unreleased feature contract after integration tests pass.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/phase-07-performance-rollout-and-documentation.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/phase-07-performance-rollout-and-documentation.md
@@ -1,0 +1,85 @@
+---
+phase: 7
+title: "Performance Rollout And Documentation"
+status: completed-local
+priority: P1
+effort: "1-2d"
+dependencies: [3, 4, 5, 6]
+mode: tdd
+---
+
+# Phase 7: Performance Rollout And Documentation
+
+## Overview
+
+Prove deterministic, database, concurrency, latency, payload, and mobile-startup gains; deploy in reversible order; document operations.
+
+## Requirements
+
+- Unit CI gates golden parity, call/query counts, SQL shape, payload ratio, cache state, and the final HTTP contract.
+- Only a pinned runner or staging gates absolute p95.
+- Benchmark 180/1,000/5,000 catalogs with fixed inputs, 10 warmups, >=50 samples, and runner metadata.
+- Record SQL count, hydrated rows, response bytes, snapshot refreshes, stage histograms, p50, and p95.
+- Backend and mobile ship one final contract; the recommendation feature stays disabled if either side fails integration.
+
+## File Inventory
+
+| Action | Files |
+|---|---|
+| Finalize | `scripts/testing/benchmark_meal_recommendation_performance.py` |
+| Conditional | CI/staging load job only if a pinned runner exists |
+| Update | `docs/api-endpoints.md`, `docs/system-architecture.md`, `docs/database-guide.md`, `docs/troubleshooting.md` |
+| Update | roadmap/changelog when implementation status changes |
+| Evidence | `plans/reports/meal-recommendation-performance-final.json` and query plans |
+
+## Verification Matrix
+
+| Gate | Target |
+|---|---|
+| Active compact-plan read | p95 <300 ms |
+| Swap/log changed-slot response | p95 <300 ms |
+| Warm create | p95 <500 ms; zero full-catalog SQL |
+| Cold snapshot refresh + create | p95 <1,000 ms |
+| 5,000 vs 1,000 optimizer | no superlinear pass growth; pinned p95 <=3x |
+| Compact payload | <35% of phase-1 fixture |
+| Slot mutation | no full-plan hydration; lock <=6 candidate rows |
+| Mobile first state | cached plan visible before remote completion |
+
+## Tests Before
+
+1. Completed focused backend and Flutter suites from phases 1-6.
+2. Completed local owner/replay/idempotency regression coverage; real PostgreSQL concurrency remains a staging gate.
+3. Captured before/after JSON locally with matching script metadata.
+4. Verified `/v1/meal-suggestions` regressions remain unchanged and green.
+
+## Rollout
+
+1. Complete backend and Flutter contract integration before enabling the unreleased feature.
+2. Warm one snapshot per process and observe refresh/error metrics; startup must not depend on Neon.
+3. Canary the complete feature internally, then enable the compact-plan/changed-slot flow.
+4. Monitor latency/error, snapshot age/failure, affinity query rows/time, replay conflicts, and mobile refresh failure.
+5. If contract errors rise, disable the unreleased recommendation feature and revert the paired backend/mobile change.
+
+## Tests After And Regression Gate
+
+```bash
+.venv/bin/python3 -m pytest -q tests/unit/domain/services/meal_recommendation tests/unit/app/services/test_meal_recommendation_history_projector.py tests/unit/app/services/test_meal_recommendation_analytics_service.py tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/infra/repositories/test_catalog_recipe_repository_async.py tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/api/test_meal_recommendations_route.py tests/unit/api/test_meal_recommendation_http_contract.py
+.venv/bin/python3 scripts/testing/benchmark_meal_recommendation_performance.py --catalog-sizes 180,1000,5000 --output plans/reports/meal-recommendation-performance-final.json
+/Users/alexnguyen/flutter/bin/flutter test test/features/meal_recommendation
+```
+
+## Success Criteria
+
+- [x] Deterministic, HTTP-contract, owner, and idempotency regressions pass locally.
+- [ ] Every performance gate is evidenced on its intended runner; staging p95 remains a rollout gate.
+- [x] The unreleased feature can be disabled or reverted without data migration.
+- [x] Active docs explain snapshot lifecycle, compact/delta contracts, metrics, and troubleshooting.
+- [x] No Redis result cache, speculative index, or compatibility branch entered scope.
+
+## Risks And Security
+
+Use dedicated staging users and idempotency keys. Never load-test production accounts or expose IDs in metrics.
+
+## Next Steps
+
+Proceed to staging p95 and real-PostgreSQL concurrency verification before production rollout.

--- a/plans/260720-0211-meal-recommendation-performance-redesign/plan.md
+++ b/plans/260720-0211-meal-recommendation-performance-redesign/plan.md
@@ -1,0 +1,75 @@
+---
+title: "Meal Recommendation Performance Redesign"
+description: "Remove repeated catalog/history hydration, synchronous analytics, full-plan mutations, and blank mobile loading from catalog recommendations."
+status: completed-local
+priority: P1
+effort: "10-14d"
+branch: "delivery"
+tags: [performance, backend, mobile, database, api, tdd, critical]
+blockedBy: []
+blocks: []
+created: "2026-07-19T19:13:01.327Z"
+createdBy: "ck:plan"
+source: skill
+mode: deep-tdd
+---
+
+# Meal Recommendation Performance Redesign
+
+## Overview
+
+Keep the deterministic four-table recommendation model, but make catalog work process-local and reusable, replace full meal-history hydration with one aggregate query, return compact or target-slot projections, move analytics off the request path, and let Flutter render cached data immediately while it refreshes.
+
+## Scope Decision
+
+- Keep: four feature tables, `food_reference` authority, backend-derived calories, deterministic output, owner scoping, operation replay, and separate `/v1/meal-suggestions` behavior.
+- Add: immutable process-local catalog snapshot, revision/TTL refresh, one-pass ranked pools, compact plan responses, slot mutation responses, lazy slot detail, stage metrics, and mobile stale-while-revalidate.
+- Replace: the current unreleased full-plan HTTP contract and matching Flutter models directly.
+- Defer: Redis recommendation-result cache, vectors/ML ranking, background plan generation, catalog schema redesign, and speculative indexes.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Baseline And Contract Characterization](./phase-01-baseline-and-contract-characterization.md) | Completed |
+| 2 | [Nonblocking Observability And Summary Contract](./phase-02-nonblocking-observability-and-summary-contract.md) | Completed |
+| 3 | [Process-Local Catalog Snapshot And Ranking](./phase-03-process-local-catalog-snapshot-and-ranking.md) | Completed |
+| 4 | [Aggregate Affinity And Fast Generation](./phase-04-aggregate-affinity-and-fast-generation.md) | Completed except staging p95 evidence |
+| 5 | [Targeted Mutations And Delta Responses](./phase-05-targeted-mutations-and-delta-responses.md) | Completed except staging p95 evidence |
+| 6 | [Mobile Stale-While-Revalidate](./phase-06-mobile-stale-while-revalidate.md) | Completed |
+| 7 | [Performance Rollout And Documentation](./phase-07-performance-rollout-and-documentation.md) | Completed locally except staging p95 evidence |
+
+## Dependencies
+
+- Design source: [approved brainstorm](../reports/brainstorm-260720-0205-recommendation-performance-redesign.md).
+- Related unfinished plan: `../260716-1509-four-table-meal-catalog-rework/`. Its implementation exists on `delivery`, but phases 3-6 remain open; resolve shared-file ownership before executing phases 2-5 here rather than rewriting the older plan's status.
+- Dependency graph: 1 -> {2,3,4}; 2 -> 5; {2,5} -> 6; {3,4,5,6} -> 7.
+
+## Performance Gates
+
+- Active compact-plan read p95 <300 ms; swap/log changed-slot response p95 <300 ms.
+- Warm generation p95 <500 ms; cold refresh plus generation p95 <1,000 ms.
+- Warm generation performs zero full-catalog SQL; swap/log perform no full-plan hydration.
+- Catalog sizes 180, 1,000, and 5,000 preserve deterministic selections and alternatives.
+
+## Red Team Review
+
+- Contract drift is contained by changing the unreleased backend and mobile feature together and locking one final HTTP contract.
+- Staleness is contained by revision checks, bounded TTL, single-flight refresh, and last-good fallback.
+- Every compact/detail/mutation query authorizes through the owner anchor.
+- Unit CI gates call counts, SQL shape, payload ratio, and injected clocks; absolute p95 runs only on a pinned runner or staging.
+- Fixed: fresh create and replay explicitly avoid the repository's current post-save/full-plan hydration.
+- Fixed: aggregate-affinity parity caps each item before bucket aggregation, not the grouped total.
+
+## Validation Log
+
+- Backend, mobile, and test inventories independently reviewed against live code.
+- All seven phases use tests-before/refactor/tests-after gates and exact file ownership.
+- Unresolved contradictions: 0.
+- Phase 1 completed with characterization-only tests and baseline evidence at `plans/reports/meal-recommendation-performance-baseline.json`.
+- Phases 2-6 implemented compact/detail/delta backend contracts, process-local catalog snapshots, aggregate affinity, targeted mutations, and mobile stale-while-revalidate.
+- Final local benchmark evidence generated at `plans/reports/meal-recommendation-performance-final.json`; staging p95 gates remain pending.
+
+## Unresolved Questions
+
+- None.

--- a/plans/reports/brainstorm-260720-0205-recommendation-performance-redesign.md
+++ b/plans/reports/brainstorm-260720-0205-recommendation-performance-redesign.md
@@ -1,0 +1,222 @@
+---
+title: Meal Recommendation Performance Redesign
+type: brainstorm
+status: approved
+date: 2026-07-20
+---
+
+# Meal Recommendation Performance Redesign
+
+## Summary
+
+Current latency is mostly repeated database hydration, response expansion, and
+request-bound analytics. Deterministic ranking is not the primary bottleneck:
+the 180-meal optimizer benchmark measured p50 3.19 ms and p95 4.05 ms.
+
+Approved direction: compiled catalog snapshot, compact plan reads and mutation
+responses, aggregate affinity queries, non-blocking analytics, and immediate
+mobile rendering from the last stored plan.
+
+## Problem
+
+- Generation loads every active catalog meal plus ingredients, food references,
+  and serving-size rows. Cost grows linearly with catalog size.
+- App initialization automatically waits for a plan read or new generation.
+- Plan reads hydrate and serialize 9 selected meals plus 45 alternatives, each
+  with full macros and ingredient lists.
+- Log loads and locks the full plan twice, fetches the selected catalog meal
+  again, persists an unnecessary placeholder image, reloads the normal meal,
+  then returns the full plan.
+- Swap locks and returns the full plan for a one-slot mutation.
+- PostHog capture runs synchronously in the response path.
+
+## Requirements
+
+- Preserve deterministic recommendations and stable tie-breaking.
+- Preserve four-table persistence and operation replay.
+- Keep `food_reference` as canonical ingredient and nutrition authority.
+- Keep calories backend-derived from macros; do not add a client calorie source.
+- Preserve the separate AI `/v1/meal-suggestions` flow.
+- Support at least 1,000 active catalog meals without full-catalog hydration per
+  recommendation request.
+- Avoid making mobile home-screen rendering depend on network completion.
+
+## Scope
+
+### Included
+
+- Create, read, swap, and log recommendation paths.
+- Catalog and user-affinity data preparation.
+- Response payload shape and mobile state updates.
+- Stage-level latency measurement.
+
+### Excluded
+
+- Learned ranking, vector search, or runtime LLM generation.
+- Replacing the existing meal-suggestions feature.
+- Background plan scheduling in the first performance slice.
+- Changing recommendation product rules or calorie allocation.
+
+## Findings
+
+### Generate
+
+`AsyncCatalogMealRepository.list_active_meals()` loads every active catalog row
+and its complete nutrition dependency graph. Nutrition conversion repeats for
+every ingredient on each request. History personalization separately hydrates up
+to 5,000 meals across 90 days. The optimizer then performs repeated rankings,
+but this CPU portion is small at the current catalog size.
+
+### App load
+
+The mobile recommendation provider starts `_loadBackendPlan()` immediately. A
+stored plan triggers a full GET; a missing or expired plan triggers full
+generation. No locally rendered stale plan shields the screen from network time.
+
+### Read and mutation responses
+
+All operations use `MealRecommendationPlanResponse`. Therefore a single-slot log
+or swap returns the complete plan, including all alternative meal details and
+ingredients. This amplifies database reads, serialization, transfer size, and
+mobile parsing/state replacement.
+
+### Log
+
+The log command hydrates the full batch for `claim_slot_log()`, loads the selected
+catalog meal again, saves and reloads a normal meal, hydrates the full batch again
+for `finalize_slot_logged()`, and finally serializes the full plan.
+
+## Evaluated Approaches
+
+| Approach | Advantages | Costs | Decision |
+|---|---|---|---|
+| Tactical cleanup only | Smallest change; removes obvious blocking work | Generation still scales with full catalog | First phase only |
+| Compiled catalog plus compact APIs | Removes repeated catalog work; fixes create/read/log/swap; handles thousands | Requires backend and mobile contract changes | Approved |
+| Background plan generation | Best perceived generation latency | Jobs, retries, stale-state rules, operational overhead | Defer |
+
+## Approved Design
+
+### 1. Compiled catalog snapshot
+
+- Build an immutable in-process catalog index on first use.
+- Snapshot contains display fields, backend-computed macros, ingredient IDs,
+  eligible meal types, cuisine, and active status.
+- Refresh on bounded TTL and catalog revision change; imports are infrequent, so
+  short catalog staleness is acceptable.
+- Each backend worker owns one snapshot. Do not introduce Redis recommendation
+  result caching in the first slice.
+- Generation does not hydrate the catalog from SQL unless refreshing the index.
+
+### 2. Aggregate affinity projection
+
+- Replace full meal-domain hydration with one owner-scoped aggregate query.
+- Return only linked `food_reference_id`, eaten timestamp/date, and effective
+  quantity needed for recency weighting.
+- Cache the resulting daily affinity profile briefly by user and local date when
+  safe; invalidate after relevant meal logging.
+
+### 3. Reduced ranking passes
+
+- Partition candidates once by meal type.
+- Compute stable scores once for each meal-type target.
+- Select winners by filtering already selected IDs from the ranked lists.
+- Select alternatives from the same rankings after all winners are known.
+- Preserve current scoring weights, tolerance behavior, and deterministic order.
+
+### 4. Compact plan contract
+
+- Active-plan/home response returns plan metadata and 9 selected slot summaries:
+  identity, name, image, calories, macros, selection version, and log status.
+- Ingredient lists and full meal details load only for the opened meal/slot.
+- Alternatives and ingredient-heavy meal details load through one owner-scoped
+  slot-detail endpoint.
+- Replace the current unreleased full-plan response directly; do not add
+  representation flags or compatibility branches.
+
+### 5. Delta mutation responses
+
+- Swap locks and loads only candidates for the target slot.
+- Log locks and loads only the target selected candidate plus required anchor
+  metadata.
+- Reuse the already loaded catalog snapshot during meal materialization.
+- Do not create a placeholder image when the catalog meal has no real image.
+- Mark the recommendation logged in the same transaction as normal meal
+  persistence.
+- Return slot delta fields instead of the full plan: `slot_id`, selected catalog
+  meal, `selection_version`, and `logged_meal_id` as applicable.
+- Mobile applies the delta to its existing plan state.
+
+### 6. Non-blocking analytics and stage metrics
+
+- Remove PostHog network calls from response completion.
+- Reuse an analytics client or enqueue bounded background delivery.
+- Record latency for target lookup, affinity query, catalog refresh, ranking,
+  persistence, hydration, serialization, and analytics enqueue.
+
+### 7. Mobile stale-while-revalidate
+
+- Persist the last successful plan payload, not only its ID.
+- Render it immediately on provider initialization.
+- Refresh in the background and replace state only when a newer plan arrives.
+- Keep slot-level mutation indicators; avoid replacing the full plan after a
+  successful log or swap.
+
+## Target Flow
+
+1. Mobile renders last persisted plan immediately.
+2. Backend reads active plan summary or validates client plan version.
+3. New generation reads lightweight daily target and aggregate affinity.
+4. Planner uses warm compiled catalog and performs bounded ranking.
+5. Backend bulk-persists candidates and returns compact plan payload.
+6. Log and swap operate on one slot and return deltas.
+7. Analytics delivery occurs outside response latency.
+
+## Success Metrics
+
+- Existing active-plan read p95 below 300 ms.
+- Log and swap p95 below 300 ms.
+- Warm generation p95 below 500 ms.
+- Cold catalog refresh plus generation p95 below 1 second.
+- Home screen displays persisted recommendations without waiting for network.
+- No full-catalog SQL hydration on warm generation.
+- No full-plan hydration for log or swap.
+- Same selected meal IDs for existing deterministic characterization fixtures.
+- Catalog size benchmark passes at 180, 1,000, and 5,000 meals.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stale catalog snapshot | Short TTL plus revision check; refresh after import |
+| Multi-worker snapshot divergence | Deterministic revision and bounded TTL |
+| Backend/mobile contract drift | Change backend and mobile together and lock one HTTP contract with integration tests |
+| Delta mutation race | Keep selection version and transactional row locks |
+| Affinity cache staleness after logging | Invalidate user/date key after meal write |
+| Hidden DB latency remains | Stage-level metrics and query-count tests before/after |
+
+## Touchpoints
+
+- `src/api/routes/v1/meal_recommendations.py`
+- `src/api/routes/v1/meal_recommendation_route_support.py`
+- `src/api/schemas/response/meal_recommendation_responses.py`
+- `src/app/handlers/command_handlers/meal_recommendation/`
+- `src/app/services/meal_recommendation_history_projector.py`
+- `src/app/services/recommended_meal_materialization_service.py`
+- `src/domain/services/meal_recommendation/`
+- `src/infra/repositories/catalog_recipe_repository_async.py`
+- `src/infra/repositories/meal_recommendation_plan_repository_async.py`
+- Mobile `meal_recommendation_controller.dart`, repository, data source, models,
+  mappers, and targeted tests.
+
+## Next Steps
+
+1. Create tests-first implementation plan covering backend contracts, repository
+   query shape, compiled catalog lifecycle, metrics, and mobile migration.
+2. Capture representative test/staging baselines before changing behavior.
+3. Ship tactical request-path cleanup before catalog-index changes.
+4. Verify each phase with endpoint latency, SQL count, payload size, and mobile
+   render timing.
+
+## Unresolved Questions
+
+- Exact staging p50/p95 baseline unavailable from local environment.

--- a/plans/reports/meal-recommendation-performance-baseline.json
+++ b/plans/reports/meal-recommendation-performance-baseline.json
@@ -1,0 +1,114 @@
+{
+  "generated_at": "2026-07-19T19:48:37.234860+00:00",
+  "parameters": {
+    "catalog_sizes": [
+      180,
+      1000,
+      5000
+    ],
+    "samples": 50,
+    "warmups": 10
+  },
+  "results": [
+    {
+      "alternatives": 45,
+      "catalog_refresh_count_current_contract": 60,
+      "catalog_size": 180,
+      "generation": {
+        "max_ms": 4.566,
+        "min_ms": 2.3109,
+        "p50_ms": 2.7489,
+        "p95_ms": 4.4689,
+        "samples": 50
+      },
+      "hydrated_candidate_rows_current_contract": 54,
+      "response_bytes": {
+        "last": 25452,
+        "max": 25452,
+        "min": 25452
+      },
+      "selected_slots": 9,
+      "serialization": {
+        "max_ms": 1.9143,
+        "min_ms": 0.3523,
+        "p50_ms": 0.4193,
+        "p95_ms": 1.2121,
+        "samples": 50
+      },
+      "sql_count_current_contract_notes": {
+        "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+        "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+        "synthetic_script_sql_count": 0
+      }
+    },
+    {
+      "alternatives": 45,
+      "catalog_refresh_count_current_contract": 60,
+      "catalog_size": 1000,
+      "generation": {
+        "max_ms": 30.7818,
+        "min_ms": 14.5962,
+        "p50_ms": 17.1188,
+        "p95_ms": 27.2022,
+        "samples": 50
+      },
+      "hydrated_candidate_rows_current_contract": 54,
+      "response_bytes": {
+        "last": 25314,
+        "max": 25314,
+        "min": 25314
+      },
+      "selected_slots": 9,
+      "serialization": {
+        "max_ms": 1.5089,
+        "min_ms": 0.4028,
+        "p50_ms": 0.4887,
+        "p95_ms": 1.0522,
+        "samples": 50
+      },
+      "sql_count_current_contract_notes": {
+        "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+        "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+        "synthetic_script_sql_count": 0
+      }
+    },
+    {
+      "alternatives": 45,
+      "catalog_refresh_count_current_contract": 60,
+      "catalog_size": 5000,
+      "generation": {
+        "max_ms": 125.3469,
+        "min_ms": 78.8315,
+        "p50_ms": 91.135,
+        "p95_ms": 118.5888,
+        "samples": 50
+      },
+      "hydrated_candidate_rows_current_contract": 54,
+      "response_bytes": {
+        "last": 25314,
+        "max": 25314,
+        "min": 25314
+      },
+      "selected_slots": 9,
+      "serialization": {
+        "max_ms": 2.2812,
+        "min_ms": 0.4133,
+        "p50_ms": 0.4637,
+        "p95_ms": 1.5429,
+        "samples": 50
+      },
+      "sql_count_current_contract_notes": {
+        "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+        "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+        "synthetic_script_sql_count": 0
+      }
+    }
+  ],
+  "runner": {
+    "machine": "arm64",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "processor": "arm",
+    "python": "3.13.2"
+  },
+  "schema_version": "meal_recommendation_performance_baseline_v1"
+}

--- a/plans/reports/meal-recommendation-performance-final.json
+++ b/plans/reports/meal-recommendation-performance-final.json
@@ -1,0 +1,114 @@
+{
+  "generated_at": "2026-07-19T20:19:56.143464+00:00",
+  "parameters": {
+    "catalog_sizes": [
+      180,
+      1000,
+      5000
+    ],
+    "samples": 50,
+    "warmups": 10
+  },
+  "results": [
+    {
+      "alternatives": 45,
+      "catalog_refresh_count_current_contract": 60,
+      "catalog_size": 180,
+      "generation": {
+        "max_ms": 2.355,
+        "min_ms": 1.0341,
+        "p50_ms": 1.2606,
+        "p95_ms": 2.1725,
+        "samples": 50
+      },
+      "hydrated_candidate_rows_current_contract": 54,
+      "response_bytes": {
+        "last": 25452,
+        "max": 25452,
+        "min": 25452
+      },
+      "selected_slots": 9,
+      "serialization": {
+        "max_ms": 1.1456,
+        "min_ms": 0.3512,
+        "p50_ms": 0.4757,
+        "p95_ms": 0.9533,
+        "samples": 50
+      },
+      "sql_count_current_contract_notes": {
+        "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+        "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+        "synthetic_script_sql_count": 0
+      }
+    },
+    {
+      "alternatives": 45,
+      "catalog_refresh_count_current_contract": 60,
+      "catalog_size": 1000,
+      "generation": {
+        "max_ms": 11.8505,
+        "min_ms": 5.1475,
+        "p50_ms": 6.4746,
+        "p95_ms": 9.0543,
+        "samples": 50
+      },
+      "hydrated_candidate_rows_current_contract": 54,
+      "response_bytes": {
+        "last": 25314,
+        "max": 25314,
+        "min": 25314
+      },
+      "selected_slots": 9,
+      "serialization": {
+        "max_ms": 1.1166,
+        "min_ms": 0.3555,
+        "p50_ms": 0.4345,
+        "p95_ms": 0.9831,
+        "samples": 50
+      },
+      "sql_count_current_contract_notes": {
+        "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+        "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+        "synthetic_script_sql_count": 0
+      }
+    },
+    {
+      "alternatives": 45,
+      "catalog_refresh_count_current_contract": 60,
+      "catalog_size": 5000,
+      "generation": {
+        "max_ms": 70.4846,
+        "min_ms": 29.6947,
+        "p50_ms": 34.0357,
+        "p95_ms": 54.9771,
+        "samples": 50
+      },
+      "hydrated_candidate_rows_current_contract": 54,
+      "response_bytes": {
+        "last": 25314,
+        "max": 25314,
+        "min": 25314
+      },
+      "selected_slots": 9,
+      "serialization": {
+        "max_ms": 2.7181,
+        "min_ms": 0.4219,
+        "p50_ms": 0.5235,
+        "p95_ms": 1.5296,
+        "samples": 50
+      },
+      "sql_count_current_contract_notes": {
+        "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+        "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+        "synthetic_script_sql_count": 0
+      }
+    }
+  ],
+  "runner": {
+    "machine": "arm64",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "processor": "arm",
+    "python": "3.13.2"
+  },
+  "schema_version": "meal_recommendation_performance_baseline_v1"
+}

--- a/scripts/testing/benchmark_meal_recommendation_performance.py
+++ b/scripts/testing/benchmark_meal_recommendation_performance.py
@@ -1,0 +1,275 @@
+"""Synthetic meal recommendation baseline benchmark.
+
+This script intentionally avoids live databases and user data. It records repeatable
+domain-generation and serialization measurements before the performance redesign.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from time import perf_counter_ns
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.api.routes.v1.meal_recommendation_route_support import to_response
+from src.domain.model.meal_recommendation import (
+    CatalogMeal,
+    CatalogMealIngredient,
+    MealRecommendationInsufficiency,
+    PersistedMealRecommendationCandidate,
+    PersistedMealRecommendationPlan,
+    PersistedMealRecommendationSlot,
+)
+from src.domain.services.meal_recommendation.ingredient_affinity_service import (
+    IngredientAffinityService,
+)
+from src.domain.services.meal_recommendation.three_day_plan_optimizer import (
+    ThreeDayPlanOptimizer,
+)
+
+DEFAULT_CATALOG_SIZES = (180, 1000, 5000)
+DEFAULT_SAMPLES = 50
+DEFAULT_WARMUPS = 10
+
+
+@dataclass(frozen=True)
+class BenchmarkStats:
+    p50_ms: float
+    p95_ms: float
+    min_ms: float
+    max_ms: float
+    samples: int
+
+
+def main() -> None:
+    args = _parse_args()
+    output = args.output
+    sizes = tuple(int(item.strip()) for item in args.catalog_sizes.split(",") if item)
+    report = {
+        "schema_version": "meal_recommendation_performance_baseline_v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "runner": _runner_metadata(),
+        "parameters": {
+            "catalog_sizes": sizes,
+            "warmups": args.warmups,
+            "samples": args.samples,
+        },
+        "results": [
+            _benchmark_catalog_size(size, warmups=args.warmups, samples=args.samples)
+            for size in sizes
+        ],
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+
+def _benchmark_catalog_size(catalog_size: int, *, warmups: int, samples: int) -> dict:
+    catalog = _catalog(catalog_size)
+    affinity = IngredientAffinityService().build_profile(
+        [], now=datetime(2026, 7, 20, tzinfo=UTC)
+    )
+    optimizer = ThreeDayPlanOptimizer()
+
+    for _ in range(warmups):
+        _build_persisted_plan(optimizer, catalog, affinity)
+
+    generation_durations = []
+    serialization_durations = []
+    response_sizes = []
+    selected_count = 0
+    alternative_count = 0
+    for _ in range(samples):
+        started = perf_counter_ns()
+        plan = _build_persisted_plan(optimizer, catalog, affinity)
+        generation_durations.append(_elapsed_ms(started))
+
+        started = perf_counter_ns()
+        response = to_response(plan)
+        response_sizes.append(len(response.model_dump_json().encode("utf-8")))
+        serialization_durations.append(_elapsed_ms(started))
+
+        selected_count = len(plan.slots)
+        alternative_count = sum(len(slot.alternatives) for slot in plan.slots)
+
+    return {
+        "catalog_size": catalog_size,
+        "selected_slots": selected_count,
+        "alternatives": alternative_count,
+        "hydrated_candidate_rows_current_contract": selected_count + alternative_count,
+        "catalog_refresh_count_current_contract": samples + warmups,
+        "sql_count_current_contract_notes": {
+            "create_fresh": "lock + idempotency + full catalog + history + supersede + post-save full batch reload",
+            "read": "full batch reload with catalog meal, ingredients, food_reference, serving sizes",
+            "synthetic_script_sql_count": 0,
+        },
+        "response_bytes": {
+            "min": min(response_sizes),
+            "max": max(response_sizes),
+            "last": response_sizes[-1],
+        },
+        "generation": asdict(_stats(generation_durations)),
+        "serialization": asdict(_stats(serialization_durations)),
+    }
+
+
+def _build_persisted_plan(
+    optimizer: ThreeDayPlanOptimizer,
+    catalog: list[CatalogMeal],
+    affinity,
+) -> PersistedMealRecommendationPlan:
+    result = optimizer.build_plan(catalog, daily_calories=2000, affinity=affinity)
+    if isinstance(result, MealRecommendationInsufficiency):
+        raise RuntimeError(result.message)
+
+    slots = []
+    batch_id = "benchmark-plan"
+    start_date = date(2026, 7, 20)
+    for position, slot in enumerate(result.slots):
+        slot_id = f"slot-{position}"
+        selected = PersistedMealRecommendationCandidate(
+            id=batch_id if position == 0 else f"selected-{position}",
+            slot_id=slot_id,
+            recommendation_date=start_date + timedelta(days=slot.day_index),
+            meal_type=slot.meal_type,
+            catalog_meal_id=slot.catalog_meal.id,
+            candidate_rank=0,
+            is_selected=True,
+            score=Decimal(str(slot.score)),
+            selection_version=1,
+            catalog_meal=slot.catalog_meal,
+        )
+        alternatives = tuple(
+            PersistedMealRecommendationCandidate(
+                id=f"alternative-{position}-{alternative_position}",
+                slot_id=slot_id,
+                recommendation_date=start_date + timedelta(days=slot.day_index),
+                meal_type=slot.meal_type,
+                catalog_meal_id=alternative.catalog_meal.id,
+                candidate_rank=alternative_position + 1,
+                is_selected=False,
+                score=Decimal(str(alternative.score)),
+                selection_version=1,
+                catalog_meal=alternative.catalog_meal,
+            )
+            for alternative_position, alternative in enumerate(
+                result.alternatives[(slot.day_index, slot.meal_type)]
+            )
+        )
+        slots.append(
+            PersistedMealRecommendationSlot(
+                id=slot_id,
+                slot_date=start_date + timedelta(days=slot.day_index),
+                day_index=slot.day_index,
+                meal_type=slot.meal_type,
+                catalog_meal_id=slot.catalog_meal.id,
+                target_calories=slot.target_calories,
+                score=slot.score,
+                position=position,
+                selected=selected,
+                alternatives=alternatives,
+            )
+        )
+
+    return PersistedMealRecommendationPlan(
+        id=batch_id,
+        user_id="synthetic-user",
+        status="active",
+        timezone="UTC",
+        start_date=start_date,
+        daily_calories=2000,
+        algorithm_version=result.algorithm_version,
+        operation="three_day",
+        idempotency_key="synthetic-key",
+        request_fingerprint="f" * 64,
+        slots=tuple(slots),
+    )
+
+
+def _catalog(size: int) -> list[CatalogMeal]:
+    meal_types = ("breakfast", "lunch", "dinner")
+    targets = {"breakfast": 500, "lunch": 750, "dinner": 750}
+    catalog = []
+    for index in range(size):
+        meal_type = meal_types[index % len(meal_types)]
+        calories = targets[meal_type] + (index // len(meal_types)) % 25
+        catalog.append(
+            CatalogMeal(
+                id=f"{meal_type}-{index:04d}",
+                catalog_key=f"key-{index:04d}",
+                content_hash=f"{index:064d}"[:64],
+                name=f"{meal_type.title()} Recipe {index:04d}",
+                cuisine="vietnamese",
+                description="Synthetic benchmark recipe",
+                image_url=None,
+                protein_g=Decimal(str(calories / 4)),
+                carbs_g=Decimal("0"),
+                fat_g=Decimal("0"),
+                fiber_g=Decimal("0"),
+                meal_types=(meal_type,),
+                ingredients=(
+                    CatalogMealIngredient(
+                        food_reference_id=index + 1,
+                        display_name="Synthetic ingredient",
+                        quantity=Decimal("100"),
+                        unit="g",
+                    ),
+                ),
+            )
+        )
+    return catalog
+
+
+def _stats(values: list[float]) -> BenchmarkStats:
+    sorted_values = sorted(values)
+    return BenchmarkStats(
+        p50_ms=round(statistics.median(sorted_values), 4),
+        p95_ms=round(_percentile(sorted_values, 0.95), 4),
+        min_ms=round(sorted_values[0], 4),
+        max_ms=round(sorted_values[-1], 4),
+        samples=len(sorted_values),
+    )
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    index = int(round((len(values) - 1) * percentile))
+    return values[index]
+
+
+def _elapsed_ms(started_ns: int) -> float:
+    return (perf_counter_ns() - started_ns) / 1_000_000
+
+
+def _runner_metadata() -> dict:
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+    }
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--catalog-sizes", default=",".join(map(str, DEFAULT_CATALOG_SIZES)))
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("plans/reports/meal-recommendation-performance-baseline.json"),
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -153,6 +153,9 @@ from src.app.handlers.query_handlers.get_cheat_days_query_handler import (
 from src.app.handlers.query_handlers.get_meal_recommendation_plan_query_handler import (
     GetMealRecommendationPlanQueryHandler,
 )
+from src.app.handlers.query_handlers.get_meal_recommendation_slot_detail_query_handler import (
+    GetMealRecommendationSlotDetailQueryHandler,
+)
 from src.app.handlers.query_handlers.get_nutrition_bulk_query_handler import (
     GetNutritionBulkQueryHandler,
 )
@@ -174,7 +177,10 @@ from src.app.queries.meal import (
     GetMealsByDateQuery,
     GetStreakQuery,
 )
-from src.app.queries.meal_recommendation import GetMealRecommendationPlanQuery
+from src.app.queries.meal_recommendation import (
+    GetMealRecommendationPlanQuery,
+    GetMealRecommendationSlotDetailQuery,
+)
 from src.app.queries.movement import GetDailyMovementQuery, GetMovementCatalogQuery
 from src.app.queries.notification import GetNotificationPreferencesQuery
 from src.app.queries.nutrition import GetActivitiesPresenceQuery, GetNutritionBulkQuery
@@ -193,6 +199,7 @@ from src.app.queries.user.get_user_onboarding_status_query import (
     GetUserOnboardingStatusQuery,
 )
 from src.app.queries.weight import GetWeightEntriesQuery
+from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshotService
 from src.infra.event_bus import EventBus, PyMediatorEventBus
 
 logger = logging.getLogger(__name__)
@@ -565,7 +572,10 @@ def get_configured_event_bus() -> EventBus:
 
     event_bus.register_handler(
         CreateThreeDayMealRecommendationCommand,
-        CreateThreeDayMealRecommendationCommandHandler(uow=AsyncUnitOfWork()),
+        CreateThreeDayMealRecommendationCommandHandler(
+            uow=AsyncUnitOfWork(),
+            catalog_snapshot_service=CatalogMealSnapshotService(),
+        ),
     )
     event_bus.register_handler(
         SwapMealRecommendationSlotCommand,
@@ -578,6 +588,10 @@ def get_configured_event_bus() -> EventBus:
     event_bus.register_handler(
         GetMealRecommendationPlanQuery,
         GetMealRecommendationPlanQueryHandler(AsyncUnitOfWork),
+    )
+    event_bus.register_handler(
+        GetMealRecommendationSlotDetailQuery,
+        GetMealRecommendationSlotDetailQueryHandler(AsyncUnitOfWork),
     )
 
     # Register meal suggestion handlers

--- a/src/api/routes/v1/meal_recommendation_route_support.py
+++ b/src/api/routes/v1/meal_recommendation_route_support.py
@@ -10,10 +10,14 @@ from pydantic import BaseModel, Field, field_validator
 from src.api.schemas.response.meal_recommendation_responses import (
     MealRecommendationAlternativeResponse,
     MealRecommendationCatalogMealResponse,
+    MealRecommendationCatalogMealSummaryResponse,
     MealRecommendationIngredientResponse,
     MealRecommendationMacrosResponse,
     MealRecommendationPlanResponse,
+    MealRecommendationPlanSummaryResponse,
+    MealRecommendationSlotDetailResponse,
     MealRecommendationSlotResponse,
+    MealRecommendationSlotSummaryResponse,
 )
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
@@ -72,13 +76,43 @@ async def capture_plan_events(
     user_id: str,
     plan: PersistedMealRecommendationPlan,
     events: tuple[str, ...],
+    task_manager=None,
 ) -> None:
-    for event in events:
-        await analytics_service.capture_plan_response(
+    async def capture_all() -> None:
+        for event in events:
+            await analytics_service.capture_plan_response(
+                user_id=user_id,
+                event=event,
+                plan=plan,
+            )
+
+    if task_manager is not None and hasattr(task_manager, "spawn"):
+        task_manager.spawn("meal_recommendation_analytics", capture_all())
+        return
+
+    await capture_all()
+
+
+async def capture_slot_event(
+    analytics_service: MealRecommendationAnalyticsService,
+    *,
+    user_id: str,
+    event: str,
+    plan_id: str,
+    task_manager=None,
+) -> None:
+    async def capture_one() -> None:
+        await analytics_service.capture_slot_response(
             user_id=user_id,
             event=event,
-            plan=plan,
+            plan_id=plan_id,
         )
+
+    if task_manager is not None and hasattr(task_manager, "spawn"):
+        task_manager.spawn("meal_recommendation_slot_analytics", capture_one())
+        return
+
+    await capture_one()
 
 
 def to_response(
@@ -123,6 +157,71 @@ def to_response(
     )
 
 
+def to_summary_response(
+    plan: PersistedMealRecommendationPlan,
+) -> MealRecommendationPlanSummaryResponse:
+    return MealRecommendationPlanSummaryResponse(
+        id=plan.id,
+        status=plan.status,
+        timezone=plan.timezone,
+        start_date=plan.start_date,
+        daily_calories=plan.daily_calories,
+        algorithm_version=plan.algorithm_version,
+        allergy_evaluated=False,
+        slots=[
+            MealRecommendationSlotSummaryResponse(
+                id=slot.id,
+                slot_date=slot.slot_date,
+                day_index=slot.day_index,
+                meal_type=slot.meal_type,
+                catalog_meal_id=slot.catalog_meal_id,
+                catalog_meal=_catalog_meal_summary_response(
+                    _selected_catalog_meal(slot)
+                ),
+                target_calories=slot.target_calories,
+                position=slot.position,
+                selection_version=slot.selection_version,
+                logged_meal_id=slot.logged_meal_id,
+            )
+            for slot in plan.slots
+        ],
+    )
+
+
+def to_slot_detail_response(
+    plan_id: str,
+    slot,
+) -> MealRecommendationSlotDetailResponse:
+    return MealRecommendationSlotDetailResponse(
+        plan_id=plan_id,
+        slot=MealRecommendationSlotResponse(
+            id=slot.id,
+            slot_date=slot.slot_date,
+            day_index=slot.day_index,
+            meal_type=slot.meal_type,
+            catalog_meal_id=slot.catalog_meal_id,
+            catalog_meal=_catalog_meal_response(_selected_catalog_meal(slot)),
+            target_calories=slot.target_calories,
+            score=slot.score,
+            position=slot.position,
+            selection_version=slot.selection_version,
+            logged_meal_id=slot.logged_meal_id,
+            alternatives=[
+                MealRecommendationAlternativeResponse(
+                    id=alternative.id,
+                    catalog_meal_id=alternative.catalog_meal_id,
+                    catalog_meal=_catalog_meal_response(
+                        _required_catalog_meal(alternative.catalog_meal)
+                    ),
+                    score=alternative.score,
+                    candidate_rank=alternative.candidate_rank,
+                )
+                for alternative in slot.alternatives
+            ],
+        ),
+    )
+
+
 def _selected_catalog_meal(slot) -> CatalogMeal:
     if slot.selected is not None and slot.selected.catalog_meal is not None:
         return slot.selected.catalog_meal
@@ -159,4 +258,23 @@ def _catalog_meal_response(catalog_meal: CatalogMeal) -> MealRecommendationCatal
             )
             for ingredient in catalog_meal.ingredients
         ],
+    )
+
+
+def _catalog_meal_summary_response(
+    catalog_meal: CatalogMeal,
+) -> MealRecommendationCatalogMealSummaryResponse:
+    return MealRecommendationCatalogMealSummaryResponse(
+        id=catalog_meal.id,
+        name=catalog_meal.name,
+        cuisine=catalog_meal.cuisine,
+        image_url=catalog_meal.image_url,
+        calories=catalog_meal.calories,
+        macros=MealRecommendationMacrosResponse(
+            protein_g=float(catalog_meal.protein_g),
+            carbs_g=float(catalog_meal.carbs_g),
+            fat_g=float(catalog_meal.fat_g),
+            fiber_g=float(catalog_meal.fiber_g),
+            sugar_g=float(catalog_meal.sugar_g),
+        ),
     )

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -12,16 +12,20 @@ from src.api.base_dependencies import (
 )
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.dependencies.task_manager import get_optional_task_manager
 from src.api.middleware.rate_limit import limiter
 from src.api.routes.v1.meal_recommendation_route_support import (
     LogRecommendedMealRequest,
     SwapMealRecommendationSlotRequest,
     capture_plan_events,
+    capture_slot_event,
     record_operation_latency,
-    to_response,
+    to_slot_detail_response,
+    to_summary_response,
 )
 from src.api.schemas.response.meal_recommendation_responses import (
-    MealRecommendationPlanResponse,
+    MealRecommendationPlanSummaryResponse,
+    MealRecommendationSlotDetailResponse,
 )
 from src.app.commands.meal_recommendation import (
     CreateThreeDayMealRecommendationCommand,
@@ -29,7 +33,10 @@ from src.app.commands.meal_recommendation import (
     SwapMealRecommendationSlotCommand,
 )
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
-from src.app.queries.meal_recommendation import GetMealRecommendationPlanQuery
+from src.app.queries.meal_recommendation import (
+    GetMealRecommendationPlanQuery,
+    GetMealRecommendationSlotDetailQuery,
+)
 from src.app.queries.user import GetUserTimezoneQuery
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
@@ -42,7 +49,7 @@ from src.domain.utils.timezone_utils import get_zone_info
 router = APIRouter(prefix="/v1/meal-recommendations", tags=["Meal Recommendations"])
 
 
-@router.post("/three-day", response_model=MealRecommendationPlanResponse)
+@router.post("/three-day", response_model=MealRecommendationPlanSummaryResponse)
 @limiter.limit("5/minute")
 async def create_three_day_recommendations(
     request: Request,
@@ -52,7 +59,8 @@ async def create_three_day_recommendations(
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
-) -> MealRecommendationPlanResponse:
+    task_manager=Depends(get_optional_task_manager),
+) -> MealRecommendationPlanSummaryResponse:
     """Create or replay a durable three-day catalog recommendation plan."""
 
     started = perf_counter()
@@ -104,12 +112,13 @@ async def create_three_day_recommendations(
                 status_code=exc.status_code,
                 detail=exc.public_detail,
             ) from exc
-        response = to_response(plan)
+        response = to_summary_response(plan)
         await capture_plan_events(
             analytics_service,
             user_id=user_id,
             plan=plan,
             events=("plan_shown", "alternatives_shown"),
+            task_manager=task_manager,
         )
         metric_status = "success"
         return response
@@ -120,7 +129,10 @@ async def create_three_day_recommendations(
         record_operation_latency("create", started, metric_status)
 
 
-@router.post("/{plan_id}/slots/{slot_id}/swap", response_model=MealRecommendationPlanResponse)
+@router.post(
+    "/{plan_id}/slots/{slot_id}/swap",
+    response_model=MealRecommendationSlotDetailResponse,
+)
 async def swap_meal_recommendation_slot(
     plan_id: str,
     slot_id: str,
@@ -130,11 +142,12 @@ async def swap_meal_recommendation_slot(
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
-) -> MealRecommendationPlanResponse:
+    task_manager=Depends(get_optional_task_manager),
+) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
     try:
-        plan = await event_bus.send(
+        result = await event_bus.send(
             SwapMealRecommendationSlotCommand(
                 user_id=user_id,
                 plan_id=plan_id,
@@ -148,19 +161,23 @@ async def swap_meal_recommendation_slot(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_response(plan)
-    await capture_plan_events(
+    response = to_slot_detail_response(result.plan_id, result.slot)
+    await capture_slot_event(
         analytics_service,
         user_id=user_id,
-        plan=plan,
-        events=("swap_selected",),
+        event="swap_selected",
+        plan_id=result.plan_id,
+        task_manager=task_manager,
     )
     metric_status = "success"
     record_operation_latency("swap", started, metric_status)
     return response
 
 
-@router.post("/{plan_id}/slots/{slot_id}/log", response_model=MealRecommendationPlanResponse)
+@router.post(
+    "/{plan_id}/slots/{slot_id}/log",
+    response_model=MealRecommendationSlotDetailResponse,
+)
 async def log_recommended_meal(
     plan_id: str,
     slot_id: str,
@@ -170,11 +187,12 @@ async def log_recommended_meal(
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
-) -> MealRecommendationPlanResponse:
+    task_manager=Depends(get_optional_task_manager),
+) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
     try:
-        plan = await event_bus.send(
+        result = await event_bus.send(
             LogRecommendedMealCommand(
                 user_id=user_id,
                 plan_id=plan_id,
@@ -185,19 +203,20 @@ async def log_recommended_meal(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_response(plan)
-    await capture_plan_events(
+    response = to_slot_detail_response(result.plan_id, result.slot)
+    await capture_slot_event(
         analytics_service,
         user_id=user_id,
-        plan=plan,
-        events=("meal_logged",),
+        event="meal_logged",
+        plan_id=result.plan_id,
+        task_manager=task_manager,
     )
     metric_status = "success"
     record_operation_latency("log", started, metric_status)
     return response
 
 
-@router.get("/{plan_id}", response_model=MealRecommendationPlanResponse)
+@router.get("/{plan_id}", response_model=MealRecommendationPlanSummaryResponse)
 async def get_meal_recommendation_plan(
     plan_id: str,
     user_id: str = Depends(get_current_user_id),
@@ -205,7 +224,8 @@ async def get_meal_recommendation_plan(
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
-) -> MealRecommendationPlanResponse:
+    task_manager=Depends(get_optional_task_manager),
+) -> MealRecommendationPlanSummaryResponse:
     """Read an owner-scoped durable recommendation plan."""
 
     started = perf_counter()
@@ -217,13 +237,56 @@ async def get_meal_recommendation_plan(
         metric_status = "http_404"
         record_operation_latency("read", started, metric_status)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    response = to_response(plan)
+    response = to_summary_response(plan)
     await capture_plan_events(
         analytics_service,
         user_id=user_id,
         plan=plan,
         events=("plan_shown", "alternatives_shown"),
+        task_manager=task_manager,
     )
     metric_status = "success"
     record_operation_latency("read", started, metric_status)
+    return response
+
+
+@router.get(
+    "/{plan_id}/slots/{slot_id}",
+    response_model=MealRecommendationSlotDetailResponse,
+)
+async def get_meal_recommendation_slot_detail(
+    plan_id: str,
+    slot_id: str,
+    user_id: str = Depends(get_current_user_id),
+    event_bus=Depends(get_configured_event_bus),
+    analytics_service: MealRecommendationAnalyticsService = Depends(
+        get_meal_recommendation_analytics_service
+    ),
+    task_manager=Depends(get_optional_task_manager),
+) -> MealRecommendationSlotDetailResponse:
+    """Read one owner-scoped recommendation slot with alternatives."""
+
+    started = perf_counter()
+    metric_status = "error"
+    slot = await event_bus.send(
+        GetMealRecommendationSlotDetailQuery(
+            user_id=user_id,
+            plan_id=plan_id,
+            slot_id=slot_id,
+        )
+    )
+    if slot is None:
+        metric_status = "http_404"
+        record_operation_latency("slot_detail", started, metric_status)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    response = to_slot_detail_response(plan_id, slot)
+    await capture_slot_event(
+        analytics_service,
+        user_id=user_id,
+        event="slot_detail_shown",
+        plan_id=plan_id,
+        task_manager=task_manager,
+    )
+    metric_status = "success"
+    record_operation_latency("slot_detail", started, metric_status)
     return response

--- a/src/api/schemas/response/meal_recommendation_responses.py
+++ b/src/api/schemas/response/meal_recommendation_responses.py
@@ -33,12 +33,34 @@ class MealRecommendationCatalogMealResponse(BaseModel):
     ingredients: list[MealRecommendationIngredientResponse]
 
 
+class MealRecommendationCatalogMealSummaryResponse(BaseModel):
+    id: str
+    name: str
+    cuisine: str
+    image_url: str | None = None
+    calories: int
+    macros: MealRecommendationMacrosResponse
+
+
 class MealRecommendationAlternativeResponse(BaseModel):
     id: str
     catalog_meal_id: str
     catalog_meal: MealRecommendationCatalogMealResponse
     score: float
     candidate_rank: int
+
+
+class MealRecommendationSlotSummaryResponse(BaseModel):
+    id: str
+    slot_date: date
+    day_index: int
+    meal_type: str
+    catalog_meal_id: str
+    catalog_meal: MealRecommendationCatalogMealSummaryResponse
+    target_calories: int
+    position: int
+    selection_version: int
+    logged_meal_id: str | None = None
 
 
 class MealRecommendationSlotResponse(BaseModel):
@@ -54,6 +76,22 @@ class MealRecommendationSlotResponse(BaseModel):
     selection_version: int
     logged_meal_id: str | None = None
     alternatives: list[MealRecommendationAlternativeResponse]
+
+
+class MealRecommendationPlanSummaryResponse(BaseModel):
+    id: str
+    status: str
+    timezone: str
+    start_date: date
+    daily_calories: int
+    algorithm_version: str
+    allergy_evaluated: bool = False
+    slots: list[MealRecommendationSlotSummaryResponse]
+
+
+class MealRecommendationSlotDetailResponse(BaseModel):
+    plan_id: str
+    slot: MealRecommendationSlotResponse
 
 
 class MealRecommendationPlanResponse(BaseModel):

--- a/src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py
@@ -45,10 +45,12 @@ class CreateThreeDayMealRecommendationCommandHandler(
         uow,
         optimizer: ThreeDayPlanOptimizer | None = None,
         history_projector: MealRecommendationHistoryProjector | None = None,
+        catalog_snapshot_service=None,
     ):
         self.uow = uow
         self.optimizer = optimizer or ThreeDayPlanOptimizer()
         self.history_projector = history_projector or MealRecommendationHistoryProjector()
+        self.catalog_snapshot_service = catalog_snapshot_service
 
     async def handle(
         self,
@@ -69,7 +71,11 @@ class CreateThreeDayMealRecommendationCommandHandler(
                     raise MealRecommendationIdempotencyConflictError
                 return existing
 
-            catalog_meals = await uow.catalog_recipes.list_active_meals()
+            if self.catalog_snapshot_service is not None:
+                snapshot = await self.catalog_snapshot_service.get_snapshot(uow)
+                catalog_meals = list(snapshot.meals)
+            else:
+                catalog_meals = await uow.catalog_recipes.list_active_meals()
             if not catalog_meals:
                 raise MealRecommendationCatalogUnavailableError
 

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -5,12 +5,17 @@ from src.app.events.base import EventHandler, handles
 from src.app.services.recommended_meal_materialization_service import (
     RecommendedMealMaterializationService,
 )
-from src.domain.model.meal_recommendation import PersistedMealRecommendationPlan
+from src.domain.model.meal_recommendation import (
+    PersistedMealRecommendationSlotMutationResult,
+)
 
 
 @handles(LogRecommendedMealCommand)
 class LogRecommendedMealCommandHandler(
-    EventHandler[LogRecommendedMealCommand, PersistedMealRecommendationPlan]
+    EventHandler[
+        LogRecommendedMealCommand,
+        PersistedMealRecommendationSlotMutationResult,
+    ]
 ):
     def __init__(
         self,
@@ -22,7 +27,7 @@ class LogRecommendedMealCommandHandler(
 
     async def handle(
         self, command: LogRecommendedMealCommand
-    ) -> PersistedMealRecommendationPlan:
+    ) -> PersistedMealRecommendationSlotMutationResult:
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -31,7 +36,11 @@ class LogRecommendedMealCommandHandler(
                 request_id=command.request_id,
             )
             if replayed:
-                return plan
+                return PersistedMealRecommendationSlotMutationResult(
+                    plan_id=plan.id,
+                    user_id=plan.user_id,
+                    slot=slot,
+                )
             meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
             return await uow.meal_recommendation_plans.finalize_slot_logged(
                 user_id=command.user_id,

--- a/src/app/handlers/command_handlers/meal_recommendation/swap_meal_recommendation_slot_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/swap_meal_recommendation_slot_command_handler.py
@@ -2,19 +2,24 @@
 
 from src.app.commands.meal_recommendation import SwapMealRecommendationSlotCommand
 from src.app.events.base import EventHandler, handles
-from src.domain.model.meal_recommendation import PersistedMealRecommendationPlan
+from src.domain.model.meal_recommendation import (
+    PersistedMealRecommendationSlotMutationResult,
+)
 
 
 @handles(SwapMealRecommendationSlotCommand)
 class SwapMealRecommendationSlotCommandHandler(
-    EventHandler[SwapMealRecommendationSlotCommand, PersistedMealRecommendationPlan]
+    EventHandler[
+        SwapMealRecommendationSlotCommand,
+        PersistedMealRecommendationSlotMutationResult,
+    ]
 ):
     def __init__(self, uow):
         self.uow = uow
 
     async def handle(
         self, command: SwapMealRecommendationSlotCommand
-    ) -> PersistedMealRecommendationPlan:
+    ) -> PersistedMealRecommendationSlotMutationResult:
         async with self.uow as uow:
             return await uow.meal_recommendation_plans.swap_slot(
                 user_id=command.user_id,

--- a/src/app/handlers/query_handlers/get_meal_recommendation_plan_query_handler.py
+++ b/src/app/handlers/query_handlers/get_meal_recommendation_plan_query_handler.py
@@ -24,7 +24,7 @@ class GetMealRecommendationPlanQueryHandler(
         query: GetMealRecommendationPlanQuery,
     ) -> PersistedMealRecommendationPlan | None:
         async with self._uow_factory() as uow:
-            return await uow.meal_recommendation_plans.get_by_id(
+            return await uow.meal_recommendation_plans.get_summary(
                 user_id=query.user_id,
                 plan_id=query.plan_id,
             )

--- a/src/app/handlers/query_handlers/get_meal_recommendation_slot_detail_query_handler.py
+++ b/src/app/handlers/query_handlers/get_meal_recommendation_slot_detail_query_handler.py
@@ -1,0 +1,31 @@
+"""Query handler for meal recommendation slot detail reads."""
+
+from __future__ import annotations
+
+from src.app.events.base import EventHandler, handles
+from src.app.queries.meal_recommendation import GetMealRecommendationSlotDetailQuery
+from src.domain.model.meal_recommendation import PersistedMealRecommendationSlot
+
+
+@handles(GetMealRecommendationSlotDetailQuery)
+class GetMealRecommendationSlotDetailQueryHandler(
+    EventHandler[
+        GetMealRecommendationSlotDetailQuery,
+        PersistedMealRecommendationSlot | None,
+    ]
+):
+    """Read one owner-scoped durable recommendation slot."""
+
+    def __init__(self, uow_factory):
+        self._uow_factory = uow_factory
+
+    async def handle(
+        self,
+        query: GetMealRecommendationSlotDetailQuery,
+    ) -> PersistedMealRecommendationSlot | None:
+        async with self._uow_factory() as uow:
+            return await uow.meal_recommendation_plans.get_slot_detail(
+                user_id=query.user_id,
+                plan_id=query.plan_id,
+                slot_id=query.slot_id,
+            )

--- a/src/app/queries/meal_recommendation/__init__.py
+++ b/src/app/queries/meal_recommendation/__init__.py
@@ -1,6 +1,11 @@
 """Meal recommendation queries."""
 
 from .get_meal_recommendation_plan_query import GetMealRecommendationPlanQuery
+from .get_meal_recommendation_slot_detail_query import (
+    GetMealRecommendationSlotDetailQuery,
+)
 
-__all__ = ["GetMealRecommendationPlanQuery"]
-
+__all__ = [
+    "GetMealRecommendationPlanQuery",
+    "GetMealRecommendationSlotDetailQuery",
+]

--- a/src/app/queries/meal_recommendation/get_meal_recommendation_slot_detail_query.py
+++ b/src/app/queries/meal_recommendation/get_meal_recommendation_slot_detail_query.py
@@ -1,0 +1,16 @@
+"""Query for one owner-scoped recommendation slot detail."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.app.events.base import Query
+
+
+@dataclass
+class GetMealRecommendationSlotDetailQuery(Query):
+    """Get one durable recommendation slot with alternatives."""
+
+    user_id: str
+    plan_id: str
+    slot_id: str

--- a/src/app/services/catalog_meal_snapshot_service.py
+++ b/src/app/services/catalog_meal_snapshot_service.py
@@ -1,0 +1,122 @@
+"""Process-local immutable catalog meal snapshot."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from time import monotonic
+
+from src.domain.exceptions.meal_recommendation_exceptions import (
+    MealRecommendationCatalogUnavailableError,
+)
+from src.domain.model.meal_recommendation import CatalogMeal
+from src.domain.ports.catalog_recipe_repository_port import CatalogMealRevision
+from src.observability import increment_metric
+
+
+@dataclass(frozen=True)
+class CatalogMealSnapshot:
+    """Immutable active catalog snapshot for deterministic recommendation generation."""
+
+    revision: CatalogMealRevision
+    meals: tuple[CatalogMeal, ...]
+    refreshed_at: float
+    expires_at: float
+
+
+class CatalogMealSnapshotService:
+    """Cache active catalog meals once per process and catalog revision."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = 300,
+        failure_retry_seconds: float = 30,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._failure_retry_seconds = failure_retry_seconds
+        self._clock = clock
+        self._lock = asyncio.Lock()
+        self._snapshot: CatalogMealSnapshot | None = None
+        self._next_refresh_after = 0.0
+
+    async def get_snapshot(self, uow) -> CatalogMealSnapshot:
+        now = self._clock()
+        snapshot = self._snapshot
+        if snapshot is not None and snapshot.expires_at > now:
+            return snapshot
+
+        revision = await uow.catalog_recipes.get_active_catalog_revision()
+        snapshot = self._snapshot
+        if (
+            snapshot is not None
+            and snapshot.revision == revision
+            and snapshot.expires_at > now
+        ):
+            return snapshot
+        if snapshot is not None and snapshot.revision == revision:
+            refreshed = CatalogMealSnapshot(
+                revision=snapshot.revision,
+                meals=snapshot.meals,
+                refreshed_at=snapshot.refreshed_at,
+                expires_at=now + self._ttl_seconds,
+            )
+            self._snapshot = refreshed
+            return refreshed
+
+        return await self._refresh_singleflight(uow, expected_revision=revision)
+
+    async def _refresh_singleflight(
+        self,
+        uow,
+        *,
+        expected_revision: CatalogMealRevision,
+    ) -> CatalogMealSnapshot:
+        async with self._lock:
+            now = self._clock()
+            current = self._snapshot
+            if (
+                current is not None
+                and current.revision == expected_revision
+                and current.expires_at > now
+            ):
+                return current
+            if current is not None and now < self._next_refresh_after:
+                return current
+
+            try:
+                meals = tuple(await uow.catalog_recipes.list_active_meals())
+                loaded_revision = await uow.catalog_recipes.get_active_catalog_revision()
+                if loaded_revision != expected_revision:
+                    meals = tuple(await uow.catalog_recipes.list_active_meals())
+                    loaded_revision = await uow.catalog_recipes.get_active_catalog_revision()
+                if not meals:
+                    raise MealRecommendationCatalogUnavailableError
+                snapshot = CatalogMealSnapshot(
+                    revision=loaded_revision,
+                    meals=meals,
+                    refreshed_at=now,
+                    expires_at=now + self._ttl_seconds,
+                )
+                self._snapshot = snapshot
+                self._next_refresh_after = 0.0
+                increment_metric(
+                    "meal_recommendation.catalog_snapshot.refresh",
+                    attributes={"status": "success"},
+                )
+                return snapshot
+            except Exception:
+                if current is not None:
+                    self._next_refresh_after = now + self._failure_retry_seconds
+                    increment_metric(
+                        "meal_recommendation.catalog_snapshot.refresh",
+                        attributes={"status": "last_good"},
+                    )
+                    return current
+                increment_metric(
+                    "meal_recommendation.catalog_snapshot.refresh",
+                    attributes={"status": "cold_failure"},
+                )
+                raise

--- a/src/app/services/meal_recommendation_analytics_service.py
+++ b/src/app/services/meal_recommendation_analytics_service.py
@@ -47,6 +47,24 @@ class MealRecommendationAnalyticsService:
             },
         )
 
+    async def capture_slot_response(
+        self,
+        *,
+        user_id: str,
+        event: str,
+        plan_id: str,
+    ) -> None:
+        if not self.adapter or not self.salt:
+            return
+        await self.adapter.capture(
+            distinct_id=_pseudonymous_id(user_id, self.salt),
+            event=event,
+            properties={
+                "schema_version": "meal_recommendation_v1",
+                "plan_id_hash": _pseudonymous_id(plan_id, self.salt),
+            },
+        )
+
 
 def _pseudonymous_id(user_id: str, salt: str) -> str:
     digest = hmac.new(

--- a/src/app/services/meal_recommendation_history_projector.py
+++ b/src/app/services/meal_recommendation_history_projector.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import date, timedelta
 from typing import Any
 
-from src.domain.model.meal_projection import MealProjection
 from src.domain.services.meal_recommendation.ingredient_affinity_service import (
     IngredientAffinityProfile,
     IngredientAffinityService,
-    IngredientHistoryEvent,
 )
 
 _HISTORY_DAYS = 90
-_HISTORY_LIMIT = 5000
 
 
 class MealRecommendationHistoryProjector:
@@ -32,31 +29,11 @@ class MealRecommendationHistoryProjector:
     ) -> IngredientAffinityProfile:
         history_start = start_date - timedelta(days=_HISTORY_DAYS)
         history_end = start_date - timedelta(days=1)
-        meals = await uow.meals.find_by_date_range(
+        buckets = await uow.meals.aggregate_linked_ingredient_history(
             user_id=user_id,
             start_date=history_start,
             end_date=history_end,
-            limit=_HISTORY_LIMIT,
             user_timezone=timezone,
-            projection=MealProjection.MACROS_ONLY,
+            reference_date=start_date,
         )
-        events: list[IngredientHistoryEvent] = []
-        for meal in meals:
-            nutrition = getattr(meal, "nutrition", None)
-            if not nutrition or not nutrition.food_items:
-                continue
-            occurred_at = meal.ready_at or meal.created_at
-            for item in nutrition.food_items:
-                if item.food_reference_id is None:
-                    continue
-                events.append(
-                    IngredientHistoryEvent(
-                        food_reference_id=item.food_reference_id,
-                        eaten_at=occurred_at,
-                        grams=float(item.quantity),
-                    )
-                )
-        return self._affinity_service.build_profile(
-            events,
-            now=datetime.combine(start_date, time.min, tzinfo=UTC),
-        )
+        return self._affinity_service.build_profile_from_buckets(buckets)

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from src.domain.exceptions.meal_recommendation_exceptions import (
     MealRecommendationNotFoundError,
 )
-from src.domain.model.meal import Meal, MealImage, MealStatus
+from src.domain.model.meal import Meal, MealStatus
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
@@ -26,9 +26,9 @@ class RecommendedMealMaterializationService:
         plan: PersistedMealRecommendationPlan,
         slot: PersistedMealRecommendationSlot,
     ) -> Meal:
-        catalog_meal = await uow.catalog_recipes.get_meal(slot.catalog_meal_id)
-        if catalog_meal is None:
+        if slot.selected is None or slot.selected.catalog_meal is None:
             raise MealRecommendationNotFoundError
+        catalog_meal = slot.selected.catalog_meal
 
         food_items = [
             FoodItem(
@@ -48,12 +48,7 @@ class RecommendedMealMaterializationService:
             status=MealStatus.READY,
             created_at=meal_time,
             ready_at=meal_time,
-            image=MealImage(
-                image_id=str(uuid4()),
-                format="jpeg",
-                size_bytes=1,
-                url=None,
-            ),
+            image=None,
             dish_name=catalog_meal.name,
             nutrition=Nutrition(
                 macros=Macros(

--- a/src/domain/model/meal_recommendation/__init__.py
+++ b/src/domain/model/meal_recommendation/__init__.py
@@ -13,6 +13,7 @@ from .meal_recommendation_plan import (
     PersistedMealRecommendationCandidate,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
+    PersistedMealRecommendationSlotMutationResult,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "PersistedMealRecommendationCandidate",
     "PersistedMealRecommendationPlan",
     "PersistedMealRecommendationSlot",
+    "PersistedMealRecommendationSlotMutationResult",
 ]

--- a/src/domain/model/meal_recommendation/meal_recommendation_plan.py
+++ b/src/domain/model/meal_recommendation/meal_recommendation_plan.py
@@ -67,3 +67,12 @@ class PersistedMealRecommendationPlan:
     request_fingerprint: str
     slots: tuple[PersistedMealRecommendationSlot, ...] = field(default_factory=tuple)
     created_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PersistedMealRecommendationSlotMutationResult:
+    """Changed-slot result for recommendation swap/log mutations."""
+
+    plan_id: str
+    user_id: str
+    slot: PersistedMealRecommendationSlot

--- a/src/domain/ports/catalog_recipe_repository_port.py
+++ b/src/domain/ports/catalog_recipe_repository_port.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 
 from src.domain.model.meal_recommendation.catalog_recipe import CatalogMeal
 
@@ -40,6 +41,15 @@ class CatalogMealSeedExisting:
     content_hash: str
 
 
+@dataclass(frozen=True, order=True)
+class CatalogMealRevision:
+    """Comparable active catalog revision."""
+
+    active_count: int
+    catalog_updated_at: datetime | None
+    food_reference_updated_at: datetime | None
+
+
 class CatalogMealRepositoryPort(ABC):
     """Read/write contract for catalog meals during the rework."""
 
@@ -51,6 +61,10 @@ class CatalogMealRepositoryPort(ABC):
         meal_type: str | None = None,
     ) -> list[CatalogMeal]:
         """Return active catalog meals."""
+
+    @abstractmethod
+    async def get_active_catalog_revision(self) -> CatalogMealRevision:
+        """Return a lightweight comparable active catalog revision."""
 
     @abstractmethod
     async def get_meal(self, catalog_meal_id: str) -> CatalogMeal | None:

--- a/src/domain/ports/meal_recommendation_plan_repository_port.py
+++ b/src/domain/ports/meal_recommendation_plan_repository_port.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
+    PersistedMealRecommendationSlotMutationResult,
 )
 
 
@@ -21,6 +22,25 @@ class MealRecommendationPlanRepositoryPort(ABC):
         plan_id: str,
     ) -> PersistedMealRecommendationPlan | None:
         """Return an owner-scoped plan by ID."""
+
+    @abstractmethod
+    async def get_summary(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+    ) -> PersistedMealRecommendationPlan | None:
+        """Return selected owner-scoped slots without alternatives."""
+
+    @abstractmethod
+    async def get_slot_detail(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+        slot_id: str,
+    ) -> PersistedMealRecommendationSlot | None:
+        """Return one owner-scoped hydrated slot with alternatives."""
 
     @abstractmethod
     async def get_by_idempotency_key(
@@ -54,8 +74,8 @@ class MealRecommendationPlanRepositoryPort(ABC):
         expected_version: int,
         alternative_catalog_meal_id: str | None,
         reason: str,
-    ) -> PersistedMealRecommendationPlan:
-        """Swap one owned slot and return the updated plan."""
+    ) -> PersistedMealRecommendationSlotMutationResult:
+        """Swap one owned slot and return the changed slot."""
 
     @abstractmethod
     async def claim_slot_log(
@@ -65,7 +85,11 @@ class MealRecommendationPlanRepositoryPort(ABC):
         plan_id: str,
         slot_id: str,
         request_id: str,
-    ) -> tuple[PersistedMealRecommendationPlan, PersistedMealRecommendationSlot, bool]:
+    ) -> tuple[
+        PersistedMealRecommendationPlan,
+        PersistedMealRecommendationSlot,
+        bool,
+    ]:
         """Claim a slot log request before materializing a normal meal."""
 
     @abstractmethod
@@ -77,5 +101,5 @@ class MealRecommendationPlanRepositoryPort(ABC):
         slot_id: str,
         request_id: str,
         meal_id: str,
-    ) -> PersistedMealRecommendationPlan:
-        """Attach a materialized meal to a claimed slot log and return the plan."""
+    ) -> PersistedMealRecommendationSlotMutationResult:
+        """Attach a materialized meal to a claimed slot log and return the slot."""

--- a/src/domain/ports/meal_repository_port.py
+++ b/src/domain/ports/meal_repository_port.py
@@ -3,6 +3,9 @@ from datetime import date, datetime
 from typing import Any
 
 from src.domain.model.meal import Meal, MealStatus
+from src.domain.services.meal_recommendation.ingredient_affinity_service import (
+    IngredientHistoryBucket,
+)
 
 
 class MealRepositoryPort(ABC):
@@ -108,6 +111,18 @@ class MealRepositoryPort(ABC):
         projection: Any = None,
     ) -> list[Meal]:
         """Find meals created within a local date range, inclusive."""
+        return []
+
+    async def aggregate_linked_ingredient_history(
+        self,
+        *,
+        user_id: str,
+        start_date: date,
+        end_date: date,
+        reference_date: date,
+        user_timezone: str | None = None,
+    ) -> list[IngredientHistoryBucket]:
+        """Return linked canonical ingredient usage buckets for recommendations."""
         return []
 
     @abstractmethod

--- a/src/domain/services/meal_recommendation/ingredient_affinity_service.py
+++ b/src/domain/services/meal_recommendation/ingredient_affinity_service.py
@@ -16,6 +16,15 @@ class IngredientHistoryEvent:
 
 
 @dataclass(frozen=True)
+class IngredientHistoryBucket:
+    """Aggregated canonical ingredient usage for one local age-day bucket."""
+
+    food_reference_id: int
+    age_days: int
+    capped_grams: float
+
+
+@dataclass(frozen=True)
 class IngredientAffinityProfile:
     """Normalized 90-day ingredient affinity weights."""
 
@@ -46,6 +55,38 @@ class IngredientAffinityService:
             value = min(event.grams, 500.0) / 100.0 * recency_weight
             weighted[event.food_reference_id] = (
                 weighted.get(event.food_reference_id, 0.0) + value
+            )
+            total += value
+
+        if total <= 0:
+            return IngredientAffinityProfile(weights={}, confidence=0.0)
+
+        normalized = {
+            food_reference_id: value / total
+            for food_reference_id, value in weighted.items()
+        }
+        confidence = min(1.0, total / 25.0)
+        return IngredientAffinityProfile(weights=normalized, confidence=confidence)
+
+    def build_profile_from_buckets(
+        self,
+        buckets: list[IngredientHistoryBucket],
+    ) -> IngredientAffinityProfile:
+        weighted: dict[int, float] = {}
+        total = 0.0
+
+        for bucket in buckets:
+            if (
+                bucket.food_reference_id <= 0
+                or bucket.capped_grams <= 0
+                or bucket.age_days < 0
+                or bucket.age_days > 90
+            ):
+                continue
+            recency_weight = max(0.1, 1.0 - (bucket.age_days / 90))
+            value = bucket.capped_grams / 100.0 * recency_weight
+            weighted[bucket.food_reference_id] = (
+                weighted.get(bucket.food_reference_id, 0.0) + value
             )
             total += value
 

--- a/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
+++ b/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
+    MealRecommendationAlternative,
     MealRecommendationInsufficiency,
     MealRecommendationInsufficiencyReason,
     MealRecommendationPlan,
@@ -17,6 +18,7 @@ from src.domain.services.meal_recommendation.ingredient_affinity_service import 
     IngredientAffinityProfile,
 )
 from src.domain.services.meal_recommendation.recipe_scoring_service import (
+    RecipeScore,
     RecipeScoringService,
 )
 from src.domain.services.meal_recommendation.slot_alternative_service import (
@@ -58,17 +60,24 @@ class ThreeDayPlanOptimizer:
             )
 
         allocations = self._allocation.allocate(daily_calories)
+        ranked_pools = {
+            meal_type: self._scoring.rank(
+                candidates,
+                meal_type=meal_type,
+                target_calories=allocations[meal_type],
+                affinity=affinity,
+            )
+            for meal_type in MEAL_TYPE_ORDER
+        }
         selected_ids: set[str] = set()
         slots: list[MealRecommendationSlot] = []
 
         for day_index in range(PLAN_DAYS):
             for meal_type in MEAL_TYPE_ORDER:
                 target_calories = allocations[meal_type]
-                ranked = self._rank_with_fallback(
-                    candidates,
-                    meal_type=meal_type,
+                ranked = self._rank_pool_with_fallback(
+                    ranked_pools[meal_type],
                     target_calories=target_calories,
-                    affinity=affinity,
                     selected_ids=selected_ids,
                 )
                 if not ranked:
@@ -92,14 +101,13 @@ class ThreeDayPlanOptimizer:
 
         alternatives = {}
         for slot in slots:
-            result = self._alternatives.select_alternatives(
-                candidates,
+            result = self._select_alternatives_from_pool(
+                ranked_pools[slot.meal_type],
                 day_index=slot.day_index,
                 meal_type=slot.meal_type,
                 target_calories=slot.target_calories,
                 selected_catalog_meal_id=slot.catalog_meal.id,
                 selected_catalog_meal_ids=selected_ids,
-                affinity=affinity,
             )
             if isinstance(result, MealRecommendationInsufficiency):
                 return result
@@ -143,6 +151,70 @@ class ThreeDayPlanOptimizer:
                 -item.score,
                 item.catalog_meal.id,
             ),
+        )
+
+    def _rank_pool_with_fallback(
+        self,
+        ranked_pool: list[RecipeScore],
+        *,
+        target_calories: int,
+        selected_ids: set[str],
+    ) -> list[RecipeScore]:
+        ranked = [
+            item
+            for item in ranked_pool
+            if item.catalog_meal.id not in selected_ids and item.catalog_meal.calories > 0
+        ]
+        for tolerance in (0.20, 0.30):
+            within_tolerance = [
+                item
+                for item in ranked
+                if abs(item.catalog_meal.calories - target_calories) / target_calories
+                <= tolerance
+            ]
+            if within_tolerance:
+                return within_tolerance
+        return sorted(
+            ranked,
+            key=lambda item: (
+                abs(item.catalog_meal.calories - target_calories),
+                -item.score,
+                item.catalog_meal.id,
+            ),
+        )
+
+    def _select_alternatives_from_pool(
+        self,
+        ranked_pool: list[RecipeScore],
+        *,
+        day_index: int,
+        meal_type: str,
+        target_calories: int,
+        selected_catalog_meal_id: str,
+        selected_catalog_meal_ids: set[str],
+        count: int = 5,
+    ) -> tuple[MealRecommendationAlternative, ...] | MealRecommendationInsufficiency:
+        excluded = set(selected_catalog_meal_ids)
+        excluded.add(selected_catalog_meal_id)
+        ranked = [
+            item for item in ranked_pool if item.catalog_meal.id not in excluded
+        ]
+        if len(ranked) < count:
+            return MealRecommendationInsufficiency(
+                reason=MealRecommendationInsufficiencyReason.NOT_ENOUGH_ALTERNATIVES,
+                message=f"not enough alternatives for {meal_type}",
+                required=count,
+                available=len(ranked),
+            )
+        return tuple(
+            MealRecommendationAlternative(
+                day_index=day_index,
+                meal_type=meal_type,
+                target_calories=target_calories,
+                catalog_meal=item.catalog_meal,
+                score=item.score,
+            )
+            for item in ranked[:count]
         )
 
 

--- a/src/infra/repositories/catalog_recipe_repository_async.py
+++ b/src/infra/repositories/catalog_recipe_repository_async.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import cast
 
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -15,6 +15,7 @@ from src.domain.model.meal_recommendation.catalog_recipe import (
 )
 from src.domain.ports.catalog_recipe_repository_port import (
     CatalogMealRepositoryPort,
+    CatalogMealRevision,
     CatalogMealSeedExisting,
     CatalogMealSeedWrite,
 )
@@ -65,6 +66,25 @@ class AsyncCatalogMealRepository(CatalogMealRepositoryPort):
 
         result = await self._session.execute(stmt)
         return [_meal_to_domain(row) for row in result.scalars().unique().all()]
+
+    async def get_active_catalog_revision(self) -> CatalogMealRevision:
+        result = await self._session.execute(
+            select(
+                func.count(func.distinct(MealCatalogORM.id)),
+                func.max(MealCatalogORM.updated_at),
+                func.max(FoodReferenceModel.updated_at),
+            )
+            .select_from(MealCatalogORM)
+            .outerjoin(MealCatalogIngredientORM)
+            .outerjoin(FoodReferenceModel)
+            .where(MealCatalogORM.is_active.is_(True))
+        )
+        active_count, catalog_updated_at, food_reference_updated_at = result.one()
+        return CatalogMealRevision(
+            active_count=int(active_count or 0),
+            catalog_updated_at=catalog_updated_at,
+            food_reference_updated_at=food_reference_updated_at,
+        )
 
     async def get_meal(self, catalog_meal_id: str) -> CatalogMeal | None:
         result = await self._session.execute(

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import cast
@@ -24,6 +25,7 @@ from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationCandidate,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
+    PersistedMealRecommendationSlotMutationResult,
 )
 from src.domain.ports.meal_recommendation_plan_repository_port import (
     MealRecommendationPlanRepositoryPort,
@@ -52,6 +54,30 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
     ) -> PersistedMealRecommendationPlan | None:
         rows = await self._load_batch(user_id=user_id, batch_id=plan_id)
         return _rows_to_plan(rows) if rows else None
+
+    async def get_summary(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+    ) -> PersistedMealRecommendationPlan | None:
+        rows = await self._load_selected_slots(user_id=user_id, batch_id=plan_id)
+        return _rows_to_summary(rows) if rows else None
+
+    async def get_slot_detail(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+        slot_id: str,
+    ) -> PersistedMealRecommendationSlot | None:
+        anchor = await self._load_anchor(user_id=user_id, batch_id=plan_id)
+        if anchor is None:
+            return None
+        rows = await self._load_slot(user_id=user_id, batch_id=plan_id, slot_id=slot_id)
+        if not rows:
+            return None
+        return _rows_to_slot_detail(anchor, rows)
 
     async def get_by_idempotency_key(
         self,
@@ -101,10 +127,7 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
                 await self._session.flush()
         except IntegrityError as exc:
             raise MealRecommendationPersistenceConflictError from exc
-        loaded_rows = await self._load_batch(user_id=plan.user_id, batch_id=plan.id)
-        if not loaded_rows:
-            raise MealRecommendationNotFoundError
-        return _rows_to_plan(loaded_rows)
+        return plan
 
     async def swap_slot(
         self,
@@ -116,7 +139,7 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         expected_version: int,
         alternative_catalog_meal_id: str | None,
         reason: str,
-    ) -> PersistedMealRecommendationPlan:
+    ) -> PersistedMealRecommendationSlotMutationResult:
         replay = await self._get_operation_replay(
             user_id=user_id, operation_type="swap", request_id=request_id
         )
@@ -130,12 +153,20 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         if replay is not None:
             if cast(str, replay.request_fingerprint) != fingerprint:
                 raise MealRecommendationIdempotencyConflictError
-            plan = await self.get_by_id(user_id=user_id, plan_id=plan_id)
-            if plan is None:
+            slot = await self.get_slot_detail(
+                user_id=user_id, plan_id=plan_id, slot_id=slot_id
+            )
+            if slot is None:
                 raise MealRecommendationNotFoundError
-            return plan
+            return PersistedMealRecommendationSlotMutationResult(
+                plan_id=plan_id,
+                user_id=user_id,
+                slot=slot,
+            )
 
-        rows = await self._load_batch_for_update(user_id=user_id, batch_id=plan_id)
+        anchor, rows = await self._load_slot_for_update(
+            user_id=user_id, batch_id=plan_id, slot_id=slot_id
+        )
         if not rows:
             raise MealRecommendationNotFoundError
         selected = _selected_row(rows, slot_id)
@@ -186,7 +217,11 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             )
         )
         await self._flush_operations()
-        return _rows_to_plan(rows)
+        return PersistedMealRecommendationSlotMutationResult(
+            plan_id=plan_id,
+            user_id=user_id,
+            slot=_rows_to_slot_detail(anchor, rows),
+        )
 
     async def claim_slot_log(
         self,
@@ -199,17 +234,34 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         replay = await self._get_operation_replay(
             user_id=user_id, operation_type="log", request_id=request_id
         )
-        rows = await self._load_batch_for_update(user_id=user_id, batch_id=plan_id)
+        anchor, rows = await self._load_slot_for_update(
+            user_id=user_id, batch_id=plan_id, slot_id=slot_id
+        )
         if not rows:
             raise MealRecommendationNotFoundError
-        plan = _rows_to_plan(rows)
-        slot = next(item for item in plan.slots if item.id == slot_id)
+        slot = _rows_to_slot_detail(anchor, rows)
+        plan = _plan_from_anchor_and_slot(anchor, slot)
         if replay is not None:
             if (
                 cast(str, replay.batch_id) != plan_id
                 or cast(str, replay.slot_id) != slot_id
             ):
                 raise MealRecommendationIdempotencyConflictError
+            logged_meal_id = cast(str | None, getattr(replay, "result_logged_meal_id", None))
+            if not logged_meal_id:
+                raise MealRecommendationIdempotencyConflictError
+            if (
+                cast(str | None, getattr(replay, "request_fingerprint", None))
+                != _operation_fingerprint(
+                    plan_id=plan_id,
+                    slot_id=slot_id,
+                    meal_id=logged_meal_id,
+                )
+            ):
+                raise MealRecommendationIdempotencyConflictError
+            if slot.logged_meal_id != logged_meal_id:
+                slot = replace(slot, logged_meal_id=logged_meal_id)
+                plan = _plan_from_anchor_and_slot(anchor, slot)
             return plan, slot, True
         selected = _selected_row(rows, slot_id)
         if selected.logged_meal_id:
@@ -224,14 +276,20 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         slot_id: str,
         request_id: str,
         meal_id: str,
-    ) -> PersistedMealRecommendationPlan:
-        rows = await self._load_batch_for_update(user_id=user_id, batch_id=plan_id)
+    ) -> PersistedMealRecommendationSlotMutationResult:
+        anchor, rows = await self._load_slot_for_update(
+            user_id=user_id, batch_id=plan_id, slot_id=slot_id
+        )
         if not rows:
             raise MealRecommendationNotFoundError
         selected = _selected_row(rows, slot_id)
         if selected.logged_meal_id:
             if cast(str | None, selected.logged_meal_id) == meal_id:
-                return _rows_to_plan(rows)
+                return PersistedMealRecommendationSlotMutationResult(
+                    plan_id=plan_id,
+                    user_id=user_id,
+                    slot=_rows_to_slot_detail(anchor, rows),
+                )
             raise MealRecommendationAlreadyLoggedError
         now = datetime.now(UTC)
         selected.logged_meal_id = meal_id  # type: ignore[assignment]
@@ -252,7 +310,11 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             )
         )
         await self._flush_operations()
-        return _rows_to_plan(rows)
+        return PersistedMealRecommendationSlotMutationResult(
+            plan_id=plan_id,
+            user_id=user_id,
+            slot=_rows_to_slot_detail(anchor, rows),
+        )
 
     async def _load_batch(
         self, *, user_id: str, batch_id: str
@@ -274,6 +336,53 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             return []
         return rows
 
+    async def _load_selected_slots(
+        self, *, user_id: str, batch_id: str
+    ) -> list[MealRecommendationORM]:
+        stmt = (
+            select(MealRecommendationORM)
+            .where(MealRecommendationORM.batch_id == batch_id)
+            .where(MealRecommendationORM.is_selected.is_(True))
+            .options(_recommendation_catalog_meal_load_options())
+            .order_by(
+                MealRecommendationORM.recommendation_date,
+                MealRecommendationORM.meal_type,
+                MealRecommendationORM.candidate_rank,
+            )
+        )
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().unique().all())
+        anchor = _anchor_row(rows)
+        if anchor is None or cast(str | None, anchor.user_id) != user_id:
+            return []
+        return rows
+
+    async def _load_anchor(
+        self, *, user_id: str, batch_id: str
+    ) -> MealRecommendationORM | None:
+        result = await self._session.execute(
+            select(MealRecommendationORM)
+            .where(MealRecommendationORM.id == batch_id)
+            .where(MealRecommendationORM.batch_id == batch_id)
+            .where(MealRecommendationORM.user_id == user_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def _load_slot(
+        self, *, user_id: str, batch_id: str, slot_id: str
+    ) -> list[MealRecommendationORM]:
+        if await self._load_anchor(user_id=user_id, batch_id=batch_id) is None:
+            return []
+        stmt = (
+            select(MealRecommendationORM)
+            .where(MealRecommendationORM.batch_id == batch_id)
+            .where(MealRecommendationORM.slot_id == slot_id)
+            .options(_recommendation_catalog_meal_load_options())
+            .order_by(MealRecommendationORM.candidate_rank)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().unique().all())
+
     async def _load_batch_for_update(
         self, *, user_id: str, batch_id: str
     ) -> list[MealRecommendationORM]:
@@ -294,6 +403,23 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         if anchor is None or cast(str | None, anchor.user_id) != user_id:
             return []
         return rows
+
+    async def _load_slot_for_update(
+        self, *, user_id: str, batch_id: str, slot_id: str
+    ) -> tuple[MealRecommendationORM, list[MealRecommendationORM]]:
+        anchor = await self._load_anchor(user_id=user_id, batch_id=batch_id)
+        if anchor is None:
+            raise MealRecommendationNotFoundError
+        stmt = (
+            select(MealRecommendationORM)
+            .where(MealRecommendationORM.batch_id == batch_id)
+            .where(MealRecommendationORM.slot_id == slot_id)
+            .options(_recommendation_catalog_meal_load_options())
+            .order_by(MealRecommendationORM.candidate_rank)
+            .with_for_update()
+        )
+        result = await self._session.execute(stmt)
+        return anchor, list(result.scalars().unique().all())
 
     async def _get_operation_replay(
         self, *, user_id: str, operation_type: str, request_id: str
@@ -419,6 +545,107 @@ def _rows_to_plan(rows: list[MealRecommendationORM]) -> PersistedMealRecommendat
         request_fingerprint=cast(str, anchor.request_fingerprint),
         created_at=cast(datetime | None, anchor.created_at),
         slots=tuple(slots),
+    )
+
+
+def _rows_to_summary(rows: list[MealRecommendationORM]) -> PersistedMealRecommendationPlan:
+    anchor = _anchor_row(rows)
+    if anchor is None:
+        raise MealRecommendationNotFoundError
+    selected_rows = sorted(
+        (row for row in rows if cast(bool, row.is_selected)),
+        key=lambda item: (
+            cast(date, item.recommendation_date),
+            cast(str, item.meal_type),
+            cast(int, item.candidate_rank),
+        ),
+    )
+    slots = []
+    for position, row in enumerate(selected_rows):
+        selected_candidate = _candidate_to_domain(row)
+        slots.append(
+            PersistedMealRecommendationSlot(
+                id=cast(str, row.slot_id),
+                slot_date=cast(date, row.recommendation_date),
+                day_index=(
+                    cast(date, row.recommendation_date) - cast(date, anchor.start_date)
+                ).days,
+                meal_type=cast(str, row.meal_type),
+                catalog_meal_id=cast(str, row.catalog_meal_id),
+                target_calories=cast(int, anchor.target_calories),
+                score=float(row.score),
+                position=position,
+                selection_version=cast(int, row.selection_version),
+                logged_meal_id=cast(str | None, row.logged_meal_id),
+                selected=selected_candidate,
+                alternatives=(),
+            )
+        )
+    return PersistedMealRecommendationPlan(
+        id=cast(str, anchor.id),
+        user_id=cast(str, anchor.user_id),
+        status=cast(str, anchor.status),
+        timezone=cast(str, anchor.timezone),
+        start_date=cast(date, anchor.start_date),
+        daily_calories=cast(int, anchor.target_calories),
+        algorithm_version=cast(str, anchor.algorithm_version),
+        operation=cast(str, anchor.operation),
+        idempotency_key=cast(str, anchor.idempotency_key),
+        request_fingerprint=cast(str, anchor.request_fingerprint),
+        created_at=cast(datetime | None, anchor.created_at),
+        slots=tuple(slots),
+    )
+
+
+def _rows_to_slot_detail(
+    anchor: MealRecommendationORM,
+    rows: list[MealRecommendationORM],
+) -> PersistedMealRecommendationSlot:
+    ordered = sorted(rows, key=lambda item: cast(int, item.candidate_rank))
+    selected = next((row for row in ordered if cast(bool, row.is_selected)), None)
+    if selected is None:
+        raise MealRecommendationNotFoundError
+    selected_candidate = _candidate_to_domain(selected)
+    alternatives = tuple(
+        _candidate_to_domain(row)
+        for row in ordered
+        if cast(str, row.id) != selected_candidate.id
+    )
+    return PersistedMealRecommendationSlot(
+        id=cast(str, selected.slot_id),
+        slot_date=cast(date, selected.recommendation_date),
+        day_index=(
+            cast(date, selected.recommendation_date) - cast(date, anchor.start_date)
+        ).days,
+        meal_type=cast(str, selected.meal_type),
+        catalog_meal_id=cast(str, selected.catalog_meal_id),
+        target_calories=cast(int, anchor.target_calories),
+        score=float(selected.score),
+        position=0,
+        selection_version=cast(int, selected.selection_version),
+        logged_meal_id=cast(str | None, selected.logged_meal_id),
+        selected=selected_candidate,
+        alternatives=alternatives,
+    )
+
+
+def _plan_from_anchor_and_slot(
+    anchor: MealRecommendationORM,
+    slot: PersistedMealRecommendationSlot,
+) -> PersistedMealRecommendationPlan:
+    return PersistedMealRecommendationPlan(
+        id=cast(str, anchor.id),
+        user_id=cast(str, anchor.user_id),
+        status=cast(str, anchor.status),
+        timezone=cast(str, anchor.timezone),
+        start_date=cast(date, anchor.start_date),
+        daily_calories=cast(int, anchor.target_calories),
+        algorithm_version=cast(str, anchor.algorithm_version),
+        operation=cast(str, anchor.operation),
+        idempotency_key=cast(str, anchor.idempotency_key),
+        request_fingerprint=cast(str, anchor.request_fingerprint),
+        created_at=cast(datetime | None, anchor.created_at),
+        slots=(slot,),
     )
 
 

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -11,6 +11,9 @@ from src.domain.model.meal import Meal, MealStatus
 from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition import Nutrition
 from src.domain.ports.meal_repository_port import MealRepositoryPort
+from src.domain.services.meal_recommendation.ingredient_affinity_service import (
+    IngredientHistoryBucket,
+)
 from src.domain.utils.timezone_utils import get_zone_info, utc_now
 from src.infra.database.models.enums import MealStatusEnum
 from src.infra.database.models.meal.food_item_translation_model import (
@@ -403,6 +406,62 @@ class AsyncMealRepository(MealRepositoryPort):
             .limit(limit)
         )
         return _map_domain_hydratable_meals(result.unique().scalars().all())
+
+    async def aggregate_linked_ingredient_history(
+        self,
+        *,
+        user_id: str,
+        start_date: date,
+        end_date: date,
+        reference_date: date,
+        user_timezone: str | None = None,
+    ) -> list[IngredientHistoryBucket]:
+        tz = get_zone_info(user_timezone) if user_timezone else UTC
+        start_dt = datetime.combine(
+            start_date, datetime.min.time(), tzinfo=tz
+        ).astimezone(UTC)
+        end_dt = (
+            datetime.combine(end_date, datetime.min.time(), tzinfo=tz)
+            + timedelta(days=1)
+        ).astimezone(UTC)
+        occurred_at = func.coalesce(MealORM.ready_at, MealORM.created_at)
+        if user_timezone and user_timezone != "UTC":
+            local_date_expr = func.date(func.timezone(user_timezone, occurred_at))
+        else:
+            local_date_expr = func.date(occurred_at)
+        capped_quantity = func.least(FoodItemORM.quantity, 500.0)
+
+        result = await self.session.execute(
+            select(
+                FoodItemORM.food_reference_id,
+                local_date_expr,
+                func.coalesce(func.sum(capped_quantity), 0),
+            )
+            .select_from(MealORM)
+            .join(NutritionORM, NutritionORM.meal_id == MealORM.meal_id)
+            .join(FoodItemORM, FoodItemORM.nutrition_id == NutritionORM.id)
+            .where(
+                MealORM.user_id == user_id,
+                occurred_at >= start_dt,
+                occurred_at < end_dt,
+                FoodItemORM.food_reference_id.is_not(None),
+                FoodItemORM.is_deleted.is_(False),
+                _domain_hydratable_active_meal_filter(),
+            )
+            .group_by(FoodItemORM.food_reference_id, local_date_expr)
+        )
+        buckets: list[IngredientHistoryBucket] = []
+        for food_reference_id, local_date, capped_grams in result.all():
+            if isinstance(local_date, str):
+                local_date = date.fromisoformat(local_date)
+            buckets.append(
+                IngredientHistoryBucket(
+                    food_reference_id=int(food_reference_id),
+                    age_days=max((reference_date - local_date).days, 0),
+                    capped_grams=float(capped_grams or 0),
+                )
+            )
+        return buckets
 
     async def get_daily_meal_counts(
         self,

--- a/tests/unit/api/test_meal_recommendation_http_contract.py
+++ b/tests/unit/api/test_meal_recommendation_http_contract.py
@@ -1,0 +1,226 @@
+import asyncio
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from starlette.requests import Request
+
+from src.api.routes.v1.meal_recommendation_route_support import to_response
+from src.api.routes.v1.meal_recommendations import create_three_day_recommendations
+from src.api.schemas.response.meal_recommendation_responses import (
+    MealRecommendationPlanResponse,
+    MealRecommendationPlanSummaryResponse,
+)
+from src.app.commands.meal_recommendation import CreateThreeDayMealRecommendationCommand
+from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
+from src.app.queries.user import GetUserTimezoneQuery
+from src.domain.model.meal_recommendation import (
+    CatalogMeal,
+    CatalogMealIngredient,
+    PersistedMealRecommendationCandidate,
+    PersistedMealRecommendationPlan,
+    PersistedMealRecommendationSlot,
+)
+
+
+class _EventBus:
+    def __init__(self, plan: PersistedMealRecommendationPlan):
+        self.plan = plan
+        self.commands = []
+
+    async def send(self, message):
+        self.commands.append(message)
+        if isinstance(message, GetUserTimezoneQuery):
+            return "Asia/Ho_Chi_Minh"
+        if isinstance(message, GetWeeklyBudgetQuery):
+            return {"adjusted_daily_calories": 2000}
+        if isinstance(message, CreateThreeDayMealRecommendationCommand):
+            return self.plan
+        raise AssertionError(f"unexpected message {message!r}")
+
+
+class _BlockingAnalytics:
+    def __init__(self):
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.events = []
+
+    async def capture_plan_response(self, *, user_id, event, plan):
+        self.events.append((user_id, event, plan.id))
+        self.started.set()
+        await self.release.wait()
+
+
+def test_current_response_contract_is_full_plan_with_hydrated_candidates():
+    response = to_response(_full_plan())
+    payload = response.model_dump(mode="json")
+
+    assert response.id == "plan-baseline"
+    assert response.allergy_evaluated is False
+    assert len(response.slots) == 9
+    assert sum(len(slot.alternatives) for slot in response.slots) == 45
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "Rice"
+    assert response.slots[0].alternatives[0].catalog_meal.ingredients[0].unit == "g"
+    assert _json_size(response) == 28206
+    assert "alternatives" in payload["slots"][0]
+    assert "ingredients" in payload["slots"][0]["catalog_meal"]
+
+
+def test_current_openapi_schema_exposes_full_plan_fields():
+    schema = MealRecommendationPlanResponse.model_json_schema()
+    definitions = schema["$defs"]
+
+    slot_fields = definitions["MealRecommendationSlotResponse"]["properties"]
+    meal_fields = definitions["MealRecommendationCatalogMealResponse"]["properties"]
+
+    assert "alternatives" in slot_fields
+    assert "catalog_meal" in slot_fields
+    assert "ingredients" in meal_fields
+    assert "macros" in meal_fields
+
+
+def test_summary_openapi_schema_omits_full_plan_fields():
+    schema = MealRecommendationPlanSummaryResponse.model_json_schema()
+    definitions = schema["$defs"]
+
+    slot_fields = definitions["MealRecommendationSlotSummaryResponse"]["properties"]
+    meal_fields = definitions["MealRecommendationCatalogMealSummaryResponse"]["properties"]
+
+    assert "alternatives" not in slot_fields
+    assert "score" not in slot_fields
+    assert "ingredients" not in meal_fields
+    assert "description" not in meal_fields
+    assert "macros" in meal_fields
+
+
+@pytest.mark.asyncio
+async def test_create_route_waits_for_analytics_capture_before_returning():
+    analytics = _BlockingAnalytics()
+    task = asyncio.create_task(
+        create_three_day_recommendations(
+            request=_request(),
+            idempotency_key="key-1",
+            user_id="user-1",
+            event_bus=_EventBus(_full_plan()),
+            analytics_service=analytics,
+        )
+    )
+
+    await asyncio.wait_for(analytics.started.wait(), timeout=1)
+    assert not task.done()
+
+    analytics.release.set()
+    response = await task
+
+    assert response.id == "plan-baseline"
+    assert analytics.events == [
+        ("user-1", "plan_shown", "plan-baseline"),
+        ("user-1", "alternatives_shown", "plan-baseline"),
+    ]
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/meal-recommendations/three-day",
+            "client": ("127.0.0.1", 12345),
+            "headers": [(b"x-timezone", b"Asia/Ho_Chi_Minh")],
+        }
+    )
+
+
+def _json_size(response: MealRecommendationPlanResponse) -> int:
+    return len(response.model_dump_json().encode("utf-8"))
+
+
+def _full_plan() -> PersistedMealRecommendationPlan:
+    slots = []
+    for day_index in range(3):
+        for position, meal_type in enumerate(("breakfast", "lunch", "dinner")):
+            slot_number = day_index * 3 + position
+            slot_id = f"slot-{slot_number}"
+            selected_meal = _catalog_meal(f"{meal_type}-selected-{day_index}", meal_type)
+            selected = PersistedMealRecommendationCandidate(
+                id="plan-baseline" if slot_number == 0 else f"selected-{slot_number}",
+                slot_id=slot_id,
+                recommendation_date=date(2026, 7, 20 + day_index),
+                meal_type=meal_type,
+                catalog_meal_id=selected_meal.id,
+                candidate_rank=0,
+                is_selected=True,
+                score=Decimal("0.82"),
+                selection_version=1,
+                catalog_meal=selected_meal,
+            )
+            alternatives = tuple(
+                PersistedMealRecommendationCandidate(
+                    id=f"alternative-{slot_number}-{rank}",
+                    slot_id=slot_id,
+                    recommendation_date=date(2026, 7, 20 + day_index),
+                    meal_type=meal_type,
+                    catalog_meal_id=f"{meal_type}-alternative-{day_index}-{rank}",
+                    candidate_rank=rank,
+                    is_selected=False,
+                    score=Decimal(f"0.8{rank}"),
+                    selection_version=1,
+                    catalog_meal=_catalog_meal(
+                        f"{meal_type}-alternative-{day_index}-{rank}", meal_type
+                    ),
+                )
+                for rank in range(1, 6)
+            )
+            slots.append(
+                PersistedMealRecommendationSlot(
+                    id=slot_id,
+                    slot_date=date(2026, 7, 20 + day_index),
+                    day_index=day_index,
+                    meal_type=meal_type,
+                    catalog_meal_id=selected_meal.id,
+                    target_calories=500 if meal_type == "breakfast" else 750,
+                    score=0.82,
+                    position=slot_number,
+                    selected=selected,
+                    alternatives=alternatives,
+                )
+            )
+    return PersistedMealRecommendationPlan(
+        id="plan-baseline",
+        user_id="user-1",
+        status="active",
+        timezone="Asia/Ho_Chi_Minh",
+        start_date=date(2026, 7, 20),
+        daily_calories=2000,
+        algorithm_version="catalog_deterministic_v1",
+        operation="three_day",
+        idempotency_key="key-1",
+        request_fingerprint="f" * 64,
+        slots=tuple(slots),
+    )
+
+
+def _catalog_meal(catalog_meal_id: str, meal_type: str) -> CatalogMeal:
+    return CatalogMeal(
+        id=catalog_meal_id,
+        catalog_key=f"key-{catalog_meal_id}",
+        content_hash=f"{catalog_meal_id:0<64}"[:64],
+        name=f"{meal_type.title()} Meal {catalog_meal_id}",
+        cuisine="vietnamese",
+        description="Baseline full response description",
+        image_url="https://example.com/meal.jpg",
+        protein_g=Decimal("25"),
+        carbs_g=Decimal("50"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("5"),
+        sugar_g=Decimal("4"),
+        meal_types=(meal_type,),
+        ingredients=(
+            CatalogMealIngredient(
+                food_reference_id=7,
+                display_name="Rice",
+                quantity=Decimal("100"),
+                unit="g",
+            ),
+        ),
+    )

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -11,6 +11,8 @@ from src.api.routes.v1.meal_recommendations import (
     LogRecommendedMealRequest,
     SwapMealRecommendationSlotRequest,
     create_three_day_recommendations,
+    get_meal_recommendation_plan,
+    get_meal_recommendation_slot_detail,
     log_recommended_meal,
     swap_meal_recommendation_slot,
 )
@@ -20,7 +22,14 @@ from src.app.commands.meal_recommendation import (
     SwapMealRecommendationSlotCommand,
 )
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
+from src.app.queries.meal_recommendation import (
+    GetMealRecommendationPlanQuery,
+    GetMealRecommendationSlotDetailQuery,
+)
 from src.app.queries.user import GetUserTimezoneQuery
+from src.domain.model.meal_recommendation import (
+    PersistedMealRecommendationSlotMutationResult,
+)
 
 
 class _EventBus:
@@ -33,6 +42,16 @@ class _EventBus:
             return "Asia/Ho_Chi_Minh"
         if isinstance(message, GetWeeklyBudgetQuery):
             return {"adjusted_daily_calories": 2150}
+        if isinstance(message, GetMealRecommendationPlanQuery):
+            return _plan()
+        if isinstance(message, GetMealRecommendationSlotDetailQuery):
+            return _plan().slots[0]
+        if isinstance(message, (SwapMealRecommendationSlotCommand, LogRecommendedMealCommand)):
+            return PersistedMealRecommendationSlotMutationResult(
+                plan_id="plan-1",
+                user_id="user-1",
+                slot=_plan().slots[0],
+            )
         return _plan()
 
 
@@ -42,6 +61,18 @@ class _Analytics:
 
     async def capture_plan_response(self, *, user_id, event, plan):
         self.events.append((user_id, event, plan.id))
+
+    async def capture_slot_response(self, *, user_id, event, plan_id):
+        self.events.append((user_id, event, plan_id))
+
+
+class _TaskManager:
+    def __init__(self):
+        self.tasks = []
+
+    def spawn(self, name, coro):
+        self.tasks.append((name, coro))
+        coro.close()
 
 
 def _request(timezone: str = "Asia/Ho_Chi_Minh") -> Request:
@@ -115,6 +146,8 @@ async def test_create_three_day_recommendations_snapshots_target_and_timezone():
         if isinstance(item, CreateThreeDayMealRecommendationCommand)
     )
     assert response.id == "plan-1"
+    assert not hasattr(response.slots[0], "alternatives")
+    assert not hasattr(response.slots[0].catalog_meal, "ingredients")
     assert command.idempotency_key == "key-1"
     assert command.timezone == "Asia/Ho_Chi_Minh"
     assert command.daily_calories == 2150
@@ -125,10 +158,62 @@ async def test_create_three_day_recommendations_snapshots_target_and_timezone():
 
 
 @pytest.mark.asyncio
+async def test_create_three_day_recommendations_enqueues_analytics_when_task_manager_exists():
+    event_bus = _EventBus()
+    analytics = _Analytics()
+    task_manager = _TaskManager()
+
+    response = await create_three_day_recommendations(
+        request=_request(),
+        idempotency_key="key-1",
+        user_id="user-1",
+        event_bus=event_bus,
+        analytics_service=analytics,
+        task_manager=task_manager,
+    )
+
+    assert response.id == "plan-1"
+    assert analytics.events == []
+    assert [name for name, _ in task_manager.tasks] == ["meal_recommendation_analytics"]
+
+
+@pytest.mark.asyncio
+async def test_get_plan_returns_owner_scoped_compact_summary():
+    response = await get_meal_recommendation_plan(
+        plan_id="plan-1",
+        user_id="user-1",
+        event_bus=_EventBus(),
+        analytics_service=_Analytics(),
+    )
+
+    assert response.id == "plan-1"
+    assert response.slots[0].catalog_meal.name == "Breakfast Rice"
+    assert response.slots[0].catalog_meal.calories == 380
+    assert not hasattr(response.slots[0], "alternatives")
+    assert not hasattr(response.slots[0].catalog_meal, "ingredients")
+
+
+@pytest.mark.asyncio
+async def test_get_slot_detail_returns_one_hydrated_slot_with_alternatives():
+    response = await get_meal_recommendation_slot_detail(
+        plan_id="plan-1",
+        slot_id="slot-1",
+        user_id="user-1",
+        event_bus=_EventBus(),
+        analytics_service=_Analytics(),
+    )
+
+    assert response.plan_id == "plan-1"
+    assert response.slot.id == "slot-1"
+    assert response.slot.catalog_meal.ingredients[0].display_name == "Rice"
+    assert response.slot.alternatives[0].catalog_meal.name == "Chicken Bowl"
+
+
+@pytest.mark.asyncio
 async def test_swap_route_sends_expected_selection_version_command():
     event_bus = _EventBus()
 
-    await swap_meal_recommendation_slot(
+    response = await swap_meal_recommendation_slot(
         plan_id="plan-1",
         slot_id="slot-1",
         body=SwapMealRecommendationSlotRequest(
@@ -148,13 +233,15 @@ async def test_swap_route_sends_expected_selection_version_command():
     )
     assert command.expected_selection_version == 1
     assert command.alternative_catalog_meal_id == "selection_version-2"
+    assert response.plan_id == "plan-1"
+    assert response.slot.id == "slot-1"
 
 
 @pytest.mark.asyncio
 async def test_log_route_sends_recommended_meal_command():
     event_bus = _EventBus()
 
-    await log_recommended_meal(
+    response = await log_recommended_meal(
         plan_id="plan-1",
         slot_id="slot-1",
         body=LogRecommendedMealRequest(request_id="log-1"),
@@ -167,3 +254,5 @@ async def test_log_route_sends_recommended_meal_command():
         item for item in event_bus.commands if isinstance(item, LogRecommendedMealCommand)
     )
     assert command.request_id == "log-1"
+    assert response.plan_id == "plan-1"
+    assert response.slot.id == "slot-1"

--- a/tests/unit/app/handlers/test_meal_recommendation_handlers.py
+++ b/tests/unit/app/handlers/test_meal_recommendation_handlers.py
@@ -31,6 +31,7 @@ from src.domain.model.meal_recommendation import (
     MealRecommendationAlternative,
     MealRecommendationPlan,
     MealRecommendationSlot,
+    PersistedMealRecommendationSlotMutationResult,
 )
 from src.domain.services.meal_recommendation.ingredient_affinity_service import (
     IngredientAffinityProfile,
@@ -43,6 +44,7 @@ class _PlanRepo:
         self.lock_generation_for_user = AsyncMock()
         self.get_by_idempotency_key = AsyncMock(side_effect=self._get_by_key)
         self.get_by_id = AsyncMock(return_value=_plan())
+        self.get_summary = AsyncMock(return_value=_plan())
         self.save_new_active_plan = AsyncMock(side_effect=lambda plan: plan)
 
     async def _get_by_key(self, **kwargs):
@@ -75,7 +77,13 @@ class _LogPlanRepo(_PlanRepo):
     def __init__(self, *, replayed=False):
         super().__init__()
         self.claim_slot_log = AsyncMock(return_value=(_plan(), _plan().slots[0], replayed))
-        self.finalize_slot_logged = AsyncMock(return_value=_plan())
+        self.finalize_slot_logged = AsyncMock(
+            return_value=PersistedMealRecommendationSlotMutationResult(
+                plan_id="plan-1",
+                user_id="user-1",
+                slot=_plan().slots[0],
+            )
+        )
 
 
 class _Materializer:
@@ -244,7 +252,7 @@ async def test_query_handler_reads_owner_scoped_plan():
 
     assert result is not None
     assert result.id == "plan-1"
-    plans.get_by_id.assert_awaited_once_with(user_id="user-1", plan_id="plan-1")
+    plans.get_summary.assert_awaited_once_with(user_id="user-1", plan_id="plan-1")
 
 
 @pytest.mark.asyncio
@@ -258,7 +266,7 @@ async def test_log_handler_replays_without_materializing_duplicate_meal():
 
     result = await handler.handle(_log_command())
 
-    assert result.id == "plan-1"
+    assert result.plan_id == "plan-1"
     plans.claim_slot_log.assert_awaited_once()
     materializer.materialize.assert_not_awaited()
     plans.finalize_slot_logged.assert_not_awaited()
@@ -275,7 +283,7 @@ async def test_log_handler_claims_materializes_then_finalizes():
 
     result = await handler.handle(_log_command())
 
-    assert result.id == "plan-1"
+    assert result.plan_id == "plan-1"
     plans.claim_slot_log.assert_awaited_once()
     materializer.materialize.assert_awaited_once()
     plans.finalize_slot_logged.assert_awaited_once_with(

--- a/tests/unit/app/services/test_catalog_meal_snapshot_service.py
+++ b/tests/unit/app/services/test_catalog_meal_snapshot_service.py
@@ -1,0 +1,121 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshotService
+from src.domain.exceptions.meal_recommendation_exceptions import (
+    MealRecommendationCatalogUnavailableError,
+)
+from src.domain.model.meal_recommendation import CatalogMeal
+from src.domain.ports.catalog_recipe_repository_port import CatalogMealRevision
+
+
+class _Clock:
+    def __init__(self):
+        self.value = 100.0
+
+    def __call__(self):
+        return self.value
+
+
+class _CatalogRepo:
+    def __init__(self, *, meals=None, revision=None):
+        self.meals = meals or [_meal("meal-1")]
+        self.revision = revision or _revision(1)
+        self.revision_calls = 0
+        self.load_calls = 0
+
+    async def get_active_catalog_revision(self):
+        self.revision_calls += 1
+        return self.revision
+
+    async def list_active_meals(self):
+        self.load_calls += 1
+        if isinstance(self.meals, Exception):
+            raise self.meals
+        return self.meals
+
+
+class _Uow:
+    def __init__(self, catalog):
+        self.catalog_recipes = catalog
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cold_loads_once_and_warm_reuses_without_catalog_sql():
+    clock = _Clock()
+    catalog = _CatalogRepo()
+    service = CatalogMealSnapshotService(clock=clock)
+
+    first = await service.get_snapshot(_Uow(catalog))
+    second = await service.get_snapshot(_Uow(catalog))
+
+    assert first is second
+    assert catalog.load_calls == 1
+    assert catalog.revision_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_snapshot_refreshes_when_revision_changes_after_ttl():
+    clock = _Clock()
+    catalog = _CatalogRepo()
+    service = CatalogMealSnapshotService(ttl_seconds=10, clock=clock)
+
+    first = await service.get_snapshot(_Uow(catalog))
+    clock.value += 11
+    catalog.revision = _revision(2)
+    second = await service.get_snapshot(_Uow(catalog))
+
+    assert first is not second
+    assert second.revision == _revision(2)
+    assert catalog.load_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_snapshot_extends_ttl_when_revision_is_unchanged():
+    clock = _Clock()
+    catalog = _CatalogRepo()
+    service = CatalogMealSnapshotService(ttl_seconds=10, clock=clock)
+
+    first = await service.get_snapshot(_Uow(catalog))
+    clock.value += 11
+    second = await service.get_snapshot(_Uow(catalog))
+
+    assert second.meals == first.meals
+    assert second.expires_at > first.expires_at
+    assert catalog.load_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cold_failure_fails_closed():
+    catalog = _CatalogRepo(meals=MealRecommendationCatalogUnavailableError())
+    service = CatalogMealSnapshotService(clock=_Clock())
+
+    with pytest.raises(MealRecommendationCatalogUnavailableError):
+        await service.get_snapshot(_Uow(catalog))
+
+
+def _revision(value: int) -> CatalogMealRevision:
+    return CatalogMealRevision(
+        active_count=value,
+        catalog_updated_at=datetime(2026, 7, value, tzinfo=UTC),
+        food_reference_updated_at=datetime(2026, 7, value, tzinfo=UTC),
+    )
+
+
+def _meal(meal_id: str) -> CatalogMeal:
+    return CatalogMeal(
+        id=meal_id,
+        catalog_key=f"key-{meal_id}",
+        content_hash=f"{meal_id:0<64}"[:64],
+        name=f"Meal {meal_id}",
+        cuisine="vietnamese",
+        description=None,
+        image_url=None,
+        protein_g=Decimal("20"),
+        carbs_g=Decimal("40"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("5"),
+        meal_types=("breakfast",),
+    )

--- a/tests/unit/app/services/test_meal_recommendation_history_projector.py
+++ b/tests/unit/app/services/test_meal_recommendation_history_projector.py
@@ -1,57 +1,41 @@
 from datetime import UTC, datetime
-from uuid import uuid4
 
 import pytest
 
 from src.app.services.meal_recommendation_history_projector import (
     MealRecommendationHistoryProjector,
 )
-from src.domain.model.meal import Meal, MealStatus
-from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+from src.domain.services.meal_recommendation.ingredient_affinity_service import (
+    IngredientHistoryBucket,
+)
 
 
 class _MealRepo:
-    def __init__(self, meals):
-        self.meals = meals
+    def __init__(self, buckets):
+        self.buckets = buckets
         self.call = None
 
-    async def find_by_date_range(self, **kwargs):
+    async def aggregate_linked_ingredient_history(self, **kwargs):
         self.call = kwargs
-        return self.meals
+        return self.buckets
+
+    async def find_by_date_range(self, **kwargs):
+        raise AssertionError("history projector must use aggregate history")
 
 
 class _Uow:
-    def __init__(self, meals):
-        self.meals = _MealRepo(meals)
-
-
-def _meal(food_reference_id: int | None) -> Meal:
-    return Meal(
-        meal_id=str(uuid4()),
-        user_id=str(uuid4()),
-        status=MealStatus.READY,
-        created_at=datetime(2026, 7, 10, tzinfo=UTC),
-        ready_at=datetime(2026, 7, 10, tzinfo=UTC),
-        image=None,
-        nutrition=Nutrition(
-            macros=Macros(protein=20, carbs=30, fat=10),
-            food_items=[
-                FoodItem(
-                    id=str(uuid4()),
-                    name="Ingredient",
-                    quantity=120,
-                    unit="g",
-                    macros=Macros(protein=10, carbs=10, fat=5),
-                    food_reference_id=food_reference_id,
-                )
-            ],
-        ),
-    )
+    def __init__(self, buckets):
+        self.meals = _MealRepo(buckets)
 
 
 @pytest.mark.asyncio
-async def test_history_projector_uses_recent_linked_food_reference_events():
-    uow = _Uow([_meal(11), _meal(None)])
+async def test_history_projector_uses_aggregate_linked_food_reference_buckets():
+    uow = _Uow(
+        [
+            IngredientHistoryBucket(food_reference_id=11, age_days=1, capped_grams=120),
+            IngredientHistoryBucket(food_reference_id=0, age_days=1, capped_grams=120),
+        ]
+    )
 
     profile = await MealRecommendationHistoryProjector().build_affinity(
         uow,
@@ -62,4 +46,10 @@ async def test_history_projector_uses_recent_linked_food_reference_events():
 
     assert set(profile.weights) == {11}
     assert profile.confidence > 0
-    assert uow.meals.call["limit"] == 5000
+    assert uow.meals.call == {
+        "user_id": "user-1",
+        "start_date": datetime(2026, 4, 17, tzinfo=UTC).date(),
+        "end_date": datetime(2026, 7, 15, tzinfo=UTC).date(),
+        "user_timezone": "UTC",
+        "reference_date": datetime(2026, 7, 16, tzinfo=UTC).date(),
+    }

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -12,6 +12,7 @@ from src.domain.exceptions.meal_recommendation_exceptions import (
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
     CatalogMealIngredient,
+    PersistedMealRecommendationCandidate,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
@@ -76,6 +77,28 @@ def _plan_and_slot():
         idempotency_key="key",
         request_fingerprint="f" * 64,
     )
+    catalog_meal = CatalogMeal(
+        id="catalog-1",
+        catalog_key="catalog-key",
+        content_hash="a" * 64,
+        name="Catalog Recipe",
+        cuisine="vietnamese",
+        description=None,
+        image_url=None,
+        protein_g=Decimal("30"),
+        carbs_g=Decimal("50"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("5"),
+        meal_types=("breakfast",),
+        ingredients=(
+            CatalogMealIngredient(
+                food_reference_id=123,
+                display_name="Ingredient",
+                quantity=Decimal("100"),
+                unit="g",
+            ),
+        ),
+    )
     slot = PersistedMealRecommendationSlot(
         id="slot-1",
         slot_date=date(2026, 7, 16),
@@ -85,6 +108,18 @@ def _plan_and_slot():
         target_calories=500,
         score=1.0,
         position=0,
+        selected=PersistedMealRecommendationCandidate(
+            id="candidate-1",
+            slot_id="slot-1",
+            recommendation_date=date(2026, 7, 16),
+            meal_type="breakfast",
+            catalog_meal_id="catalog-1",
+            candidate_rank=0,
+            is_selected=True,
+            score=Decimal("1.0"),
+            selection_version=1,
+            catalog_meal=catalog_meal,
+        ),
     )
     return plan, slot
 
@@ -103,15 +138,19 @@ async def test_materializer_preserves_food_reference_ids_and_macro_snapshot():
     assert meal.nutrition is not None
     assert meal.nutrition.macros.protein == 30
     assert meal.nutrition.food_items[0].food_reference_id == 123
+    assert meal.image is None
 
 
 @pytest.mark.asyncio
-async def test_materializer_fails_with_public_error_when_recipe_missing():
+async def test_materializer_fails_with_public_error_when_selected_meal_missing():
     plan, slot = _plan_and_slot()
+    slot = PersistedMealRecommendationSlot(
+        **{**slot.__dict__, "selected": None}
+    )
 
     with pytest.raises(MealRecommendationNotFoundError):
         await RecommendedMealMaterializationService().materialize(
-            _Uow(_MissingCatalogRepo()),
+            _Uow(),
             plan=plan,
             slot=slot,
         )

--- a/tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py
+++ b/tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py
@@ -198,6 +198,73 @@ def test_three_day_optimizer_produces_9_slots_and_45_alternatives():
         assert slot.catalog_meal.id not in {item.catalog_meal.id for item in alternatives}
 
 
+def test_three_day_optimizer_matches_normal_golden_ids_and_scores():
+    profile = IngredientAffinityService().build_profile(
+        [], now=datetime(2026, 7, 16, tzinfo=UTC)
+    )
+
+    result = ThreeDayPlanOptimizer().build_plan(
+        _candidate_pool(),
+        daily_calories=2000,
+        affinity=profile,
+        cuisines={"vietnamese"},
+    )
+
+    assert not isinstance(result, MealRecommendationInsufficiency)
+    assert [
+        (slot.day_index, slot.meal_type, slot.catalog_meal.id, round(slot.score, 6))
+        for slot in result.slots
+    ] == [
+        (0, "breakfast", "breakfast-00", 0.82),
+        (0, "lunch", "lunch-00", 0.82),
+        (0, "dinner", "dinner-00", 0.82),
+        (1, "breakfast", "breakfast-01", 0.81836),
+        (1, "lunch", "lunch-01", 0.818907),
+        (1, "dinner", "dinner-01", 0.818907),
+        (2, "breakfast", "breakfast-02", 0.81672),
+        (2, "lunch", "lunch-02", 0.817813),
+        (2, "dinner", "dinner-02", 0.817813),
+    ]
+    assert {
+        key: [(item.catalog_meal.id, round(item.score, 6)) for item in alternatives]
+        for key, alternatives in result.alternatives.items()
+    } == _expected_normal_alternatives()
+
+
+def test_three_day_optimizer_matches_affinity_golden_ids_and_scores():
+    profile = IngredientAffinityService().build_profile(
+        [IngredientHistoryEvent(3, datetime(2026, 7, 15, tzinfo=UTC), 250)],
+        now=datetime(2026, 7, 16, tzinfo=UTC),
+    )
+
+    result = ThreeDayPlanOptimizer().build_plan(
+        _candidate_pool(),
+        daily_calories=2000,
+        affinity=profile,
+        cuisines={"vietnamese"},
+    )
+
+    assert not isinstance(result, MealRecommendationInsufficiency)
+    assert [
+        (slot.day_index, slot.meal_type, slot.catalog_meal.id, round(slot.score, 6))
+        for slot in result.slots
+    ] == [
+        (0, "breakfast", "breakfast-02", 0.83452),
+        (0, "lunch", "lunch-02", 0.835613),
+        (0, "dinner", "dinner-02", 0.835613),
+        (1, "breakfast", "breakfast-00", 0.82),
+        (1, "lunch", "lunch-00", 0.82),
+        (1, "dinner", "dinner-00", 0.82),
+        (2, "breakfast", "breakfast-01", 0.81836),
+        (2, "lunch", "lunch-01", 0.818907),
+        (2, "dinner", "dinner-01", 0.818907),
+    ]
+    assert {
+        key: [(item.catalog_meal.id, round(item.score, 6)) for item in alternatives]
+        for key, alternatives in result.alternatives.items()
+    } == _expected_normal_alternatives()
+
+
 def test_three_day_optimizer_returns_typed_insufficiency_for_sparse_catalog():
     profile = IngredientAffinityService().build_profile([], now=datetime.now(UTC))
 
@@ -221,6 +288,53 @@ def test_optimizer_is_repeatable_for_same_inputs():
 
     assert not isinstance(first, MealRecommendationInsufficiency)
     assert not isinstance(second, MealRecommendationInsufficiency)
-    assert [slot.catalog_meal.id for slot in first.slots] == [
-        slot.catalog_meal.id for slot in second.slots
+    assert _slot_golden(first) == _slot_golden(second)
+    assert _alternative_golden(first) == _alternative_golden(second)
+
+
+def _slot_golden(plan):
+    return [
+        (slot.day_index, slot.meal_type, slot.catalog_meal.id, round(slot.score, 6))
+        for slot in plan.slots
     ]
+
+
+def _alternative_golden(plan):
+    return {
+        key: [(item.catalog_meal.id, round(item.score, 6)) for item in alternatives]
+        for key, alternatives in plan.alternatives.items()
+    }
+
+
+def _expected_normal_alternatives():
+    breakfast = [
+        ("breakfast-03", 0.81508),
+        ("breakfast-04", 0.81344),
+        ("breakfast-05", 0.8118),
+        ("breakfast-06", 0.81016),
+        ("breakfast-07", 0.80852),
+    ]
+    lunch = [
+        ("lunch-03", 0.81672),
+        ("lunch-04", 0.815627),
+        ("lunch-05", 0.814533),
+        ("lunch-06", 0.81344),
+        ("lunch-07", 0.812347),
+    ]
+    dinner = [
+        ("dinner-03", 0.81672),
+        ("dinner-04", 0.815627),
+        ("dinner-05", 0.814533),
+        ("dinner-06", 0.81344),
+        ("dinner-07", 0.812347),
+    ]
+    return {
+        (day_index, "breakfast"): breakfast
+        for day_index in range(3)
+    } | {
+        (day_index, "lunch"): lunch
+        for day_index in range(3)
+    } | {
+        (day_index, "dinner"): dinner
+        for day_index in range(3)
+    }

--- a/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
@@ -17,6 +17,7 @@ from src.domain.model.meal_recommendation import (
 )
 from src.infra.repositories.meal_recommendation_plan_repository_async import (
     AsyncMealRecommendationPlanRepository,
+    _operation_fingerprint,
 )
 
 
@@ -141,7 +142,7 @@ def _catalog_meal(catalog_meal_id: str, name: str) -> CatalogMeal:
 
 @pytest.mark.asyncio
 async def test_save_new_active_plan_supersedes_existing_and_flushes_candidate_rows():
-    session = _AsyncSession([_Result(), _Result(rows=_plan_to_candidate_rows(_plan()))])
+    session = _AsyncSession([_Result()])
     repo = AsyncMealRecommendationPlanRepository(session)
 
     saved = await repo.save_new_active_plan(_plan())
@@ -153,7 +154,7 @@ async def test_save_new_active_plan_supersedes_existing_and_flushes_candidate_ro
     assert session.added_rows[1].user_id is None
     session.flush.assert_awaited_once()
     session.begin_nested.assert_called_once()
-    assert session.execute.await_count == 2
+    assert session.execute.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -204,14 +205,66 @@ class _LogReplayRepo(AsyncMealRecommendationPlanRepository):
     async def _get_operation_replay(self, *, user_id, operation_type, request_id):
         return self.replay
 
-    async def _load_batch_for_update(self, *, user_id, batch_id):
-        return _plan_to_candidate_rows(_plan())
+    async def _load_slot_for_update(self, *, user_id, batch_id, slot_id):
+        rows = _plan_to_candidate_rows(_plan())
+        return rows[0], rows
 
 
 @pytest.mark.asyncio
 async def test_claim_slot_log_rejects_reused_request_id_for_different_slot():
     repo = _LogReplayRepo(
         replay=SimpleNamespace(batch_id="plan-1", slot_id="other-slot")
+    )
+
+    with pytest.raises(MealRecommendationIdempotencyConflictError):
+        await repo.claim_slot_log(
+            user_id="user-1",
+            plan_id="plan-1",
+            slot_id="slot-1",
+            request_id="log-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_claim_slot_log_replay_returns_stored_logged_meal_id():
+    repo = _LogReplayRepo(
+        replay=SimpleNamespace(
+            batch_id="plan-1",
+            slot_id="slot-1",
+            request_fingerprint=_operation_fingerprint(
+                plan_id="plan-1",
+                slot_id="slot-1",
+                meal_id="meal-replayed",
+            ),
+            result_logged_meal_id="meal-replayed",
+        )
+    )
+
+    plan, slot, replayed = await repo.claim_slot_log(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="log-1",
+    )
+
+    assert replayed is True
+    assert slot.logged_meal_id == "meal-replayed"
+    assert plan.slots[0].logged_meal_id == "meal-replayed"
+
+
+@pytest.mark.asyncio
+async def test_claim_slot_log_rejects_replay_with_wrong_fingerprint():
+    repo = _LogReplayRepo(
+        replay=SimpleNamespace(
+            batch_id="plan-1",
+            slot_id="slot-1",
+            request_fingerprint=_operation_fingerprint(
+                plan_id="plan-1",
+                slot_id="slot-1",
+                meal_id="other-meal",
+            ),
+            result_logged_meal_id="meal-replayed",
+        )
     )
 
     with pytest.raises(MealRecommendationIdempotencyConflictError):

--- a/tests/unit/infra/repositories/test_meal_repository_history_aggregate.py
+++ b/tests/unit/infra/repositories/test_meal_repository_history_aggregate.py
@@ -1,0 +1,42 @@
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.repositories.meal_repository_async import AsyncMealRepository
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Session:
+    def __init__(self, rows):
+        self.execute = AsyncMock(return_value=_Result(rows))
+
+
+@pytest.mark.asyncio
+async def test_aggregate_linked_ingredient_history_uses_grouped_projection():
+    session = _Session(rows=[(11, date(2026, 7, 15), 500.0)])
+    repo = AsyncMealRepository(session)
+
+    buckets = await repo.aggregate_linked_ingredient_history(
+        user_id="user-1",
+        start_date=date(2026, 4, 17),
+        end_date=date(2026, 7, 15),
+        reference_date=date(2026, 7, 16),
+        user_timezone="UTC",
+    )
+
+    statement = str(session.execute.await_args.args[0])
+    assert "food_item.food_reference_id" in statement
+    assert "least(food_item.quantity" in statement
+    assert "GROUP BY food_item.food_reference_id" in statement
+    assert "meal.user_id" in statement
+    assert buckets[0].food_reference_id == 11
+    assert buckets[0].age_days == 1
+    assert buckets[0].capped_grams == 500.0


### PR DESCRIPTION
## Summary
- return compact meal recommendation plan summaries and lazy hydrated slot details
- replace full-plan swap/log responses with changed-slot mutation responses
- add process-local catalog snapshots, aggregate affinity projection, and optimized deterministic ranking pools
- update docs, plan artifacts, and local benchmark evidence for the rollout gate

## Test plan
- [x] `.venv/bin/python3 -m pytest -q tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py tests/unit/app/services/test_catalog_meal_snapshot_service.py tests/unit/app/services/test_meal_recommendation_history_projector.py tests/unit/app/services/test_meal_recommendation_analytics_service.py tests/unit/app/services/test_recommended_meal_materialization_service.py tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/infra/repositories/test_catalog_recipe_repository_async.py tests/unit/infra/repositories/test_meal_repository_history_aggregate.py tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/api/test_meal_recommendations_route.py tests/unit/api/test_meal_recommendation_http_contract.py tests/unit/api/test_meal_suggestions_routes.py`
- [x] `.venv/bin/ruff check <meal-recommendation touched files>`
- [x] `.venv/bin/python3 -m mypy src/infra/repositories/meal_recommendation_plan_repository_async.py src/domain/ports/meal_recommendation_plan_repository_port.py src/domain/model/meal_recommendation/meal_recommendation_plan.py`
- [x] backend pre-push unit suite: `1969 passed`

## Rollout notes
- Staging p95 and real PostgreSQL concurrency remain rollout gates before production enablement.
- No Redis result cache, speculative index, or compatibility branch was added.
