### PR TITLE
slot recommendation

### DIFF
--- a/docs/meal-recommendation-mobile-handoff.md
+++ b/docs/meal-recommendation-mobile-handoff.md
@@ -99,6 +99,9 @@ Notes:
 
 - `expected_selection_version` prevents stale swaps.
 - If `alternative_catalog_meal_id` is omitted, backend chooses the next best alternative.
+- Automatic swaps consume unseen candidates stored for that slot. After the pool is
+  exhausted, the backend replenishes only that slot with five fresh candidates;
+  previously seen candidates remain auditable but are never selected again.
 - Use a stable `request_id` for retry safety.
 
 ### Log Recommended Meal
@@ -151,6 +154,10 @@ Ready:
 - Create, get, slot-detail, swap, and log endpoints exist.
 - Operation idempotency exists.
 - Recommendation read paths now use the compact/delta contract for mobile cache patching.
+- Candidate lifecycle state (`seen_at` and `retired_at`) is backend-owned; the
+  existing slot detail response remains unchanged, so no Flutter source change is required.
+- Replenishment emits the same delta response and must be staged with database-pool
+  and latency observation before production enablement. Daily readiness/cron remain deferred.
 - Focused backend tests pass.
 
 Environment prerequisites:

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -155,6 +155,7 @@ downloading Cloudinary bytes. Graph nodes must not import provider SDKs,
 3. `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` hydrates one selected slot and its alternatives when the client needs drill-down data.
 4. `swap`, `log`, and `skip` return the changed-slot detail shape so the mobile client can patch its cached plan without reloading everything.
 5. Recommendation analytics are scheduled through `BackgroundTaskManager` when available. Catalog meals are read from the process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback. Meal-history affinity is projected from aggregate linked ingredient buckets instead of loading the full meal graph, and logging a recommended meal reuses the already loaded selected catalog projection without fabricating image data.
+6. Candidate rows retain `seen_at` and `retired_at`. Swap locks only the requested slot, consumes unseen active candidates, and when exhausted retires that slot's inactive pool before inserting five deterministic fresh alternatives. Replenishment never mutates another slot or changes the response contract; daily jobs remain out of scope.
 
 ---
 

--- a/migrations/versions/20260727000001_add_meal_recommendation_candidate_lifecycle.py
+++ b/migrations/versions/20260727000001_add_meal_recommendation_candidate_lifecycle.py
@@ -1,0 +1,29 @@
+"""Track seen and retired recommendation candidates."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260727000001"
+down_revision = "20260726000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "meal_recommendations",
+        sa.Column("seen_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "meal_recommendations",
+        sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        "UPDATE meal_recommendations SET seen_at = COALESCE(seen_at, created_at) "
+        "WHERE is_selected = TRUE"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("meal_recommendations", "retired_at")
+    op.drop_column("meal_recommendations", "seen_at")

--- a/plans/260727-1905-slot-only-recommendation-replenishment/phase-01-characterize-candidate-pool-lifecycle.md
+++ b/plans/260727-1905-slot-only-recommendation-replenishment/phase-01-characterize-candidate-pool-lifecycle.md
@@ -1,0 +1,54 @@
+---
+phase: 1
+title: "Characterize Candidate Pool Lifecycle"
+status: in-progress
+priority: P1
+effort: "1-1.5d"
+dependencies: []
+---
+
+# Phase 1: Characterize Candidate Pool Lifecycle
+
+## Overview
+
+Add tests that prove the present cycle, then introduce durable candidate lifecycle fields so unseen, seen, active, and retired candidates are distinguishable per slot.
+
+## Related Code Files
+
+- Modify: `src/infra/database/models/meal_recommendation/meal_recommendation_plan.py`
+- Create: `migrations/versions/<timestamp>_add_meal_recommendation_candidate_pool_lifecycle.py`
+- Modify: `src/infra/repositories/meal_recommendation_plan_repository_async.py`
+- Modify: `src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py`
+- Modify: `tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py`
+- Create: `tests/integration/postgres/test_meal_recommendation_slot_concurrency.py`
+
+## Requirements
+
+- A new plan records the selected candidate as seen and its five alternatives as unseen.
+- Retired candidates remain auditable but are excluded from slot detail and future automatic selection.
+- The currently selected candidate remains in the active pool during replenishment; five new alternatives form its next active pool.
+- Forward-only migration only; do not edit deployed migration history.
+
+## Tests Before
+
+1. Characterize today’s automatic rank-0/rank-1 cycle.
+2. Prove a candidate selected once is never returned by automatic swap again.
+3. Prove retired candidates are absent from active slot detail while historical operations remain valid.
+4. Run migration upgrade against PostgreSQL integration database and assert safe legacy defaults.
+
+## Implementation Steps
+
+1. Add minimal lifecycle persistence (`seen_at` and an active-pool discriminator) to recommendation candidate rows; name columns from their invariant, not this plan.
+2. Backfill existing selected rows as seen. Keep old inactive candidates available only until normal lifecycle handling safely retires them; document exact compatibility behavior in migration comments.
+3. Restrict active slot loaders/serializers to the current candidate pool while retaining owner-anchor authorization.
+4. Mark the initially selected candidate seen during plan persistence.
+
+## Success Criteria
+
+- [x] Candidate lifecycle fields and additive migration preserve candidate history.
+- [ ] An active replenished slot exposes exactly one selected candidate plus five active alternatives in PostgreSQL integration coverage.
+- [ ] Migration downgrade is tested against PostgreSQL.
+
+## Risks
+
+Legacy active slots lack prior selection history. Treat their current selected meal as seen at migration time; do not invent historical data.

--- a/plans/260727-1905-slot-only-recommendation-replenishment/phase-02-replenish-one-exhausted-slot.md
+++ b/plans/260727-1905-slot-only-recommendation-replenishment/phase-02-replenish-one-exhausted-slot.md
@@ -1,0 +1,58 @@
+---
+phase: 2
+title: "Replenish One Exhausted Slot"
+status: in-progress
+priority: P1
+effort: "2-3d"
+dependencies: [1]
+---
+
+# Phase 2: Replenish One Exhausted Slot
+
+## Overview
+
+Preserve normal swaps, but when no unseen active alternative remains, generate and persist a new five-alternative pool for the requested slot only.
+
+## Related Code Files
+
+- Modify: `src/app/handlers/command_handlers/meal_recommendation/swap_meal_recommendation_slot_command_handler.py`
+- Modify: `src/domain/ports/meal_recommendation_plan_repository_port.py`
+- Modify: `src/infra/repositories/meal_recommendation_plan_repository_async.py`
+- Modify: `src/domain/services/meal_recommendation/three_day_plan_optimizer.py`
+- Modify: `src/api/dependencies/event_bus.py`
+- Extend: `tests/unit/app/handlers/test_meal_recommendation_handlers.py`
+- Extend: `tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py`
+- Create: `tests/integration/postgres/test_meal_recommendation_slot_concurrency.py`
+
+## Architecture
+
+`swap` first locks and validates only the requested slot. It selects the next unseen active alternative. If none exists, it derives a new alternative pool using the existing catalog snapshot, calorie target, user affinity, and exclusions: all candidates ever seen in this slot plus all currently selected meals in other slots. It then rechecks the target slot version under lock, retires only its old inactive candidates, persists five new inactive alternatives, selects the first fresh one, and records the normal idempotent swap operation.
+
+## Tests Before
+
+1. Five automatic swaps traverse the five initially stored alternatives without repetition; the sixth swap replenishes only that slot and selects one fresh alternative.
+2. Explicit user selection still accepts only an active unseen alternative.
+3. Stale version, logged, skipped, invalid target, and idempotent replay semantics remain unchanged.
+4. Two concurrent exhausted-pool swaps yield one replacement pool and one selected candidate.
+5. Replenishment excludes selected meals in all other slots and every seen meal in the target slot.
+6. SQL characterization proves no full-batch hydration and locks no unrelated slot.
+
+## Implementation Steps
+
+1. Extract the existing alternative-ranking seam needed to score one slot without rebuilding a full plan.
+2. Add repository operations for active pool/seen IDs, other selected IDs, and atomic retirement/insertion for one slot.
+3. Update swap handler orchestration without holding an open transaction across unrelated network/AI work; catalog ranking remains deterministic and local. Re-lock and recheck candidate exhaustion before writing.
+4. Enforce per-slot candidate identity uniqueness at persistence level or handle the database conflict deterministically, so concurrent replenishment cannot insert duplicate candidates.
+5. Preserve the current endpoint and `MealRecommendationSlotDetailResponse`; return the refreshed slot only.
+6. Add distinct operation outcome/latency dimensions for `stored_candidate` and `replenished_candidate` without user IDs or meal names.
+
+## Success Criteria
+
+- [x] Repository mutation returns a complete changed-slot result and stable plan ID.
+- [x] Duplicate request IDs are rechecked after the slot lock.
+- [ ] PostgreSQL concurrency proves one replacement pool and unrelated-slot immutability.
+- [ ] Repeated HTTP automatic swaps prove no seen-candidate cycling.
+
+## Risks
+
+Ranking while retaining a row lock could worsen the known small-pool incident. Keep lock windows restricted to validation and persistence; revalidate state before writing replacement candidates.

--- a/plans/260727-1905-slot-only-recommendation-replenishment/phase-03-contract-mobile-and-release-validation.md
+++ b/plans/260727-1905-slot-only-recommendation-replenishment/phase-03-contract-mobile-and-release-validation.md
@@ -1,0 +1,49 @@
+---
+phase: 3
+title: "Contract, Mobile, And Release Validation"
+status: pending
+priority: P1
+effort: "1-1.5d"
+dependencies: [2]
+---
+
+# Phase 3: Contract, Mobile, And Release Validation
+
+## Overview
+
+Prove backend compatibility, explicitly record that Flutter needs no source change under the retained contract, and release behind measured database-pool safeguards.
+
+## Related Code Files
+
+- Modify: `docs/meal-recommendation-mobile-handoff.md`
+- Modify: `docs/system-architecture.md`
+- Modify: `docs/project-changelog.md` if present
+- Verify only: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/core/network/api_service.dart`
+- Verify only: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/lib/features/meal_recommendation/data/repositories/meal_recommendation_repository_impl.dart`
+- Verify only: `/Users/alexnguyen/Desktop/Nut/nutree/nutree_ai/test/features/meal_recommendation/application/providers/meal_recommendation_controller_test.dart`
+
+## Requirements
+
+- No mobile codegen, schema, mapper, repository, or UI change if the endpoint body and response shape remain unchanged.
+- Add Flutter tests only if the backend needs a new visible state or changes its error/response contract.
+- Document that daily readiness and cron remain deferred.
+- Verify on staging with actual database pool metrics before production enablement.
+
+## Implementation Steps
+
+1. Run backend unit, architecture, migration, and PostgreSQL concurrency tests; isolate and report pre-existing failures separately.
+2. Run focused Flutter recommendation tests against existing slot-patch expectations; do not add e2e work.
+3. Inspect generated OpenAPI diff and Flutter API models to prove compatibility.
+4. Stage a repeated-swap scenario while observing `/v1/health/db-pool`, request latency, and SQL query count; do not label a local run as production proof.
+5. Update handoff/architecture/changelog docs with the slot-only invariant, lifecycle semantics, metrics, rollback, and deferred daily job.
+
+## Success Criteria
+
+- [ ] Backend API stays backward compatible.
+- [ ] Flutter source changes: none, unless contract proof disproves this assumption.
+- [ ] Staging proves unrelated slots are unchanged and no pool checkout remains held after swaps.
+- [ ] Rollback is a feature/code rollback; candidate history remains harmless and readable.
+
+## Risk Assessment
+
+The app currently has a small deployed pool in the reported incident. Staging must prove bounded transaction duration before rollout; pool-size tuning is a separate operational decision.

--- a/plans/260727-1905-slot-only-recommendation-replenishment/plan.md
+++ b/plans/260727-1905-slot-only-recommendation-replenishment/plan.md
@@ -1,0 +1,96 @@
+---
+title: "Slot-Only Recommendation Replenishment"
+description: "Replace exhausted swap candidates for one recommendation slot without changing the remaining plan."
+status: in-progress
+priority: P1
+effort: "4-6d"
+branch: delivery
+tags: [feature, backend, database, api, mobile]
+blockedBy: []
+blocks: []
+created: 2026-07-27
+source: ck:plan-hard
+---
+
+# Slot-Only Recommendation Replenishment
+
+## Decision
+
+Keep the three-day plan length. A swap consumes unseen candidates in its own six-meal slot pool. Once exhausted, replenish only that slot with five fresh alternatives; retain its current selected meal and leave every other slot unchanged. Do not add daily cron/pre-generation or Meal Insight work in this slice.
+
+## Why
+
+Current automatic swap chooses the lowest-ranked inactive row. After one swap, the original rank-0 row is inactive again, so repeated automatic swaps cycle instead of offering new meals. The plan must retain durable seen/pool state; operation history alone cannot reliably distinguish the initial selected candidate from an unshown one.
+
+## Mobile Decision
+
+No Flutter production change is required if `POST /swap` keeps returning the existing `MealRecommendationSlotDetailResponse`. The client already patches one returned slot into its cache. Add mobile contract tests only if backend response fields change; this plan forbids such fields unless implementation proves the current shape insufficient.
+
+## Phases
+
+| Phase | Deliverable | Status |
+|---|---|---|
+| 1 | Characterize swap semantics and persist candidate-pool lifecycle | In Progress |
+| 2 | Replenish only an exhausted slot under concurrency control | In Progress |
+| 3 | Verify HTTP/mobile compatibility, observability, docs, and release gates | Pending |
+
+## Non-Goals
+
+- Full-plan regeneration or mutation.
+- Re-ranking on every swap.
+- Daily cron, one-day readiness, notifications, or a durable worker.
+- Meal Insight generation changes.
+- Changes to `/v1/meal-suggestions`.
+
+## Cross-Plan Relationship
+
+This extends the completed-local performance redesign’s targeted mutation contract. It must preserve that plan’s invariants: lock one slot, return one slot, and avoid full-plan hydration. No blocking dependency is needed because the contract is already present on `delivery`.
+
+## Success Metrics
+
+- Automatic swaps traverse unseen stored candidates before replenishment.
+- Replenishment changes only the requested slot and returns the existing delta response shape.
+- A concurrent/stale swap cannot create duplicate candidate pools or overwrite another selection.
+- Replenishment and normal swap emit separate bounded latency metrics; no full-plan hydration.
+- Existing Flutter slot-cache patch tests remain green without source changes.
+
+## Validation Log
+
+### Implementation Progress
+
+- Branch created: `codex/slot-only-recommendation-replenishment`.
+- Added candidate lifecycle migration and slot-scoped replenishment implementation.
+- Current validation: 75 focused recommendation/migration tests passed; changed-module mypy and Ruff passed.
+- PostgreSQL integration, Flutter focused validation, and staging pool metrics remain release gates.
+
+### Research Findings
+
+- Backend uses a slot-scoped `FOR UPDATE` loader and optimistic `selection_version` for swap.
+- Five alternatives are persisted per slot; all inactive rows presently remain eligible, causing rank-0/rank-1 cycling.
+- Flutter consumes slot-scoped mutation responses and patches only that slot; backend-compatible behavior needs no mobile implementation change.
+
+### Verification Results
+
+- **Tier:** Standard
+- **Claims checked:** 14
+- **Verified:** 14 | **Failed:** 0 | **Unverified:** 0
+- Verified handler composition at `src/api/dependencies/event_bus.py:596-604`, slot lock at `src/infra/repositories/meal_recommendation_plan_repository_async.py:508-523`, and the five-alternative selector at `src/domain/services/meal_recommendation/three_day_plan_optimizer.py:208-257`.
+
+## Red Team Review
+
+### Accepted Findings
+
+- Corrected swap-count acceptance: the initially selected meal is already seen, therefore five stored alternatives are consumed before the sixth automatic swap replenishes the pool.
+- Concurrent refresh needs a persistence-level duplicate-candidate guard in addition to slot locking and optimistic version recheck.
+- Legacy candidate history cannot be reconstructed. Migration must only mark the current selected row as seen and document that strict no-repeat behavior starts with the new lifecycle state.
+
+### Whole-Plan Consistency Sweep
+
+- Files reread: `plan.md`, all three phase files.
+- Decision deltas checked: swap count, concurrent candidate uniqueness, legacy history behavior.
+- Reconciled stale references: 2.
+- Unresolved contradictions: 0.
+
+## Unresolved Questions
+
+- None. Product decisions are locked above.

--- a/plans/reports/pm-20260727-slot-only-recommendation-replenishment.md
+++ b/plans/reports/pm-20260727-slot-only-recommendation-replenishment.md
@@ -1,0 +1,34 @@
+# Slot-only recommendation replenishment progress
+
+## Status
+
+- Branch: `codex/slot-only-recommendation-replenishment`
+- Plan: `in-progress`
+- Phase 1: `in-progress`
+- Phase 2: `in-progress`
+- Phase 3: `pending`
+
+## Delivered
+
+- Added forward migration `20260727000001_add_meal_recommendation_candidate_lifecycle.py`.
+- Added backend-owned `seen_at` and `retired_at` candidate lifecycle state.
+- Initial selected candidates are persisted as seen; retired rows remain auditable and are omitted from active detail.
+- Automatic swaps consume unseen active candidates and replenish only an exhausted slot with five deterministic candidates.
+- Added post-lock swap idempotency replay check and internal `stored_candidate` / `replenished_candidate` outcome metrics.
+- Preserved `MealRecommendationSlotDetailResponse`; no Flutter source change required by the current response contract.
+- Updated mobile handoff and architecture docs.
+
+## Verification
+
+- `2024 passed` in the full unit plus migration suite before the final focused rerun; final focused migration/recommendation slice: `44 passed`.
+- Focused mypy passed on changed recommendation modules.
+- Focused Ruff passed on changed implementation/test files.
+- Alembic heads: `20260727000001 (head)`.
+- Full repository Ruff remains pre-existing/noisy (`1,085` findings); not treated as feature evidence.
+- Migration status/test scripts remain blocked locally by invalid SQLAlchemy URL configuration after the shell `python` PATH issue is corrected; offline migration graph/schema tests pass.
+
+## Remaining gates
+
+- Add/run PostgreSQL integration coverage for six-swap replenishment, concurrent exhaustion, downgrade, and unrelated-slot immutability.
+- Add direct handler-level coverage for snapshot/history replenishment and metric outcome propagation.
+- Run focused Flutter slot-cache tests and staging database-pool/latency observation before release enablement.

--- a/plans/reports/tester-260727-slot-only-recommendation-replenishment.md
+++ b/plans/reports/tester-260727-slot-only-recommendation-replenishment.md
@@ -1,0 +1,64 @@
+# Slot-Only Recommendation Replenishment Validation
+
+Work context: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend`
+Plans: `/Users/alexnguyen/Desktop/Nut/mealtrack_backend/plans/260727-1905-slot-only-recommendation-replenishment/`
+
+## Diff Scope
+
+Changed files:
+- `src/api/dependencies/event_bus.py`
+- `src/api/routes/v1/meal_recommendation_route_support.py`
+- `src/api/routes/v1/meal_recommendations.py`
+- `src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py`
+- `src/app/handlers/command_handlers/meal_recommendation/swap_meal_recommendation_slot_command_handler.py`
+- `src/domain/model/meal_recommendation/meal_recommendation_plan.py`
+- `src/domain/ports/meal_recommendation_plan_repository_port.py`
+- `src/domain/services/meal_recommendation/three_day_plan_optimizer.py`
+- `src/infra/database/models/meal_recommendation/meal_recommendation_plan.py`
+- `src/infra/repositories/meal_recommendation_plan_repository_async.py`
+- `tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py`
+- plus docs and one Alembic migration
+
+## Commands
+
+1. `pytest tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/api/test_meal_recommendations_route.py tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py tests/unit/app/services/test_meal_recommendation_history_projector.py tests/unit/domain/services/meal_recommendation/test_plan_diversity_reranking_service.py`
+   - Failed in shell Python 3.10 env:
+   - `ImportError: cannot import name 'UTC' from 'datetime'`
+
+2. `.venv/bin/pytest tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/api/test_meal_recommendations_route.py tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py tests/unit/app/services/test_meal_recommendation_history_projector.py tests/unit/domain/services/meal_recommendation/test_plan_diversity_reranking_service.py`
+   - `49 passed in 1.23s`
+
+3. `.venv/bin/alembic heads`
+   - Output: `20260727000001 (head)`
+
+4. `.venv/bin/pytest tests/migrations/test_alembic_revision_graph.py tests/migrations/test_catalog_recipe_tables_migration.py`
+   - `10 passed, 1 failed`
+   - Failed test: `tests/migrations/test_catalog_recipe_tables_migration.py::test_catalog_schema_has_one_head_and_no_stored_calories`
+   - Assertion: expected `['20260726000001']`, got `['20260727000001']`
+
+5. `.venv/bin/pytest tests/unit`
+   - `2013 passed, 14 warnings in 92.91s`
+
+6. `.venv/bin/pytest tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/api/test_meal_recommendations_route.py tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py tests/unit/app/services/test_meal_recommendation_history_projector.py tests/unit/domain/services/meal_recommendation/test_plan_diversity_reranking_service.py --cov=src --cov-report=term-missing`
+   - `49 passed in 3.73s`
+   - Coverage: `TOTAL 29.83%`
+   - Changed-area coverage highlights:
+     - `src/api/routes/v1/meal_recommendation_route_support.py` `93.67%`
+     - `src/api/routes/v1/meal_recommendations.py` `83.72%`
+     - `src/infra/repositories/meal_recommendation_plan_repository_async.py` `63.04%`
+
+## Findings
+
+- Local recommendation-focused tests passed on the project venv.
+- Full unit suite passed.
+- Migration graph is a single head, but one migration test is stale against the new head revision.
+
+## Pre-Existing / Non-Code Issues
+
+- Shell `pytest` used Python 3.10 and failed on `datetime.UTC`; project venv `.venv/bin/pytest` is required here.
+- Migration expectation in `tests/migrations/test_catalog_recipe_tables_migration.py::test_catalog_schema_has_one_head_and_no_stored_calories` still expects the previous head `20260726000001`.
+
+## Coverage / Gaps
+
+- No direct unit test exercised the new handler replenishment branch; repository replenishment behavior is covered, but the handler branch still needs explicit coverage.
+- Migration test should be updated to accept the new head revision.

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -202,6 +202,9 @@ from src.app.queries.user.get_user_onboarding_status_query import (
 )
 from src.app.queries.weight import GetWeightEntriesQuery
 from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshotService
+from src.app.services.meal_recommendation_history_projector import (
+    MealRecommendationHistoryProjector,
+)
 from src.domain.ports.food_reference_repository_port import (
     FoodReferenceSearchProjection,
 )
@@ -381,6 +384,8 @@ def get_configured_event_bus() -> EventBus:
     cache_invalidation_service = CacheInvalidationService(cache_service)
 
     event_bus = PyMediatorEventBus()
+    recommendation_snapshot = CatalogMealSnapshotService()
+    recommendation_history = MealRecommendationHistoryProjector()
     graph_settings = get_meal_analyze_graph_settings()
 
     async def find_food_references_by_normalized_names(
@@ -596,12 +601,17 @@ def get_configured_event_bus() -> EventBus:
         CreateThreeDayMealRecommendationCommandHandler(
             uow=AsyncUnitOfWork(),
             optimizer=ThreeDayPlanOptimizer(),
-            catalog_snapshot_service=CatalogMealSnapshotService(),
+            catalog_snapshot_service=recommendation_snapshot,
         ),
     )
     event_bus.register_handler(
         SwapMealRecommendationSlotCommand,
-        SwapMealRecommendationSlotCommandHandler(uow=AsyncUnitOfWork()),
+        SwapMealRecommendationSlotCommandHandler(
+            uow=AsyncUnitOfWork(),
+            optimizer=ThreeDayPlanOptimizer(),
+            catalog_snapshot_service=recommendation_snapshot,
+            history_projector=recommendation_history,
+        ),
     )
     event_bus.register_handler(
         LogRecommendedMealCommand,

--- a/src/api/routes/v1/meal_recommendation_route_support.py
+++ b/src/api/routes/v1/meal_recommendation_route_support.py
@@ -66,13 +66,21 @@ class SkipMealRecommendationSlotRequest(BaseModel):
         return normalized
 
 
-def record_operation_latency(operation: str, started: float, status_value: str) -> None:
+def record_operation_latency(
+    operation: str,
+    started: float,
+    status_value: str,
+    *,
+    outcome: str | None = None,
+) -> None:
     elapsed_ms = (perf_counter() - started) * 1000
     attributes = {
         "component": "meal_recommendation",
         "operation": operation,
         "status": status_value,
     }
+    if outcome is not None:
+        attributes["outcome"] = outcome
     distribution_metric(
         "meal_recommendation.operation.latency_ms",
         elapsed_ms,

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -176,7 +176,9 @@ async def swap_meal_recommendation_slot(
         task_manager=task_manager,
     )
     metric_status = "success"
-    record_operation_latency("swap", started, metric_status)
+    record_operation_latency(
+        "swap", started, metric_status, outcome=result.outcome
+    )
     return response
 
 

--- a/src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 from src.app.commands.meal_recommendation import (
     CreateThreeDayMealRecommendationCommand,
@@ -133,6 +133,7 @@ def _to_persisted_plan(
             is_selected=True,
             score=_decimal_score(slot.score),
             selection_version=1,
+            seen_at=datetime.now(UTC),
             catalog_meal=slot.catalog_meal,
         )
         alternatives = tuple(
@@ -146,6 +147,7 @@ def _to_persisted_plan(
                 is_selected=False,
                 score=_decimal_score(alternative.score),
                 selection_version=1,
+                seen_at=None,
                 catalog_meal=alternative.catalog_meal,
             )
             for alternative_position, alternative in enumerate(

--- a/src/app/handlers/command_handlers/meal_recommendation/swap_meal_recommendation_slot_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/swap_meal_recommendation_slot_command_handler.py
@@ -3,7 +3,11 @@
 from src.app.commands.meal_recommendation import SwapMealRecommendationSlotCommand
 from src.app.events.base import EventHandler, handles
 from src.domain.model.meal_recommendation import (
+    MealRecommendationAlternative,
     PersistedMealRecommendationSlotMutationResult,
+)
+from src.domain.services.meal_recommendation.three_day_plan_optimizer import (
+    ThreeDayPlanOptimizer,
 )
 
 
@@ -14,13 +18,63 @@ class SwapMealRecommendationSlotCommandHandler(
         PersistedMealRecommendationSlotMutationResult,
     ]
 ):
-    def __init__(self, uow):
+    def __init__(
+        self,
+        uow,
+        optimizer: ThreeDayPlanOptimizer | None = None,
+        catalog_snapshot_service=None,
+        history_projector=None,
+    ):
         self.uow = uow
+        self.optimizer = optimizer or ThreeDayPlanOptimizer()
+        self.catalog_snapshot_service = catalog_snapshot_service
+        self.history_projector = history_projector
 
     async def handle(
         self, command: SwapMealRecommendationSlotCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
         async with self.uow as uow:
+            replenishment: tuple[MealRecommendationAlternative, ...] = ()
+            context_loader = getattr(
+                uow.meal_recommendation_plans,
+                "get_slot_replenishment_context",
+                None,
+            )
+            context = (
+                await context_loader(
+                    user_id=command.user_id,
+                    plan_id=command.plan_id,
+                    slot_id=command.slot_id,
+                )
+                if context_loader
+                else None
+            )
+            if (
+                context
+                and not any(candidate.seen_at is None for candidate in context[0].alternatives)
+                and self.catalog_snapshot_service
+                and self.history_projector
+            ):
+                slot, seen_ids, other_selected_ids, timezone = context
+                snapshot = await self.catalog_snapshot_service.get_snapshot(uow)
+                affinity = await self.history_projector.build_affinity(
+                    uow,
+                    user_id=command.user_id,
+                    start_date=slot.slot_date,
+                    timezone=timezone,
+                )
+                excluded_ids = set(seen_ids) | set(other_selected_ids)
+                excluded_ids.add(slot.catalog_meal_id)
+                result = self.optimizer.select_slot_replenishment(
+                    list(snapshot.meals),
+                    meal_type=slot.meal_type,
+                    target_calories=slot.target_calories,
+                    excluded_catalog_meal_ids=excluded_ids,
+                    affinity=affinity,
+                    ingredient_statistics=snapshot.ingredient_statistics,
+                )
+                if not hasattr(result, "message"):
+                    replenishment = result
             return await uow.meal_recommendation_plans.swap_slot(
                 user_id=command.user_id,
                 plan_id=command.plan_id,
@@ -29,4 +83,5 @@ class SwapMealRecommendationSlotCommandHandler(
                 expected_version=command.expected_selection_version,
                 alternative_catalog_meal_id=command.alternative_catalog_meal_id,
                 reason=command.reason,
+                replenishment_alternatives=replenishment,
             )

--- a/src/domain/model/meal_recommendation/meal_recommendation_plan.py
+++ b/src/domain/model/meal_recommendation/meal_recommendation_plan.py
@@ -23,6 +23,8 @@ class PersistedMealRecommendationCandidate:
     score: Decimal
     selection_version: int
     catalog_meal: CatalogMeal | None = None
+    seen_at: datetime | None = None
+    retired_at: datetime | None = None
     logged_at: datetime | None = None
     logged_meal_id: str | None = None
     shown_at: datetime | None = None
@@ -79,3 +81,4 @@ class PersistedMealRecommendationSlotMutationResult:
     plan_id: str
     user_id: str
     slot: PersistedMealRecommendationSlot
+    outcome: str = "stored_candidate"

--- a/src/domain/ports/meal_recommendation_plan_repository_port.py
+++ b/src/domain/ports/meal_recommendation_plan_repository_port.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from src.domain.model.meal_recommendation import (
+    MealRecommendationAlternative,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
     PersistedMealRecommendationSlotMutationResult,
@@ -74,8 +75,20 @@ class MealRecommendationPlanRepositoryPort(ABC):
         expected_version: int,
         alternative_catalog_meal_id: str | None,
         reason: str,
+        replenishment_alternatives: tuple[MealRecommendationAlternative, ...] = (),
     ) -> PersistedMealRecommendationSlotMutationResult:
         """Swap one owned slot and return the changed slot."""
+
+    async def get_slot_replenishment_context(
+        self, *, user_id: str, plan_id: str, slot_id: str
+    ) -> tuple[
+        PersistedMealRecommendationSlot,
+        frozenset[str],
+        frozenset[str],
+        str,
+    ] | None:
+        """Return target slot, seen target candidates, and other selected IDs."""
+        return None
 
     @abstractmethod
     async def mark_shown(

--- a/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
+++ b/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
@@ -253,6 +253,37 @@ class ThreeDayPlanOptimizer:
             for item in ranked[:count]
         )
 
+    def select_slot_replenishment(
+        self,
+        catalog_meals: list[CatalogMeal],
+        *,
+        meal_type: str,
+        target_calories: int,
+        excluded_catalog_meal_ids: set[str],
+        affinity: IngredientAffinityProfile,
+        comparison_meals: tuple[CatalogMeal, ...] = (),
+        ingredient_statistics: CatalogIngredientStatistics | None = None,
+        count: int = 5,
+    ) -> tuple[MealRecommendationAlternative, ...] | MealRecommendationInsufficiency:
+        ranked = self._scoring.rank(
+            _filter_supported_catalog_meals(catalog_meals, None),
+            meal_type=meal_type,
+            target_calories=target_calories,
+            affinity=affinity,
+            excluded_catalog_meal_ids=excluded_catalog_meal_ids,
+        )
+        return self._select_alternatives_from_pool(
+            ranked,
+            day_index=0,
+            meal_type=meal_type,
+            target_calories=target_calories,
+            selected_catalog_meal_id="",
+            selected_catalog_meal_ids=excluded_catalog_meal_ids,
+            comparison_meals=comparison_meals,
+            ingredient_statistics=ingredient_statistics,
+            count=count,
+        )
+
 
 def _filter_supported_catalog_meals(
     catalog_meals: list[CatalogMeal],

--- a/src/infra/database/models/meal_recommendation/meal_recommendation_plan.py
+++ b/src/infra/database/models/meal_recommendation/meal_recommendation_plan.py
@@ -48,6 +48,8 @@ class MealRecommendationORM(Base):
     is_selected = Column(Boolean, nullable=False, default=False)
     score = Column(Numeric(10, 6), nullable=False)
     selection_version = Column(Integer, nullable=False, default=1)
+    seen_at = Column(DateTime(timezone=True), nullable=True)
+    retired_at = Column(DateTime(timezone=True), nullable=True)
     logged_at = Column(DateTime(timezone=True), nullable=True)
     shown_at = Column(DateTime(timezone=True), nullable=True)
     skipped_at = Column(DateTime(timezone=True), nullable=True)

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -23,6 +24,7 @@ from src.domain.exceptions.meal_recommendation_exceptions import (
 )
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
+    MealRecommendationAlternative,
     PersistedMealRecommendationCandidate,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
@@ -140,6 +142,7 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         expected_version: int,
         alternative_catalog_meal_id: str | None,
         reason: str,
+        replenishment_alternatives: tuple[MealRecommendationAlternative, ...] = (),
     ) -> PersistedMealRecommendationSlotMutationResult:
         replay = await self._get_operation_replay(
             user_id=user_id, operation_type="swap", request_id=request_id
@@ -173,6 +176,17 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
         )
         if not rows:
             raise MealRecommendationNotFoundError
+        replay = await self._get_operation_replay(
+            user_id=user_id, operation_type="swap", request_id=request_id
+        )
+        if replay is not None:
+            if cast(str, replay.request_fingerprint) != fingerprint:
+                raise MealRecommendationIdempotencyConflictError
+            return PersistedMealRecommendationSlotMutationResult(
+                plan_id=plan_id,
+                user_id=user_id,
+                slot=_rows_to_slot_detail(anchor, rows),
+            )
         selected = _selected_row(rows, slot_id)
         if int(cast(int, selected.selection_version)) != expected_version:
             raise MealRecommendationVersionConflictError
@@ -183,7 +197,10 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             (
                 row
                 for row in rows
-                if cast(str, row.slot_id) == slot_id and not cast(bool, row.is_selected)
+                if cast(str, row.slot_id) == slot_id
+                and not cast(bool, row.is_selected)
+                and getattr(row, "retired_at", None) is None
+                and getattr(row, "seen_at", None) is None
             ),
             key=lambda item: cast(int, item.candidate_rank),
         )
@@ -198,12 +215,54 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
                 ),
                 None,
             )
+        outcome = "stored_candidate"
+        if (
+            target is None
+            and alternative_catalog_meal_id is None
+            and replenishment_alternatives
+        ):
+            now = datetime.now(UTC)
+            active_rows = [
+                row
+                for row in rows
+                if getattr(row, "retired_at", None) is None
+                and not cast(bool, row.is_selected)
+            ]
+            for row in active_rows:
+                row.retired_at = now  # type: ignore[assignment]
+            next_rank = max(
+                (cast(int, row.candidate_rank) for row in rows), default=0
+            ) + 1
+            new_rows = []
+            for position, alternative in enumerate(replenishment_alternatives):
+                row = MealRecommendationORM(
+                    id=str(uuid.uuid4()),
+                    batch_id=plan_id,
+                    slot_id=slot_id,
+                    recommendation_date=selected.recommendation_date,
+                    meal_type=selected.meal_type,
+                    catalog_meal_id=alternative.catalog_meal.id,
+                    candidate_rank=next_rank + position,
+                    is_selected=position == 0,
+                    score=Decimal(str(alternative.score)),
+                    selection_version=expected_version + 1,
+                    seen_at=now if position == 0 else None,
+                    catalog_meal=alternative.catalog_meal,
+                )
+                self._session.add(row)
+                new_rows.append(row)
+            target = new_rows[0]
+            rows.extend(new_rows)
+            outcome = "replenished_candidate"
         if target is None:
             raise MealRecommendationInvalidAlternativeError
 
         new_version = expected_version + 1
         selected.is_selected = False  # type: ignore[assignment]
         selected.selection_version = new_version  # type: ignore[assignment]
+        selected_seen_at = getattr(selected, "seen_at", None) or datetime.now(UTC)
+        selected.seen_at = selected_seen_at  # type: ignore[assignment]
+        selected.retired_at = selected_seen_at  # type: ignore[assignment]
         await self._flush_operations()
 
         for row in rows:
@@ -212,6 +271,7 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             row.selection_version = new_version  # type: ignore[assignment]
         target.is_selected = True  # type: ignore[assignment]
         target.logged_at = None  # type: ignore[assignment]
+        target.seen_at = getattr(target, "seen_at", None) or datetime.now(UTC)  # type: ignore[assignment]
         self._session.add(
             MealRecommendationOperationORM(
                 user_id=user_id,
@@ -229,7 +289,36 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             plan_id=plan_id,
             user_id=user_id,
             slot=_rows_to_slot_detail(anchor, rows),
+            outcome=outcome,
         )
+
+    async def get_slot_replenishment_context(
+        self, *, user_id: str, plan_id: str, slot_id: str
+    ) -> tuple[
+        PersistedMealRecommendationSlot,
+        frozenset[str],
+        frozenset[str],
+        str,
+    ] | None:
+        rows = await self._load_batch(user_id=user_id, batch_id=plan_id)
+        target_rows = [row for row in rows if cast(str, row.slot_id) == slot_id]
+        if not target_rows:
+            return None
+        anchor = _anchor_row(rows)
+        if anchor is None:
+            return None
+        target = _rows_to_slot_detail(anchor, target_rows)
+        seen_ids = frozenset(
+            cast(str, row.catalog_meal_id)
+            for row in target_rows
+            if getattr(row, "seen_at", None) is not None
+        )
+        other_selected_ids = frozenset(
+            cast(str, row.catalog_meal_id)
+            for row in rows
+            if cast(str, row.slot_id) != slot_id and cast(bool, row.is_selected)
+        )
+        return target, seen_ids, other_selected_ids, cast(str, anchor.timezone)
 
     async def mark_shown(
         self,
@@ -478,6 +567,7 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             select(MealRecommendationORM)
             .where(MealRecommendationORM.batch_id == batch_id)
             .where(MealRecommendationORM.slot_id == slot_id)
+            .where(MealRecommendationORM.retired_at.is_(None))
             .options(_recommendation_catalog_meal_load_options())
             .order_by(MealRecommendationORM.candidate_rank)
         )
@@ -560,6 +650,8 @@ def _plan_to_rows(plan: PersistedMealRecommendationPlan) -> list[MealRecommendat
                     is_selected=candidate.is_selected,
                     score=candidate.score,
                     selection_version=candidate.selection_version,
+                    seen_at=candidate.seen_at,
+                    retired_at=candidate.retired_at,
                     logged_at=candidate.logged_at,
                     logged_meal_id=candidate.logged_meal_id,
                     shown_at=candidate.shown_at,
@@ -608,7 +700,8 @@ def _rows_to_plan(rows: list[MealRecommendationORM]) -> PersistedMealRecommendat
     slots: list[PersistedMealRecommendationSlot] = []
     grouped: dict[str, list[MealRecommendationORM]] = {}
     for row in rows:
-        grouped.setdefault(cast(str, row.slot_id), []).append(row)
+        if getattr(row, "retired_at", None) is None:
+            grouped.setdefault(cast(str, row.slot_id), []).append(row)
 
     for position, slot_rows in enumerate(grouped.values()):
         ordered = sorted(slot_rows, key=lambda item: cast(int, item.candidate_rank))
@@ -707,7 +800,10 @@ def _rows_to_slot_detail(
     anchor: MealRecommendationORM,
     rows: list[MealRecommendationORM],
 ) -> PersistedMealRecommendationSlot:
-    ordered = sorted(rows, key=lambda item: cast(int, item.candidate_rank))
+    ordered = sorted(
+        (row for row in rows if getattr(row, "retired_at", None) is None),
+        key=lambda item: cast(int, item.candidate_rank),
+    )
     selected = next((row for row in ordered if cast(bool, row.is_selected)), None)
     if selected is None:
         raise MealRecommendationNotFoundError
@@ -770,6 +866,8 @@ def _candidate_to_domain(
         score=cast(Decimal, row.score),
         selection_version=cast(int, row.selection_version),
         catalog_meal=_candidate_catalog_meal(row),
+        seen_at=cast(datetime | None, getattr(row, "seen_at", None)),
+        retired_at=cast(datetime | None, getattr(row, "retired_at", None)),
         logged_at=cast(datetime | None, row.logged_at),
         logged_meal_id=cast(str | None, row.logged_meal_id),
         shown_at=cast(datetime | None, getattr(row, "shown_at", None)),

--- a/tests/migrations/test_catalog_recipe_tables_migration.py
+++ b/tests/migrations/test_catalog_recipe_tables_migration.py
@@ -36,7 +36,7 @@ def test_catalog_schema_has_one_head_and_no_stored_calories() -> None:
 
     assert [
         revision.revision for revision in script_dir.get_revisions("heads")
-    ] == ["20260726000001"]
+    ] == ["20260727000001"]
     assert '"calories"' not in catalog_section
 
 

--- a/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
@@ -12,6 +12,7 @@ from src.domain.exceptions.meal_recommendation_exceptions import (
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
     CatalogMealIngredient,
+    MealRecommendationAlternative,
     PersistedMealRecommendationCandidate,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
@@ -410,6 +411,44 @@ async def test_swap_slot_flushes_deselection_before_selecting_alternative():
     assert flush_states[0] == {"plan-1": False, "alt-1": False}
     assert flush_states[-1] == {"plan-1": False, "alt-1": True}
     assert result.slot.catalog_meal_id == "catalog-2"
+    assert repo.loaded_rows[0].retired_at is not None
+    assert repo.loaded_rows[1].seen_at is not None
+
+
+@pytest.mark.asyncio
+async def test_swap_slot_replenishes_exhausted_pool_and_marks_outcome():
+    repo = _SlotMutationRepo()
+    rows = _plan_to_candidate_rows(_plan())
+    for row in rows:
+        row.seen_at = datetime(2026, 7, 16)
+    repo._load_slot_for_update = AsyncMock(return_value=(rows[0], rows))  # type: ignore[method-assign]
+    fresh = tuple(
+        MealRecommendationAlternative(
+            day_index=0,
+            meal_type="breakfast",
+            target_calories=500,
+            catalog_meal=_catalog_meal(f"catalog-{index}", f"Fresh {index}"),
+            score=0.8,
+        )
+        for index in range(3, 8)
+    )
+
+    result = await repo.swap_slot(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="swap-replenish-1",
+        expected_version=1,
+        alternative_catalog_meal_id=None,
+        reason="user_requested",
+        replenishment_alternatives=fresh,
+    )
+
+    assert result.outcome == "replenished_candidate"
+    assert result.slot.catalog_meal_id == "catalog-3"
+    assert len(result.slot.alternatives) == 4
+    assert rows[0].retired_at is not None
+    assert len(repo._session.added_rows) == 6
 
 
 @pytest.mark.asyncio
@@ -474,6 +513,8 @@ def _plan_to_candidate_rows(plan):
                     is_selected=candidate.is_selected,
                     score=candidate.score,
                     selection_version=candidate.selection_version,
+                    seen_at=candidate.seen_at,
+                    retired_at=candidate.retired_at,
                     logged_at=None,
                     logged_meal_id=None,
                     skipped_at=None,


### PR DESCRIPTION
## Summary

- Track recommendation candidate lifecycle with backend-owned `seen_at` and `retired_at` timestamps.
- Replenish only the exhausted slot with five deterministic alternatives while preserving unseen-candidate exclusions.
- Preserve the existing slot-detail response and add swap outcome observability.
- Add migration, repository coverage, and mobile handoff documentation.

## Testing

- Unit tests cover candidate retirement, slot-only replenishment, idempotent swaps, and replenishment outcomes.