### PR TITLE
feat(meal-recommendations): localize catalog responses

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -124,6 +124,8 @@ The two health routes are declared with `api_route` and answer both GET and HEAD
 - `shown_at`, `skipped_at`, and `logged_at` are backend-owned outcome fields. Clients must not infer terminal state by recalculating recommendation logic.
 - Recommendation analytics are scheduled through `BackgroundTaskManager` when the dependency is available; the route falls back to inline capture when it is not.
 - New plan generation uses snapshot-scoped ingredient IDF, confidence-scaled ingredient similarity, and bounded diversity reranking. Existing persisted plans replay their stored candidates and scores. This does not change endpoint paths and does not touch `/v1/meal-suggestions`.
+- The existing `Accept-Language` header selects response language (`en`, `vi`, `es`, `fr`, `de`, `ja`, `zh`). For non-English requests, meal names, cuisine, descriptions, and ingredient display names are translated at response time; IDs, units, nutrition, scores, and recommendation state remain canonical.
+- Missing/unsupported language, an unset DeepL key, or translation-provider failure returns the successful canonical English response rather than failing the recommendation request.
 
 ---
 

--- a/docs/journals/260729-1055-catalog-recommendation-response-localization.md
+++ b/docs/journals/260729-1055-catalog-recommendation-response-localization.md
@@ -1,0 +1,21 @@
+# Catalog Recommendation Response Localization
+
+## Context
+
+Catalog-backed recommendation responses were canonical English even though the backend already parsed `Accept-Language` and provided a DeepL text translation service.
+
+## Change
+
+- Added an application-layer response localizer that batches and deduplicates display text per response.
+- Localized meal names, cuisines, descriptions, and ingredient display names after CQRS reads.
+- Kept catalog data, persisted recommendation plans, units, nutrition, IDs, scores, and state immutable and canonical.
+- Added canonical-English fallback for missing DeepL configuration, provider failures, and short provider responses.
+
+## Evidence
+
+- 109 recommendation-focused tests passed.
+- Ruff, mypy, import-layer contracts, route registration smoke test, and documentation validation passed.
+
+## Decision
+
+`Accept-Language` is authoritative for these endpoints. User-profile language is not consulted, and no translated catalog data is persisted.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -19,6 +19,11 @@
 - [ ] Approved 180-meal production corpus import/replay evidence is pending because the manifest and resolver map are not present locally.
 - [ ] Staging load, degraded-load, and rollback-drill evidence remain release gates.
 
+### July 2026: Catalog Recommendation Response Localization
+- [x] Catalog-backed recommendation responses now honor `Accept-Language` for the seven supported app languages.
+- [x] Localization translates presentation text only (meal name, cuisine, description, ingredient display name); IDs, units, ranking, state, and backend-derived nutrition remain canonical.
+- [x] Missing configuration or translation-provider failure returns the canonical English response without failing the recommendation request.
+
 ### July 2026: Meal Recommendation Performance Redesign
 - [x] `POST /v1/meal-recommendations/three-day` and `GET /v1/meal-recommendations/{plan_id}` now return compact selected-slot summaries instead of full hydrated plans.
 - [x] `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` returns one hydrated selected slot plus alternatives for drill-down.

--- a/plans/260729-1055-meal-catalog-response-translation/phase-01-localization-contract-and-translation-boundary.md
+++ b/plans/260729-1055-meal-catalog-response-translation/phase-01-localization-contract-and-translation-boundary.md
@@ -1,0 +1,43 @@
+---
+phase: 1
+title: Localization contract and translation boundary
+status: completed
+priority: P2
+effort: 2h
+dependencies: []
+---
+
+# Phase 1: Localization contract and translation boundary
+
+## Overview
+
+Define the response localization contract before implementation. Keep catalog/recommendation logic deterministic and English-canonical; localization belongs at the API projection boundary.
+
+## Requirements
+
+- Translate `name`, `cuisine`, optional `description`, and ingredient `display_name`.
+- Preserve units, quantities, macros, calories, IDs, meal types, scores, ordering, and state.
+- Use `get_request_language(request)`; do not parse raw headers or add a query/body override.
+- Missing service, English target, provider error, and short output fall back to canonical text.
+
+## Architecture
+
+Reuse `DeepLTextTranslationService`; add one response-localizer seam only if the mapping logic cannot remain small. It receives the loaded plan/slot and returns new frozen catalog projections. It performs one deduplicated batch per response and never writes to catalog or recommendation storage.
+
+## Related Code Files
+
+- Read: `src/api/middleware/accept_language.py`, `src/domain/services/translation/deepl_text_translation_service.py`.
+- Modify: `src/api/routes/v1/meal_recommendation_route_support.py`, route tests and contract tests.
+
+## Implementation Steps
+
+1. Characterize current English response shapes and all callers of the shared mapping helpers.
+2. Document the field allowlist and fallback semantics in tests.
+3. Decide async mapping/dependency injection shape for all six response-producing routes.
+4. Confirm no DB schema, catalog model, ranking, persistence, or analytics changes are needed.
+
+## Success Criteria
+
+- [x] Contract covers summary, detail, and mutation responses.
+- [x] Only user-facing text fields are candidates for translation.
+- [x] Async mapping and dependency boundary are explicit.

--- a/plans/260729-1055-meal-catalog-response-translation/phase-02-implement-catalog-response-translation.md
+++ b/plans/260729-1055-meal-catalog-response-translation/phase-02-implement-catalog-response-translation.md
@@ -1,0 +1,49 @@
+---
+phase: 2
+title: Implement catalog response translation
+status: completed
+priority: P2
+effort: 1d
+dependencies:
+  - 1
+---
+
+# Phase 2: Implement catalog response translation
+
+## Overview
+
+Implement request-language localization in the existing recommendation response path. Translation is presentation-only and transparent when DeepL is unavailable.
+
+## Requirements
+
+- All recommendation response shapes use the same localization seam.
+- No domain/catalog object is mutated.
+- Provider work is skipped for English and deduplicated for repeated strings.
+
+## Architecture
+
+The route obtains `get_request_language(request)` and the existing text translation dependency. After CQRS/domain results are loaded, an async localizer reconstructs translated `CatalogMeal` projections, then existing Pydantic response builders serialize them. Ranking, snapshot refresh, persistence, and analytics remain untouched. Avoid cross-request caching initially; add only a bounded content-hash/language cache if measured need justifies it.
+
+## Related Code Files
+
+- Modify: `src/api/routes/v1/meal_recommendation_route_support.py` — async localizer and translated projections.
+- Modify: `src/api/routes/v1/meal_recommendations.py` — request language and translator dependency for create/get/detail/swap/log/skip.
+- Modify: `src/api/base_dependencies.py` only if a narrowly scoped localizer dependency is required.
+- Create only if needed: `src/app/services/catalog_meal_response_localizer.py`.
+- Modify: `tests/unit/api/test_meal_recommendation_http_contract.py`, `tests/unit/api/test_meal_recommendations_route.py`.
+- Create only if needed: `tests/unit/app/services/test_catalog_meal_response_localizer.py`.
+
+## Implementation Steps
+
+1. Write fake-translator tests that record batches and return deterministic output.
+2. Implement deduplication, empty-description handling, frozen projection reconstruction, and safe padding/fallback.
+3. Make mapping helpers async or delegate to an async localizer; update all six route paths consistently.
+4. Preserve units, quantities, macros, calories, IDs, scores, and recommendation state exactly.
+5. Reuse the existing service fallback; do not add duplicate route-level error logging.
+
+## Success Criteria
+
+- [x] Supported non-English requests localize names, cuisine, descriptions, and ingredient names.
+- [x] English/missing/unsupported/provider-failure paths return canonical content successfully.
+- [x] Repeated strings translate once per response and no domain object changes.
+- [x] No migration or catalog write path changes.

--- a/plans/260729-1055-meal-catalog-response-translation/phase-03-verification-and-documentation.md
+++ b/plans/260729-1055-meal-catalog-response-translation/phase-03-verification-and-documentation.md
@@ -1,0 +1,53 @@
+---
+phase: 3
+title: Verification and documentation
+status: completed
+priority: P2
+effort: 3h
+dependencies:
+  - 2
+---
+
+# Phase 3: Verification and documentation
+
+## Overview
+
+Prove localized response behavior, graceful degradation, and compatibility with existing catalog recommendation behavior. Update API documentation only after focused verification passes.
+
+## Test Scenario Matrix
+
+| Scenario | Expected result |
+|---|---|
+| `en` / no header | Canonical English; translator not called |
+| Supported non-English | Allowlisted text translated in summary/detail/mutation shapes |
+| Unsupported language | Middleware resolves `en`; canonical response |
+| Missing key | Endpoint succeeds with English |
+| Provider exception/short batch | Safe canonical fallback |
+| Repeated text | One request-level translation per unique text |
+| Persisted plan | Same stored selection/ranking/state, localized only at projection |
+
+## Related Code Files
+
+- Modify: `docs/api-endpoints.md` — document request-language behavior and fallback.
+- Modify tests adjacent to the recommendation route and middleware seams.
+
+## Implementation Steps
+
+1. Run focused localizer, middleware, response-schema, and all recommendation route tests.
+2. Run `ruff check` on changed source/tests and applicable `mypy` checks.
+3. Run the broader recommendation/API subset; do not claim live DeepL verification unless executed.
+4. Inspect the final diff for controlled-field translation, raw provider logging, schema drift, or catalog persistence changes.
+
+## Success Criteria
+
+- [x] English, all supported non-English, missing-key, failure, and nested alternative paths pass.
+- [x] Ranking/persistence tests remain green.
+- [x] Ruff and applicable mypy checks pass.
+- [x] API docs state `Accept-Language` behavior and English fallback.
+- [x] No migration or canonical catalog data changes.
+
+## Security and Performance
+
+- DeepL calls remain off the request path for English.
+- Translation failures cannot expose provider payloads or request content in logs.
+- Deduplication and bounded response traversal prevent unbounded provider requests.

--- a/plans/260729-1055-meal-catalog-response-translation/plan.md
+++ b/plans/260729-1055-meal-catalog-response-translation/plan.md
@@ -1,0 +1,58 @@
+---
+title: Meal catalog response translation
+description: >-
+  Translate catalog-backed meal recommendation text at response time using the
+  request language while keeping canonical catalog data in English.
+status: completed
+priority: P2
+effort: 1d 5h
+branch: delivery
+tags:
+  - feature
+  - backend
+  - api
+blockedBy: []
+blocks: []
+created: '2026-07-29'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Meal catalog response translation
+
+## Overview
+
+Add locale-aware presentation for catalog-backed meal recommendation endpoints. Canonical `meal_catalog` rows and persisted recommendation plans remain English and unchanged; response mapping translates user-facing catalog text using the existing validated `Accept-Language` request state.
+
+Verified reusable seams:
+
+- `AcceptLanguageMiddleware` supports `en`, `vi`, `es`, `fr`, `de`, `ja`, `zh` and defaults to English.
+- `DeepLTextTranslationService` already batches text and returns originals on provider failure.
+- `meal_recommendation_route_support.py` is the shared projection seam for all recommendation response shapes.
+- `CatalogMeal` is frozen and calories are backend-derived, so localization must create projections rather than mutate domain/catalog data.
+
+Scope: translate meal `name`, `cuisine`, `description`, and ingredient `display_name`. Preserve IDs, meal types, units, quantities, macros, calories, scores, ordering, and state. No translation columns, migration, client language override, or persisted translated content.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Localization contract and translation boundary](./phase-01-localization-contract-and-translation-boundary.md) | Completed |
+| 2 | [Implement catalog response translation](./phase-02-implement-catalog-response-translation.md) | Completed |
+| 3 | [Verification and documentation](./phase-03-verification-and-documentation.md) | Completed |
+
+## Dependencies
+
+- No unfinished plan blocks this work. The current four-table catalog response contract is the integration target.
+- Runtime dependency: configured `DEEPL_API_KEY`; without it, responses remain canonical English.
+
+## Success Criteria
+
+- Non-English requests receive translated catalog text across every recommendation response shape.
+- English, unsupported, missing, provider-error, and partial-result paths remain safe.
+- Translation is batched/deduplicated and does not alter ranking, persistence, cache keys, nutrition, or IDs.
+- Focused tests, lint/type checks, and API documentation are complete.
+
+## Unresolved Questions
+
+None.

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -9,11 +9,13 @@ from time import perf_counter
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 
 from src.api.base_dependencies import (
+    get_deepl_text_translation_service,
     get_meal_recommendation_analytics_service,
 )
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.dependencies.task_manager import get_optional_task_manager
+from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
 from src.api.routes.v1.meal_recommendation_route_support import (
     LogRecommendedMealRequest,
@@ -41,6 +43,10 @@ from src.app.queries.meal_recommendation import (
     GetMealRecommendationSlotDetailQuery,
 )
 from src.app.queries.user import GetUserTimezoneQuery
+from src.app.services.catalog_meal_response_localizer import (
+    localize_meal_recommendation_plan,
+    localize_meal_recommendation_slot,
+)
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
 )
@@ -64,6 +70,7 @@ async def create_three_day_recommendations(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationPlanSummaryResponse:
     """Create or replay a durable three-day catalog recommendation plan."""
 
@@ -116,7 +123,13 @@ async def create_three_day_recommendations(
                 status_code=exc.status_code,
                 detail=exc.public_detail,
             ) from exc
-        response = to_summary_response(plan)
+        response = to_summary_response(
+            await localize_meal_recommendation_plan(
+                plan,
+                language=get_request_language(request),
+                translation_service=translation_service,
+            )
+        )
         await capture_plan_events(
             analytics_service,
             user_id=user_id,
@@ -149,6 +162,7 @@ async def swap_meal_recommendation_slot(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
@@ -167,7 +181,14 @@ async def swap_meal_recommendation_slot(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_slot_detail_response(result.plan_id, result.slot)
+    response = to_slot_detail_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await _capture_mutation_slot_event(
         analytics_service=analytics_service,
         user_id=user_id,
@@ -198,6 +219,7 @@ async def log_recommended_meal(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
@@ -213,7 +235,14 @@ async def log_recommended_meal(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_slot_detail_response(result.plan_id, result.slot)
+    response = to_slot_detail_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await _capture_mutation_slot_event(
         analytics_service=analytics_service,
         user_id=user_id,
@@ -242,6 +271,7 @@ async def skip_meal_recommendation_slot(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
@@ -257,7 +287,14 @@ async def skip_meal_recommendation_slot(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_slot_detail_response(result.plan_id, result.slot)
+    response = to_slot_detail_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await _capture_mutation_slot_event(
         analytics_service=analytics_service,
         user_id=user_id,
@@ -273,12 +310,14 @@ async def skip_meal_recommendation_slot(
 @router.get("/{plan_id}", response_model=MealRecommendationPlanSummaryResponse)
 async def get_meal_recommendation_plan(
     plan_id: str,
+    request: Request,
     user_id: str = Depends(get_current_user_id),
     event_bus=Depends(get_configured_event_bus),
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationPlanSummaryResponse:
     """Read an owner-scoped durable recommendation plan."""
 
@@ -291,7 +330,13 @@ async def get_meal_recommendation_plan(
         metric_status = "http_404"
         record_operation_latency("read", started, metric_status)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    response = to_summary_response(plan)
+    response = to_summary_response(
+        await localize_meal_recommendation_plan(
+            plan,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        )
+    )
     await capture_plan_events(
         analytics_service,
         user_id=user_id,
@@ -311,12 +356,14 @@ async def get_meal_recommendation_plan(
 async def get_meal_recommendation_slot_detail(
     plan_id: str,
     slot_id: str,
+    request: Request,
     user_id: str = Depends(get_current_user_id),
     event_bus=Depends(get_configured_event_bus),
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     """Read one owner-scoped recommendation slot with alternatives."""
 
@@ -333,7 +380,14 @@ async def get_meal_recommendation_slot_detail(
         metric_status = "http_404"
         record_operation_latency("slot_detail", started, metric_status)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    response = to_slot_detail_response(plan_id, slot)
+    response = to_slot_detail_response(
+        plan_id,
+        await localize_meal_recommendation_slot(
+            slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await capture_slot_event(
         analytics_service,
         user_id=user_id,

--- a/src/app/services/catalog_meal_response_localizer.py
+++ b/src/app/services/catalog_meal_response_localizer.py
@@ -1,0 +1,190 @@
+"""Request-language localization for catalog meal response projections."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Protocol
+
+from src.domain.model.meal_recommendation import (
+    CatalogMeal,
+    PersistedMealRecommendationCandidate,
+    PersistedMealRecommendationPlan,
+    PersistedMealRecommendationSlot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TextTranslationService(Protocol):
+    """Minimal translation dependency needed by catalog response localization."""
+
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]: ...
+
+
+async def localize_meal_recommendation_plan(
+    plan: PersistedMealRecommendationPlan,
+    *,
+    language: str,
+    translation_service: TextTranslationService | None,
+) -> PersistedMealRecommendationPlan:
+    """Return a localized presentation copy of a recommendation plan."""
+
+    if language == "en" or translation_service is None:
+        return plan
+
+    meals = [
+        meal
+        for slot in plan.slots
+        for meal in _slot_catalog_meals(slot)
+    ]
+    localized_meals = await _localized_meals(
+        meals,
+        language=language,
+        translation_service=translation_service,
+    )
+    if localized_meals is None:
+        return plan
+
+    return replace(
+        plan,
+        slots=tuple(
+            _replace_slot_catalog_meals(slot, localized_meals) for slot in plan.slots
+        ),
+    )
+
+
+async def localize_meal_recommendation_slot(
+    slot: PersistedMealRecommendationSlot,
+    *,
+    language: str,
+    translation_service: TextTranslationService | None,
+) -> PersistedMealRecommendationSlot:
+    """Return a localized presentation copy of one recommendation slot."""
+
+    if language == "en" or translation_service is None:
+        return slot
+
+    localized_meals = await _localized_meals(
+        list(_slot_catalog_meals(slot)),
+        language=language,
+        translation_service=translation_service,
+    )
+    if localized_meals is None:
+        return slot
+
+    return _replace_slot_catalog_meals(slot, localized_meals)
+
+
+def _slot_catalog_meals(slot: PersistedMealRecommendationSlot) -> tuple[CatalogMeal, ...]:
+    candidates = (slot.selected, *slot.alternatives)
+    return tuple(
+        candidate.catalog_meal
+        for candidate in candidates
+        if candidate is not None and candidate.catalog_meal is not None
+    )
+
+
+async def _localized_meals(
+    meals: list[CatalogMeal],
+    *,
+    language: str,
+    translation_service: TextTranslationService,
+) -> dict[str, CatalogMeal] | None:
+    unique_meals = {meal.id: meal for meal in meals}
+    texts = _unique_display_texts(unique_meals.values())
+    if not texts:
+        return dict(unique_meals)
+
+    try:
+        translated = await translation_service.translate_texts(texts, language)
+    except Exception as exc:
+        logger.warning(
+            "catalog response translation failed language=%s error_type=%s",
+            language,
+            type(exc).__name__,
+        )
+        return None
+
+    translations = {
+        text: translated[index] if index < len(translated) else text
+        for index, text in enumerate(texts)
+    }
+    return {
+        meal_id: _replace_meal_display_text(meal, translations)
+        for meal_id, meal in unique_meals.items()
+    }
+
+
+def _unique_display_texts(meals: Iterable[CatalogMeal]) -> list[str]:
+    texts: list[str] = []
+    for meal in meals:
+        _append_unique(texts, meal.name)
+        _append_unique(texts, meal.cuisine)
+        if meal.description:
+            _append_unique(texts, meal.description)
+        for ingredient in meal.ingredients:
+            _append_unique(texts, ingredient.display_name)
+    return texts
+
+
+def _append_unique(texts: list[str], value: str) -> None:
+    if value and value not in texts:
+        texts.append(value)
+
+
+def _replace_meal_display_text(
+    meal: CatalogMeal,
+    translations: dict[str, str],
+) -> CatalogMeal:
+    return replace(
+        meal,
+        name=translations.get(meal.name, meal.name),
+        cuisine=translations.get(meal.cuisine, meal.cuisine),
+        description=(
+            translations.get(meal.description, meal.description)
+            if meal.description
+            else None
+        ),
+        ingredients=tuple(
+            replace(
+                ingredient,
+                display_name=translations.get(
+                    ingredient.display_name,
+                    ingredient.display_name,
+                ),
+            )
+            for ingredient in meal.ingredients
+        ),
+    )
+
+
+def _replace_slot_catalog_meals(
+    slot: PersistedMealRecommendationSlot,
+    localized_meals: dict[str, CatalogMeal],
+) -> PersistedMealRecommendationSlot:
+    return replace(
+        slot,
+        selected=(
+            _replace_candidate_catalog_meal(slot.selected, localized_meals)
+            if slot.selected is not None
+            else None
+        ),
+        alternatives=tuple(
+            _replace_candidate_catalog_meal(candidate, localized_meals)
+            for candidate in slot.alternatives
+        ),
+    )
+
+
+def _replace_candidate_catalog_meal(
+    candidate: PersistedMealRecommendationCandidate,
+    localized_meals: dict[str, CatalogMeal],
+) -> PersistedMealRecommendationCandidate:
+    if candidate.catalog_meal is None:
+        return candidate
+    return replace(
+        candidate,
+        catalog_meal=localized_meals.get(candidate.catalog_meal.id, candidate.catalog_meal),
+    )

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -85,7 +85,19 @@ class _TaskManager:
         coro.close()
 
 
-def _request(timezone: str = "Asia/Ho_Chi_Minh") -> Request:
+class _Translator:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def translate_texts(self, texts, target_lang):
+        self.calls.append((texts, target_lang))
+        return [f"vi:{text}" for text in texts]
+
+
+def _request(
+    timezone: str = "Asia/Ho_Chi_Minh",
+    language: str = "en",
+) -> Request:
     return Request(
         {
             "type": "http",
@@ -93,6 +105,7 @@ def _request(timezone: str = "Asia/Ho_Chi_Minh") -> Request:
             "path": "/v1/meal-recommendations/three-day",
             "client": ("127.0.0.1", 12345),
             "headers": [(b"x-timezone", timezone.encode("utf-8"))],
+            "state": {"language": language},
         }
     )
 
@@ -196,6 +209,7 @@ async def test_create_three_day_recommendations_enqueues_analytics_when_task_man
 async def test_get_plan_returns_owner_scoped_compact_summary():
     response = await get_meal_recommendation_plan(
         plan_id="plan-1",
+        request=_request(),
         user_id="user-1",
         event_bus=_EventBus(),
         analytics_service=_Analytics(),
@@ -213,6 +227,7 @@ async def test_get_slot_detail_returns_one_hydrated_slot_with_alternatives():
     response = await get_meal_recommendation_slot_detail(
         plan_id="plan-1",
         slot_id="slot-1",
+        request=_request(),
         user_id="user-1",
         event_bus=_EventBus(),
         analytics_service=_Analytics(),
@@ -222,6 +237,36 @@ async def test_get_slot_detail_returns_one_hydrated_slot_with_alternatives():
     assert response.slot.id == "slot-1"
     assert response.slot.catalog_meal.ingredients[0].display_name == "Rice"
     assert response.slot.alternatives[0].catalog_meal.name == "Chicken Bowl"
+
+
+@pytest.mark.asyncio
+async def test_get_plan_translates_catalog_text_from_request_language():
+    translator = _Translator()
+
+    response = await get_meal_recommendation_plan(
+        plan_id="plan-1",
+        request=_request(language="vi"),
+        user_id="user-1",
+        event_bus=_EventBus(),
+        analytics_service=_Analytics(),
+        translation_service=translator,
+    )
+
+    assert response.slots[0].catalog_meal.name == "vi:Breakfast Rice"
+    assert response.slots[0].catalog_meal.cuisine == "vi:vietnamese"
+    assert response.slots[0].catalog_meal.calories == 380
+    assert translator.calls == [
+        (
+            [
+                "Breakfast Rice",
+                "vietnamese",
+                "Display copy",
+                "Rice",
+                "Chicken Bowl",
+            ],
+            "vi",
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_catalog_meal_response_localizer.py
+++ b/tests/unit/app/services/test_catalog_meal_response_localizer.py
@@ -1,0 +1,190 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from src.app.services.catalog_meal_response_localizer import (
+    localize_meal_recommendation_plan,
+    localize_meal_recommendation_slot,
+)
+from src.domain.model.meal_recommendation import (
+    CatalogMeal,
+    CatalogMealIngredient,
+    PersistedMealRecommendationCandidate,
+    PersistedMealRecommendationPlan,
+    PersistedMealRecommendationSlot,
+)
+
+
+class _Translator:
+    def __init__(self, translations: dict[str, str]) -> None:
+        self.translations = translations
+        self.calls: list[tuple[list[str], str]] = []
+
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
+        self.calls.append((texts, target_lang))
+        return [self.translations.get(text, text) for text in texts]
+
+
+class _FailingTranslator:
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
+        raise RuntimeError("provider unavailable")
+
+
+class _ShortTranslator:
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
+        return ["Cơm tô"]
+
+
+def _meal(meal_id: str, name: str = "Rice Bowl") -> CatalogMeal:
+    return CatalogMeal(
+        id=meal_id,
+        catalog_key=f"key-{meal_id}",
+        content_hash=f"{meal_id:0<64}"[:64],
+        name=name,
+        cuisine="Vietnamese",
+        description="Warm rice with vegetables",
+        image_url="https://example.com/meal.jpg",
+        protein_g=Decimal("25"),
+        carbs_g=Decimal("50"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("5"),
+        meal_types=("lunch",),
+        ingredients=(
+            CatalogMealIngredient(
+                food_reference_id=7,
+                display_name="Rice",
+                quantity=Decimal("100"),
+                unit="g",
+            ),
+        ),
+    )
+
+
+def _slot(meal: CatalogMeal, alternative: CatalogMeal | None = None) -> PersistedMealRecommendationSlot:
+    selected = PersistedMealRecommendationCandidate(
+        id="candidate-1",
+        slot_id="slot-1",
+        recommendation_date=date(2026, 7, 29),
+        meal_type="lunch",
+        catalog_meal_id=meal.id,
+        candidate_rank=0,
+        is_selected=True,
+        score=Decimal("0.9"),
+        selection_version=2,
+        catalog_meal=meal,
+    )
+    alternatives = ()
+    if alternative is not None:
+        alternatives = (
+            PersistedMealRecommendationCandidate(
+                id="candidate-2",
+                slot_id="slot-1",
+                recommendation_date=date(2026, 7, 29),
+                meal_type="lunch",
+                catalog_meal_id=alternative.id,
+                candidate_rank=1,
+                is_selected=False,
+                score=Decimal("0.8"),
+                selection_version=2,
+                catalog_meal=alternative,
+            ),
+        )
+    return PersistedMealRecommendationSlot(
+        id="slot-1",
+        slot_date=date(2026, 7, 29),
+        day_index=0,
+        meal_type="lunch",
+        catalog_meal_id=meal.id,
+        target_calories=550,
+        score=0.9,
+        position=0,
+        selection_version=2,
+        selected=selected,
+        alternatives=alternatives,
+    )
+
+
+@pytest.mark.asyncio
+async def test_localize_slot_translates_allowlisted_text_once_and_preserves_contract():
+    meal = _meal("meal-1")
+    alternative = _meal("meal-2")
+    translator = _Translator(
+        {
+            "Rice Bowl": "Cơm tô",
+            "Vietnamese": "Việt Nam",
+            "Warm rice with vegetables": "Cơm nóng cùng rau",
+            "Rice": "Cơm",
+        }
+    )
+
+    localized = await localize_meal_recommendation_slot(
+        _slot(meal, alternative), language="vi", translation_service=translator
+    )
+
+    assert translator.calls == [
+        (
+            ["Rice Bowl", "Vietnamese", "Warm rice with vegetables", "Rice"],
+            "vi",
+        )
+    ]
+    assert localized.selected.catalog_meal.name == "Cơm tô"
+    assert localized.selected.catalog_meal.cuisine == "Việt Nam"
+    assert localized.selected.catalog_meal.description == "Cơm nóng cùng rau"
+    assert localized.selected.catalog_meal.ingredients[0].display_name == "Cơm"
+    assert localized.alternatives[0].catalog_meal.name == "Cơm tô"
+    assert localized.catalog_meal_id == meal.id
+    assert localized.target_calories == 550
+    assert localized.selected.catalog_meal.ingredients[0].unit == "g"
+    assert localized.selected.catalog_meal.calories == meal.calories
+    assert meal.name == "Rice Bowl"
+
+
+@pytest.mark.asyncio
+async def test_localize_plan_skips_english_and_missing_translation_service():
+    plan = PersistedMealRecommendationPlan(
+        id="plan-1",
+        user_id="user-1",
+        status="active",
+        timezone="Asia/Ho_Chi_Minh",
+        start_date=date(2026, 7, 29),
+        daily_calories=2000,
+        operation="three_day",
+        idempotency_key="key-1",
+        request_fingerprint="f" * 64,
+        slots=(_slot(_meal("meal-1")),),
+    )
+    translator = _Translator({})
+
+    assert await localize_meal_recommendation_plan(
+        plan, language="en", translation_service=translator
+    ) is plan
+    assert await localize_meal_recommendation_plan(
+        plan, language="vi", translation_service=None
+    ) is plan
+    assert translator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_localize_slot_returns_canonical_values_when_translation_fails():
+    slot = _slot(_meal("meal-1"))
+
+    localized = await localize_meal_recommendation_slot(
+        slot, language="vi", translation_service=_FailingTranslator()
+    )
+
+    assert localized is slot
+
+
+@pytest.mark.asyncio
+async def test_localize_slot_falls_back_for_missing_translated_values():
+    slot = _slot(_meal("meal-1"))
+
+    localized = await localize_meal_recommendation_slot(
+        slot, language="vi", translation_service=_ShortTranslator()
+    )
+
+    assert localized.selected.catalog_meal.name == "Cơm tô"
+    assert localized.selected.catalog_meal.cuisine == "Vietnamese"
+    assert localized.selected.catalog_meal.description == "Warm rice with vegetables"
+    assert localized.selected.catalog_meal.ingredients[0].display_name == "Rice"


### PR DESCRIPTION
## Summary
- Localize catalog-backed recommendation response text from `Accept-Language`.
- Batch and deduplicate translation work while keeping catalog/persisted data, units, nutrition, scores, and state canonical.
- Fall back to English when DeepL is unavailable, fails, or returns a partial batch.

## Test plan
- [x] `uv run pytest -q tests/unit/app/services/test_catalog_meal_response_localizer.py tests/unit/api/test_meal_recommendations_route.py tests/unit/api/test_meal_recommendation_http_contract.py tests/unit/api/middleware/test_accept_language.py`
- [x] `uv run ruff check src/app/services/catalog_meal_response_localizer.py src/api/routes/v1/meal_recommendations.py tests/unit/app/services/test_catalog_meal_response_localizer.py tests/unit/api/test_meal_recommendations_route.py`
- [x] `uv run mypy src/app/services/catalog_meal_response_localizer.py src/api/routes/v1/meal_recommendations.py`
- [x] `uv run lint-imports`
- [x] Pre-push unit suite: `2018 passed`