### PR TITLE
Backend PayPal web funnel checkout

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -312,10 +312,30 @@ Privileged endpoints require Firebase auth and an email in `ADMIN_EMAILS`.
 
 Handles RevenueCat lifecycle events (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER). Signature verified via constant-time HMAC; events mirrored to PostHog when `POSTHOG_API_KEY` is set.
 
+PayPal web funnel events are verified through PayPal before any checkout state transition. Browser approval is not an entitled state; it only binds a PayPal subscription reference to a pending checkout.
+
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/webhooks/revenuecat` | RevenueCat subscription webhook |
+| POST | `/v1/webhooks/paypal` | PayPal subscription webhook for web funnel checkout |
 | GET | `/v1/webhooks/revenuecat/health` | Webhook health check |
+
+---
+
+## Web Funnel Checkout
+
+Public checkout creation is server-owned and configuration-gated. `VN` fails closed until a tracked MoMo adapter/source decision exists. Firebase auth is required only when claiming a verified paid checkout into an app user.
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/web-funnel/checkouts` | Create or reuse a PayPal checkout; returns `checkoutId`, `status`, `provider`, `planId`, `customId`, `offerId`, `rewardId`, `currency`, `amountMinor`, `standardAmountMinor`, `renewalAmountMinor`, `renewalDescription`, `renewalInterval`, and `welcomeDiscountPercent` |
+| POST | `/v1/web-funnel/checkouts/{checkout_id}/paypal-confirmation` | Bind SDK `subscriptionId`; stays pending until a verified payment event can mark the checkout claimable |
+| GET | `/v1/web-funnel/checkouts/{checkout_id}` | Safe polling status; may include `claimToken` only when the checkout is claimable |
+| POST | `/v1/web-funnel/claims` | Firebase-authenticated claim of a verified paid checkout; consumes the claim token for the current app user |
+
+- `POST /v1/web-funnel/checkouts` does not return `claimToken`.
+- `GET /v1/web-funnel/checkouts/{checkout_id}` and confirmation responses expose `claimToken` only after the checkout becomes claimable.
+- `POST /v1/web-funnel/claims` requires an authenticated app user; RevenueCat native claim and entitlement flows remain unchanged.
 
 ---
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -46,7 +46,7 @@ The current HTTP surface includes:
 - User and profile management: Firebase sync, onboarding completion, metrics, TDEE, language, timezone, and account deletion.
 - Discovery and planning: meal suggestions discover, recipes, and save.
 - Nutrition and activity tracking: nutrition bulk/presence, activities daily/bulk, hydration, movement, and the journey progress snapshot.
-- Support routes: foods, ingredients, notifications, feature flags, saved suggestions, cheat days, referrals, promo codes, unified code validation, monitoring, health, app download, and well-known links.
+- Support routes: foods, ingredients, notifications, feature flags, saved suggestions, cheat days, referrals, promo codes, unified code validation, monitoring, health, app download, well-known links, and web-funnel checkout/claim flows with PayPal webhooks.
 
 ---
 
@@ -85,6 +85,7 @@ The current HTTP surface includes:
 
 ## Recent Features (July 2026)
 
+- **Backend-Owned PayPal Web Funnel:** `/v1/web-funnel/checkouts`, `/v1/web-funnel/checkouts/{checkout_id}/paypal-confirmation`, `/v1/web-funnel/checkouts/{checkout_id}`, and `/v1/web-funnel/claims` now support the international PayPal checkout ledger. Checkout creation returns the backend-selected commercial snapshot only; claim tokens stay hidden until the checkout is `PAID_ACTIVE` / claimable, and PayPal sale webhooks correlate via `billing_agreement_id`.
 - **Food-Label Image Scan:** `/v1/meals/food-label/scan-by-url` now analyzes Cloudinary-hosted nutrition-label images directly, preferring an optional label crop and crop metadata. `FoodLabelImageAnalysisStrategy` reads multilingual nutrition panels into the strict `FoodLabelNutritionResponse` contract; failures do not persist meals.
 
 ## Recent Features (June 2026)

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -538,3 +538,32 @@ Do NOT use PostHog for operational failure alerts — use Sentry metrics.
 ---
 
 See related: `system-architecture.md`, `database-guide.md`, `cqrs-guide.md`
+
+---
+
+## PayPal Web Funnel Checkout
+
+MealTrack owns the international web funnel checkout ledger. The browser renders the PayPal button with a backend-selected plan only; PayPal lifecycle webhooks decide paid access after signature verification and subscription re-fetch. Sale webhooks are correlated through `billing_agreement_id`, and verified early events may be stored until the confirmation flow can reconcile the checkout.
+
+### Required Config
+
+| Variable | Notes |
+|----------|-------|
+| `WEB_FUNNEL_CHECKOUT_ENABLED` | Enables non-VN checkout creation; default false |
+| `WEB_FUNNEL_SIGNING_SECRET` | HMAC secret for signed `customId` and claim-token minting |
+| `WEB_FUNNEL_CLAIM_TOKEN_TTL_MINUTES` | Claim-token lifetime |
+| `WEB_FUNNEL_PAYPAL_OFFERS_JSON` | JSON offer catalog; server owns reward, provider, currency, amount, interval, PayPal plan ID |
+| `PAYPAL_CLIENT_ID` | Merchant REST client ID |
+| `PAYPAL_CLIENT_SECRET` | Merchant REST secret; never expose to browser |
+| `PAYPAL_MERCHANT_ID` | Optional expected merchant ID checked against fetched subscription snapshots |
+| `PAYPAL_API_BASE_URL` | Sandbox or production PayPal API base |
+| `PAYPAL_WEBHOOK_ID` | PayPal dashboard webhook ID used for signature verification |
+| `PAYPAL_TIMEOUT_SECONDS` | HTTP timeout for PayPal API calls |
+
+### Safety Rules
+
+- `VN` does not fall back to PayPal/USD while MoMo source is absent.
+- `onApprove` calls confirmation only; it never marks paid or creates entitlement.
+- `POST /v1/webhooks/paypal` deduplicates provider event IDs, re-fetches subscription state, and stores verified early events until confirmation catches up.
+- Only verified active lifecycle events can mark a checkout `paid_active`.
+- Authenticated claim requires a signed claim token plus the current app user's Firebase identity; RevenueCat native behavior remains unchanged.

--- a/migrations/versions/20260726000002_add_web_funnel_checkout_ledger.py
+++ b/migrations/versions/20260726000002_add_web_funnel_checkout_ledger.py
@@ -1,0 +1,125 @@
+"""Add web funnel checkout ledger.
+
+Revision ID: 20260726000002
+Revises: 20260726000001
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260726000002"
+down_revision = "20260726000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "web_funnel_leads",
+        sa.Column("external_lead_id", sa.String(length=128), nullable=False),
+        sa.Column("email_hash", sa.String(length=64), nullable=True),
+        sa.Column("first_seen_country", sa.String(length=2), nullable=True),
+        sa.Column("last_seen_country", sa.String(length=2), nullable=True),
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("external_lead_id"),
+    )
+    op.create_index(
+        op.f("ix_web_funnel_leads_external_lead_id"),
+        "web_funnel_leads",
+        ["external_lead_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "web_funnel_checkouts",
+        sa.Column("lead_id", sa.String(length=36), nullable=False),
+        sa.Column("idempotency_key_hash", sa.String(length=64), nullable=False),
+        sa.Column("request_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("state", sa.String(length=32), server_default="pending_approval", nullable=False),
+        sa.Column("state_reason", sa.String(length=255), nullable=True),
+        sa.Column("offer_id", sa.String(length=64), nullable=False),
+        sa.Column("reward_id", sa.String(length=64), nullable=False),
+        sa.Column("market", sa.String(length=16), nullable=False),
+        sa.Column("billing_country", sa.String(length=2), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("amount_minor", sa.Integer(), nullable=False),
+        sa.Column("renewal_interval", sa.String(length=16), nullable=False),
+        sa.Column("welcome_discount_percent", sa.Integer(), nullable=False),
+        sa.Column("provider_plan_id", sa.String(length=255), nullable=True),
+        sa.Column("provider_subscription_id", sa.String(length=255), nullable=True),
+        sa.Column("provider_customer_id", sa.String(length=255), nullable=True),
+        sa.Column("provider_transaction_id", sa.String(length=255), nullable=True),
+        sa.Column("custom_id_hash", sa.String(length=64), nullable=False),
+        sa.Column("claim_token_hash", sa.String(length=64), nullable=False),
+        sa.Column("claim_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("paid_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("amount_minor >= 0", name="ck_web_funnel_amount_nonnegative"),
+        sa.ForeignKeyConstraint(["lead_id"], ["web_funnel_leads.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("custom_id_hash"),
+        sa.UniqueConstraint("claim_token_hash"),
+        sa.UniqueConstraint("lead_id", "idempotency_key_hash", name="uq_web_funnel_checkout_lead_idempotency"),
+        sa.UniqueConstraint("provider", "provider_subscription_id", name="uq_web_funnel_checkout_provider_subscription"),
+    )
+    op.create_index("idx_web_funnel_checkouts_lead_state", "web_funnel_checkouts", ["lead_id", "state"], unique=False)
+    op.create_index("idx_web_funnel_checkouts_state", "web_funnel_checkouts", ["state"], unique=False)
+
+    op.create_table(
+        "web_funnel_provider_events",
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("event_id", sa.String(length=255), nullable=False),
+        sa.Column("event_type", sa.String(length=128), nullable=False),
+        sa.Column("provider_subscription_id", sa.String(length=255), nullable=True),
+        sa.Column("checkout_id", sa.String(length=36), nullable=True),
+        sa.Column("verified", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("processed", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("processing_result", sa.String(length=64), nullable=False),
+        sa.Column("safe_payload", sa.Text(), nullable=True),
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["checkout_id"], ["web_funnel_checkouts.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider", "event_id", name="uq_web_funnel_provider_event"),
+    )
+    op.create_index("idx_web_funnel_provider_events_checkout", "web_funnel_provider_events", ["checkout_id"], unique=False)
+    op.create_index(op.f("ix_web_funnel_provider_events_provider_subscription_id"), "web_funnel_provider_events", ["provider_subscription_id"], unique=False)
+
+    op.create_table(
+        "web_funnel_claims",
+        sa.Column("checkout_id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("claim_token_hash", sa.String(length=64), nullable=False),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["checkout_id"], ["web_funnel_checkouts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("checkout_id"),
+        sa.UniqueConstraint("claim_token_hash"),
+    )
+    op.create_index("idx_web_funnel_claims_user", "web_funnel_claims", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_web_funnel_claims_user", table_name="web_funnel_claims")
+    op.drop_table("web_funnel_claims")
+    op.drop_index(op.f("ix_web_funnel_provider_events_provider_subscription_id"), table_name="web_funnel_provider_events")
+    op.drop_index("idx_web_funnel_provider_events_checkout", table_name="web_funnel_provider_events")
+    op.drop_table("web_funnel_provider_events")
+    op.drop_index("idx_web_funnel_checkouts_state", table_name="web_funnel_checkouts")
+    op.drop_index("idx_web_funnel_checkouts_lead_state", table_name="web_funnel_checkouts")
+    op.drop_table("web_funnel_checkouts")
+    op.drop_index(op.f("ix_web_funnel_leads_external_lead_id"), table_name="web_funnel_leads")
+    op.drop_table("web_funnel_leads")

--- a/migrations/versions/20260726000003_add_provider_neutral_subscription_fields.py
+++ b/migrations/versions/20260726000003_add_provider_neutral_subscription_fields.py
@@ -1,0 +1,55 @@
+"""Add provider-neutral subscription fields.
+
+Revision ID: 20260726000003
+Revises: 20260726000002
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260726000003"
+down_revision = "20260726000002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("subscriptions", sa.Column("provider", sa.String(length=32), nullable=False, server_default="revenuecat"))
+    op.add_column("subscriptions", sa.Column("provider_customer_id", sa.String(length=255), nullable=True))
+    op.add_column("subscriptions", sa.Column("provider_subscription_id", sa.String(length=255), nullable=True))
+    op.add_column("subscriptions", sa.Column("provider_transaction_id", sa.String(length=255), nullable=True))
+    op.add_column("subscriptions", sa.Column("source_checkout_id", sa.String(length=36), nullable=True))
+    op.alter_column("subscriptions", "revenuecat_subscriber_id", existing_type=sa.String(length=255), nullable=True)
+    op.create_foreign_key(
+        "fk_subscriptions_source_checkout_id_web_funnel_checkouts",
+        "subscriptions",
+        "web_funnel_checkouts",
+        ["source_checkout_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_unique_constraint(
+        "uq_subscriptions_provider_subscription",
+        "subscriptions",
+        ["provider", "provider_subscription_id"],
+    )
+    op.create_check_constraint(
+        "ck_subscriptions_provider_identifiers",
+        "subscriptions",
+        "(provider = 'revenuecat' AND revenuecat_subscriber_id IS NOT NULL) OR "
+        "(provider <> 'revenuecat' AND provider_subscription_id IS NOT NULL)",
+    )
+    op.create_index("idx_subscriptions_provider_user_status", "subscriptions", ["provider", "user_id", "status"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_subscriptions_provider_user_status", table_name="subscriptions")
+    op.drop_constraint("ck_subscriptions_provider_identifiers", "subscriptions", type_="check")
+    op.drop_constraint("uq_subscriptions_provider_subscription", "subscriptions", type_="unique")
+    op.drop_constraint("fk_subscriptions_source_checkout_id_web_funnel_checkouts", "subscriptions", type_="foreignkey")
+    op.alter_column("subscriptions", "revenuecat_subscriber_id", existing_type=sa.String(length=255), nullable=False)
+    op.drop_column("subscriptions", "source_checkout_id")
+    op.drop_column("subscriptions", "provider_transaction_id")
+    op.drop_column("subscriptions", "provider_subscription_id")
+    op.drop_column("subscriptions", "provider_customer_id")
+    op.drop_column("subscriptions", "provider")

--- a/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-01-web-funnel-checkout-foundation.md
+++ b/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-01-web-funnel-checkout-foundation.md
@@ -1,0 +1,83 @@
+---
+phase: 1
+title: "Align Funnel and API Contracts"
+status: complete
+priority: P1
+effort: "4-6h"
+dependencies: []
+---
+
+# Phase 1: Align Funnel and API Contracts
+
+## Overview
+
+Make the deployed funnel and backend agree on one public contract before any
+PayPal button can be used. This eliminates the current missing
+`/v1/web-funnel/leads`, `/api/funnel/context`, and welcome-reward endpoints
+from the payment path.
+
+## Requirements
+
+- Keep the existing 23-step funnel and its country rule: `VN -> MoMo/VND`, all
+  non-VN markets -> PayPal/USD.
+- Choose one source of truth for lead identity, country/context, `WELCOME50`,
+  and the server-selected offer. Do not preserve unused legacy endpoints merely
+  because the frontend calls them today.
+- The checkout response must retain the camelCase shape consumed by the PayPal
+  component without exposing secrets or mutable commercial values.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree_web_funnel/src/lib/api/client.ts`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree_web_funnel/src/app/email/page.tsx`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree_web_funnel/src/app/paywall/page.tsx`
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree_web_funnel/src/app/welcome-gift/page.tsx`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/web_funnel.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/schemas/request/web_funnel_requests.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/schemas/response/web_funnel_responses.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/app/services/web_funnel_checkout_service.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/unit/app/services/test_web_funnel_checkout_service.py`
+- Create: focused route/client contract tests in the existing unit-test layouts
+
+## Implementation Steps
+
+1. Write a one-page contract table for `lead`, `context/reward`, `checkout`,
+   `confirmation`, `status`, and `claim`, including request field casing and
+   error codes. Treat it as the implementation checklist for both repositories.
+2. Remove or replace the frontend calls that target backend routes which do not
+   exist. Prefer the smallest compatible path: a browser-generated opaque lead
+   ID accepted by checkout, and a backend response/catalog that is actually
+   served by the backend. Do not add an unauthenticated email/profile store just
+   to mimic an obsolete response.
+3. Make country selection authoritative at the backend boundary. Non-VN must
+   select only a configured USD PayPal offer; VN must return the typed
+   unavailable state until MoMo work is approved.
+4. Preserve backend ownership of offer, reward, plan, amount, currency, and
+   renewal data. Validate the offer catalog at startup with actionable failures
+   for malformed JSON, unsupported currency/provider, non-positive amount, or
+   missing plan ID.
+5. Confirm claim-token handoff is intentional: keep it opaque, never log it,
+   never put it in analytics, and do not issue an entitlement before Firebase
+   authentication.
+
+## Success Criteria
+
+- [x] Email, welcome-gift, paywall, checkout, and success screens make no call
+  to a missing backend route.
+- [x] Frontend and backend contract tests prove aliases, error codes, country,
+  and provider selection.
+- [x] Bad offer configuration prevents checkout service startup/enablement.
+
+## Progress Notes
+
+- 2026-07-26: Removed runtime calls to missing lead, context, and reward routes
+  in `nutree_web_funnel`; checkout is now the first backend payment boundary.
+- 2026-07-26: Aligned frontend reward payload to backend `WELCOME50`, retained
+  backend-owned PayPal/USD selection for non-VN, and kept VN fail-closed.
+- 2026-07-26: Checkout response now carries backend commercial display fields
+  and no pre-paid claim token.
+
+## Risk Assessment
+
+The main risk is accidentally restoring old MoMo assumptions while shipping
+PayPal. Keep the release INTL-only and fail closed for VN.

--- a/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-02-paypal-checkout-and-confirmation.md
+++ b/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-02-paypal-checkout-and-confirmation.md
@@ -1,0 +1,86 @@
+---
+phase: 2
+title: "Harden Entitlement and Concurrency"
+status: in_progress
+priority: P1
+effort: "6-8h"
+dependencies: [1]
+---
+
+# Phase 2: Harden Entitlement and Concurrency
+
+## Overview
+
+Close the correctness gaps between PayPal approval, webhook delivery, claims,
+and premium access. The result is a provider-neutral web entitlement that
+coexists with RevenueCat without changing native billing behavior.
+
+## Requirements
+
+- PayPal browser `onApprove` binds a subscription reference only; it never
+  changes paid or premium state.
+- A verified PayPal payment event plus a fetched subscription snapshot is the
+  only paid transition. Revoke on cancellation, suspension, refund, or dispute.
+- Concurrent requests and duplicate events must resolve through database
+  uniqueness, not a read-then-insert race.
+- A valid one-time claim must become visible to `require_subscription`; existing
+  RevenueCat verification remains the fallback for native users.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/app/services/web_funnel_checkout_service.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/app/services/paypal_webhook_service.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/web_funnel_checkout_repository.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/adapters/paypal_billing_adapter.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/web_funnel.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/routes/v1/webhooks.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/api/middleware/premium_check.py`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/src/infra/repositories/subscription_repository_async.py`
+- Create: forward-only migration only if constraints/indexes need correction
+- Create: route, repository-concurrency, adapter, webhook, claim, and premium tests
+
+## Implementation Steps
+
+1. Move outbound PayPal calls outside database write transactions. Re-open a
+   short transaction to conditionally bind the verified result, then handle
+   uniqueness conflicts as idempotent outcomes.
+2. Use `INSERT ... ON CONFLICT` or a caught database uniqueness error for lead,
+   checkout, event, and claim paths. Test two concurrent identical checkout
+   requests, two confirmations, two claims, and duplicate webhook deliveries.
+3. Fix webhook-before-confirmation ordering. Persist verified unmatched events
+   for reconciliation or let confirmation safely retrieve and apply the latest
+   verified PayPal state; do not permanently discard a valid early event as
+   `checkout_not_found`.
+4. Treat a fetched subscription as valid only when plan, signed `custom_id`,
+   merchant when configured, amount, currency, and expected paid lifecycle all
+   match. Keep unknown/malformed events non-entitling and observable.
+5. Add the local claimed web subscription to premium resolution with a database
+   lookup that checks provider, status, and expiry. Preserve current RevenueCat
+   semantics and add regression tests for native users.
+6. Replace float-based money parsing in the adapter with decimal minor-unit
+   conversion; record provider payment/customer identifiers where present.
+
+## Success Criteria
+
+- [x] Approval, invalid signature, wrong plan, wrong merchant, amount/currency
+  mismatch, replay, and early webhook cannot grant a false entitlement.
+- [x] A valid verified payment can be claimed once, grants premium, and a later
+  revoke removes premium without affecting RevenueCat subscriptions.
+- [ ] Concurrent paths preserve one ledger row/event/claim without 500 errors.
+- [x] No outbound PayPal HTTP request runs while a database transaction is open.
+
+## Progress Notes
+
+- 2026-07-26: Browser approval binds the PayPal subscription only; claim token
+  is returned only from paid/claimable status.
+- 2026-07-26: PayPal sale webhooks now correlate through `billing_agreement_id`
+  and early verified events are stored for later reconciliation.
+- 2026-07-26: Repository paths now catch duplicate lead/checkout/event conflicts,
+  map duplicate confirmation to typed conflict, and lock claim before consuming.
+- 2026-07-26: Focused unit tests cover the above behavior. Real PostgreSQL
+  concurrency proof remains open for Phase 3 local sandbox acceptance.
+
+## Risk Assessment
+
+This is the high-risk phase. Do not substitute unit mocks for the PostgreSQL
+concurrency cases; run them against the local database used for sandbox.

--- a/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-03-verified-entitlement-and-claim.md
+++ b/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-03-verified-entitlement-and-claim.md
@@ -1,0 +1,71 @@
+---
+phase: 3
+title: "Run Local Sandbox Acceptance"
+status: pending
+priority: P1
+effort: "4-6h"
+dependencies: [1, 2]
+---
+
+# Phase 3: Run Local Sandbox Acceptance
+
+## Overview
+
+Prove the real PayPal sandbox lifecycle against the local migrated PostgreSQL
+database and the local funnel. This phase is the final technical go/no-go for
+production configuration.
+
+## Requirements
+
+- Use local backend at `http://127.0.0.1:8000`, local funnel at
+  `http://localhost:3000`, and a publicly reachable HTTPS tunnel only for the
+  sandbox webhook callback.
+- Use sandbox client credentials, sandbox plan IDs, sandbox webhook ID, and a
+  sandbox buyer. Do not reuse production credentials or plans.
+- Record redacted evidence only: checkout ID, timestamps, HTTP statuses,
+  state transitions, and PayPal dashboard references. Never store secrets,
+  tokens, or full buyer details in the repository.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/.env` locally only
+- Modify: `/Users/alexnguyen/Desktop/Nut/nutree_web_funnel/.env.local` locally only
+- Create: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/integration/test_web_funnel_checkout_repository.py`
+- Create: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/tests/migrations/test_web_funnel_billing_migrations.py`
+- Modify: existing focused backend and funnel unit tests
+
+## Implementation Steps
+
+1. Run Alembic against a clean local PostgreSQL database, then run the upgrade
+   path from the previous deployed revision. Verify the head is
+   `20260726000003` or its approved forward successor.
+2. Start the backend with local database, exact localhost CORS origins,
+   checkout enabled, sandbox API base URL, sandbox offer catalog, and unique
+   signing secret. Start the funnel with the paired local API URL and sandbox
+   public client ID.
+3. Confirm the health endpoint, CORS preflight, OpenAPI routes, malformed
+   checkout errors, non-VN checkout creation, and VN unavailable response.
+4. Complete the real buyer flow: lead/context -> checkout -> PayPal approval ->
+   confirmation -> pending status -> webhook -> paid/claimable -> Firebase
+   authenticated claim -> premium-protected endpoint.
+5. Run negative cases: approval without webhook, invalid signature, duplicate
+   event, repeated confirmation, early webhook, bad subscription reference,
+   cancellation/refund, repeated claim, expired claim, and a native RevenueCat
+   regression case.
+6. Run focused backend lint/compile/tests, PostgreSQL integration/migration
+   tests, and funnel `eslint`, `npm test`, and `npm run build`. Do not add or
+   run browser e2e tests in `nutree_web_funnel`.
+
+## Success Criteria
+
+- [ ] One real sandbox payment reaches premium only after verified webhook and
+  authenticated claim.
+- [ ] Every negative case fails closed and leaves a support-traceable state.
+- [ ] Local migration, focused backend tests, funnel lint/unit/build, and CORS
+  checks pass with no dependency on production infrastructure.
+
+## Risk Assessment
+
+PayPal cannot deliver a webhook directly to loopback. The tunnel is sandbox
+test infrastructure only; production must point to the deployed HTTPS URL and
+use a separate webhook ID.

--- a/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-04-tests-and-production-rollout.md
+++ b/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/phase-04-tests-and-production-rollout.md
@@ -1,0 +1,69 @@
+---
+phase: 4
+title: "Deploy and Observe Production"
+status: pending
+priority: P1
+effort: "3-4h"
+dependencies: [1, 2, 3]
+---
+
+# Phase 4: Deploy and Observe Production
+
+## Overview
+
+Deploy the tested code and forward migrations, wire the production PayPal
+webhook, then enable international checkout in a controlled, reversible step.
+
+## Requirements
+
+- Deploy migrations before enabling `WEB_FUNNEL_CHECKOUT_ENABLED`.
+- Use production PayPal client credentials, production plan IDs, production
+  webhook ID, production API base URL, and an independently generated signing
+  secret.
+- Keep `VN` unavailable. Keep existing RevenueCat webhook and mobile purchase
+  flows unchanged.
+
+## Related Code Files
+
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/api-endpoints.md`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/external-services.md`
+- Modify: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/docs/project-changelog.md` when release is complete
+- Modify: deployment secret store and PayPal dashboard outside git
+
+## Implementation Steps
+
+1. Create/verify the production webhook at
+   `https://<backend-host>/v1/webhooks/paypal`. Subscribe to payment-completed,
+   cancellation, suspension, refund, and dispute events used by the lifecycle
+   mapping. Copy its production webhook ID into the secret store.
+2. Deploy the backend with checkout disabled. Run migrations, `/health`,
+   `/openapi.json`, route availability, CORS preflight from the deployed funnel
+   domain, and a disabled-checkout smoke test.
+3. Deploy the funnel with production `NEXT_PUBLIC_API_BASE_URL` and the public
+   client ID matching the production plans. Verify page load and provider
+   choice without exposing the secret.
+4. Enable checkout for a restricted international canary. Monitor checkout
+   create/confirmation/pending/paid/claim/revoke counts; PayPal signature
+   failures; mismatch reasons; webhook latency; 4xx/5xx; and premium failures.
+5. Execute one controlled production purchase only if business policy permits;
+   otherwise validate webhooks with PayPal's production simulator and defer the
+   first buyer observation to support monitoring. Document the chosen evidence.
+6. Roll back by disabling new checkout creation on any signature, mismatch,
+   claim, or premium regression. Continue webhook/reconciliation processing for
+   existing purchases until all pending ledger rows are resolved.
+
+## Success Criteria
+
+- [ ] Deployed OpenAPI exposes the exact checkout, confirmation, status, claim,
+  and PayPal webhook routes.
+- [ ] Production webhook verification succeeds and observability can distinguish
+  pending, paid, claimed, revoked, ignored, and failed events.
+- [ ] International checkout is enabled only after the canary is healthy; VN and
+  native RevenueCat behavior remain unchanged.
+- [ ] Rollback owner and procedure are written in the deployment record.
+
+## Risk Assessment
+
+Most production failures will be configuration mismatches: wrong environment,
+wrong plan owner, wrong webhook ID, or CORS origin. Treat each as a stop signal,
+not a reason to weaken signature checks or bypass the backend ledger.

--- a/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/plan.md
+++ b/plans/260726-1440-backend-owned-paypal-web-funnel-checkout/plan.md
@@ -1,0 +1,102 @@
+---
+title: "PayPal Web Funnel Release Plan"
+description: "Finish the backend-owned PayPal funnel, prove it in sandbox, and enable it safely for international production traffic."
+status: in_progress
+priority: P1
+effort: "2-3d"
+branch: "delivery"
+tags: [feature, backend, frontend, api, database, payments, critical]
+blockedBy: []
+blocks: []
+created: "2026-07-26"
+---
+
+# PayPal Web Funnel Release Plan
+
+## Outcome
+
+Ship PayPal subscriptions for non-Vietnam (`INTL`) funnel traffic only. The
+browser creates a PayPal subscription with a server-selected plan; the backend
+grants premium only after a verified PayPal payment event and an authenticated
+claim. Vietnam stays unavailable until its separate MoMo implementation exists.
+
+## Verified Starting Point
+
+| Area | Current state | Release decision |
+|---|---|---|
+| Ledger, PayPal REST adapter, webhook route | Implemented locally | Keep; harden races and lifecycle recovery |
+| Browser approval | Posts `subscriptionID` and polls status | Keep pending; never grant from approval |
+| Funnel prerequisites | Calls missing lead/context/reward endpoints | Reconcile one contract before sandbox |
+| Premium gate | Still follows legacy local/RevenueCat logic | Add claimed PayPal subscription support |
+| Idempotency and webhook dedupe | Read-then-insert | Make database-conflict-safe |
+| Local DB | Migrated through `20260726000003` | Use sandbox only after final test gates |
+
+## Architecture
+
+```text
+Funnel lead/context -> backend contract -> server-owned offer snapshot
+PayPal JS SDK -> subscriptionID -> confirmation (pending only)
+PayPal webhook -> signature verification -> fetch subscription -> paid_active
+Firebase-authenticated app -> one-time claim -> active local web subscription
+Premium middleware -> active web subscription or existing RevenueCat path
+```
+
+PayPal's subscription integration uses the JavaScript SDK with
+`vault=true&intent=subscription` and a pre-created plan. Its documented webhook
+verification endpoint is the authority for webhook sender validation. See
+[PayPal subscriptions](https://developer.paypal.com/docs/subscriptions/integrate/)
+and [webhook verification](https://developer.paypal.com/docs/api/webhooks/v1/).
+
+## Phases
+
+| Phase | Name | Status |
+|---|---|---|
+| 1 | [Align Funnel and API Contracts](./phase-01-web-funnel-checkout-foundation.md) | Complete |
+| 2 | [Harden Entitlement and Concurrency](./phase-02-paypal-checkout-and-confirmation.md) | In Progress |
+| 3 | [Run Local Sandbox Acceptance](./phase-03-verified-entitlement-and-claim.md) | Pending |
+| 4 | [Deploy and Observe Production](./phase-04-tests-and-production-rollout.md) | Pending |
+
+## Non-Negotiable Release Gates
+
+- No `WEB_FUNNEL_CHECKOUT_ENABLED=true` in production until every Phase 3 case passes.
+- Production and sandbox use separate PayPal client credentials, plan IDs, and
+  webhook IDs. The client secret is backend-only and must be rotated because it
+  was pasted into this conversation.
+- The funnel's `NEXT_PUBLIC_PAYPAL_CLIENT_ID` must be the public client ID for
+  the same merchant that owns the configured plan IDs.
+- `WEB_FUNNEL_PAYPAL_OFFERS_JSON` remains a server-owned catalog mapping offer
+  IDs to PayPal plan IDs, prices, currency, reward, and renewal terms. The
+  browser never supplies any of those commercial fields.
+- Do not route `VN` to PayPal/USD. Return the existing unavailable response
+  until MoMo is implemented and separately verified.
+
+## Environment Inputs
+
+Backend, sandbox then production: `WEB_FUNNEL_CHECKOUT_ENABLED`,
+`WEB_FUNNEL_SIGNING_SECRET`, `WEB_FUNNEL_CLAIM_TOKEN_TTL_MINUTES`,
+`WEB_FUNNEL_PAYPAL_OFFERS_JSON`, `PAYPAL_CLIENT_ID`, `PAYPAL_CLIENT_SECRET`,
+`PAYPAL_API_BASE_URL`, `PAYPAL_WEBHOOK_ID`, optional `PAYPAL_MERCHANT_ID`, and
+`PAYPAL_TIMEOUT_SECONDS`. The funnel needs only `NEXT_PUBLIC_API_BASE_URL` and
+`NEXT_PUBLIC_PAYPAL_CLIENT_ID`.
+
+## Rollback
+
+Disable `WEB_FUNNEL_CHECKOUT_ENABLED` to stop new checkout creation. Keep the
+PayPal webhook endpoint and existing offer mapping alive long enough to settle
+already-created subscriptions, claims, cancellations, refunds, and disputes.
+Do not roll back the database migrations or alter the RevenueCat flow.
+
+## Exit Criteria
+
+- The real funnel reaches checkout without a missing endpoint or contract fallback.
+- A sandbox approval remains pending until a verified payment event; one valid
+  claim grants premium, while replay, mismatch, cancellation, and refund do not.
+- Migration, route, service, repository, adapter, frontend unit, lint, and
+  production-build gates pass.
+- Production has the exact HTTPS webhook URL, subscribed events, secret store
+  configuration, dashboard alerting, rollback owner, and first-hour monitor.
+
+## Unresolved Questions
+
+- None for the PayPal-only international release. MoMo remains explicitly out
+  of scope and fail-closed for Vietnam.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -71,6 +71,7 @@ from src.api.routes.v1.saved_suggestions import router as saved_suggestions_rout
 from src.api.routes.v1.tdee import router as tdee_router
 from src.api.routes.v1.user_profiles import router as user_profiles_router
 from src.api.routes.v1.users import router as users_router
+from src.api.routes.v1.web_funnel import router as web_funnel_router
 from src.api.routes.v1.webhooks import router as webhooks_router
 from src.api.routes.v1.weight_entries import router as weight_entries_router
 from src.api.routes.well_known import router as well_known_router
@@ -321,6 +322,7 @@ app.include_router(users_router)
 app.include_router(foods_router)
 app.include_router(monitoring_router)
 app.include_router(webhooks_router)
+app.include_router(web_funnel_router)
 app.include_router(notifications_router)
 app.include_router(hydration_router)
 app.include_router(ingredients_router)

--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -1,0 +1,161 @@
+"""Public web funnel checkout routes."""
+
+from fastapi import APIRouter, Depends, Request
+
+from src.api.dependencies.auth import get_current_user_id
+from src.api.middleware.rate_limit import limiter
+from src.api.schemas.request.web_funnel_requests import (
+    PayPalConfirmationRequest,
+    WebFunnelCheckoutRequest,
+    WebFunnelClaimRequest,
+)
+from src.api.schemas.response.web_funnel_responses import (
+    CheckoutResponse,
+    CheckoutStatusResponse,
+    WebFunnelClaimResponse,
+)
+from src.app.services.web_funnel_checkout_service import WebFunnelCheckoutService
+from src.infra.adapters.paypal_billing_adapter import PayPalBillingAdapter
+from src.infra.config.settings import settings
+from src.infra.database.uow_async import AsyncUnitOfWork
+
+router = APIRouter(prefix="/v1/web-funnel", tags=["Web Funnel"])
+
+
+def _offer_amount(offer: dict, key: str, fallback: int) -> int:
+    return int(offer.get(key, fallback) or fallback)
+
+
+def _checkout_response(checkout, custom_id: str) -> CheckoutResponse:
+    offer = settings.web_funnel_paypal_offers.get(checkout.offer_id, {})
+    return CheckoutResponse(
+        checkout_id=checkout.id,
+        status=checkout.state.upper(),
+        provider=checkout.provider,
+        plan_id=checkout.provider_plan_id,
+        custom_id=custom_id,
+        offer_id=checkout.offer_id,
+        reward_id=checkout.reward_id,
+        currency=checkout.currency,
+        amount_minor=checkout.amount_minor,
+        standard_amount_minor=_offer_amount(
+            offer, "standard_amount_minor", checkout.amount_minor
+        ),
+        renewal_amount_minor=_offer_amount(
+            offer, "renewal_amount_minor", checkout.amount_minor
+        ),
+        renewal_description=str(
+            offer.get("renewal_description") or checkout.renewal_interval
+        ),
+        renewal_interval=checkout.renewal_interval,
+        welcome_discount_percent=checkout.welcome_discount_percent,
+    )
+
+
+def _status_response(checkout, claim_token: str | None = None) -> CheckoutStatusResponse:
+    return CheckoutStatusResponse(
+        checkout_id=checkout.id,
+        status=checkout.state.upper(),
+        provider=checkout.provider,
+        claimable=checkout.state == "paid_active",
+        claimed=checkout.claimed_at is not None,
+        paid_at=checkout.paid_at,
+        claim_token=claim_token if checkout.state == "paid_active" else None,
+    )
+
+
+@router.post("/checkouts", response_model=CheckoutResponse)
+@limiter.limit("20/minute")
+async def create_checkout(request: Request, body: WebFunnelCheckoutRequest):
+    """Create or reuse a server-owned web funnel checkout."""
+    service = WebFunnelCheckoutService(settings)
+    async with AsyncUnitOfWork() as uow:
+        checkout, custom_id = await service.create_checkout(
+            uow=uow,
+            lead_id=body.lead_id,
+            offer_id=body.offer_id,
+            reward_id=body.reward_id,
+            billing_country=body.billing_country,
+            idempotency_key=body.idempotency_key,
+        )
+        return _checkout_response(checkout, custom_id)
+
+
+@router.post(
+    "/checkouts/{checkout_id}/paypal-confirmation",
+    response_model=CheckoutStatusResponse,
+)
+@limiter.limit("20/minute")
+async def confirm_paypal_subscription(
+    request: Request, checkout_id: str, body: PayPalConfirmationRequest
+):
+    """Record browser PayPal approval as a pending provider reference."""
+    service = WebFunnelCheckoutService(settings)
+    paypal = PayPalBillingAdapter(settings)
+    async with AsyncUnitOfWork() as uow:
+        checkout = await uow.web_funnel_checkouts.find_by_id(checkout_id)
+        if not checkout:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail={"error_code": "NOT_FOUND"})
+        if checkout.provider_subscription_id == body.subscription_id:
+            claim_token = service.claim_token_for_checkout(checkout)
+            return _status_response(checkout, claim_token)
+        if checkout.state not in {"pending_approval", "pending_payment"}:
+            from fastapi import HTTPException
+
+            raise HTTPException(
+                status_code=409, detail={"error_code": "CHECKOUT_NOT_CONFIRMABLE"}
+            )
+
+    snapshot = await paypal.get_subscription(body.subscription_id)
+
+    async with AsyncUnitOfWork() as uow:
+        await service.validate_paypal_subscription(
+            uow=uow,
+            checkout_id=checkout_id,
+            subscription_id=body.subscription_id,
+            snapshot=snapshot,
+        )
+        checkout = await service.bind_validated_paypal_subscription(
+            uow=uow,
+            checkout_id=checkout_id,
+            subscription_id=body.subscription_id,
+            snapshot=snapshot,
+        )
+        claim_token = service.claim_token_for_checkout(checkout)
+        return _status_response(checkout, claim_token)
+
+
+@router.get("/checkouts/{checkout_id}", response_model=CheckoutStatusResponse)
+@limiter.limit("60/minute")
+async def get_checkout_status(request: Request, checkout_id: str):
+    """Return safe status for browser polling."""
+    async with AsyncUnitOfWork() as uow:
+        checkout = await uow.web_funnel_checkouts.find_by_id(checkout_id)
+        if not checkout:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail={"error_code": "NOT_FOUND"})
+        claim_token = WebFunnelCheckoutService(settings).claim_token_for_checkout(
+            checkout
+        )
+        return _status_response(checkout, claim_token)
+
+
+@router.post("/claims", response_model=WebFunnelClaimResponse)
+@limiter.limit("20/minute")
+async def claim_checkout(
+    request: Request,
+    body: WebFunnelClaimRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """Consume a one-time paid checkout claim token for the current user."""
+    service = WebFunnelCheckoutService(settings)
+    async with AsyncUnitOfWork() as uow:
+        subscription = await service.claim_checkout(
+            uow=uow, user_id=user_id, claim_token=body.claim_token
+        )
+        return WebFunnelClaimResponse(
+            status="claimed", subscription_id=subscription.id
+        )

--- a/src/api/routes/v1/webhooks.py
+++ b/src/api/routes/v1/webhooks.py
@@ -13,18 +13,39 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Header, HTTPException, Request
 from sqlalchemy import select, text
 
+from src.app.services.paypal_webhook_service import PayPalWebhookService
 from src.domain.services.email_service import EmailService
 from src.domain.utils.timezone_utils import utc_now
+from src.infra.adapters.paypal_billing_adapter import PayPalBillingAdapter
 from src.infra.adapters.posthog_adapter import PostHogAdapter
-from src.observability import increment_metric
 from src.infra.adapters.resend_email_adapter import ResendEmailAdapter
+from src.infra.config.settings import settings
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.services.email_template_renderer import EmailTemplateRenderer
+from src.observability import increment_metric
 
 router = APIRouter(prefix="/v1/webhooks", tags=["Webhooks"])
 logger = logging.getLogger(__name__)
+
+
+@router.post("/paypal")
+async def paypal_webhook(request: Request):
+    """Handle PayPal webhooks after provider-side signature verification."""
+    raw_body = await request.body()
+    paypal = PayPalBillingAdapter(settings)
+    service = PayPalWebhookService(
+        expected_merchant_id=settings.PAYPAL_MERCHANT_ID,
+        signing_secret=settings.WEB_FUNNEL_SIGNING_SECRET,
+    )
+    async with AsyncUnitOfWork() as uow:
+        return await service.process(
+            uow=uow,
+            paypal=paypal,
+            headers=request.headers,
+            raw_body=raw_body,
+        )
 
 NON_RETRYABLE_USERLESS_EVENTS = {
     "TRANSFER",

--- a/src/api/schemas/request/web_funnel_requests.py
+++ b/src/api/schemas/request/web_funnel_requests.py
@@ -1,0 +1,31 @@
+"""Request schemas for web funnel checkout APIs."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WebFunnelCheckoutRequest(BaseModel):
+    """Create or reuse a backend-owned checkout."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    lead_id: str = Field(alias="leadId", min_length=1, max_length=128)
+    offer_id: str = Field(alias="offerId", min_length=1, max_length=64)
+    reward_id: str = Field(alias="rewardId", min_length=1, max_length=64)
+    billing_country: str = Field(alias="billingCountry", min_length=2, max_length=2)
+    idempotency_key: str = Field(alias="idempotencyKey", min_length=8, max_length=128)
+
+
+class PayPalConfirmationRequest(BaseModel):
+    """Bind a PayPal SDK subscription reference to a checkout."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    subscription_id: str = Field(alias="subscriptionId", min_length=3, max_length=255)
+
+
+class WebFunnelClaimRequest(BaseModel):
+    """Claim a paid checkout into the authenticated app user."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    claim_token: str = Field(alias="claimToken", min_length=16, max_length=255)

--- a/src/api/schemas/response/web_funnel_responses.py
+++ b/src/api/schemas/response/web_funnel_responses.py
@@ -1,0 +1,49 @@
+"""Response schemas for web funnel checkout APIs."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CheckoutResponse(BaseModel):
+    """Frontend PayPal checkout contract."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    checkout_id: str = Field(alias="checkoutId")
+    status: str
+    provider: str
+    plan_id: str | None = Field(alias="planId")
+    custom_id: str = Field(alias="customId")
+    offer_id: str = Field(alias="offerId")
+    reward_id: str = Field(alias="rewardId")
+    currency: str
+    amount_minor: int = Field(alias="amountMinor")
+    standard_amount_minor: int = Field(alias="standardAmountMinor")
+    renewal_amount_minor: int = Field(alias="renewalAmountMinor")
+    renewal_description: str = Field(alias="renewalDescription")
+    renewal_interval: str = Field(alias="renewalInterval")
+    welcome_discount_percent: int = Field(alias="welcomeDiscountPercent")
+
+
+class CheckoutStatusResponse(BaseModel):
+    """Safe checkout status for browser polling."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    checkout_id: str = Field(alias="checkoutId")
+    status: str
+    provider: str
+    claimable: bool
+    claimed: bool
+    paid_at: datetime | None = Field(alias="paidAt")
+    claim_token: str | None = Field(default=None, alias="claimToken")
+
+
+class WebFunnelClaimResponse(BaseModel):
+    """Claim result for an authenticated user."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    status: str
+    subscription_id: str = Field(alias="subscriptionId")

--- a/src/app/services/paypal_webhook_service.py
+++ b/src/app/services/paypal_webhook_service.py
@@ -1,0 +1,110 @@
+"""Verified PayPal webhook processing."""
+
+from fastapi import HTTPException, status
+
+from src.app.services.web_funnel_checkout_service import PAYPAL_PROVIDER
+from src.domain.ports.paypal_billing_port import PayPalBillingPort
+
+PAYMENT_COMPLETED_EVENTS = {
+    "PAYMENT.SALE.COMPLETED",
+    "PAYMENT.CAPTURE.COMPLETED",
+}
+REVOKE_EVENTS = {
+    "BILLING.SUBSCRIPTION.CANCELLED": "paypal_cancelled",
+    "BILLING.SUBSCRIPTION.SUSPENDED": "paypal_suspended",
+    "PAYMENT.SALE.REFUNDED": "paypal_refunded",
+    "CUSTOMER.DISPUTE.CREATED": "paypal_dispute",
+}
+
+
+class PayPalWebhookService:
+    """Processes PayPal webhooks only after provider signature verification."""
+
+    def __init__(self, expected_merchant_id: str = "", signing_secret: str = ""):
+        self.expected_merchant_id = expected_merchant_id
+        self.signing_secret = signing_secret
+
+    async def process(self, *, uow, paypal: PayPalBillingPort, headers, raw_body):
+        verification = await paypal.verify_webhook(dict(headers), raw_body)
+        if not verification.verified or not verification.event_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={"error_code": "INVALID_PAYPAL_SIGNATURE"},
+            )
+
+        checkout = None
+        if verification.resource_id:
+            checkout = await uow.web_funnel_checkouts.find_by_provider_subscription(
+                PAYPAL_PROVIDER, verification.resource_id
+            )
+
+        event, inserted = await uow.web_funnel_checkouts.record_provider_event(
+            provider=PAYPAL_PROVIDER,
+            event_id=verification.event_id,
+            event_type=verification.event_type or "UNKNOWN",
+            provider_subscription_id=verification.resource_id,
+            checkout_id=getattr(checkout, "id", None),
+            verified=True,
+            processing_result="stored",
+        )
+        if not inserted:
+            return {"status": "ignored", "reason": "duplicate", "event_id": event.id}
+        if not checkout:
+            return {"status": "stored", "reason": "checkout_not_found"}
+
+        snapshot = await paypal.get_subscription(checkout.provider_subscription_id)
+        mismatch_reason = self._snapshot_mismatch_reason(checkout, snapshot)
+        if mismatch_reason:
+            return {"status": "ignored", "reason": mismatch_reason}
+
+        event_type = verification.event_type or ""
+        if event_type in PAYMENT_COMPLETED_EVENTS and snapshot.status == "ACTIVE":
+            await uow.web_funnel_checkouts.mark_paid(checkout)
+            return {"status": "success", "state": "paid_active"}
+        if event_type in REVOKE_EVENTS:
+            await uow.web_funnel_checkouts.mark_revoked(
+                checkout, REVOKE_EVENTS[event_type]
+            )
+            return {"status": "success", "state": "revoked"}
+        return {"status": "ignored", "reason": "non_entitling_event"}
+
+    def _snapshot_mismatch_reason(self, checkout, snapshot) -> str | None:
+        if snapshot.plan_id != checkout.provider_plan_id:
+            return "plan_mismatch"
+        if not self._custom_id_matches_checkout(snapshot.custom_id, checkout.id):
+            return "custom_id_mismatch"
+        if snapshot.currency and snapshot.currency != checkout.currency:
+            return "currency_mismatch"
+        if (
+            snapshot.amount_minor is not None
+            and snapshot.amount_minor != checkout.amount_minor
+        ):
+            return "amount_mismatch"
+        if (
+            self.expected_merchant_id
+            and snapshot.merchant_id
+            and snapshot.merchant_id != self.expected_merchant_id
+        ):
+            return "merchant_mismatch"
+        return None
+
+    def _custom_id_matches_checkout(self, custom_id: str | None, checkout_id: str) -> bool:
+        if not custom_id or not self.signing_secret:
+            return False
+        import hashlib
+        import hmac
+        import json
+
+        try:
+            encoded, signature = custom_id.rsplit(".", 1)
+            expected = hmac.new(
+                self.signing_secret.encode("utf-8"),
+                encoded.encode("utf-8"),
+                hashlib.sha256,
+            ).hexdigest()
+            if not hmac.compare_digest(signature, expected):
+                return False
+            payload = json.loads(encoded)
+        except (ValueError, json.JSONDecodeError):
+            return False
+        return payload.get("checkout_id") == checkout_id

--- a/src/app/services/web_funnel_checkout_service.py
+++ b/src/app/services/web_funnel_checkout_service.py
@@ -1,0 +1,412 @@
+"""Application service for backend-owned web funnel checkouts."""
+
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from src.domain.ports.paypal_billing_port import (
+    PayPalBillingPort,
+    PayPalSubscriptionSnapshot,
+)
+from src.domain.utils.timezone_utils import utc_now
+from src.infra.config.settings import Settings
+from src.infra.database.models.web_funnel import WebFunnelCheckout
+
+PAYPAL_PROVIDER = "paypal"
+VN_COUNTRY = "VN"
+WELCOME_REWARD_ID = "WELCOME50"
+PAYMENT_COMPLETED_EVENTS = {
+    "PAYMENT.SALE.COMPLETED",
+    "PAYMENT.CAPTURE.COMPLETED",
+}
+
+
+@dataclass(frozen=True)
+class OfferSnapshot:
+    """Server-owned commercial snapshot for a funnel checkout."""
+
+    offer_id: str
+    reward_id: str
+    market: str
+    provider: str
+    currency: str
+    amount_minor: int
+    renewal_interval: str
+    plan_id: str
+    welcome_discount_percent: int
+
+
+class WebFunnelCheckoutService:
+    """Coordinates checkout ledger creation, confirmation, and claims."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def _require_secret(self) -> str:
+        secret = self.settings.WEB_FUNNEL_SIGNING_SECRET
+        if not secret:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "error_code": "WEB_FUNNEL_NOT_CONFIGURED",
+                    "message": "Web funnel checkout is not configured.",
+                },
+            )
+        return secret
+
+    @staticmethod
+    def _hash(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    def _sign(self, payload: dict[str, Any]) -> str:
+        secret = self._require_secret().encode("utf-8")
+        encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        signature = hmac.new(secret, encoded.encode("utf-8"), hashlib.sha256).hexdigest()
+        return f"{encoded}.{signature}"
+
+    def _verify_signed(self, signed_value: str) -> dict[str, Any]:
+        try:
+            encoded, signature = signed_value.rsplit(".", 1)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error_code": "INVALID_CUSTOM_ID"},
+            ) from exc
+        expected = hmac.new(
+            self._require_secret().encode("utf-8"),
+            encoded.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error_code": "INVALID_CUSTOM_ID"},
+            )
+        try:
+            return json.loads(encoded)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error_code": "INVALID_CUSTOM_ID"},
+            ) from exc
+
+    def _request_fingerprint(
+        self,
+        *,
+        lead_id: str,
+        offer_id: str,
+        reward_id: str,
+        billing_country: str,
+    ) -> str:
+        return self._hash(
+            json.dumps(
+                {
+                    "lead_id": lead_id,
+                    "offer_id": offer_id,
+                    "reward_id": reward_id,
+                    "billing_country": billing_country.upper(),
+                },
+                sort_keys=True,
+            )
+        )
+
+    def _select_offer(
+        self, offer_id: str, reward_id: str, billing_country: str
+    ) -> OfferSnapshot:
+        country = billing_country.upper()
+        if country == VN_COUNTRY:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "error_code": "PROVIDER_UNAVAILABLE",
+                    "message": "Vietnam web checkout is unavailable.",
+                },
+            )
+        if not self.settings.WEB_FUNNEL_CHECKOUT_ENABLED:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "error_code": "WEB_FUNNEL_DISABLED",
+                    "message": "Web funnel checkout is disabled.",
+                },
+            )
+
+        offer = self.settings.web_funnel_paypal_offers.get(offer_id)
+        if not offer:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error_code": "UNKNOWN_OFFER"},
+            )
+        if offer.get("reward_id") != reward_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error_code": "OFFER_REWARD_MISMATCH"},
+            )
+        provider = str(offer.get("provider", PAYPAL_PROVIDER)).lower()
+        currency = str(offer.get("currency", "USD")).upper()
+        plan_id = str(offer.get("paypal_plan_id") or "")
+        if provider != PAYPAL_PROVIDER or currency != "USD" or not plan_id:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"error_code": "PROVIDER_UNAVAILABLE"},
+            )
+        return OfferSnapshot(
+            offer_id=offer_id,
+            reward_id=reward_id,
+            market=str(offer.get("market", "INTL")),
+            provider=provider,
+            currency=currency,
+            amount_minor=int(offer.get("amount_minor", 0)),
+            renewal_interval=str(offer.get("renewal_interval", "monthly")),
+            plan_id=plan_id,
+            welcome_discount_percent=int(
+                offer.get(
+                    "welcome_discount_percent",
+                    50 if reward_id == WELCOME_REWARD_ID else 0,
+                )
+            ),
+        )
+
+    def _snapshot_mismatch_reason(
+        self, checkout: WebFunnelCheckout, snapshot: PayPalSubscriptionSnapshot
+    ) -> str | None:
+        if snapshot.plan_id != checkout.provider_plan_id:
+            return "PLAN_MISMATCH"
+        custom_payload = self._verify_signed(snapshot.custom_id or "")
+        if custom_payload.get("checkout_id") != checkout.id:
+            return "CUSTOM_ID_MISMATCH"
+        if snapshot.currency and snapshot.currency != checkout.currency:
+            return "CURRENCY_MISMATCH"
+        if (
+            snapshot.amount_minor is not None
+            and snapshot.amount_minor != checkout.amount_minor
+        ):
+            return "AMOUNT_MISMATCH"
+        expected_merchant = getattr(self.settings, "PAYPAL_MERCHANT_ID", "")
+        if (
+            expected_merchant
+            and snapshot.merchant_id
+            and snapshot.merchant_id != expected_merchant
+        ):
+            return "MERCHANT_MISMATCH"
+        return None
+
+    async def create_checkout(
+        self,
+        *,
+        uow,
+        lead_id: str,
+        offer_id: str,
+        reward_id: str,
+        billing_country: str,
+        idempotency_key: str,
+    ) -> tuple[WebFunnelCheckout, str]:
+        snapshot = self._select_offer(offer_id, reward_id, billing_country)
+        lead = await uow.web_funnel_checkouts.get_or_create_lead(
+            lead_id, billing_country.upper()
+        )
+        fingerprint = self._request_fingerprint(
+            lead_id=lead_id,
+            offer_id=offer_id,
+            reward_id=reward_id,
+            billing_country=billing_country,
+        )
+        idempotency_hash = self._hash(idempotency_key)
+        existing = await uow.web_funnel_checkouts.find_by_lead_idempotency(
+            lead.id, idempotency_hash
+        )
+        if existing:
+            if existing.request_fingerprint != fingerprint:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={"error_code": "IDEMPOTENCY_CONFLICT"},
+                )
+            custom_id = self._sign(
+                {"checkout_id": existing.id, "provider": existing.provider}
+            )
+            return existing, custom_id
+
+        checkout = WebFunnelCheckout(
+            lead_id=lead.id,
+            idempotency_key_hash=idempotency_hash,
+            request_fingerprint=fingerprint,
+            state="pending_approval",
+            offer_id=snapshot.offer_id,
+            reward_id=snapshot.reward_id,
+            market=snapshot.market,
+            billing_country=billing_country.upper(),
+            provider=snapshot.provider,
+            currency=snapshot.currency,
+            amount_minor=snapshot.amount_minor,
+            renewal_interval=snapshot.renewal_interval,
+            welcome_discount_percent=snapshot.welcome_discount_percent,
+            provider_plan_id=snapshot.plan_id,
+            custom_id_hash=self._hash(secrets.token_urlsafe(32)),
+            claim_token_hash=self._hash(secrets.token_urlsafe(32)),
+            claim_expires_at=utc_now()
+            + timedelta(minutes=self.settings.WEB_FUNNEL_CLAIM_TOKEN_TTL_MINUTES),
+        )
+        await uow.web_funnel_checkouts.add_checkout(checkout)
+        if checkout.request_fingerprint != fingerprint:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"error_code": "IDEMPOTENCY_CONFLICT"},
+            )
+        custom_id = self._sign({"checkout_id": checkout.id, "provider": snapshot.provider})
+        checkout.custom_id_hash = self._hash(custom_id)
+        checkout.claim_token_hash = self._hash(self.claim_token_for_checkout(checkout))
+        await uow.session.flush()
+        return checkout, custom_id
+
+    def claim_token_for_checkout(self, checkout: WebFunnelCheckout) -> str:
+        return self._sign({"checkout_id": checkout.id, "purpose": "claim"})
+
+    async def confirm_paypal_subscription(
+        self,
+        *,
+        uow,
+        paypal: PayPalBillingPort,
+        checkout_id: str,
+        subscription_id: str,
+    ) -> WebFunnelCheckout:
+        checkout = await uow.web_funnel_checkouts.find_by_id(checkout_id)
+        if not checkout:
+            raise HTTPException(status_code=404, detail={"error_code": "NOT_FOUND"})
+        if checkout.state not in {"pending_approval", "pending_payment"}:
+            raise HTTPException(
+                status_code=409, detail={"error_code": "CHECKOUT_NOT_CONFIRMABLE"}
+            )
+        if checkout.provider != PAYPAL_PROVIDER or not checkout.provider_plan_id:
+            raise HTTPException(
+                status_code=400, detail={"error_code": "PROVIDER_UNAVAILABLE"}
+            )
+        if checkout.provider_subscription_id:
+            if checkout.provider_subscription_id != subscription_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail={"error_code": "SUBSCRIPTION_ALREADY_BOUND"},
+                )
+            return checkout
+
+        snapshot = await paypal.get_subscription(subscription_id)
+        mismatch_reason = self._snapshot_mismatch_reason(checkout, snapshot)
+        if mismatch_reason:
+            raise HTTPException(
+                status_code=400, detail={"error_code": mismatch_reason}
+            )
+        await uow.web_funnel_checkouts.record_confirmation(
+            checkout, subscription_id
+        )
+        await self._apply_early_verified_payment_if_present(
+            uow=uow, checkout=checkout, snapshot=snapshot
+        )
+        return checkout
+
+    async def validate_paypal_subscription(
+        self,
+        *,
+        uow,
+        checkout_id: str,
+        subscription_id: str,
+        snapshot: PayPalSubscriptionSnapshot,
+    ) -> WebFunnelCheckout:
+        checkout = await uow.web_funnel_checkouts.find_by_id(checkout_id)
+        if not checkout:
+            raise HTTPException(status_code=404, detail={"error_code": "NOT_FOUND"})
+        if checkout.state not in {"pending_approval", "pending_payment"}:
+            raise HTTPException(
+                status_code=409, detail={"error_code": "CHECKOUT_NOT_CONFIRMABLE"}
+            )
+        if checkout.provider_subscription_id:
+            if checkout.provider_subscription_id != subscription_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail={"error_code": "SUBSCRIPTION_ALREADY_BOUND"},
+                )
+            return checkout
+        mismatch_reason = self._snapshot_mismatch_reason(checkout, snapshot)
+        if mismatch_reason:
+            raise HTTPException(
+                status_code=400, detail={"error_code": mismatch_reason}
+            )
+        return checkout
+
+    async def bind_validated_paypal_subscription(
+        self,
+        *,
+        uow,
+        checkout_id: str,
+        subscription_id: str,
+        snapshot: PayPalSubscriptionSnapshot,
+    ) -> WebFunnelCheckout:
+        checkout = await uow.web_funnel_checkouts.find_by_id(checkout_id)
+        if not checkout:
+            raise HTTPException(status_code=404, detail={"error_code": "NOT_FOUND"})
+        if checkout.provider_subscription_id:
+            if checkout.provider_subscription_id != subscription_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail={"error_code": "SUBSCRIPTION_ALREADY_BOUND"},
+                )
+            return checkout
+        mismatch_reason = self._snapshot_mismatch_reason(checkout, snapshot)
+        if mismatch_reason:
+            raise HTTPException(
+                status_code=400, detail={"error_code": mismatch_reason}
+            )
+        bound = await uow.web_funnel_checkouts.record_confirmation(
+            checkout, subscription_id
+        )
+        if bound.id != checkout.id:
+            raise HTTPException(
+                status_code=409,
+                detail={"error_code": "SUBSCRIPTION_ALREADY_BOUND"},
+            )
+        checkout = bound
+        await self._apply_early_verified_payment_if_present(
+            uow=uow, checkout=checkout, snapshot=snapshot
+        )
+        return checkout
+
+    async def _apply_early_verified_payment_if_present(
+        self,
+        *,
+        uow,
+        checkout: WebFunnelCheckout,
+        snapshot: PayPalSubscriptionSnapshot,
+    ) -> None:
+        if snapshot.status != "ACTIVE":
+            return
+        event = await uow.web_funnel_checkouts.find_latest_verified_event_for_subscription(
+            PAYPAL_PROVIDER,
+            checkout.provider_subscription_id,
+            PAYMENT_COMPLETED_EVENTS,
+        )
+        if event:
+            await uow.web_funnel_checkouts.mark_paid(checkout)
+
+    async def claim_checkout(self, *, uow, user_id: str, claim_token: str):
+        checkout = await uow.web_funnel_checkouts.find_by_claim_hash(
+            self._hash(claim_token)
+        )
+        if not checkout or checkout.claim_expires_at < utc_now():
+            raise HTTPException(status_code=404, detail={"error_code": "NOT_FOUND"})
+        if checkout.state != "paid_active" or not checkout.provider_subscription_id:
+            raise HTTPException(
+                status_code=409, detail={"error_code": "CHECKOUT_NOT_CLAIMABLE"}
+            )
+        if checkout.claimed_at:
+            raise HTTPException(
+                status_code=409, detail={"error_code": "CHECKOUT_ALREADY_CLAIMED"}
+            )
+        try:
+            return await uow.web_funnel_checkouts.claim_checkout(checkout, user_id)
+        except ValueError as exc:
+            error_code = str(exc).upper()
+            raise HTTPException(status_code=409, detail={"error_code": error_code}) from exc

--- a/src/domain/ports/paypal_billing_port.py
+++ b/src/domain/ports/paypal_billing_port.py
@@ -1,0 +1,42 @@
+"""Port for PayPal subscription billing operations."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class PayPalSubscriptionSnapshot:
+    """Safe subscription fields needed for checkout validation."""
+
+    id: str
+    plan_id: str | None
+    custom_id: str | None
+    status: str | None
+    merchant_id: str | None = None
+    subscriber_id: str | None = None
+    currency: str | None = None
+    amount_minor: int | None = None
+
+
+@dataclass(frozen=True)
+class PayPalWebhookVerification:
+    """Result of provider-side webhook signature verification."""
+
+    verified: bool
+    event_id: str | None = None
+    event_type: str | None = None
+    resource_id: str | None = None
+
+
+class PayPalBillingPort(Protocol):
+    """Provider interface for PayPal subscription APIs."""
+
+    async def get_subscription(
+        self, subscription_id: str
+    ) -> PayPalSubscriptionSnapshot:
+        """Fetch a subscription from PayPal."""
+
+    async def verify_webhook(
+        self, headers: dict[str, str], raw_body: bytes
+    ) -> PayPalWebhookVerification:
+        """Verify a PayPal webhook signature with PayPal."""

--- a/src/infra/adapters/paypal_billing_adapter.py
+++ b/src/infra/adapters/paypal_billing_adapter.py
@@ -1,0 +1,125 @@
+"""HTTP adapter for PayPal subscription billing."""
+
+import json
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from src.domain.ports.paypal_billing_port import (
+    PayPalSubscriptionSnapshot,
+    PayPalWebhookVerification,
+)
+from src.infra.config.settings import Settings
+
+
+class PayPalBillingAdapter:
+    """PayPal REST API adapter with server-only credentials."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def _client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.settings.PAYPAL_API_BASE_URL.rstrip("/"),
+            timeout=self.settings.PAYPAL_TIMEOUT_SECONDS,
+        )
+
+    async def _access_token(self) -> str:
+        async with self._client() as client:
+            response = await client.post(
+                "/v1/oauth2/token",
+                data={"grant_type": "client_credentials"},
+                auth=(
+                    self.settings.PAYPAL_CLIENT_ID,
+                    self.settings.PAYPAL_CLIENT_SECRET,
+                ),
+            )
+            response.raise_for_status()
+            return str(response.json()["access_token"])
+
+    async def get_subscription(
+        self, subscription_id: str
+    ) -> PayPalSubscriptionSnapshot:
+        token = await self._access_token()
+        async with self._client() as client:
+            response = await client.get(
+                f"/v1/billing/subscriptions/{subscription_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+        return self._subscription_snapshot(payload)
+
+    async def verify_webhook(
+        self, headers: dict[str, str], raw_body: bytes
+    ) -> PayPalWebhookVerification:
+        token = await self._access_token()
+        event = json.loads(raw_body.decode("utf-8"))
+        payload = {
+            "auth_algo": headers.get("paypal-auth-algo")
+            or headers.get("PAYPAL-AUTH-ALGO"),
+            "cert_url": headers.get("paypal-cert-url")
+            or headers.get("PAYPAL-CERT-URL"),
+            "transmission_id": headers.get("paypal-transmission-id")
+            or headers.get("PAYPAL-TRANSMISSION-ID"),
+            "transmission_sig": headers.get("paypal-transmission-sig")
+            or headers.get("PAYPAL-TRANSMISSION-SIG"),
+            "transmission_time": headers.get("paypal-transmission-time")
+            or headers.get("PAYPAL-TRANSMISSION-TIME"),
+            "webhook_id": self.settings.PAYPAL_WEBHOOK_ID,
+            "webhook_event": event,
+        }
+        async with self._client() as client:
+            response = await client.post(
+                "/v1/notifications/verify-webhook-signature",
+                headers={"Authorization": f"Bearer {token}"},
+                json=payload,
+            )
+            response.raise_for_status()
+            verification = response.json()
+        resource = event.get("resource") or {}
+        event_type = event.get("event_type")
+        return PayPalWebhookVerification(
+            verified=verification.get("verification_status") == "SUCCESS",
+            event_id=event.get("id"),
+            event_type=event_type,
+            resource_id=self._webhook_subscription_id(event_type, resource),
+        )
+
+    @staticmethod
+    def _subscription_snapshot(payload: dict[str, Any]) -> PayPalSubscriptionSnapshot:
+        billing_info = payload.get("billing_info") or {}
+        last_payment = billing_info.get("last_payment") or {}
+        amount = last_payment.get("amount") or {}
+        amount_minor = None
+        if amount.get("value") is not None:
+            value = Decimal(str(amount["value"]))
+            if value.as_tuple().exponent < -2:
+                raise ValueError("PayPal amount has more than two decimal places")
+            amount_minor = int(value * Decimal("100"))
+        subscriber = payload.get("subscriber") or {}
+        return PayPalSubscriptionSnapshot(
+            id=str(payload.get("id")),
+            plan_id=payload.get("plan_id"),
+            custom_id=payload.get("custom_id"),
+            status=payload.get("status"),
+            merchant_id=(payload.get("payee") or {}).get("merchant_id"),
+            subscriber_id=subscriber.get("payer_id"),
+            currency=amount.get("currency_code"),
+            amount_minor=amount_minor,
+        )
+
+    @staticmethod
+    def _webhook_subscription_id(
+        event_type: str | None, resource: dict[str, Any]
+    ) -> str | None:
+        if (event_type or "").startswith("PAYMENT.SALE."):
+            return resource.get("billing_agreement_id") or resource.get("id")
+        supplementary = resource.get("supplementary_data") or {}
+        related = supplementary.get("related_ids") or {}
+        return (
+            related.get("subscription_id")
+            or resource.get("billing_agreement_id")
+            or resource.get("id")
+        )

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -162,6 +162,25 @@ class Settings(BaseSettings):
     )
     REVENUECAT_SECRET_API_KEY: str | None = Field(default=None)
     REVENUECAT_WEBHOOK_SECRET: str | None = Field(default=None)
+    WEB_FUNNEL_CHECKOUT_ENABLED: bool = Field(
+        default=False,
+        description="Enable creation of non-VN web funnel checkout records.",
+    )
+    WEB_FUNNEL_SIGNING_SECRET: str = Field(
+        default="",
+        description="HMAC secret for opaque web funnel checkout correlation values.",
+    )
+    WEB_FUNNEL_CLAIM_TOKEN_TTL_MINUTES: int = Field(default=60)
+    WEB_FUNNEL_PAYPAL_OFFERS_JSON: str = Field(
+        default="{}",
+        description="JSON map of offer IDs to backend-owned PayPal catalog snapshots.",
+    )
+    PAYPAL_CLIENT_ID: str = Field(default="")
+    PAYPAL_CLIENT_SECRET: str = Field(default="")
+    PAYPAL_MERCHANT_ID: str = Field(default="")
+    PAYPAL_API_BASE_URL: str = Field(default="https://api-m.sandbox.paypal.com")
+    PAYPAL_WEBHOOK_ID: str = Field(default="")
+    PAYPAL_TIMEOUT_SECONDS: float = Field(default=10.0)
     CLOUDINARY_CLOUD_NAME: str | None = Field(default=None)
     CLOUDINARY_API_KEY: str | None = Field(default=None)
     CLOUDINARY_API_SECRET: str | None = Field(default=None)
@@ -332,6 +351,30 @@ class Settings(BaseSettings):
         if isinstance(v, str):
             return json.loads(v)
         return v
+
+    @property
+    def web_funnel_paypal_offers(self) -> dict[str, dict[str, Any]]:
+        """Return configured backend-owned web funnel offer snapshots."""
+        if not self.WEB_FUNNEL_PAYPAL_OFFERS_JSON:
+            return {}
+        parsed = json.loads(self.WEB_FUNNEL_PAYPAL_OFFERS_JSON)
+        if not isinstance(parsed, dict):
+            raise ValueError("WEB_FUNNEL_PAYPAL_OFFERS_JSON must be a JSON object")
+        for offer_id, offer in parsed.items():
+            if not isinstance(offer, dict):
+                raise ValueError(f"web funnel offer {offer_id} must be an object")
+            provider = str(offer.get("provider", "")).lower()
+            currency = str(offer.get("currency", "")).upper()
+            amount_minor = int(offer.get("amount_minor", 0) or 0)
+            if provider != "paypal":
+                raise ValueError(f"web funnel offer {offer_id} must use provider paypal")
+            if currency != "USD":
+                raise ValueError(f"web funnel offer {offer_id} must use USD")
+            if amount_minor <= 0:
+                raise ValueError(f"web funnel offer {offer_id} amount_minor must be positive")
+            if not offer.get("paypal_plan_id"):
+                raise ValueError(f"web funnel offer {offer_id} needs paypal_plan_id")
+        return parsed
 
     def get_commission(self, currency: str) -> float:
         """Get commission amount for a currency, fallback to default."""

--- a/src/infra/database/models/__init__.py
+++ b/src/infra/database/models/__init__.py
@@ -88,6 +88,12 @@ from .movement_entry import MovementEntryORM
 # Promo codes (email marketing)
 from .promo_code import PromoCode, PromoCodeRedemption
 from .referral import PayoutRequest, ReferralCode, ReferralConversion, ReferralWallet
+from .web_funnel import (
+    WebFunnelCheckout,
+    WebFunnelClaim,
+    WebFunnelLead,
+    WebFunnelProviderEvent,
+)
 
 # Weight tracking
 from .weight_entry import WeightEntryORM
@@ -167,4 +173,9 @@ __all__ = [
     "AffiliateEventOutbox",
     # AI Handshake guest trial quota
     "AiHandshakeGuestTrialQuota",
+    # Web funnel checkout ledger
+    "WebFunnelLead",
+    "WebFunnelCheckout",
+    "WebFunnelProviderEvent",
+    "WebFunnelClaim",
 ]

--- a/src/infra/database/models/subscription.py
+++ b/src/infra/database/models/subscription.py
@@ -2,7 +2,17 @@
 Subscription model for tracking user subscriptions.
 """
 
-from sqlalchemy import Column, String, DateTime, Boolean, Enum, ForeignKey, Index
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import relationship
 
 from src.domain.utils.timezone_utils import utc_now
@@ -12,9 +22,10 @@ from src.infra.database.models.base import BaseMixin
 
 class Subscription(Base, BaseMixin):
     """
-    Stores subscription records synced from RevenueCat.
+    Stores subscription records synced from billing providers.
 
-    RevenueCat is the source of truth - this table caches key data.
+    RevenueCat remains the native-purchase source of truth. Claimed web
+    checkouts create local provider-neutral rows after verified provider events.
     """
 
     __tablename__ = "subscriptions"
@@ -25,7 +36,16 @@ class Subscription(Base, BaseMixin):
     )
 
     # RevenueCat data
-    revenuecat_subscriber_id = Column(String(255), nullable=False, index=True)
+    revenuecat_subscriber_id = Column(String(255), nullable=True, index=True)
+    provider = Column(String(32), nullable=False, default="revenuecat")
+    provider_customer_id = Column(String(255), nullable=True)
+    provider_subscription_id = Column(String(255), nullable=True)
+    provider_transaction_id = Column(String(255), nullable=True)
+    source_checkout_id = Column(
+        String(36),
+        ForeignKey("web_funnel_checkouts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     product_id = Column(
         String(255), nullable=False
     )  # "premium_monthly" or "premium_yearly"
@@ -48,7 +68,6 @@ class Subscription(Base, BaseMixin):
     expires_at = Column(DateTime(timezone=True), nullable=True)
     cancelled_at = Column(DateTime(timezone=True), nullable=True)
 
-
     # Store metadata
     store_transaction_id = Column(String(255), nullable=True)
     is_sandbox = Column(Boolean, default=False, nullable=False)
@@ -61,6 +80,17 @@ class Subscription(Base, BaseMixin):
         Index("idx_user_id_status", "user_id", "status"),
         Index("idx_expires_at", "expires_at"),
         Index("idx_revenuecat_subscriber_id", "revenuecat_subscriber_id"),
+        Index("idx_subscriptions_provider_user_status", "provider", "user_id", "status"),
+        UniqueConstraint(
+            "provider",
+            "provider_subscription_id",
+            name="uq_subscriptions_provider_subscription",
+        ),
+        CheckConstraint(
+            "(provider = 'revenuecat' AND revenuecat_subscriber_id IS NOT NULL) OR "
+            "(provider <> 'revenuecat' AND provider_subscription_id IS NOT NULL)",
+            name="ck_subscriptions_provider_identifiers",
+        ),
     )
 
     def is_active(self) -> bool:

--- a/src/infra/database/models/web_funnel.py
+++ b/src/infra/database/models/web_funnel.py
@@ -1,0 +1,139 @@
+"""Web funnel checkout ledger models."""
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from src.infra.database.base import Base
+from src.infra.database.models.base import BaseMixin
+
+
+class WebFunnelLead(Base, BaseMixin):
+    """Public lead identity used to correlate funnel checkout attempts."""
+
+    __tablename__ = "web_funnel_leads"
+
+    external_lead_id = Column(String(128), nullable=False, unique=True, index=True)
+    email_hash = Column(String(64), nullable=True)
+    first_seen_country = Column(String(2), nullable=True)
+    last_seen_country = Column(String(2), nullable=True)
+
+    checkouts = relationship("WebFunnelCheckout", back_populates="lead")
+
+
+class WebFunnelCheckout(Base, BaseMixin):
+    """Server-owned checkout state for a web funnel purchase."""
+
+    __tablename__ = "web_funnel_checkouts"
+
+    lead_id = Column(
+        String(36),
+        ForeignKey("web_funnel_leads.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    idempotency_key_hash = Column(String(64), nullable=False)
+    request_fingerprint = Column(String(64), nullable=False)
+    state = Column(
+        String(32),
+        nullable=False,
+        default="pending_approval",
+        server_default="pending_approval",
+    )
+    state_reason = Column(String(255), nullable=True)
+
+    offer_id = Column(String(64), nullable=False)
+    reward_id = Column(String(64), nullable=False)
+    market = Column(String(16), nullable=False)
+    billing_country = Column(String(2), nullable=False)
+    provider = Column(String(32), nullable=False)
+    currency = Column(String(3), nullable=False)
+    amount_minor = Column(Integer, nullable=False)
+    renewal_interval = Column(String(16), nullable=False)
+    welcome_discount_percent = Column(Integer, nullable=False, default=0)
+
+    provider_plan_id = Column(String(255), nullable=True)
+    provider_subscription_id = Column(String(255), nullable=True)
+    provider_customer_id = Column(String(255), nullable=True)
+    provider_transaction_id = Column(String(255), nullable=True)
+    custom_id_hash = Column(String(64), nullable=False, unique=True)
+    claim_token_hash = Column(String(64), nullable=False, unique=True)
+    claim_expires_at = Column(DateTime(timezone=True), nullable=False)
+    paid_at = Column(DateTime(timezone=True), nullable=True)
+    confirmed_at = Column(DateTime(timezone=True), nullable=True)
+    claimed_at = Column(DateTime(timezone=True), nullable=True)
+
+    lead = relationship("WebFunnelLead", back_populates="checkouts")
+    claims = relationship("WebFunnelClaim", back_populates="checkout")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "lead_id",
+            "idempotency_key_hash",
+            name="uq_web_funnel_checkout_lead_idempotency",
+        ),
+        UniqueConstraint(
+            "provider",
+            "provider_subscription_id",
+            name="uq_web_funnel_checkout_provider_subscription",
+        ),
+        CheckConstraint("amount_minor >= 0", name="ck_web_funnel_amount_nonnegative"),
+        Index("idx_web_funnel_checkouts_state", "state"),
+        Index("idx_web_funnel_checkouts_lead_state", "lead_id", "state"),
+    )
+
+
+class WebFunnelProviderEvent(Base, BaseMixin):
+    """Deduplicated billing-provider webhook event."""
+
+    __tablename__ = "web_funnel_provider_events"
+
+    provider = Column(String(32), nullable=False)
+    event_id = Column(String(255), nullable=False)
+    event_type = Column(String(128), nullable=False)
+    provider_subscription_id = Column(String(255), nullable=True, index=True)
+    checkout_id = Column(
+        String(36),
+        ForeignKey("web_funnel_checkouts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    verified = Column(Boolean, nullable=False, default=False, server_default="false")
+    processed = Column(Boolean, nullable=False, default=False, server_default="false")
+    processing_result = Column(String(64), nullable=False, default="stored")
+    safe_payload = Column(Text, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "provider", "event_id", name="uq_web_funnel_provider_event"
+        ),
+        Index("idx_web_funnel_provider_events_checkout", "checkout_id"),
+    )
+
+
+class WebFunnelClaim(Base, BaseMixin):
+    """One-time claim binding from a paid checkout to an app user."""
+
+    __tablename__ = "web_funnel_claims"
+
+    checkout_id = Column(
+        String(36),
+        ForeignKey("web_funnel_checkouts.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    claim_token_hash = Column(String(64), nullable=False, unique=True)
+    claimed_at = Column(DateTime(timezone=True), nullable=False)
+
+    checkout = relationship("WebFunnelCheckout", back_populates="claims")
+
+    __table_args__ = (Index("idx_web_funnel_claims_user", "user_id"),)

--- a/src/infra/database/uow_async.py
+++ b/src/infra/database/uow_async.py
@@ -42,6 +42,9 @@ from src.infra.repositories.subscription_repository_async import (
     AsyncSubscriptionRepository,
 )
 from src.infra.repositories.user_repository_async import AsyncUserRepository
+from src.infra.repositories.web_funnel_checkout_repository import (
+    WebFunnelCheckoutRepository,
+)
 from src.infra.repositories.weekly_budget_repository_async import (
     AsyncWeeklyBudgetRepository,
 )
@@ -130,6 +133,7 @@ class AsyncUnitOfWork(AsyncUnitOfWorkPort):
         self.promo_codes = PromoCodeRepository(session)
         self.referrals = ReferralRepository(session)
         self.affiliate_outbox = AffiliateEventOutboxRepository(session)
+        self.web_funnel_checkouts = WebFunnelCheckoutRepository(session)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         session = self.session

--- a/src/infra/repositories/subscription_repository_async.py
+++ b/src/infra/repositories/subscription_repository_async.py
@@ -61,12 +61,28 @@ class AsyncSubscriptionRepository(SubscriptionRepositoryPort):
         return result.scalars().first()
 
     async def find_by_revenuecat_id(
-        self, revenuecat_subscriber_id: str
+        self, revenuecat_subscriber_id: str | None
     ) -> Subscription | None:
         """Find a subscription by RevenueCat subscriber ID."""
+        if not revenuecat_subscriber_id:
+            return None
         result = await self.session.execute(
             select(Subscription).where(
                 Subscription.revenuecat_subscriber_id == revenuecat_subscriber_id
+            )
+        )
+        return result.scalars().first()
+
+    async def find_by_provider_subscription(
+        self, provider: str, provider_subscription_id: str
+    ) -> Subscription | None:
+        """Find a subscription by provider-owned subscription ID."""
+        result = await self.session.execute(
+            select(Subscription).where(
+                and_(
+                    Subscription.provider == provider,
+                    Subscription.provider_subscription_id == provider_subscription_id,
+                )
             )
         )
         return result.scalars().first()

--- a/src/infra/repositories/web_funnel_checkout_repository.py
+++ b/src/infra/repositories/web_funnel_checkout_repository.py
@@ -1,0 +1,337 @@
+"""Repository for web funnel checkout ledger state."""
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.utils.timezone_utils import utc_now
+from src.infra.database.models.subscription import Subscription
+from src.infra.database.models.user.user import User
+from src.infra.database.models.web_funnel import (
+    WebFunnelCheckout,
+    WebFunnelClaim,
+    WebFunnelLead,
+    WebFunnelProviderEvent,
+)
+
+
+class WebFunnelCheckoutRepository:
+    """Async repository for web funnel checkout records. Never commits."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_or_create_lead(
+        self, external_lead_id: str, billing_country: str
+    ) -> WebFunnelLead:
+        result = await self.session.execute(
+            select(WebFunnelLead).where(
+                WebFunnelLead.external_lead_id == external_lead_id
+            )
+        )
+        lead = result.scalars().first()
+        if lead:
+            lead.last_seen_country = billing_country
+            return lead
+
+        lead = WebFunnelLead(
+            external_lead_id=external_lead_id,
+            first_seen_country=billing_country,
+            last_seen_country=billing_country,
+        )
+        try:
+            async with self.session.begin_nested():
+                self.session.add(lead)
+                await self.session.flush()
+            return lead
+        except IntegrityError:
+            result = await self.session.execute(
+                select(WebFunnelLead).where(
+                    WebFunnelLead.external_lead_id == external_lead_id
+                )
+            )
+            lead = result.scalars().first()
+            if lead is None:
+                raise
+            lead.last_seen_country = billing_country
+            return lead
+
+    async def find_by_id(self, checkout_id: str) -> WebFunnelCheckout | None:
+        result = await self.session.execute(
+            select(WebFunnelCheckout).where(WebFunnelCheckout.id == checkout_id)
+        )
+        return result.scalars().first()
+
+    async def find_by_custom_hash(
+        self, custom_id_hash: str
+    ) -> WebFunnelCheckout | None:
+        result = await self.session.execute(
+            select(WebFunnelCheckout).where(
+                WebFunnelCheckout.custom_id_hash == custom_id_hash
+            )
+        )
+        return result.scalars().first()
+
+    async def find_by_claim_hash(
+        self, claim_token_hash: str
+    ) -> WebFunnelCheckout | None:
+        result = await self.session.execute(
+            select(WebFunnelCheckout).where(
+                WebFunnelCheckout.claim_token_hash == claim_token_hash
+            )
+        )
+        return result.scalars().first()
+
+    async def find_by_provider_subscription(
+        self, provider: str, provider_subscription_id: str
+    ) -> WebFunnelCheckout | None:
+        result = await self.session.execute(
+            select(WebFunnelCheckout).where(
+                WebFunnelCheckout.provider == provider,
+                WebFunnelCheckout.provider_subscription_id
+                == provider_subscription_id,
+            )
+        )
+        return result.scalars().first()
+
+    async def find_by_lead_idempotency(
+        self, lead_id: str, idempotency_key_hash: str
+    ) -> WebFunnelCheckout | None:
+        result = await self.session.execute(
+            select(WebFunnelCheckout).where(
+                WebFunnelCheckout.lead_id == lead_id,
+                WebFunnelCheckout.idempotency_key_hash == idempotency_key_hash,
+            )
+        )
+        return result.scalars().first()
+
+    async def add_checkout(
+        self, checkout: WebFunnelCheckout
+    ) -> WebFunnelCheckout:
+        try:
+            async with self.session.begin_nested():
+                self.session.add(checkout)
+                await self.session.flush()
+            return checkout
+        except IntegrityError:
+            existing = await self.find_by_lead_idempotency(
+                checkout.lead_id, checkout.idempotency_key_hash
+            )
+            if existing:
+                return existing
+            raise
+
+    async def record_confirmation(
+        self, checkout: WebFunnelCheckout, subscription_id: str
+    ) -> WebFunnelCheckout:
+        try:
+            async with self.session.begin_nested():
+                checkout.provider_subscription_id = subscription_id
+                checkout.confirmed_at = checkout.confirmed_at or utc_now()
+                if checkout.state == "pending_approval":
+                    checkout.state = "pending_payment"
+                await self.session.flush()
+            return checkout
+        except IntegrityError:
+            existing = await self.find_by_provider_subscription(
+                checkout.provider, subscription_id
+            )
+            if existing:
+                return existing
+            raise
+
+    async def record_provider_event(
+        self,
+        provider: str,
+        event_id: str,
+        event_type: str,
+        provider_subscription_id: str | None,
+        checkout_id: str | None,
+        verified: bool,
+        processing_result: str,
+    ) -> tuple[WebFunnelProviderEvent, bool]:
+        result = await self.session.execute(
+            select(WebFunnelProviderEvent).where(
+                WebFunnelProviderEvent.provider == provider,
+                WebFunnelProviderEvent.event_id == event_id,
+            )
+        )
+        existing = result.scalars().first()
+        if existing:
+            return existing, False
+
+        event = WebFunnelProviderEvent(
+            provider=provider,
+            event_id=event_id,
+            event_type=event_type,
+            provider_subscription_id=provider_subscription_id,
+            checkout_id=checkout_id,
+            verified=verified,
+            processed=True,
+            processing_result=processing_result,
+        )
+        try:
+            async with self.session.begin_nested():
+                self.session.add(event)
+                await self.session.flush()
+            return event, True
+        except IntegrityError:
+            result = await self.session.execute(
+                select(WebFunnelProviderEvent).where(
+                    WebFunnelProviderEvent.provider == provider,
+                    WebFunnelProviderEvent.event_id == event_id,
+                )
+            )
+            existing = result.scalars().first()
+            if existing:
+                return existing, False
+            raise
+
+    async def find_latest_verified_event_for_subscription(
+        self, provider: str, provider_subscription_id: str, event_types: set[str]
+    ) -> WebFunnelProviderEvent | None:
+        result = await self.session.execute(
+            select(WebFunnelProviderEvent)
+            .where(
+                WebFunnelProviderEvent.provider == provider,
+                WebFunnelProviderEvent.provider_subscription_id
+                == provider_subscription_id,
+                WebFunnelProviderEvent.verified.is_(True),
+                WebFunnelProviderEvent.event_type.in_(event_types),
+            )
+            .order_by(WebFunnelProviderEvent.created_at.desc())
+        )
+        return result.scalars().first()
+
+    async def mark_paid(
+        self, checkout: WebFunnelCheckout, paid_at: datetime | None = None
+    ) -> WebFunnelCheckout:
+        checkout.state = "paid_active"
+        checkout.state_reason = "paypal_verified_active"
+        checkout.paid_at = paid_at or utc_now()
+        await self.session.flush()
+        return checkout
+
+    async def mark_revoked(
+        self, checkout: WebFunnelCheckout, reason: str
+    ) -> WebFunnelCheckout:
+        checkout.state = "revoked"
+        checkout.state_reason = reason
+        result = await self.session.execute(
+            select(Subscription).where(
+                Subscription.provider == checkout.provider,
+                Subscription.provider_subscription_id
+                == checkout.provider_subscription_id,
+            )
+        )
+        subscription = result.scalars().first()
+        if subscription:
+            subscription.status = (
+                "refunded" if "refund" in reason or "dispute" in reason else "cancelled"
+            )
+            subscription.updated_at = utc_now()
+        await self.session.flush()
+        return checkout
+
+    async def claim_checkout(
+        self, checkout: WebFunnelCheckout, user_id: str
+    ) -> Subscription:
+        now = utc_now()
+        result = await self.session.execute(
+            select(WebFunnelCheckout)
+            .where(WebFunnelCheckout.id == checkout.id)
+            .with_for_update()
+        )
+        locked_checkout = result.scalars().first()
+        if locked_checkout is None:
+            raise ValueError("checkout_not_found")
+        checkout = locked_checkout
+        if checkout.claimed_at or checkout.state == "claimed":
+            result = await self.session.execute(
+                select(Subscription).where(Subscription.source_checkout_id == checkout.id)
+            )
+            existing = result.scalars().first()
+            if existing:
+                return existing
+            raise ValueError("checkout_already_claimed")
+        if checkout.state != "paid_active":
+            raise ValueError("checkout_not_claimable")
+
+        checkout.state = "claimed"
+        checkout.claimed_at = now
+        claim = WebFunnelClaim(
+            checkout_id=checkout.id,
+            user_id=user_id,
+            claim_token_hash=checkout.claim_token_hash,
+            claimed_at=now,
+        )
+        try:
+            async with self.session.begin_nested():
+                self.session.add(claim)
+                await self.session.flush()
+        except IntegrityError:
+            checkout = await self.find_by_id(checkout.id)
+            if checkout and checkout.claimed_at:
+                result = await self.session.execute(
+                    select(Subscription).where(
+                        Subscription.source_checkout_id == checkout.id
+                    )
+                )
+                existing = result.scalars().first()
+                if existing:
+                    return existing
+            raise
+
+        result = await self.session.execute(
+            select(Subscription).where(
+                Subscription.provider == checkout.provider,
+                Subscription.provider_subscription_id
+                == checkout.provider_subscription_id,
+            )
+        )
+        subscription = result.scalars().first()
+        if subscription is None:
+            subscription = Subscription(
+                user_id=user_id,
+                revenuecat_subscriber_id=None,
+                provider=checkout.provider,
+                provider_customer_id=checkout.provider_customer_id,
+                provider_subscription_id=checkout.provider_subscription_id,
+                provider_transaction_id=checkout.provider_transaction_id,
+                source_checkout_id=checkout.id,
+                product_id=checkout.offer_id,
+                platform="web",
+                status="active",
+                purchased_at=checkout.paid_at or now,
+                expires_at=None,
+                store_transaction_id=checkout.provider_transaction_id,
+                is_sandbox=False,
+            )
+            try:
+                async with self.session.begin_nested():
+                    self.session.add(subscription)
+                    await self.session.flush()
+            except IntegrityError:
+                result = await self.session.execute(
+                    select(Subscription).where(
+                        Subscription.provider == checkout.provider,
+                        Subscription.provider_subscription_id
+                        == checkout.provider_subscription_id,
+                    )
+                )
+                subscription = result.scalars().first()
+                if subscription is None:
+                    raise
+        else:
+            subscription.user_id = user_id
+            subscription.status = "active"
+            subscription.source_checkout_id = checkout.id
+
+        await self.session.flush()
+        return subscription
+
+    async def find_user_by_id(self, user_id: str) -> User | None:
+        result = await self.session.execute(select(User).where(User.id == user_id))
+        return result.scalars().first()

--- a/tests/migrations/test_catalog_recipe_tables_migration.py
+++ b/tests/migrations/test_catalog_recipe_tables_migration.py
@@ -33,7 +33,7 @@ def test_catalog_schema_has_one_head_and_no_stored_calories() -> None:
 
     assert [
         revision.revision for revision in script_dir.get_revisions("heads")
-    ] == ["20260724000001"]
+    ] == [script_dir.get_current_head()]
     assert '"calories"' not in catalog_section
 
 

--- a/tests/unit/app/services/test_paypal_webhook_service.py
+++ b/tests/unit/app/services/test_paypal_webhook_service.py
@@ -1,0 +1,264 @@
+"""Tests for verified PayPal webhook state transitions."""
+
+import hashlib
+import hmac
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.app.services.paypal_webhook_service import PayPalWebhookService
+from src.domain.ports.paypal_billing_port import (
+    PayPalSubscriptionSnapshot,
+    PayPalWebhookVerification,
+)
+from src.infra.adapters.paypal_billing_adapter import PayPalBillingAdapter
+
+
+def _signed_custom_id(checkout_id: str, secret: str = "secret") -> str:
+    payload = json.dumps(
+        {"checkout_id": checkout_id, "provider": "paypal"},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    signature = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{signature}"
+
+
+class FakeWebFunnelRepo:
+    def __init__(self, checkout):
+        self.checkout = checkout
+        self.events = set()
+        self.marked_paid = False
+        self.revoked_reason = None
+        self.subscription = SimpleNamespace(status="active")
+        self.recorded_checkout_id = None
+
+    async def find_by_provider_subscription(self, provider, provider_subscription_id):
+        if (
+            provider == "paypal"
+            and provider_subscription_id == self.checkout.provider_subscription_id
+        ):
+            return self.checkout
+        return None
+
+    async def record_provider_event(
+        self,
+        provider,
+        event_id,
+        event_type,
+        provider_subscription_id,
+        checkout_id,
+        verified,
+        processing_result,
+    ):
+        if event_id in self.events:
+            return SimpleNamespace(id="event-1"), False
+        self.events.add(event_id)
+        self.recorded_checkout_id = checkout_id
+        return SimpleNamespace(id="event-1"), True
+
+    async def mark_paid(self, checkout):
+        self.marked_paid = True
+        checkout.state = "paid_active"
+        return checkout
+
+    async def mark_revoked(self, checkout, reason):
+        self.revoked_reason = reason
+        checkout.state = "revoked"
+        self.subscription.status = "refunded" if "refund" in reason else "cancelled"
+        return checkout
+
+
+class FakeUow:
+    def __init__(self, checkout):
+        self.web_funnel_checkouts = FakeWebFunnelRepo(checkout)
+
+
+class FakePayPal:
+    def __init__(self, *, event_type, snapshot):
+        self.event_type = event_type
+        self.snapshot = snapshot
+
+    async def verify_webhook(self, headers, raw_body):
+        return PayPalWebhookVerification(
+            verified=True,
+            event_id="evt-1",
+            event_type=self.event_type,
+            resource_id="I-SUB",
+        )
+
+    async def get_subscription(self, subscription_id):
+        return self.snapshot
+
+
+def _checkout():
+    return SimpleNamespace(
+        id="checkout-1",
+        provider="paypal",
+        provider_subscription_id="I-SUB",
+        provider_plan_id="P-PLAN",
+        currency="USD",
+        amount_minor=999,
+        state="pending_payment",
+    )
+
+
+def _snapshot(**overrides):
+    values = {
+        "id": "I-SUB",
+        "plan_id": "P-PLAN",
+        "custom_id": _signed_custom_id("checkout-1"),
+        "status": "ACTIVE",
+        "merchant_id": "merchant-1",
+        "currency": "USD",
+        "amount_minor": 999,
+    }
+    values.update(overrides)
+    return PayPalSubscriptionSnapshot(**values)
+
+
+def test_paypal_snapshot_uses_exact_decimal_minor_units():
+    snapshot = PayPalBillingAdapter._subscription_snapshot(
+        {
+            "id": "I-SUB",
+            "plan_id": "P-PLAN",
+            "custom_id": _signed_custom_id("checkout-1"),
+            "status": "ACTIVE",
+            "billing_info": {
+                "last_payment": {
+                    "amount": {"value": "10.00", "currency_code": "USD"}
+                }
+            },
+        }
+    )
+
+    assert snapshot.amount_minor == 1000
+
+
+def test_paypal_snapshot_rejects_overprecise_amount():
+    with pytest.raises(ValueError):
+        PayPalBillingAdapter._subscription_snapshot(
+            {
+                "id": "I-SUB",
+                "billing_info": {
+                    "last_payment": {
+                        "amount": {"value": "10.015", "currency_code": "USD"}
+                    }
+                },
+            }
+        )
+
+
+def test_paypal_sale_webhook_prefers_billing_agreement_id():
+    subscription_id = PayPalBillingAdapter._webhook_subscription_id(
+        "PAYMENT.SALE.COMPLETED",
+        {"id": "PAYMENT-ID", "billing_agreement_id": "I-SUB"},
+    )
+
+    assert subscription_id == "I-SUB"
+
+
+@pytest.mark.asyncio
+async def test_completed_payment_with_full_snapshot_match_marks_paid():
+    checkout = _checkout()
+    uow = FakeUow(checkout)
+    service = PayPalWebhookService(
+        expected_merchant_id="merchant-1", signing_secret="secret"
+    )
+
+    result = await service.process(
+        uow=uow,
+        paypal=FakePayPal(
+            event_type="PAYMENT.CAPTURE.COMPLETED", snapshot=_snapshot()
+        ),
+        headers={},
+        raw_body=b"{}",
+    )
+
+    assert result["state"] == "paid_active"
+    assert uow.web_funnel_checkouts.marked_paid is True
+
+
+@pytest.mark.asyncio
+async def test_subscription_activation_alone_does_not_mark_paid():
+    checkout = _checkout()
+    uow = FakeUow(checkout)
+    service = PayPalWebhookService(
+        expected_merchant_id="merchant-1", signing_secret="secret"
+    )
+
+    result = await service.process(
+        uow=uow,
+        paypal=FakePayPal(
+            event_type="BILLING.SUBSCRIPTION.ACTIVATED", snapshot=_snapshot()
+        ),
+        headers={},
+        raw_body=b"{}",
+    )
+
+    assert result["reason"] == "non_entitling_event"
+    assert uow.web_funnel_checkouts.marked_paid is False
+
+
+@pytest.mark.asyncio
+async def test_amount_mismatch_does_not_mark_paid():
+    checkout = _checkout()
+    uow = FakeUow(checkout)
+    service = PayPalWebhookService(
+        expected_merchant_id="merchant-1", signing_secret="secret"
+    )
+
+    result = await service.process(
+        uow=uow,
+        paypal=FakePayPal(
+            event_type="PAYMENT.CAPTURE.COMPLETED",
+            snapshot=_snapshot(amount_minor=100),
+        ),
+        headers={},
+        raw_body=b"{}",
+    )
+
+    assert result["reason"] == "amount_mismatch"
+    assert uow.web_funnel_checkouts.marked_paid is False
+
+
+@pytest.mark.asyncio
+async def test_refund_revokes_checkout_and_subscription():
+    checkout = _checkout()
+    uow = FakeUow(checkout)
+    service = PayPalWebhookService(
+        expected_merchant_id="merchant-1", signing_secret="secret"
+    )
+
+    result = await service.process(
+        uow=uow,
+        paypal=FakePayPal(event_type="PAYMENT.SALE.REFUNDED", snapshot=_snapshot()),
+        headers={},
+        raw_body=b"{}",
+    )
+
+    assert result["state"] == "revoked"
+    assert uow.web_funnel_checkouts.subscription.status == "refunded"
+
+
+@pytest.mark.asyncio
+async def test_verified_webhook_before_confirmation_is_stored_for_reconciliation():
+    checkout = _checkout()
+    checkout.provider_subscription_id = None
+    uow = FakeUow(checkout)
+    service = PayPalWebhookService(
+        expected_merchant_id="merchant-1", signing_secret="secret"
+    )
+
+    result = await service.process(
+        uow=uow,
+        paypal=FakePayPal(
+            event_type="PAYMENT.CAPTURE.COMPLETED", snapshot=_snapshot()
+        ),
+        headers={},
+        raw_body=b"{}",
+    )
+
+    assert result == {"status": "stored", "reason": "checkout_not_found"}
+    assert uow.web_funnel_checkouts.recorded_checkout_id is None

--- a/tests/unit/app/services/test_web_funnel_checkout_service.py
+++ b/tests/unit/app/services/test_web_funnel_checkout_service.py
@@ -1,0 +1,286 @@
+"""Tests for backend-owned web funnel checkout service."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from src.app.services.web_funnel_checkout_service import WebFunnelCheckoutService
+from src.domain.ports.paypal_billing_port import PayPalSubscriptionSnapshot
+from src.infra.database.models.web_funnel import WebFunnelLead
+
+
+class FakeWebFunnelRepo:
+    def __init__(self):
+        self.lead = WebFunnelLead(id="lead-row", external_lead_id="lead-1")
+        self.by_idempotency = {}
+        self.by_id = {}
+        self.by_claim_hash = {}
+        self.verified_payment_event = None
+        self.marked_paid = False
+
+    async def get_or_create_lead(self, external_lead_id, billing_country):
+        self.lead.external_lead_id = external_lead_id
+        self.lead.last_seen_country = billing_country
+        return self.lead
+
+    async def find_by_lead_idempotency(self, lead_id, idempotency_key_hash):
+        return self.by_idempotency.get((lead_id, idempotency_key_hash))
+
+    async def add_checkout(self, checkout):
+        checkout.id = "checkout-1"
+        self.by_id[checkout.id] = checkout
+        self.by_idempotency[
+            (checkout.lead_id, checkout.idempotency_key_hash)
+        ] = checkout
+        return checkout
+
+    async def find_by_id(self, checkout_id):
+        return self.by_id.get(checkout_id)
+
+    async def record_confirmation(self, checkout, subscription_id):
+        checkout.provider_subscription_id = subscription_id
+        checkout.state = "pending_payment"
+        return checkout
+
+    async def find_latest_verified_event_for_subscription(
+        self, provider, provider_subscription_id, event_types
+    ):
+        if self.verified_payment_event and provider_subscription_id == "I-SUB":
+            return self.verified_payment_event
+        return None
+
+    async def mark_paid(self, checkout):
+        self.marked_paid = True
+        checkout.state = "paid_active"
+        return checkout
+
+    async def find_by_claim_hash(self, claim_token_hash):
+        return self.by_claim_hash.get(claim_token_hash)
+
+    async def claim_checkout(self, checkout, user_id):
+        checkout.claimed_at = object()
+        checkout.state = "claimed"
+        return SimpleNamespace(id="sub-1", user_id=user_id)
+
+
+class FakeUow:
+    def __init__(self):
+        self.web_funnel_checkouts = FakeWebFunnelRepo()
+        self.session = SimpleNamespace(flush=AsyncMock())
+
+
+class FakePayPal:
+    def __init__(self, *, plan_id, custom_id):
+        self.plan_id = plan_id
+        self.custom_id = custom_id
+
+    async def get_subscription(self, subscription_id):
+        return PayPalSubscriptionSnapshot(
+            id=subscription_id,
+            plan_id=self.plan_id,
+            custom_id=self.custom_id,
+            status="APPROVAL_PENDING",
+        )
+
+
+def _settings(enabled=True):
+    return SimpleNamespace(
+        WEB_FUNNEL_SIGNING_SECRET="test-secret",
+        WEB_FUNNEL_CHECKOUT_ENABLED=enabled,
+        WEB_FUNNEL_CLAIM_TOKEN_TTL_MINUTES=60,
+        web_funnel_paypal_offers={
+            "premium_monthly": {
+                "reward_id": "WELCOME50",
+                "provider": "paypal",
+                "currency": "USD",
+                "amount_minor": 499,
+                "renewal_interval": "monthly",
+                "paypal_plan_id": "P-PLAN",
+                "welcome_discount_percent": 50,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_is_idempotent_for_same_payload():
+    service = WebFunnelCheckoutService(_settings())
+    uow = FakeUow()
+
+    checkout, custom_id = await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+    repeated, repeated_custom_id = await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+
+    assert repeated is checkout
+    assert repeated_custom_id == custom_id
+    assert checkout.provider_plan_id == "P-PLAN"
+    assert checkout.currency == "USD"
+    assert checkout.welcome_discount_percent == 50
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_rejects_idempotency_conflict():
+    service = WebFunnelCheckoutService(_settings())
+    uow = FakeUow()
+    await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_checkout(
+            uow=uow,
+            lead_id="lead-1",
+            offer_id="premium_monthly",
+            reward_id="WELCOME50",
+            billing_country="CA",
+            idempotency_key="idem-key-1",
+        )
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_vietnam_checkout_fails_closed_without_momo():
+    service = WebFunnelCheckoutService(_settings())
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_checkout(
+            uow=FakeUow(),
+            lead_id="lead-1",
+            offer_id="premium_monthly",
+            reward_id="WELCOME50",
+            billing_country="VN",
+            idempotency_key="idem-key-1",
+        )
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["error_code"] == "PROVIDER_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_paypal_confirmation_binds_reference_without_granting_access():
+    service = WebFunnelCheckoutService(_settings())
+    uow = FakeUow()
+    checkout, custom_id = await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+
+    confirmed = await service.confirm_paypal_subscription(
+        uow=uow,
+        paypal=FakePayPal(plan_id="P-PLAN", custom_id=custom_id),
+        checkout_id=checkout.id,
+        subscription_id="I-SUB",
+    )
+
+    assert confirmed.provider_subscription_id == "I-SUB"
+    assert confirmed.state == "pending_payment"
+
+
+@pytest.mark.asyncio
+async def test_paypal_confirmation_rejects_plan_mismatch():
+    service = WebFunnelCheckoutService(_settings())
+    uow = FakeUow()
+    checkout, custom_id = await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.confirm_paypal_subscription(
+            uow=uow,
+            paypal=FakePayPal(plan_id="P-OTHER", custom_id=custom_id),
+            checkout_id=checkout.id,
+            subscription_id="I-SUB",
+        )
+
+    assert exc.value.detail["error_code"] == "PLAN_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_paypal_confirmation_rejects_malformed_custom_id():
+    service = WebFunnelCheckoutService(_settings())
+    uow = FakeUow()
+    checkout, _ = await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await service.confirm_paypal_subscription(
+            uow=uow,
+            paypal=FakePayPal(plan_id="P-PLAN", custom_id="not-json.bad-signature"),
+            checkout_id=checkout.id,
+            subscription_id="I-SUB",
+        )
+
+    assert exc.value.detail["error_code"] == "INVALID_CUSTOM_ID"
+
+
+@pytest.mark.asyncio
+async def test_paypal_confirmation_reconciles_early_verified_payment_event():
+    service = WebFunnelCheckoutService(_settings())
+    uow = FakeUow()
+    checkout, custom_id = await service.create_checkout(
+        uow=uow,
+        lead_id="lead-1",
+        offer_id="premium_monthly",
+        reward_id="WELCOME50",
+        billing_country="US",
+        idempotency_key="idem-key-1",
+    )
+    uow.web_funnel_checkouts.verified_payment_event = object()
+
+    confirmed = await service.confirm_paypal_subscription(
+        uow=uow,
+        paypal=FakePayPal(plan_id="P-PLAN", custom_id=custom_id),
+        checkout_id=checkout.id,
+        subscription_id="I-SUB",
+    )
+
+    assert confirmed.state == "pending_payment"
+
+    active_snapshot = PayPalSubscriptionSnapshot(
+        id="I-SUB",
+        plan_id="P-PLAN",
+        custom_id=custom_id,
+        status="ACTIVE",
+    )
+    await service._apply_early_verified_payment_if_present(
+        uow=uow, checkout=confirmed, snapshot=active_snapshot
+    )
+
+    assert uow.web_funnel_checkouts.marked_paid is True
+    assert confirmed.state == "paid_active"

--- a/tests/unit/infra/repositories/test_subscription_repository_async.py
+++ b/tests/unit/infra/repositories/test_subscription_repository_async.py
@@ -15,6 +15,9 @@ class _Scalars:
     def all(self):
         return self._rows
 
+    def first(self):
+        return self._rows[0] if self._rows else None
+
 
 class _Result:
     def __init__(self, rows):
@@ -67,3 +70,14 @@ async def test_find_expiring_soon_returns_active_future_rows():
     assert "subscriptions.status" in compiled
     assert "subscriptions.expires_at <= " in compiled
     assert "subscriptions.expires_at > " in compiled
+
+
+@pytest.mark.asyncio
+async def test_find_by_revenuecat_id_ignores_empty_identifier():
+    session = _AsyncSession([MagicMock(id="web-subscription")])
+    repo = AsyncSubscriptionRepository(session)
+
+    result = await repo.find_by_revenuecat_id(None)
+
+    assert result is None
+    assert session.statement is None


### PR DESCRIPTION
## Summary
- add backend-owned PayPal web funnel checkout ledger, migrations, routes, PayPal adapter, webhook handling, and claim flow
- keep VN fail-closed while non-VN uses backend-owned PayPal/USD offer catalog
- delay claim token exposure until checkout is paid/claimable and document the web-funnel contract

## Tests
- .venv/bin/pytest tests/unit/app/services/test_web_funnel_checkout_service.py tests/unit/app/services/test_paypal_webhook_service.py tests/unit/api/test_premium_middleware.py tests/unit/infra/repositories/test_subscription_repository_async.py -q
- touched-file ruff check
- touched-file py_compile
- pre-push full unit suite: 2027 passed

## Notes
- Frontend funnel changes are in /Users/alexnguyen/Desktop/Nut/nutree_web_funnel and are not included in this backend PR.
- PayPal sandbox buyer/webhook lifecycle testing remains a release gate before treating this as ready for production.