### PR TITLE
feat(catalog): add admin import and NIN dish ingestion

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -178,6 +178,8 @@ ignore_imports =
     src.api.base_dependencies -> src.infra.repositories.food_reference_repository
     src.api.base_dependencies -> src.infra.repositories.food_reference_uow_adapter
     src.api.base_dependencies -> src.infra.repositories.admin_meal_catalog_repository_async
+    src.api.base_dependencies -> src.infra.repositories.catalog_recipe_repository_async
+    src.api.base_dependencies -> src.infra.repositories.food_reference_repository_async
     src.api.base_dependencies -> src.infra.repositories.meal_repository
     src.api.base_dependencies -> src.infra.repositories.meal_suggestion_repository
     src.api.base_dependencies -> src.infra.repositories.meal_translation_repository

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -124,6 +124,8 @@ The two health routes are declared with `api_route` and answer both GET and HEAD
 - `shown_at`, `skipped_at`, and `logged_at` are backend-owned outcome fields. Clients must not infer terminal state by recalculating recommendation logic.
 - Recommendation analytics are scheduled through `BackgroundTaskManager` when the dependency is available; the route falls back to inline capture when it is not.
 - New plan generation uses snapshot-scoped ingredient IDF, confidence-scaled ingredient similarity, and bounded diversity reranking. Existing persisted plans replay their stored candidates and scores. This does not change endpoint paths and does not touch `/v1/meal-suggestions`.
+- The existing `Accept-Language` header selects response language (`en`, `vi`, `es`, `fr`, `de`, `ja`, `zh`). For non-English requests, meal names, cuisine, descriptions, and ingredient display names are translated at response time; IDs, units, nutrition, scores, and recommendation state remain canonical.
+- Missing/unsupported language, an unset DeepL key, or translation-provider failure returns the successful canonical English response rather than failing the recommendation request.
 
 ---
 

--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -235,6 +235,11 @@ concurrent requests.
 - Local food search uses `food_reference.name_normalized`, a unique normalized-name
   constraint, and a `pg_trgm` GIN index. Results are verified-first,
   region/global scoped, bounded to 50, and deduplicated by normalized name.
+- `scripts/import_food_seeds.py` imports non-barcoded scraper rows through the
+  async unit of work using that normalized-name key. NIN and VN FCT sources are
+  trusted ingredient references; manually verified rows remain protected. Run
+  `--dry-run` first. The validator reports by default; `--fix` is required to
+  rewrite source files.
 
 ---
 

--- a/docs/journals/260729-1055-catalog-recommendation-response-localization.md
+++ b/docs/journals/260729-1055-catalog-recommendation-response-localization.md
@@ -1,0 +1,21 @@
+# Catalog Recommendation Response Localization
+
+## Context
+
+Catalog-backed recommendation responses were canonical English even though the backend already parsed `Accept-Language` and provided a DeepL text translation service.
+
+## Change
+
+- Added an application-layer response localizer that batches and deduplicates display text per response.
+- Localized meal names, cuisines, descriptions, and ingredient display names after CQRS reads.
+- Kept catalog data, persisted recommendation plans, units, nutrition, IDs, scores, and state immutable and canonical.
+- Added canonical-English fallback for missing DeepL configuration, provider failures, and short provider responses.
+
+## Evidence
+
+- 109 recommendation-focused tests passed.
+- Ruff, mypy, import-layer contracts, route registration smoke test, and documentation validation passed.
+
+## Decision
+
+`Accept-Language` is authoritative for these endpoints. User-profile language is not consulted, and no translated catalog data is persisted.

--- a/docs/meal-catalog-import-schema.md
+++ b/docs/meal-catalog-import-schema.md
@@ -60,6 +60,27 @@ fiber, sugar, calories, and any needed gram conversion from
 scored. These derived values are not stored in `meal_catalog` or
 `meal_catalog_ingredients`.
 
+## Admin API
+
+The same importer and resolver are available behind the admin Firebase/local gate:
+
+```http
+POST /v1/admin/meal-catalog/resolve
+POST /v1/admin/meal-catalog/import
+```
+
+Both endpoints accept a JSON body with the manifest plus the script options:
+`manifest`, `partial`, `skip_exact_cuisine_count`, `expected_recipe_count`,
+`min_per_cuisine_meal_type`, `resolver_map`, `auto_resolve_threshold`, and
+`resolve_all_best_effort`. The import endpoint also accepts `dry_run`.
+
+`/resolve` always performs a non-mutating dry run and returns validation errors,
+unresolved ingredient candidates, near-duplicate reviews, and import counts.
+`/import` first performs the same dry run; it writes only when validation and
+resolution succeed and `dry_run` is false. A successful write returns
+`applied: true`. The default resolver remains strict: unverified or ambiguous
+ingredient matches are reported for review rather than silently selected.
+
 ## Import Commands
 
 Validate and resolve only:

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -12,6 +12,8 @@
 ### July 2026: Meal Catalog Phase 0 Production Foundation
 - [x] Four-table catalog recommendation foundation uses `meal_catalog`, `meal_catalog_ingredients`, `meal_recommendations`, and `meal_recommendation_operations`.
 - [x] Catalog import is additive, content-hash protected, serialized, and withholds near duplicates for explicit review.
+- [x] Admin meal-catalog APIs expose the same strict resolver preview and two-pass import flow as the catalog seed script.
+- [x] Food scraper seed ingestion uses the async food-reference repository and preserves verified canonical rows.
 - [x] Recommendation create/read/slot detail/swap/log/skip are owner-scoped and idempotent where mutations require request IDs.
 - [x] Provider-backed food routes and feature-flag reads require Firebase JWT; mutation routes retain stronger admin protection where applicable.
 - [x] Food search is local-first through indexed `food_reference` and degrades through cache/provider/translation outages.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -19,6 +19,11 @@
 - [ ] Approved 180-meal production corpus import/replay evidence is pending because the manifest and resolver map are not present locally.
 - [ ] Staging load, degraded-load, and rollback-drill evidence remain release gates.
 
+### July 2026: Catalog Recommendation Response Localization
+- [x] Catalog-backed recommendation responses now honor `Accept-Language` for the seven supported app languages.
+- [x] Localization translates presentation text only (meal name, cuisine, description, ingredient display name); IDs, units, ranking, state, and backend-derived nutrition remain canonical.
+- [x] Missing configuration or translation-provider failure returns the canonical English response without failing the recommendation request.
+
 ### July 2026: Meal Recommendation Performance Redesign
 - [x] `POST /v1/meal-recommendations/three-day` and `GET /v1/meal-recommendations/{plan_id}` now return compact selected-slot summaries instead of full hydrated plans.
 - [x] `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` returns one hydrated selected slot plus alternatives for drill-down.

--- a/plans/260729-1055-meal-catalog-response-translation/phase-01-localization-contract-and-translation-boundary.md
+++ b/plans/260729-1055-meal-catalog-response-translation/phase-01-localization-contract-and-translation-boundary.md
@@ -1,0 +1,43 @@
+---
+phase: 1
+title: Localization contract and translation boundary
+status: completed
+priority: P2
+effort: 2h
+dependencies: []
+---
+
+# Phase 1: Localization contract and translation boundary
+
+## Overview
+
+Define the response localization contract before implementation. Keep catalog/recommendation logic deterministic and English-canonical; localization belongs at the API projection boundary.
+
+## Requirements
+
+- Translate `name`, `cuisine`, optional `description`, and ingredient `display_name`.
+- Preserve units, quantities, macros, calories, IDs, meal types, scores, ordering, and state.
+- Use `get_request_language(request)`; do not parse raw headers or add a query/body override.
+- Missing service, English target, provider error, and short output fall back to canonical text.
+
+## Architecture
+
+Reuse `DeepLTextTranslationService`; add one response-localizer seam only if the mapping logic cannot remain small. It receives the loaded plan/slot and returns new frozen catalog projections. It performs one deduplicated batch per response and never writes to catalog or recommendation storage.
+
+## Related Code Files
+
+- Read: `src/api/middleware/accept_language.py`, `src/domain/services/translation/deepl_text_translation_service.py`.
+- Modify: `src/api/routes/v1/meal_recommendation_route_support.py`, route tests and contract tests.
+
+## Implementation Steps
+
+1. Characterize current English response shapes and all callers of the shared mapping helpers.
+2. Document the field allowlist and fallback semantics in tests.
+3. Decide async mapping/dependency injection shape for all six response-producing routes.
+4. Confirm no DB schema, catalog model, ranking, persistence, or analytics changes are needed.
+
+## Success Criteria
+
+- [x] Contract covers summary, detail, and mutation responses.
+- [x] Only user-facing text fields are candidates for translation.
+- [x] Async mapping and dependency boundary are explicit.

--- a/plans/260729-1055-meal-catalog-response-translation/phase-02-implement-catalog-response-translation.md
+++ b/plans/260729-1055-meal-catalog-response-translation/phase-02-implement-catalog-response-translation.md
@@ -1,0 +1,49 @@
+---
+phase: 2
+title: Implement catalog response translation
+status: completed
+priority: P2
+effort: 1d
+dependencies:
+  - 1
+---
+
+# Phase 2: Implement catalog response translation
+
+## Overview
+
+Implement request-language localization in the existing recommendation response path. Translation is presentation-only and transparent when DeepL is unavailable.
+
+## Requirements
+
+- All recommendation response shapes use the same localization seam.
+- No domain/catalog object is mutated.
+- Provider work is skipped for English and deduplicated for repeated strings.
+
+## Architecture
+
+The route obtains `get_request_language(request)` and the existing text translation dependency. After CQRS/domain results are loaded, an async localizer reconstructs translated `CatalogMeal` projections, then existing Pydantic response builders serialize them. Ranking, snapshot refresh, persistence, and analytics remain untouched. Avoid cross-request caching initially; add only a bounded content-hash/language cache if measured need justifies it.
+
+## Related Code Files
+
+- Modify: `src/api/routes/v1/meal_recommendation_route_support.py` — async localizer and translated projections.
+- Modify: `src/api/routes/v1/meal_recommendations.py` — request language and translator dependency for create/get/detail/swap/log/skip.
+- Modify: `src/api/base_dependencies.py` only if a narrowly scoped localizer dependency is required.
+- Create only if needed: `src/app/services/catalog_meal_response_localizer.py`.
+- Modify: `tests/unit/api/test_meal_recommendation_http_contract.py`, `tests/unit/api/test_meal_recommendations_route.py`.
+- Create only if needed: `tests/unit/app/services/test_catalog_meal_response_localizer.py`.
+
+## Implementation Steps
+
+1. Write fake-translator tests that record batches and return deterministic output.
+2. Implement deduplication, empty-description handling, frozen projection reconstruction, and safe padding/fallback.
+3. Make mapping helpers async or delegate to an async localizer; update all six route paths consistently.
+4. Preserve units, quantities, macros, calories, IDs, scores, and recommendation state exactly.
+5. Reuse the existing service fallback; do not add duplicate route-level error logging.
+
+## Success Criteria
+
+- [x] Supported non-English requests localize names, cuisine, descriptions, and ingredient names.
+- [x] English/missing/unsupported/provider-failure paths return canonical content successfully.
+- [x] Repeated strings translate once per response and no domain object changes.
+- [x] No migration or catalog write path changes.

--- a/plans/260729-1055-meal-catalog-response-translation/phase-03-verification-and-documentation.md
+++ b/plans/260729-1055-meal-catalog-response-translation/phase-03-verification-and-documentation.md
@@ -1,0 +1,53 @@
+---
+phase: 3
+title: Verification and documentation
+status: completed
+priority: P2
+effort: 3h
+dependencies:
+  - 2
+---
+
+# Phase 3: Verification and documentation
+
+## Overview
+
+Prove localized response behavior, graceful degradation, and compatibility with existing catalog recommendation behavior. Update API documentation only after focused verification passes.
+
+## Test Scenario Matrix
+
+| Scenario | Expected result |
+|---|---|
+| `en` / no header | Canonical English; translator not called |
+| Supported non-English | Allowlisted text translated in summary/detail/mutation shapes |
+| Unsupported language | Middleware resolves `en`; canonical response |
+| Missing key | Endpoint succeeds with English |
+| Provider exception/short batch | Safe canonical fallback |
+| Repeated text | One request-level translation per unique text |
+| Persisted plan | Same stored selection/ranking/state, localized only at projection |
+
+## Related Code Files
+
+- Modify: `docs/api-endpoints.md` — document request-language behavior and fallback.
+- Modify tests adjacent to the recommendation route and middleware seams.
+
+## Implementation Steps
+
+1. Run focused localizer, middleware, response-schema, and all recommendation route tests.
+2. Run `ruff check` on changed source/tests and applicable `mypy` checks.
+3. Run the broader recommendation/API subset; do not claim live DeepL verification unless executed.
+4. Inspect the final diff for controlled-field translation, raw provider logging, schema drift, or catalog persistence changes.
+
+## Success Criteria
+
+- [x] English, all supported non-English, missing-key, failure, and nested alternative paths pass.
+- [x] Ranking/persistence tests remain green.
+- [x] Ruff and applicable mypy checks pass.
+- [x] API docs state `Accept-Language` behavior and English fallback.
+- [x] No migration or canonical catalog data changes.
+
+## Security and Performance
+
+- DeepL calls remain off the request path for English.
+- Translation failures cannot expose provider payloads or request content in logs.
+- Deduplication and bounded response traversal prevent unbounded provider requests.

--- a/plans/260729-1055-meal-catalog-response-translation/plan.md
+++ b/plans/260729-1055-meal-catalog-response-translation/plan.md
@@ -1,0 +1,58 @@
+---
+title: Meal catalog response translation
+description: >-
+  Translate catalog-backed meal recommendation text at response time using the
+  request language while keeping canonical catalog data in English.
+status: completed
+priority: P2
+effort: 1d 5h
+branch: delivery
+tags:
+  - feature
+  - backend
+  - api
+blockedBy: []
+blocks: []
+created: '2026-07-29'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Meal catalog response translation
+
+## Overview
+
+Add locale-aware presentation for catalog-backed meal recommendation endpoints. Canonical `meal_catalog` rows and persisted recommendation plans remain English and unchanged; response mapping translates user-facing catalog text using the existing validated `Accept-Language` request state.
+
+Verified reusable seams:
+
+- `AcceptLanguageMiddleware` supports `en`, `vi`, `es`, `fr`, `de`, `ja`, `zh` and defaults to English.
+- `DeepLTextTranslationService` already batches text and returns originals on provider failure.
+- `meal_recommendation_route_support.py` is the shared projection seam for all recommendation response shapes.
+- `CatalogMeal` is frozen and calories are backend-derived, so localization must create projections rather than mutate domain/catalog data.
+
+Scope: translate meal `name`, `cuisine`, `description`, and ingredient `display_name`. Preserve IDs, meal types, units, quantities, macros, calories, scores, ordering, and state. No translation columns, migration, client language override, or persisted translated content.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Localization contract and translation boundary](./phase-01-localization-contract-and-translation-boundary.md) | Completed |
+| 2 | [Implement catalog response translation](./phase-02-implement-catalog-response-translation.md) | Completed |
+| 3 | [Verification and documentation](./phase-03-verification-and-documentation.md) | Completed |
+
+## Dependencies
+
+- No unfinished plan blocks this work. The current four-table catalog response contract is the integration target.
+- Runtime dependency: configured `DEEPL_API_KEY`; without it, responses remain canonical English.
+
+## Success Criteria
+
+- Non-English requests receive translated catalog text across every recommendation response shape.
+- English, unsupported, missing, provider-error, and partial-result paths remain safe.
+- Translation is batched/deduplicated and does not alter ranking, persistence, cache keys, nutrition, or IDs.
+- Focused tests, lint/type checks, and API documentation are complete.
+
+## Unresolved Questions
+
+None.

--- a/scripts/import_food_seeds.py
+++ b/scripts/import_food_seeds.py
@@ -1,9 +1,12 @@
 """Import food seed JSON into food_reference. Use --fetch to download from APIs first."""
+
 import argparse
+import asyncio
 import json
 import logging
 import subprocess
 import sys
+import tempfile
 import unicodedata
 from pathlib import Path
 
@@ -13,6 +16,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
+from src.domain.services.meal_suggestion.ingredient_name_normalizer import (
+    normalize_food_name,
+)
+from src.infra.database.uow_async import AsyncUnitOfWork
+
 SOURCE_PRIORITY: dict[str, int] = {
     "nin_vn": 1,
     "vn_fct_pdf": 2,
@@ -21,6 +29,7 @@ SOURCE_PRIORITY: dict[str, int] = {
 }
 _DEFAULT_PRIORITY = 99
 _SCRAPERS_DIR = Path(__file__).resolve().parent / "scrapers"
+_TRUSTED_SEED_SOURCES = frozenset({"nin_vn", "vn_fct_pdf"})
 
 
 def _normalize_name(text: str) -> str:
@@ -30,7 +39,7 @@ def _normalize_name(text: str) -> str:
 
 def _load_json_file(path: Path) -> list[dict]:
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, list):
             logger.warning("Skipping %s — expected JSON array", path.name)
@@ -83,7 +92,9 @@ def _dedup_entries(all_entries: list[dict], source_filter: str | None) -> list[d
         if existing is None:
             by_name[key] = entry
         else:
-            existing_pri = SOURCE_PRIORITY.get(existing.get("source", ""), _DEFAULT_PRIORITY)
+            existing_pri = SOURCE_PRIORITY.get(
+                existing.get("source", ""), _DEFAULT_PRIORITY
+            )
             new_pri = SOURCE_PRIORITY.get(source, _DEFAULT_PRIORITY)
             if new_pri < existing_pri:
                 by_name[key] = entry
@@ -97,11 +108,26 @@ def _fetch_data(data_dir: Path) -> None:
     python = sys.executable
 
     fetchers = [
-        ("NIN VN", [python, str(_SCRAPERS_DIR / "fetch_nin_vn.py"),
-                    "--output-foods", str(data_dir / "nin_vn_foods.json"),
-                    "--output-dishes", str(data_dir / "nin_vn_dishes.json")]),
-        ("OpenFoodFacts VN", [python, str(_SCRAPERS_DIR / "fetch_off_vn.py"),
-                              "--output", str(data_dir / "off_vn_products.json")]),
+        (
+            "NIN VN",
+            [
+                python,
+                str(_SCRAPERS_DIR / "fetch_nin_vn.py"),
+                "--output-foods",
+                str(data_dir / "nin_vn_foods.json"),
+                "--output-dishes",
+                str(data_dir / "nin_vn_dishes.json"),
+            ],
+        ),
+        (
+            "OpenFoodFacts VN",
+            [
+                python,
+                str(_SCRAPERS_DIR / "fetch_off_vn.py"),
+                "--output",
+                str(data_dir / "off_vn_products.json"),
+            ],
+        ),
     ]
     for label, cmd in fetchers:
         logger.info("Fetching %s ...", label)
@@ -112,7 +138,25 @@ def _fetch_data(data_dir: Path) -> None:
             logger.info("Fetched %s successfully", label)
 
 
-def _run_import(data_dir: Path, dry_run: bool, source_filter: str | None) -> None:
+def _fetch_nin_dishes(data_dir: Path) -> bool:
+    """Fetch only the NIN prepared-dishes catalog into an isolated directory."""
+    output_path = data_dir / "nin_vn_dishes.json"
+    command = [
+        sys.executable,
+        str(_SCRAPERS_DIR / "fetch_nin_vn.py"),
+        "--dishes-only",
+        "--output-dishes",
+        str(output_path),
+    ]
+    logger.info("Fetching NIN VN dishes ...")
+    result = subprocess.run(command, text=True)
+    if result.returncode != 0:
+        logger.error("Failed to fetch NIN VN dishes (exit code %d)", result.returncode)
+        return False
+    return output_path.exists()
+
+
+async def _run_import(data_dir: Path, dry_run: bool, source_filter: str | None) -> None:
     json_files = sorted(data_dir.glob("*.json"))
     if not json_files:
         logger.warning("No JSON files found in %s", data_dir)
@@ -133,55 +177,137 @@ def _run_import(data_dir: Path, dry_run: bool, source_filter: str | None) -> Non
     if dry_run:
         logger.info("Dry-run mode — validating only, no DB writes")
 
-    repo = None
-    if not dry_run:
-        from src.infra.repositories.food_reference_repository import FoodReferenceRepository
-        repo = FoodReferenceRepository()
+    if dry_run:
+        for entry in deduped:
+            if _is_invalid(entry):
+                counts["invalid"] += 1
+            else:
+                counts["inserted"] += 1
+        _print_report(counts, dry_run)
+        return
 
-    total = len(deduped)
-    for i, entry in enumerate(deduped, 1):
-        warnings = _validate_entry(entry)
-        if warnings:
-            critical = [w for w in warnings if "negative" in w or "exceeds" in w]
-            if critical:
+    async with AsyncUnitOfWork() as uow:
+        total = len(deduped)
+        for i, entry in enumerate(deduped, 1):
+            if _is_invalid(entry):
                 counts["invalid"] += 1
                 continue
+            result = await _upsert_entry(uow.food_references, entry)
+            counts[result] += 1
 
-        if dry_run:
-            counts["inserted"] += 1
-            continue
-
-        result = repo.upsert_seed(entry)  # type: ignore[union-attr]
-        counts[result] += 1
-        if result == "skipped":
-            logger.warning("  SKIPPED: %s (source=%s)",
-                           entry.get("name_vi", entry.get("name", "?")), entry.get("source"))
-
-        # Progress every 100 entries
-        if i % 100 == 0 or i == total:
-            done = sum(counts.values())
-            logger.info("Progress: %d/%d (%d inserted, %d updated, %d skipped)",
-                        done, total, counts["inserted"], counts["updated"], counts["skipped"])
+            if i % 100 == 0 or i == total:
+                done = sum(counts.values())
+                logger.info(
+                    "Progress: %d/%d (%d inserted, %d updated, %d skipped)",
+                    done,
+                    total,
+                    counts["inserted"],
+                    counts["updated"],
+                    counts["skipped"],
+                )
 
     _print_report(counts, dry_run)
 
 
+def _is_invalid(entry: dict) -> bool:
+    warnings = _validate_entry(entry)
+    return not _entry_name(entry) or any(
+        "negative" in warning or "exceeds" in warning for warning in warnings
+    )
+
+
+async def _upsert_entry(repository, entry: dict) -> str:
+    if entry.get("barcode"):
+        existing = await repository.get_by_barcode(entry["barcode"])
+        await repository.upsert(_prepared_entry(entry))
+        return "updated" if existing is not None else "inserted"
+
+    prepared = _prepared_entry(entry)
+    existing = await repository.find_by_normalized_name(prepared["name_normalized"])
+    if existing is not None and _existing_wins(existing, prepared):
+        return "skipped"
+    await repository.upsert_seed(prepared)
+    return "updated" if existing is not None else "inserted"
+
+
+def _prepared_entry(entry: dict) -> dict:
+    prepared = dict(entry)
+    prepared["name"] = _entry_name(entry)
+    prepared["name_normalized"] = normalize_food_name(prepared["name"])
+    prepared["is_verified"] = entry.get("source") in _TRUSTED_SEED_SOURCES
+    return prepared
+
+
+def _existing_wins(existing: dict, incoming: dict) -> bool:
+    existing_source = existing.get("source")
+    incoming_source = incoming.get("source")
+    existing_priority = _source_priority(existing_source)
+    incoming_priority = _source_priority(incoming_source)
+    if existing.get("is_verified"):
+        if existing_source not in _TRUSTED_SEED_SOURCES:
+            return True
+        return existing_priority <= incoming_priority
+    return existing_priority < incoming_priority
+
+
+def _source_priority(source: str | None) -> int:
+    return SOURCE_PRIORITY.get(source or "", _DEFAULT_PRIORITY)
+
+
+def _entry_name(entry: dict) -> str:
+    return str(entry.get("name") or entry.get("name_vi") or "").strip()
+
+
 def _print_report(counts: dict[str, int], dry_run: bool) -> None:
     mode = " (dry-run)" if dry_run else ""
-    print(f"\nImport report{mode}: {sum(counts.values())} total — "
-          f"{counts['inserted']} inserted, {counts['updated']} updated, "
-          f"{counts['skipped']} skipped, {counts['invalid']} invalid")
+    print(
+        f"\nImport report{mode}: {sum(counts.values())} total — "
+        f"{counts['inserted']} inserted, {counts['updated']} updated, "
+        f"{counts['skipped']} skipped, {counts['invalid']} invalid"
+    )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch and import VN food seeds.")
-    parser.add_argument("--fetch", action="store_true", help="Fetch from APIs before importing")
-    parser.add_argument("--no-validate", action="store_true", help="Skip data validation/cleaning")
-    parser.add_argument("--data-dir", default=str(Path(__file__).resolve().parent / "data"),
-                        help="JSON files directory (default: scripts/data/)")
-    parser.add_argument("--dry-run", action="store_true", help="Validate only, no DB writes")
-    parser.add_argument("--source", default=None, help="Filter by source (e.g. 'nin_vn')")
+    parser.add_argument(
+        "--fetch", action="store_true", help="Fetch from APIs before importing"
+    )
+    parser.add_argument(
+        "--fetch-nin-dishes",
+        action="store_true",
+        help="Fetch and import only the NIN prepared-dishes catalog",
+    )
+    parser.add_argument(
+        "--no-validate", action="store_true", help="Skip validation report"
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Explicitly rewrite invalid seed files"
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(Path(__file__).resolve().parent / "data"),
+        help="JSON files directory (default: scripts/data/)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Validate only, no DB writes"
+    )
+    parser.add_argument(
+        "--source", default=None, help="Filter by source (e.g. 'nin_vn')"
+    )
     args = parser.parse_args()
+
+    if args.fetch_nin_dishes:
+        with tempfile.TemporaryDirectory(prefix="nutree-nin-dishes-") as temp_dir:
+            if not _fetch_nin_dishes(Path(temp_dir)):
+                sys.exit(1)
+            asyncio.run(
+                _run_import(
+                    data_dir=Path(temp_dir),
+                    dry_run=args.dry_run,
+                    source_filter="nin_vn",
+                )
+            )
+        return
 
     data_dir = Path(args.data_dir)
 
@@ -189,15 +315,26 @@ def main() -> None:
         _fetch_data(data_dir)
 
     if not args.no_validate and data_dir.exists():
-        logger.info("Validating and cleaning seed data...")
-        subprocess.run([sys.executable, str(_SCRAPERS_DIR / "validate_seeds.py"),
-                        "--data-dir", str(data_dir), "--fix"], text=True)
+        logger.info("Validating seed data...")
+        command = [
+            sys.executable,
+            str(_SCRAPERS_DIR / "validate_seeds.py"),
+            "--data-dir",
+            str(data_dir),
+        ]
+        if args.fix:
+            command.append("--fix")
+        subprocess.run(command, text=True, check=False)
 
     if not data_dir.exists():
-        logger.error("data-dir does not exist: %s — use --fetch to download data first", data_dir)
+        logger.error(
+            "data-dir does not exist: %s — use --fetch to download data first", data_dir
+        )
         sys.exit(1)
 
-    _run_import(data_dir=data_dir, dry_run=args.dry_run, source_filter=args.source)
+    asyncio.run(
+        _run_import(data_dir=data_dir, dry_run=args.dry_run, source_filter=args.source)
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/scrapers/fetch_nin_vn.py
+++ b/scripts/scrapers/fetch_nin_vn.py
@@ -24,7 +24,7 @@ BASE_URL = "https://viendinhduong.vn"
 FOODS_API = f"{BASE_URL}/api/fe/foodNatunal/getPageFoodData"
 DISHES_API = f"{BASE_URL}/api/fe/tool/getPageFoodData"
 HEADERS = {"User-Agent": "NutreeAI/1.0 (food-database-enrichment)"}
-PAGE_SIZE = 15  # API ignores limit param, always returns 15
+PAGE_SIZE = 10_000  # The API honors pageSize; this covers the current catalog in one request.
 RATE_LIMIT = 1.0  # seconds between requests
 
 # Nutrient name mapping → our schema field names
@@ -146,7 +146,13 @@ def _fetch_paginated(api_url: str, parser, label: str) -> list[dict]:
     page = 1
 
     while True:
-        params = {"page": page, "limit": PAGE_SIZE, "foodGroupId": "", "energyType": 0, "lang": "en"}
+        params = {
+            "page": page,
+            "pageSize": PAGE_SIZE,
+            "foodGroupId": "",
+            "energyType": 0,
+            "lang": "en",
+        }
         try:
             r = requests.get(api_url, params=params, timeout=30, headers=HEADERS)
             r.raise_for_status()
@@ -168,7 +174,7 @@ def _fetch_paginated(api_url: str, parser, label: str) -> list[dict]:
         logger.info("%s: page %d/%s — %d items (total so far: %d)",
                     label, page, data.get("last_page", "?"), len(items), len(entries))
 
-        # Use actual per_page from response (API ignores our limit param)
+        # Respect the response page size if the API caps a requested pageSize.
         actual_page_size = data.get("per_page", PAGE_SIZE)
         if len(items) < actual_page_size:
             break

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.app.services.catalog_meal_seed_import_service import CatalogMealSeedImporter
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
 )
@@ -34,6 +35,12 @@ from src.infra.config.settings import settings
 from src.infra.database.config_async import get_async_db
 from src.infra.repositories.admin_meal_catalog_repository_async import (
     AsyncAdminMealCatalogRepository,
+)
+from src.infra.repositories.catalog_recipe_repository_async import (
+    AsyncCatalogMealRepository,
+)
+from src.infra.repositories.food_reference_repository_async import (
+    AsyncFoodReferenceRepository,
 )
 from src.infra.services.firebase_service import FirebaseService
 
@@ -167,6 +174,17 @@ def get_admin_meal_catalog_repository(
     """Return admin catalog repository bound to the request session."""
 
     return AsyncAdminMealCatalogRepository(db)
+
+
+def get_catalog_meal_seed_importer(
+    db: AsyncSession = Depends(get_async_db),
+) -> CatalogMealSeedImporter:
+    """Build the catalog seed importer with request-scoped repositories."""
+
+    return CatalogMealSeedImporter(
+        AsyncCatalogMealRepository(db),
+        AsyncFoodReferenceRepository(db),
+    )
 
 
 def get_catalog_image_generator() -> CloudflareWorkersImageGenerator:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -48,6 +48,7 @@ from src.api.middleware.request_logger import RequestLoggerMiddleware
 from src.api.routes.app_download import router as app_download_router
 from src.api.routes.v1.activities import router as activities_router
 from src.api.routes.v1.admin_meal_catalog import router as admin_meal_catalog_router
+from src.api.routes.v1.admin_meal_catalog_import import router as admin_meal_catalog_import_router
 from src.api.routes.v1.cheat_days import router as cheat_days_router
 from src.api.routes.v1.codes import router as codes_router
 from src.api.routes.v1.feature_flags import router as feature_flags_router
@@ -310,6 +311,7 @@ add_dev_auth_bypass(app)
 app.include_router(root_health_router)
 app.include_router(health_router)
 app.include_router(admin_meal_catalog_router)
+app.include_router(admin_meal_catalog_import_router)
 app.include_router(meals_router)
 app.include_router(meal_scan_by_url_router)
 app.include_router(activities_router)

--- a/src/api/routes/v1/admin_meal_catalog_import.py
+++ b/src/api/routes/v1/admin_meal_catalog_import.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.base_dependencies import get_async_db
+from src.api.base_dependencies import get_async_db, get_catalog_meal_seed_importer
 from src.api.dependencies.auth import require_admin_or_local
 from src.api.schemas.response.admin_meal_catalog_responses import (
     AdminMealCatalogImportRequest,
@@ -17,12 +17,6 @@ from src.domain.services.meal_recommendation.catalog_recipe_seed_validator impor
     PRODUCTION_CUISINE_COUNTS,
     validate_catalog_seed_manifest,
 )
-from src.infra.repositories.catalog_recipe_repository_async import (
-    AsyncCatalogMealRepository,
-)
-from src.infra.repositories.food_reference_repository_async import (
-    AsyncFoodReferenceRepository,
-)
 
 router = APIRouter(prefix="/v1/admin/meal-catalog", tags=["Admin Meal Catalog"])
 
@@ -31,6 +25,7 @@ router = APIRouter(prefix="/v1/admin/meal-catalog", tags=["Admin Meal Catalog"])
 async def resolve_admin_meal_catalog_ingredients(
     request: AdminMealCatalogImportRequest,
     db: AsyncSession = Depends(get_async_db),
+    importer: CatalogMealSeedImporter = Depends(get_catalog_meal_seed_importer),
     _admin: str = Depends(require_admin_or_local),
 ) -> AdminMealCatalogImportResponse:
     """Validate and resolve a manifest without changing the catalog."""
@@ -40,7 +35,7 @@ async def resolve_admin_meal_catalog_ingredients(
         return _response(
             validation, _empty_summary(validation, dry_run=True), applied=False
         )
-    summary = await _run_importer(db, request, dry_run=True)
+    summary = await _run_importer(importer, request, dry_run=True)
     return _response(validation, summary, applied=False)
 
 
@@ -48,6 +43,7 @@ async def resolve_admin_meal_catalog_ingredients(
 async def import_admin_meal_catalog(
     request: AdminMealCatalogImportRequest,
     db: AsyncSession = Depends(get_async_db),
+    importer: CatalogMealSeedImporter = Depends(get_catalog_meal_seed_importer),
     _admin: str = Depends(require_admin_or_local),
 ) -> AdminMealCatalogImportResponse:
     """Import a validated manifest, or preview it when ``dry_run`` is true."""
@@ -63,11 +59,11 @@ async def import_admin_meal_catalog(
             ).model_dump(),
         )
 
-    preview = await _run_importer(db, request, dry_run=True)
+    preview = await _run_importer(importer, request, dry_run=True)
     if not preview.is_successful or request.dry_run:
         return _response(validation, preview, applied=False)
 
-    summary = await _run_importer(db, request, dry_run=False)
+    summary = await _run_importer(importer, request, dry_run=False)
     if not summary.is_successful:
         await db.rollback()
         return _response(validation, summary, applied=False)
@@ -94,22 +90,20 @@ def _validate_manifest(request: AdminMealCatalogImportRequest):
 
 
 async def _run_importer(
-    db: AsyncSession,
+    importer: CatalogMealSeedImporter,
     request: AdminMealCatalogImportRequest,
     *,
     dry_run: bool,
 ):
-    return await CatalogMealSeedImporter(
-        AsyncCatalogMealRepository(db),
-        AsyncFoodReferenceRepository(db),
+    auto_resolve_threshold = (
+        0.0
+        if request.resolve_all_best_effort and request.auto_resolve_threshold is None
+        else request.auto_resolve_threshold
+    )
+    return await importer.with_options(
         dry_run=dry_run,
         approved_mappings=request.resolver_map,
-        auto_resolve_threshold=(
-            0.0
-            if request.resolve_all_best_effort
-            and request.auto_resolve_threshold is None
-            else request.auto_resolve_threshold
-        ),
+        auto_resolve_threshold=auto_resolve_threshold,
         resolve_all_best_effort=request.resolve_all_best_effort,
     ).import_manifest(request.manifest)
 

--- a/src/api/routes/v1/admin_meal_catalog_import.py
+++ b/src/api/routes/v1/admin_meal_catalog_import.py
@@ -1,0 +1,148 @@
+"""Protected admin endpoints for importing the curated meal catalog."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.base_dependencies import get_async_db
+from src.api.dependencies.auth import require_admin_or_local
+from src.api.schemas.response.admin_meal_catalog_responses import (
+    AdminMealCatalogImportRequest,
+    AdminMealCatalogImportResponse,
+    AdminMealCatalogValidationResponse,
+)
+from src.app.services.catalog_meal_seed_import_service import CatalogMealSeedImporter
+from src.domain.services.meal_recommendation.catalog_recipe_seed_validator import (
+    PRODUCTION_CUISINE_COUNTS,
+    validate_catalog_seed_manifest,
+)
+from src.infra.repositories.catalog_recipe_repository_async import (
+    AsyncCatalogMealRepository,
+)
+from src.infra.repositories.food_reference_repository_async import (
+    AsyncFoodReferenceRepository,
+)
+
+router = APIRouter(prefix="/v1/admin/meal-catalog", tags=["Admin Meal Catalog"])
+
+
+@router.post("/resolve", response_model=AdminMealCatalogImportResponse)
+async def resolve_admin_meal_catalog_ingredients(
+    request: AdminMealCatalogImportRequest,
+    db: AsyncSession = Depends(get_async_db),
+    _admin: str = Depends(require_admin_or_local),
+) -> AdminMealCatalogImportResponse:
+    """Validate and resolve a manifest without changing the catalog."""
+
+    validation = _validate_manifest(request)
+    if validation.errors:
+        return _response(
+            validation, _empty_summary(validation, dry_run=True), applied=False
+        )
+    summary = await _run_importer(db, request, dry_run=True)
+    return _response(validation, summary, applied=False)
+
+
+@router.post("/import", response_model=AdminMealCatalogImportResponse)
+async def import_admin_meal_catalog(
+    request: AdminMealCatalogImportRequest,
+    db: AsyncSession = Depends(get_async_db),
+    _admin: str = Depends(require_admin_or_local),
+) -> AdminMealCatalogImportResponse:
+    """Import a validated manifest, or preview it when ``dry_run`` is true."""
+
+    validation = _validate_manifest(request)
+    if validation.errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_response(
+                validation,
+                _empty_summary(validation, dry_run=request.dry_run),
+                applied=False,
+            ).model_dump(),
+        )
+
+    preview = await _run_importer(db, request, dry_run=True)
+    if not preview.is_successful or request.dry_run:
+        return _response(validation, preview, applied=False)
+
+    summary = await _run_importer(db, request, dry_run=False)
+    if not summary.is_successful:
+        await db.rollback()
+        return _response(validation, summary, applied=False)
+    await db.commit()
+    return _response(validation, summary, applied=True)
+
+
+def _validate_manifest(request: AdminMealCatalogImportRequest):
+    recipes = request.manifest.get("recipes", [])
+    if not isinstance(recipes, list):
+        recipes = []
+    expected_count = len(recipes) if request.partial else request.expected_recipe_count
+    return validate_catalog_seed_manifest(
+        request.manifest,
+        expected_recipe_count=expected_count,
+        min_per_cuisine_meal_type=request.min_per_cuisine_meal_type,
+        expected_cuisine_counts=(
+            None
+            if request.partial or request.skip_exact_cuisine_count
+            else PRODUCTION_CUISINE_COUNTS
+        ),
+        allow_declared_expected_count_mismatch=request.partial,
+    )
+
+
+async def _run_importer(
+    db: AsyncSession,
+    request: AdminMealCatalogImportRequest,
+    *,
+    dry_run: bool,
+):
+    return await CatalogMealSeedImporter(
+        AsyncCatalogMealRepository(db),
+        AsyncFoodReferenceRepository(db),
+        dry_run=dry_run,
+        approved_mappings=request.resolver_map,
+        auto_resolve_threshold=(
+            0.0
+            if request.resolve_all_best_effort
+            and request.auto_resolve_threshold is None
+            else request.auto_resolve_threshold
+        ),
+        resolve_all_best_effort=request.resolve_all_best_effort,
+    ).import_manifest(request.manifest)
+
+
+def _empty_summary(validation, *, dry_run: bool):
+    from src.app.services.catalog_meal_seed_import_service import (
+        CatalogSeedImportSummary,
+    )
+
+    return CatalogSeedImportSummary(
+        dry_run=dry_run,
+        errors=tuple(validation.errors),
+    )
+
+
+def _response(validation, summary, *, applied: bool) -> AdminMealCatalogImportResponse:
+    report = summary.resolution_report()
+    validation_response = AdminMealCatalogValidationResponse(
+        manifest_digest=validation.manifest_digest,
+        recipe_count=validation.recipe_count,
+        errors=list(validation.errors),
+        coverage=validation.coverage,
+    )
+    return AdminMealCatalogImportResponse(
+        validation=validation_response,
+        manifest_digest=validation.manifest_digest,
+        recipe_count=validation.recipe_count,
+        coverage=validation.coverage,
+        inserted=summary.inserted,
+        skipped_existing=summary.skipped_existing,
+        dry_run=summary.dry_run,
+        applied=applied,
+        errors=list(summary.errors),
+        issues=report["issues"],
+        review_required=report["review_required"],
+    )

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -9,11 +9,13 @@ from time import perf_counter
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 
 from src.api.base_dependencies import (
+    get_deepl_text_translation_service,
     get_meal_recommendation_analytics_service,
 )
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.dependencies.task_manager import get_optional_task_manager
+from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
 from src.api.routes.v1.meal_recommendation_route_support import (
     LogRecommendedMealRequest,
@@ -41,6 +43,10 @@ from src.app.queries.meal_recommendation import (
     GetMealRecommendationSlotDetailQuery,
 )
 from src.app.queries.user import GetUserTimezoneQuery
+from src.app.services.catalog_meal_response_localizer import (
+    localize_meal_recommendation_plan,
+    localize_meal_recommendation_slot,
+)
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
 )
@@ -64,6 +70,7 @@ async def create_three_day_recommendations(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationPlanSummaryResponse:
     """Create or replay a durable three-day catalog recommendation plan."""
 
@@ -116,7 +123,13 @@ async def create_three_day_recommendations(
                 status_code=exc.status_code,
                 detail=exc.public_detail,
             ) from exc
-        response = to_summary_response(plan)
+        response = to_summary_response(
+            await localize_meal_recommendation_plan(
+                plan,
+                language=get_request_language(request),
+                translation_service=translation_service,
+            )
+        )
         await capture_plan_events(
             analytics_service,
             user_id=user_id,
@@ -149,6 +162,7 @@ async def swap_meal_recommendation_slot(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
@@ -167,7 +181,14 @@ async def swap_meal_recommendation_slot(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_slot_detail_response(result.plan_id, result.slot)
+    response = to_slot_detail_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await _capture_mutation_slot_event(
         analytics_service=analytics_service,
         user_id=user_id,
@@ -198,6 +219,7 @@ async def log_recommended_meal(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
@@ -213,7 +235,14 @@ async def log_recommended_meal(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_slot_detail_response(result.plan_id, result.slot)
+    response = to_slot_detail_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await _capture_mutation_slot_event(
         analytics_service=analytics_service,
         user_id=user_id,
@@ -242,6 +271,7 @@ async def skip_meal_recommendation_slot(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
@@ -257,7 +287,14 @@ async def skip_meal_recommendation_slot(
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    response = to_slot_detail_response(result.plan_id, result.slot)
+    response = to_slot_detail_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await _capture_mutation_slot_event(
         analytics_service=analytics_service,
         user_id=user_id,
@@ -273,12 +310,14 @@ async def skip_meal_recommendation_slot(
 @router.get("/{plan_id}", response_model=MealRecommendationPlanSummaryResponse)
 async def get_meal_recommendation_plan(
     plan_id: str,
+    request: Request,
     user_id: str = Depends(get_current_user_id),
     event_bus=Depends(get_configured_event_bus),
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationPlanSummaryResponse:
     """Read an owner-scoped durable recommendation plan."""
 
@@ -291,7 +330,13 @@ async def get_meal_recommendation_plan(
         metric_status = "http_404"
         record_operation_latency("read", started, metric_status)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    response = to_summary_response(plan)
+    response = to_summary_response(
+        await localize_meal_recommendation_plan(
+            plan,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        )
+    )
     await capture_plan_events(
         analytics_service,
         user_id=user_id,
@@ -311,12 +356,14 @@ async def get_meal_recommendation_plan(
 async def get_meal_recommendation_slot_detail(
     plan_id: str,
     slot_id: str,
+    request: Request,
     user_id: str = Depends(get_current_user_id),
     event_bus=Depends(get_configured_event_bus),
     analytics_service: MealRecommendationAnalyticsService = Depends(
         get_meal_recommendation_analytics_service
     ),
     task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_deepl_text_translation_service),
 ) -> MealRecommendationSlotDetailResponse:
     """Read one owner-scoped recommendation slot with alternatives."""
 
@@ -333,7 +380,14 @@ async def get_meal_recommendation_slot_detail(
         metric_status = "http_404"
         record_operation_latency("slot_detail", started, metric_status)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    response = to_slot_detail_response(plan_id, slot)
+    response = to_slot_detail_response(
+        plan_id,
+        await localize_meal_recommendation_slot(
+            slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+    )
     await capture_slot_event(
         analytics_service,
         user_id=user_id,

--- a/src/api/schemas/response/admin_meal_catalog_responses.py
+++ b/src/api/schemas/response/admin_meal_catalog_responses.py
@@ -1,10 +1,25 @@
-"""Responses for admin meal catalog inspection."""
+"""Requests and responses for admin meal catalog operations."""
 
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class AdminMealCatalogImportRequest(BaseModel):
+    """Manifest and resolver options shared by import and preview endpoints."""
+
+    manifest: dict[str, Any]
+    dry_run: bool = False
+    partial: bool = False
+    skip_exact_cuisine_count: bool = False
+    expected_recipe_count: int = Field(default=180, ge=0)
+    min_per_cuisine_meal_type: int = Field(default=5, ge=0)
+    resolver_map: dict[str, int] = Field(default_factory=dict)
+    auto_resolve_threshold: float | None = Field(default=0.92, ge=0, le=1)
+    resolve_all_best_effort: bool = False
 
 
 class AdminMealCatalogIngredientResponse(BaseModel):
@@ -43,3 +58,51 @@ class AdminMealCatalogListResponse(BaseModel):
 class AdminMealCatalogGenerateImageResponse(BaseModel):
     item: AdminMealCatalogItemResponse
     image_url: str
+
+
+class AdminMealCatalogResolutionCandidate(BaseModel):
+    food_reference_id: int
+    name: str
+    name_normalized: str | None = None
+    source: str
+    is_verified: bool
+    score: float
+
+
+class AdminMealCatalogResolutionIssue(BaseModel):
+    recipe_index: int
+    recipe_key: str
+    ingredient_index: int
+    ingredient_name: str
+    normalized_name: str
+    reason: str
+    candidates: list[AdminMealCatalogResolutionCandidate]
+
+
+class AdminMealCatalogReviewRequired(BaseModel):
+    recipe_index: int
+    recipe_key: str
+    reason: str
+    matched_catalog_key: str
+    ingredient_jaccard: float
+
+
+class AdminMealCatalogValidationResponse(BaseModel):
+    manifest_digest: str
+    recipe_count: int
+    errors: list[str]
+    coverage: dict[str, dict[str, int]]
+
+
+class AdminMealCatalogImportResponse(BaseModel):
+    validation: AdminMealCatalogValidationResponse
+    manifest_digest: str
+    recipe_count: int
+    coverage: dict[str, dict[str, int]]
+    inserted: int
+    skipped_existing: int
+    dry_run: bool
+    applied: bool
+    errors: list[str]
+    issues: list[AdminMealCatalogResolutionIssue]
+    review_required: list[AdminMealCatalogReviewRequired]

--- a/src/app/services/catalog_meal_response_localizer.py
+++ b/src/app/services/catalog_meal_response_localizer.py
@@ -1,0 +1,190 @@
+"""Request-language localization for catalog meal response projections."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Protocol
+
+from src.domain.model.meal_recommendation import (
+    CatalogMeal,
+    PersistedMealRecommendationCandidate,
+    PersistedMealRecommendationPlan,
+    PersistedMealRecommendationSlot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TextTranslationService(Protocol):
+    """Minimal translation dependency needed by catalog response localization."""
+
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]: ...
+
+
+async def localize_meal_recommendation_plan(
+    plan: PersistedMealRecommendationPlan,
+    *,
+    language: str,
+    translation_service: TextTranslationService | None,
+) -> PersistedMealRecommendationPlan:
+    """Return a localized presentation copy of a recommendation plan."""
+
+    if language == "en" or translation_service is None:
+        return plan
+
+    meals = [
+        meal
+        for slot in plan.slots
+        for meal in _slot_catalog_meals(slot)
+    ]
+    localized_meals = await _localized_meals(
+        meals,
+        language=language,
+        translation_service=translation_service,
+    )
+    if localized_meals is None:
+        return plan
+
+    return replace(
+        plan,
+        slots=tuple(
+            _replace_slot_catalog_meals(slot, localized_meals) for slot in plan.slots
+        ),
+    )
+
+
+async def localize_meal_recommendation_slot(
+    slot: PersistedMealRecommendationSlot,
+    *,
+    language: str,
+    translation_service: TextTranslationService | None,
+) -> PersistedMealRecommendationSlot:
+    """Return a localized presentation copy of one recommendation slot."""
+
+    if language == "en" or translation_service is None:
+        return slot
+
+    localized_meals = await _localized_meals(
+        list(_slot_catalog_meals(slot)),
+        language=language,
+        translation_service=translation_service,
+    )
+    if localized_meals is None:
+        return slot
+
+    return _replace_slot_catalog_meals(slot, localized_meals)
+
+
+def _slot_catalog_meals(slot: PersistedMealRecommendationSlot) -> tuple[CatalogMeal, ...]:
+    candidates = (slot.selected, *slot.alternatives)
+    return tuple(
+        candidate.catalog_meal
+        for candidate in candidates
+        if candidate is not None and candidate.catalog_meal is not None
+    )
+
+
+async def _localized_meals(
+    meals: list[CatalogMeal],
+    *,
+    language: str,
+    translation_service: TextTranslationService,
+) -> dict[str, CatalogMeal] | None:
+    unique_meals = {meal.id: meal for meal in meals}
+    texts = _unique_display_texts(unique_meals.values())
+    if not texts:
+        return dict(unique_meals)
+
+    try:
+        translated = await translation_service.translate_texts(texts, language)
+    except Exception as exc:
+        logger.warning(
+            "catalog response translation failed language=%s error_type=%s",
+            language,
+            type(exc).__name__,
+        )
+        return None
+
+    translations = {
+        text: translated[index] if index < len(translated) else text
+        for index, text in enumerate(texts)
+    }
+    return {
+        meal_id: _replace_meal_display_text(meal, translations)
+        for meal_id, meal in unique_meals.items()
+    }
+
+
+def _unique_display_texts(meals: Iterable[CatalogMeal]) -> list[str]:
+    texts: list[str] = []
+    for meal in meals:
+        _append_unique(texts, meal.name)
+        _append_unique(texts, meal.cuisine)
+        if meal.description:
+            _append_unique(texts, meal.description)
+        for ingredient in meal.ingredients:
+            _append_unique(texts, ingredient.display_name)
+    return texts
+
+
+def _append_unique(texts: list[str], value: str) -> None:
+    if value and value not in texts:
+        texts.append(value)
+
+
+def _replace_meal_display_text(
+    meal: CatalogMeal,
+    translations: dict[str, str],
+) -> CatalogMeal:
+    return replace(
+        meal,
+        name=translations.get(meal.name, meal.name),
+        cuisine=translations.get(meal.cuisine, meal.cuisine),
+        description=(
+            translations.get(meal.description, meal.description)
+            if meal.description
+            else None
+        ),
+        ingredients=tuple(
+            replace(
+                ingredient,
+                display_name=translations.get(
+                    ingredient.display_name,
+                    ingredient.display_name,
+                ),
+            )
+            for ingredient in meal.ingredients
+        ),
+    )
+
+
+def _replace_slot_catalog_meals(
+    slot: PersistedMealRecommendationSlot,
+    localized_meals: dict[str, CatalogMeal],
+) -> PersistedMealRecommendationSlot:
+    return replace(
+        slot,
+        selected=(
+            _replace_candidate_catalog_meal(slot.selected, localized_meals)
+            if slot.selected is not None
+            else None
+        ),
+        alternatives=tuple(
+            _replace_candidate_catalog_meal(candidate, localized_meals)
+            for candidate in slot.alternatives
+        ),
+    )
+
+
+def _replace_candidate_catalog_meal(
+    candidate: PersistedMealRecommendationCandidate,
+    localized_meals: dict[str, CatalogMeal],
+) -> PersistedMealRecommendationCandidate:
+    if candidate.catalog_meal is None:
+        return candidate
+    return replace(
+        candidate,
+        catalog_meal=localized_meals.get(candidate.catalog_meal.id, candidate.catalog_meal),
+    )

--- a/src/app/services/catalog_meal_seed_import_service.py
+++ b/src/app/services/catalog_meal_seed_import_service.py
@@ -203,6 +203,25 @@ class CatalogMealSeedImporter:
         )
         self._candidate_rows: list[_FoodReferenceSearchRow] | None = None
 
+    def with_options(
+        self,
+        *,
+        dry_run: bool,
+        approved_mappings: dict[str, int],
+        auto_resolve_threshold: float | None,
+        resolve_all_best_effort: bool,
+    ) -> CatalogMealSeedImporter:
+        """Create a request-specific importer using the same repository ports."""
+
+        return CatalogMealSeedImporter(
+            self._catalog_repository,
+            self._food_reference_repository,
+            dry_run=dry_run,
+            approved_mappings=approved_mappings,
+            auto_resolve_threshold=auto_resolve_threshold,
+            resolve_all_best_effort=resolve_all_best_effort,
+        )
+
     async def import_manifest(self, manifest: dict[str, Any]) -> CatalogSeedImportSummary:
         started = perf_counter()
         skipped = 0

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -117,7 +117,9 @@ class AsyncFoodReferenceRepository:
                 FoodReferenceModel.density,
             )
             .where(FoodReferenceModel.name_normalized == name_normalized)
-            .order_by(FoodReferenceModel.is_verified.desc(), FoodReferenceModel.id.asc())
+            .order_by(
+                FoodReferenceModel.is_verified.desc(), FoodReferenceModel.id.asc()
+            )
         )
         return [_catalog_seed_candidate_projection(row) for row in result.all()]
 
@@ -165,9 +167,7 @@ class AsyncFoodReferenceRepository:
             .where(FoodReferenceModel.region.in_([region, "global"]))
             .where(
                 or_(
-                    FoodReferenceModel.name_normalized.ilike(
-                        f"%{normalized_query}%"
-                    ),
+                    FoodReferenceModel.name_normalized.ilike(f"%{normalized_query}%"),
                     similarity_score >= 0.15,
                 )
             )
@@ -220,12 +220,59 @@ class AsyncFoodReferenceRepository:
         }
         if not values["is_verified"]:
             on_conflict_kwargs["where"] = FoodReferenceModel.is_verified.is_(False)
-        await self._session.execute(
-            stmt.on_conflict_do_update(**on_conflict_kwargs)
-        )
+        await self._session.execute(stmt.on_conflict_do_update(**on_conflict_kwargs))
         await self._session.flush()
 
         refreshed = await self._find_after_upsert(values)
+        if refreshed:
+            await self._sync_normalized_children(refreshed, data)
+
+    async def upsert_seed(self, data: dict[str, Any]) -> None:
+        """Upsert a canonical, non-barcoded seed without owning commit."""
+
+        name = str(data.get("name") or data.get("name_vi") or "").strip()
+        if not name:
+            raise ValueError("seed food requires a name")
+        name_normalized = str(
+            data.get("name_normalized") or normalize_food_name(name)
+        ).strip()
+        if not name_normalized:
+            raise ValueError("seed food requires a normalized name")
+
+        values = {
+            "name": name,
+            "name_normalized": name_normalized,
+            "name_vi": data.get("name_vi"),
+            "brand": data.get("brand"),
+            "category": _truncate_category(data.get("category")),
+            "region": data.get("region", "VN"),
+            "protein_100g": data.get("protein_100g"),
+            "carbs_100g": data.get("carbs_100g"),
+            "fat_100g": data.get("fat_100g"),
+            "fiber_100g": data.get("fiber_100g", 0),
+            "sugar_100g": data.get("sugar_100g", 0),
+            "serving_size": data.get("serving_size"),
+            "serving_sizes": data.get("serving_sizes") or data.get("allowed_units"),
+            "image_url": data.get("image_url"),
+            "source": data.get("source", "seed"),
+            "is_verified": data.get("is_verified", False),
+            "density": data.get("density", 1.0),
+            "extra_nutrients": data.get("extra_nutrients"),
+        }
+        update_fields = {
+            key: value for key, value in values.items() if key != "name_normalized"
+        }
+        stmt = pg_insert(FoodReferenceModel).values(**values)
+        on_conflict_kwargs: dict[str, Any] = {
+            "index_elements": ["name_normalized"],
+            "set_": update_fields,
+        }
+        if not values["is_verified"]:
+            on_conflict_kwargs["where"] = FoodReferenceModel.is_verified.is_(False)
+        await self._session.execute(stmt.on_conflict_do_update(**on_conflict_kwargs))
+        await self._session.flush()
+
+        refreshed = await self._find_model_by_normalized_name(name_normalized)
         if refreshed:
             await self._sync_normalized_children(refreshed, data)
 
@@ -334,7 +381,9 @@ class AsyncFoodReferenceRepository:
             )
         else:
             return None
-        result = await self._session.execute(stmt.options(*_FOOD_REFERENCE_LOAD_OPTIONS))
+        result = await self._session.execute(
+            stmt.options(*_FOOD_REFERENCE_LOAD_OPTIONS)
+        )
         return result.scalars().first()
 
     async def _sync_normalized_children(
@@ -365,6 +414,13 @@ def _catalog_seed_candidate_projection(row: Any) -> FoodReferenceNutritionProjec
         density_g_ml=row.density,
         name_normalized=row.name_normalized,
     )
+
+
+def _truncate_category(value: Any) -> str | None:
+    if value is None:
+        return None
+    category = str(value).strip()
+    return category[:100] or None
 
 
 def _dedupe_search_projections(

--- a/tests/unit/api/test_admin_meal_catalog_import_route.py
+++ b/tests/unit/api/test_admin_meal_catalog_import_route.py
@@ -66,6 +66,7 @@ def _client(db):
     app = FastAPI()
     app.include_router(route_mod.router)
     app.dependency_overrides[get_async_db] = lambda: db
+    app.dependency_overrides[route_mod.get_catalog_meal_seed_importer] = object
     app.dependency_overrides[require_admin_or_local] = lambda: "admin@nutree.ai"
     return TestClient(app)
 

--- a/tests/unit/api/test_admin_meal_catalog_import_route.py
+++ b/tests/unit/api/test_admin_meal_catalog_import_route.py
@@ -1,0 +1,97 @@
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.base_dependencies import get_async_db
+from src.api.dependencies.auth import require_admin_or_local
+from src.api.routes.v1 import admin_meal_catalog_import as route_mod
+from src.app.services.catalog_meal_seed_import_service import CatalogSeedImportSummary
+
+
+def test_resolve_catalog_manifest_is_dry_run_and_does_not_commit(monkeypatch):
+    db = AsyncMock()
+    calls = []
+
+    async def fake_run_importer(db_arg, request, *, dry_run):
+        calls.append(dry_run)
+        return CatalogSeedImportSummary(dry_run=dry_run, inserted=1)
+
+    monkeypatch.setattr(route_mod, "_run_importer", fake_run_importer)
+    client = _client(db)
+
+    response = client.post("/v1/admin/meal-catalog/resolve", json=_request())
+
+    assert response.status_code == 200
+    assert response.json()["applied"] is False
+    assert response.json()["dry_run"] is True
+    assert calls == [True]
+    db.commit.assert_not_awaited()
+
+
+def test_import_catalog_manifest_previews_then_commits(monkeypatch):
+    db = AsyncMock()
+    calls = []
+
+    async def fake_run_importer(db_arg, request, *, dry_run):
+        calls.append(dry_run)
+        return CatalogSeedImportSummary(dry_run=dry_run, inserted=1)
+
+    monkeypatch.setattr(route_mod, "_run_importer", fake_run_importer)
+    client = _client(db)
+
+    response = client.post("/v1/admin/meal-catalog/import", json=_request())
+
+    assert response.status_code == 200
+    assert response.json()["applied"] is True
+    assert response.json()["inserted"] == 1
+    assert calls == [True, False]
+    db.commit.assert_awaited_once()
+
+
+def test_import_catalog_manifest_returns_validation_report_without_db_work():
+    db = AsyncMock()
+    client = _client(db)
+    payload = _request()
+    payload["manifest"]["recipes"][0]["meal_types"] = []
+
+    response = client.post("/v1/admin/meal-catalog/import", json=payload)
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["validation"]["errors"]
+    db.commit.assert_not_awaited()
+
+
+def _client(db):
+    app = FastAPI()
+    app.include_router(route_mod.router)
+    app.dependency_overrides[get_async_db] = lambda: db
+    app.dependency_overrides[require_admin_or_local] = lambda: "admin@nutree.ai"
+    return TestClient(app)
+
+
+def _request():
+    return {
+        "manifest": {
+            "release_key": "test-release",
+            "expected_recipe_count": 1,
+            "recipes": [
+                {
+                    "recipe_key": "pho-ga-001",
+                    "cuisine": "vietnamese",
+                    "name": "Pho Ga",
+                    "meal_types": ["lunch"],
+                    "ingredients": [
+                        {
+                            "food_reference_id": 1,
+                            "name": "Chicken breast",
+                            "quantity": 120,
+                            "unit": "g",
+                        }
+                    ],
+                }
+            ],
+        },
+        "partial": True,
+        "min_per_cuisine_meal_type": 0,
+    }

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -85,7 +85,19 @@ class _TaskManager:
         coro.close()
 
 
-def _request(timezone: str = "Asia/Ho_Chi_Minh") -> Request:
+class _Translator:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def translate_texts(self, texts, target_lang):
+        self.calls.append((texts, target_lang))
+        return [f"vi:{text}" for text in texts]
+
+
+def _request(
+    timezone: str = "Asia/Ho_Chi_Minh",
+    language: str = "en",
+) -> Request:
     return Request(
         {
             "type": "http",
@@ -93,6 +105,7 @@ def _request(timezone: str = "Asia/Ho_Chi_Minh") -> Request:
             "path": "/v1/meal-recommendations/three-day",
             "client": ("127.0.0.1", 12345),
             "headers": [(b"x-timezone", timezone.encode("utf-8"))],
+            "state": {"language": language},
         }
     )
 
@@ -196,6 +209,7 @@ async def test_create_three_day_recommendations_enqueues_analytics_when_task_man
 async def test_get_plan_returns_owner_scoped_compact_summary():
     response = await get_meal_recommendation_plan(
         plan_id="plan-1",
+        request=_request(),
         user_id="user-1",
         event_bus=_EventBus(),
         analytics_service=_Analytics(),
@@ -213,6 +227,7 @@ async def test_get_slot_detail_returns_one_hydrated_slot_with_alternatives():
     response = await get_meal_recommendation_slot_detail(
         plan_id="plan-1",
         slot_id="slot-1",
+        request=_request(),
         user_id="user-1",
         event_bus=_EventBus(),
         analytics_service=_Analytics(),
@@ -222,6 +237,36 @@ async def test_get_slot_detail_returns_one_hydrated_slot_with_alternatives():
     assert response.slot.id == "slot-1"
     assert response.slot.catalog_meal.ingredients[0].display_name == "Rice"
     assert response.slot.alternatives[0].catalog_meal.name == "Chicken Bowl"
+
+
+@pytest.mark.asyncio
+async def test_get_plan_translates_catalog_text_from_request_language():
+    translator = _Translator()
+
+    response = await get_meal_recommendation_plan(
+        plan_id="plan-1",
+        request=_request(language="vi"),
+        user_id="user-1",
+        event_bus=_EventBus(),
+        analytics_service=_Analytics(),
+        translation_service=translator,
+    )
+
+    assert response.slots[0].catalog_meal.name == "vi:Breakfast Rice"
+    assert response.slots[0].catalog_meal.cuisine == "vi:vietnamese"
+    assert response.slots[0].catalog_meal.calories == 380
+    assert translator.calls == [
+        (
+            [
+                "Breakfast Rice",
+                "vietnamese",
+                "Display copy",
+                "Rice",
+                "Chicken Bowl",
+            ],
+            "vi",
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_catalog_meal_response_localizer.py
+++ b/tests/unit/app/services/test_catalog_meal_response_localizer.py
@@ -1,0 +1,190 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from src.app.services.catalog_meal_response_localizer import (
+    localize_meal_recommendation_plan,
+    localize_meal_recommendation_slot,
+)
+from src.domain.model.meal_recommendation import (
+    CatalogMeal,
+    CatalogMealIngredient,
+    PersistedMealRecommendationCandidate,
+    PersistedMealRecommendationPlan,
+    PersistedMealRecommendationSlot,
+)
+
+
+class _Translator:
+    def __init__(self, translations: dict[str, str]) -> None:
+        self.translations = translations
+        self.calls: list[tuple[list[str], str]] = []
+
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
+        self.calls.append((texts, target_lang))
+        return [self.translations.get(text, text) for text in texts]
+
+
+class _FailingTranslator:
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
+        raise RuntimeError("provider unavailable")
+
+
+class _ShortTranslator:
+    async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
+        return ["Cơm tô"]
+
+
+def _meal(meal_id: str, name: str = "Rice Bowl") -> CatalogMeal:
+    return CatalogMeal(
+        id=meal_id,
+        catalog_key=f"key-{meal_id}",
+        content_hash=f"{meal_id:0<64}"[:64],
+        name=name,
+        cuisine="Vietnamese",
+        description="Warm rice with vegetables",
+        image_url="https://example.com/meal.jpg",
+        protein_g=Decimal("25"),
+        carbs_g=Decimal("50"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("5"),
+        meal_types=("lunch",),
+        ingredients=(
+            CatalogMealIngredient(
+                food_reference_id=7,
+                display_name="Rice",
+                quantity=Decimal("100"),
+                unit="g",
+            ),
+        ),
+    )
+
+
+def _slot(meal: CatalogMeal, alternative: CatalogMeal | None = None) -> PersistedMealRecommendationSlot:
+    selected = PersistedMealRecommendationCandidate(
+        id="candidate-1",
+        slot_id="slot-1",
+        recommendation_date=date(2026, 7, 29),
+        meal_type="lunch",
+        catalog_meal_id=meal.id,
+        candidate_rank=0,
+        is_selected=True,
+        score=Decimal("0.9"),
+        selection_version=2,
+        catalog_meal=meal,
+    )
+    alternatives = ()
+    if alternative is not None:
+        alternatives = (
+            PersistedMealRecommendationCandidate(
+                id="candidate-2",
+                slot_id="slot-1",
+                recommendation_date=date(2026, 7, 29),
+                meal_type="lunch",
+                catalog_meal_id=alternative.id,
+                candidate_rank=1,
+                is_selected=False,
+                score=Decimal("0.8"),
+                selection_version=2,
+                catalog_meal=alternative,
+            ),
+        )
+    return PersistedMealRecommendationSlot(
+        id="slot-1",
+        slot_date=date(2026, 7, 29),
+        day_index=0,
+        meal_type="lunch",
+        catalog_meal_id=meal.id,
+        target_calories=550,
+        score=0.9,
+        position=0,
+        selection_version=2,
+        selected=selected,
+        alternatives=alternatives,
+    )
+
+
+@pytest.mark.asyncio
+async def test_localize_slot_translates_allowlisted_text_once_and_preserves_contract():
+    meal = _meal("meal-1")
+    alternative = _meal("meal-2")
+    translator = _Translator(
+        {
+            "Rice Bowl": "Cơm tô",
+            "Vietnamese": "Việt Nam",
+            "Warm rice with vegetables": "Cơm nóng cùng rau",
+            "Rice": "Cơm",
+        }
+    )
+
+    localized = await localize_meal_recommendation_slot(
+        _slot(meal, alternative), language="vi", translation_service=translator
+    )
+
+    assert translator.calls == [
+        (
+            ["Rice Bowl", "Vietnamese", "Warm rice with vegetables", "Rice"],
+            "vi",
+        )
+    ]
+    assert localized.selected.catalog_meal.name == "Cơm tô"
+    assert localized.selected.catalog_meal.cuisine == "Việt Nam"
+    assert localized.selected.catalog_meal.description == "Cơm nóng cùng rau"
+    assert localized.selected.catalog_meal.ingredients[0].display_name == "Cơm"
+    assert localized.alternatives[0].catalog_meal.name == "Cơm tô"
+    assert localized.catalog_meal_id == meal.id
+    assert localized.target_calories == 550
+    assert localized.selected.catalog_meal.ingredients[0].unit == "g"
+    assert localized.selected.catalog_meal.calories == meal.calories
+    assert meal.name == "Rice Bowl"
+
+
+@pytest.mark.asyncio
+async def test_localize_plan_skips_english_and_missing_translation_service():
+    plan = PersistedMealRecommendationPlan(
+        id="plan-1",
+        user_id="user-1",
+        status="active",
+        timezone="Asia/Ho_Chi_Minh",
+        start_date=date(2026, 7, 29),
+        daily_calories=2000,
+        operation="three_day",
+        idempotency_key="key-1",
+        request_fingerprint="f" * 64,
+        slots=(_slot(_meal("meal-1")),),
+    )
+    translator = _Translator({})
+
+    assert await localize_meal_recommendation_plan(
+        plan, language="en", translation_service=translator
+    ) is plan
+    assert await localize_meal_recommendation_plan(
+        plan, language="vi", translation_service=None
+    ) is plan
+    assert translator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_localize_slot_returns_canonical_values_when_translation_fails():
+    slot = _slot(_meal("meal-1"))
+
+    localized = await localize_meal_recommendation_slot(
+        slot, language="vi", translation_service=_FailingTranslator()
+    )
+
+    assert localized is slot
+
+
+@pytest.mark.asyncio
+async def test_localize_slot_falls_back_for_missing_translated_values():
+    slot = _slot(_meal("meal-1"))
+
+    localized = await localize_meal_recommendation_slot(
+        slot, language="vi", translation_service=_ShortTranslator()
+    )
+
+    assert localized.selected.catalog_meal.name == "Cơm tô"
+    assert localized.selected.catalog_meal.cuisine == "Vietnamese"
+    assert localized.selected.catalog_meal.description == "Warm rice with vegetables"
+    assert localized.selected.catalog_meal.ingredients[0].display_name == "Rice"

--- a/tests/unit/infra/repositories/test_food_reference_repository_async.py
+++ b/tests/unit/infra/repositories/test_food_reference_repository_async.py
@@ -249,6 +249,45 @@ async def test_upsert_by_normalized_name_verified_protection_skips_upsert():
 
 
 @pytest.mark.asyncio
+async def test_upsert_seed_uses_normalized_name_and_preserves_seed_metadata():
+    row = _food_row(name_normalized="com tam", name="Com tam")
+    session = _AsyncSession([_Result(), _Result(rows=[row])])
+    repo = AsyncFoodReferenceRepository(session)
+    statement = MagicMock()
+    statement.values.return_value = statement
+    statement.on_conflict_do_update.return_value = statement
+
+    with patch(
+        "src.infra.repositories.food_reference_repository_async.pg_insert",
+        return_value=statement,
+    ):
+        await repo.upsert_seed(
+            {
+                "name": "Com tam",
+                "name_normalized": "com tam",
+                "name_vi": "Cơm tấm",
+                "category": "Rice dishes",
+                "region": "VN",
+                "protein_100g": 5.0,
+                "carbs_100g": 30.0,
+                "fat_100g": 4.0,
+                "source": "nin_vn",
+                "is_verified": True,
+            }
+        )
+
+    values = statement.values.call_args.kwargs
+    assert values["name_normalized"] == "com tam"
+    assert values["name_vi"] == "Cơm tấm"
+    assert values["category"] == "Rice dishes"
+    assert values["is_verified"] is True
+    assert statement.on_conflict_do_update.call_args.kwargs["index_elements"] == [
+        "name_normalized"
+    ]
+    assert session.flush.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_upsert_by_barcode_uses_on_conflict_and_flushes_children():
     row = _food_row()
     row.barcode = "123"

--- a/tests/unit/scripts/test_import_food_seeds.py
+++ b/tests/unit/scripts/test_import_food_seeds.py
@@ -1,0 +1,132 @@
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "import_food_seeds.py"
+_SPEC = importlib.util.spec_from_file_location("import_food_seeds", _SCRIPT_PATH)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MODULE)
+
+
+@pytest.mark.asyncio
+async def test_import_uses_verified_normalized_seed_for_nin_food(tmp_path, monkeypatch):
+    _write_entries(tmp_path, [_nin_entry()])
+    repository = _Repository(existing=None)
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _UnitOfWork(repository))
+
+    await _MODULE._run_import(tmp_path, dry_run=False, source_filter=None)
+
+    prepared = repository.upsert_seed.await_args.args[0]
+    assert prepared["name_normalized"] == "chicken breast"
+    assert prepared["is_verified"] is True
+    repository.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_keeps_existing_higher_priority_source(tmp_path, monkeypatch):
+    _write_entries(tmp_path, [_nin_entry(source="openfoodfacts")])
+    repository = _Repository(existing={"source": "nin_vn", "is_verified": True})
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _UnitOfWork(repository))
+
+    await _MODULE._run_import(tmp_path, dry_run=False, source_filter=None)
+
+    repository.upsert_seed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_keeps_existing_manually_verified_reference(tmp_path, monkeypatch):
+    _write_entries(tmp_path, [_nin_entry()])
+    repository = _Repository(existing={"source": "catalog_seed", "is_verified": True})
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _UnitOfWork(repository))
+
+    await _MODULE._run_import(tmp_path, dry_run=False, source_filter=None)
+
+    repository.upsert_seed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_preserves_barcode_product_path(tmp_path, monkeypatch):
+    entry = _nin_entry(source="openfoodfacts")
+    entry["barcode"] = "8938505974199"
+    _write_entries(tmp_path, [entry])
+    repository = _Repository(existing=None)
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _UnitOfWork(repository))
+
+    await _MODULE._run_import(tmp_path, dry_run=False, source_filter=None)
+
+    repository.get_by_barcode.assert_awaited_once_with("8938505974199")
+    repository.upsert.assert_awaited_once()
+    assert repository.upsert.await_args.args[0]["is_verified"] is False
+    repository.upsert_seed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_open_database_transaction(tmp_path, monkeypatch):
+    _write_entries(tmp_path, [_nin_entry()])
+    open_uow = AsyncMock()
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", open_uow)
+
+    await _MODULE._run_import(tmp_path, dry_run=True, source_filter=None)
+
+    open_uow.assert_not_called()
+
+
+def test_fetch_nin_dishes_uses_dishes_only_scraper(tmp_path, monkeypatch):
+    commands = []
+
+    def fake_run(command, text):
+        commands.append(command)
+        (tmp_path / "nin_vn_dishes.json").write_text("[]", encoding="utf-8")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(_MODULE.subprocess, "run", fake_run)
+
+    assert _MODULE._fetch_nin_dishes(tmp_path) is True
+    assert commands[0][2:] == [
+        "--dishes-only",
+        "--output-dishes",
+        str(tmp_path / "nin_vn_dishes.json"),
+    ]
+
+
+class _Repository:
+    def __init__(self, *, existing):
+        self.existing = existing
+        self.find_by_normalized_name = AsyncMock(return_value=existing)
+        self.get_by_barcode = AsyncMock(return_value=None)
+        self.upsert_seed = AsyncMock()
+        self.upsert = AsyncMock()
+
+
+class _UnitOfWork:
+    def __init__(self, repository):
+        self.food_references = repository
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return None
+
+
+def _nin_entry(*, source="nin_vn"):
+    return {
+        "name": "Chicken breast",
+        "name_vi": "Ức gà",
+        "category": "Poultry",
+        "region": "VN",
+        "source": source,
+        "protein_100g": 31.0,
+        "carbs_100g": 0.0,
+        "fat_100g": 3.6,
+    }
+
+
+def _write_entries(directory, entries):
+    (directory / "seeds.json").write_text(json.dumps(entries), encoding="utf-8")


### PR DESCRIPTION
## Summary
- add protected admin catalog resolve and import endpoints
- add priority-aware food seed upserts and NIN dish-only importer command
- request NIN API data with pageSize=10000 for reliable single-page ingestion

## Verification
- ./.venv/bin/pytest -q tests/unit/api/test_admin_meal_catalog_import_route.py tests/unit/scripts/test_import_food_seeds.py tests/unit/infra/repositories/test_food_reference_repository_async.py
- ./.venv/bin/ruff check scripts/import_food_seeds.py tests/unit/scripts/test_import_food_seeds.py
- ./.venv/bin/python -m compileall -q scripts/import_food_seeds.py scripts/scrapers/fetch_nin_vn.py

## Notes
- excludes pre-existing migrations/utils.py worktree change.