### PR TITLE
feat(catalog): enrich unresolved ingredient candidates

### DIFF
--- a/docs/meal-catalog-import-schema.md
+++ b/docs/meal-catalog-import-schema.md
@@ -66,6 +66,7 @@ The same importer and resolver are available behind the admin Firebase/local gat
 
 ```http
 POST /v1/admin/meal-catalog/resolve
+POST /v1/admin/meal-catalog/enrich
 POST /v1/admin/meal-catalog/import
 ```
 
@@ -76,6 +77,10 @@ Both endpoints accept a JSON body with the manifest plus the script options:
 
 `/resolve` always performs a non-mutating dry run and returns validation errors,
 unresolved ingredient candidates, near-duplicate reviews, and import counts.
+`/enrich` is the explicit mutating action for missing ingredient names: it caches
+an unverified FatSecret candidate for each name without creating catalog recipes.
+Those candidates must still be verified or mapped before `/import` can publish a
+recipe.
 `/import` first performs the same dry run; it writes only when validation and
 resolution succeed and `dry_run` is false. A successful write returns
 `applied: true`. The default resolver remains strict: unverified or ambiguous
@@ -174,6 +179,10 @@ Use it with:
 The importer only auto-resolves verified food references above the configured
 fuzzy threshold. Unverified or ambiguous candidates are written to the resolver
 report for review.
+
+For missing names, an admin can call `POST /v1/admin/meal-catalog/enrich` to
+cache a FatSecret candidate. The candidate remains unverified and cannot publish
+a catalog recipe until a reviewer verifies it and adds an approved resolver mapping.
 
 ## Production Corpus Gate
 

--- a/plans/260716-1509-four-table-meal-catalog-rework/plan.md
+++ b/plans/260716-1509-four-table-meal-catalog-rework/plan.md
@@ -6,7 +6,7 @@ priority: P1
 effort: "12-16d"
 branch: "codex/catalog-meal-recommendation-mvp"
 tags: [refactor, backend, database, api, critical]
-blockedBy: []
+blockedBy: [260729-1930-preparation-aware-catalog-resolution]
 blocks: [260715-1557-catalog-meal-recommendation-mvp]
 created: "2026-07-16T08:09:41.087Z"
 createdBy: "ck:plan"

--- a/plans/260729-1930-preparation-aware-catalog-resolution/phase-01-resolve-corpus.md
+++ b/plans/260729-1930-preparation-aware-catalog-resolution/phase-01-resolve-corpus.md
@@ -1,0 +1,49 @@
+---
+phase: 1
+title: "Resolve corpus"
+status: pending
+priority: P1
+effort: "1d"
+dependencies: []
+effort: ""
+---
+
+# Phase 1: Resolve corpus
+
+## Overview
+
+Build one reviewed decision set for the 158 unique ingredient names in the
+100-recipe bootstrap manifest. Do not resolve each repeated occurrence
+independently.
+
+## Requirements
+
+- Run `/resolve` with `partial: true` and a 0.85 reporting threshold.
+- Group results by source ingredient name and preparation state, not the legacy
+  qualifier-stripped normalized name alone.
+- Classify candidates as safe, review, preparation mismatch, unverified exact,
+  or missing canonical food.
+
+## Related Code Files
+
+- Read: `src/app/services/catalog_meal_seed_import_service.py`
+- Read: `src/domain/services/meal_suggestion/ingredient_name_normalizer.py`
+- Input: `/Users/alexnguyen/Downloads/meal-recommendation-recipes-english-generic-cuisines.json`
+- Output: reviewed resolver-map artifact in approved catalog storage
+
+## Implementation Steps
+
+1. Extract distinct ingredient names and occurrence counts from the manifest.
+2. Request a non-mutating resolver report with candidate IDs, scores, sources,
+   and verification state.
+3. Review one decision per distinct ingredient: map to a verified canonical row,
+   create/verify a missing canonical row, or reject the recipe content.
+4. Record approved mappings with source name, preparation state, canonical ID,
+   reviewer, and rationale.
+
+## Success Criteria
+
+- [ ] Every repeated ingredient reuses one reviewed decision.
+- [ ] No resolver-map entry points at an unverified or nutritionally
+  incompatible food reference.
+- [ ] The report distinguishes a missing food from an ambiguous match.

--- a/plans/260729-1930-preparation-aware-catalog-resolution/phase-02-implement-resolver-safeguards.md
+++ b/plans/260729-1930-preparation-aware-catalog-resolution/phase-02-implement-resolver-safeguards.md
@@ -1,0 +1,53 @@
+---
+phase: 2
+title: "Implement resolver safeguards"
+status: pending
+priority: P1
+effort: "1-2d"
+dependencies: [1]
+effort: ""
+---
+
+# Phase 2: Implement resolver safeguards
+
+## Overview
+
+Make catalog resolution preparation-aware while retaining strict verified-food
+requirements and backward-compatible reviewed resolver maps.
+
+## Requirements
+
+- Preserve raw/cooked/fried/grilled state for catalog mapping and candidate
+  scoring; do not reuse the qualifier-stripped lookup key as the sole identity.
+- Auto-resolve only verified, preparation-compatible candidates at score >=0.90
+  with the existing 0.08 runner-up margin.
+- Treat 0.80-0.89 as a review suggestion, never an automatic import decision.
+- Keep unresolved ingredients as import errors; never drop them from a recipe.
+
+## Related Code Files
+
+- Modify: `src/app/services/catalog_meal_seed_import_service.py`
+- Modify: `src/domain/services/meal_suggestion/ingredient_name_normalizer.py`
+- Modify: `src/api/schemas/response/admin_meal_catalog_responses.py`
+- Modify: `src/api/routes/v1/admin_meal_catalog_import.py`
+- Test: `tests/unit/app/services/test_catalog_meal_seed_import_service.py`
+- Test: `tests/unit/api/test_admin_meal_catalog_import_route.py`
+
+## Implementation Steps
+
+1. Write failing tests for raw-versus-cooked and exact-but-unverified matches.
+2. Add a catalog-specific name/preparation key for resolver-map lookup and
+   candidate scoring without changing generic meal-suggestion normalization.
+3. Return candidate verification and preparation compatibility in resolver
+   reports so the admin UI can present a review decision.
+4. Enforce the three resolution bands and retain the 0.08 ambiguity margin.
+5. Verify that explicit approved mappings still pass quantity/nutrition safety
+   checks before any row is written.
+
+## Success Criteria
+
+- [ ] A cooked ingredient cannot auto-map to a raw candidate solely because
+  generic normalization removed its qualifier.
+- [ ] An unverified exact candidate remains blocked until verified.
+- [ ] The importer reports all unresolved names needed for review and inserts
+  no incomplete recipe.

--- a/plans/260729-1930-preparation-aware-catalog-resolution/phase-03-verify-import.md
+++ b/plans/260729-1930-preparation-aware-catalog-resolution/phase-03-verify-import.md
@@ -1,0 +1,44 @@
+---
+phase: 3
+title: "Verify import"
+status: pending
+priority: P1
+effort: "1d"
+dependencies: [1, 2]
+effort: ""
+---
+
+# Phase 3: Verify import
+
+## Overview
+
+Prove the reviewed corpus can be resolved, imported, and replayed without
+silently changing recipe composition or nutrition identity.
+
+## Requirements
+
+- Use the admin `/resolve` endpoint before `/import`.
+- Validate with `partial: true` for the 100-recipe bootstrap corpus.
+- Do not enable `resolve_all_best_effort` for the acceptance run.
+
+## Related Code Files
+
+- Read: `docs/meal-catalog-import-schema.md`
+- Test: `tests/unit/domain/services/meal_recommendation/test_catalog_recipe_seed_validator.py`
+- Test: `tests/integration/postgres/test_catalog_import_flow.py`
+
+## Implementation Steps
+
+1. Run resolver dry-run with the approved resolver map and save the report.
+2. Require zero unresolved issues, zero review-required duplicates, and only
+   verified food references before import.
+3. Import to a non-production database and replay the same manifest.
+4. Confirm first run inserts complete recipes and replay inserts zero rows.
+5. Promote only the reviewed mapping artifact and evidence; keep bootstrap
+   best-effort mode out of production procedure.
+
+## Success Criteria
+
+- [ ] Resolver dry-run has no unresolved ingredient issues.
+- [ ] Every imported recipe retains all declared ingredients.
+- [ ] Replay is idempotent and nutrition remains backend-derived.

--- a/plans/260729-1930-preparation-aware-catalog-resolution/plan.md
+++ b/plans/260729-1930-preparation-aware-catalog-resolution/plan.md
@@ -1,0 +1,54 @@
+---
+title: "Preparation-aware catalog ingredient resolution"
+description: "Resolve the bootstrap catalog corpus without allowing raw/cooked or unverified food-reference matches to silently alter nutrition."
+status: pending
+priority: P2
+branch: "codex/fix-partial-catalog-cuisine-validation"
+tags: [catalog, food-reference, resolver, nutrition-safety]
+blockedBy: []
+blocks: [260716-1509-four-table-meal-catalog-rework]
+created: "2026-07-29T12:37:41.730Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Preparation-aware catalog ingredient resolution
+
+## Overview
+
+The 100-recipe bootstrap manifest has 528 ingredient occurrences, 158 unique
+ingredient names, and no assigned `food_reference_id`. Import remains
+fail-closed: a recipe with any unresolved ingredient is not inserted. This
+plan adds a preparation-aware resolver workflow and a reviewed mapping process;
+it does not permit partial recipes or derive calories outside the backend.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Resolve corpus](./phase-01-resolve-corpus.md) | Pending |
+| 2 | [Implement resolver safeguards](./phase-02-implement-resolver-safeguards.md) | Pending |
+| 3 | [Verify import](./phase-03-verify-import.md) | Pending |
+
+## Dependencies
+
+- Unblocks the approved-corpus import gate in
+  `../260716-1509-four-table-meal-catalog-rework/`.
+- Requires an authorized reviewer for nutrition identity decisions and the
+  current `food_reference` data set for dry-run evidence.
+
+## Resolution Policy
+
+| Result | Rule | Import action |
+| --- | --- | --- |
+| Auto-resolved | Verified candidate, preparation-compatible, score at least 0.90, and at least 0.08 ahead of runner-up | Include ingredient |
+| Review suggestion | Verified candidate with score 0.80-0.89, or an approved name needing human confirmation | Require resolver-map decision |
+| Unresolved | Score below 0.80, preparation mismatch, missing canonical food, or unverified candidate | Withhold recipe; never omit ingredient |
+
+## Success Criteria
+
+- All 158 unique manifest ingredient names are resolved, explicitly rejected,
+  or backed by a documented missing-food task.
+- A catalog import never writes a recipe missing an ingredient.
+- Raw/cooked/fried/grilled wording cannot silently collapse to the same mapping.
+- Dry-run and replay evidence show deterministic mappings and backend-derived nutrition.

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -181,9 +181,23 @@ def get_catalog_meal_seed_importer(
 ) -> CatalogMealSeedImporter:
     """Build the catalog seed importer with request-scoped repositories."""
 
+    food_reference_repository = AsyncFoodReferenceRepository(db)
+
+    async def enrich_missing_with_fatsecret(name: str) -> bool:
+        from src.domain.services.meal_suggestion.ingredient_nutrition_resolver import (
+            IngredientNutritionResolver,
+        )
+
+        resolver = IngredientNutritionResolver(
+            fatsecret=get_fat_secret_service_instance(),
+            food_ref_repo=food_reference_repository,
+        )
+        return await resolver.resolve(name) is not None
+
     return CatalogMealSeedImporter(
         AsyncCatalogMealRepository(db),
-        AsyncFoodReferenceRepository(db),
+        food_reference_repository,
+        candidate_enricher=enrich_missing_with_fatsecret,
     )
 
 

--- a/src/api/routes/v1/admin_meal_catalog_import.py
+++ b/src/api/routes/v1/admin_meal_catalog_import.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.base_dependencies import get_async_db, get_catalog_meal_seed_importer
 from src.api.dependencies.auth import require_admin_or_local
 from src.api.schemas.response.admin_meal_catalog_responses import (
+    AdminMealCatalogEnrichmentResponse,
     AdminMealCatalogImportRequest,
     AdminMealCatalogImportResponse,
     AdminMealCatalogValidationResponse,
@@ -38,6 +39,31 @@ async def resolve_admin_meal_catalog_ingredients(
         )
     summary = await _run_importer(importer, request, dry_run=True)
     return _response(validation, summary, applied=False)
+
+
+@router.post("/enrich", response_model=AdminMealCatalogEnrichmentResponse)
+async def enrich_admin_meal_catalog_candidates(
+    request: AdminMealCatalogImportRequest,
+    db: AsyncSession = Depends(get_async_db),
+    importer: CatalogMealSeedImporter = Depends(get_catalog_meal_seed_importer),
+    _admin: str = Depends(require_admin_or_local),
+) -> AdminMealCatalogEnrichmentResponse:
+    """Cache unverified FatSecret candidates without publishing catalog recipes."""
+
+    validation = _validate_manifest(request)
+    if validation.errors:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_validation_response(validation).model_dump(),
+        )
+    summary = await importer.enrich_missing_candidates(request.manifest)
+    await db.commit()
+    return AdminMealCatalogEnrichmentResponse(
+        validation=_validation_response(validation),
+        attempted=summary.attempted,
+        enriched=summary.enriched,
+        skipped_existing=summary.skipped_existing,
+    )
 
 
 @router.post("/import", response_model=AdminMealCatalogImportResponse)
@@ -124,12 +150,7 @@ def _empty_summary(validation, *, dry_run: bool):
 
 def _response(validation, summary, *, applied: bool) -> AdminMealCatalogImportResponse:
     report = summary.resolution_report()
-    validation_response = AdminMealCatalogValidationResponse(
-        manifest_digest=validation.manifest_digest,
-        recipe_count=validation.recipe_count,
-        errors=list(validation.errors),
-        coverage=validation.coverage,
-    )
+    validation_response = _validation_response(validation)
     return AdminMealCatalogImportResponse(
         validation=validation_response,
         manifest_digest=validation.manifest_digest,
@@ -142,4 +163,13 @@ def _response(validation, summary, *, applied: bool) -> AdminMealCatalogImportRe
         errors=list(summary.errors),
         issues=report["issues"],
         review_required=report["review_required"],
+    )
+
+
+def _validation_response(validation) -> AdminMealCatalogValidationResponse:
+    return AdminMealCatalogValidationResponse(
+        manifest_digest=validation.manifest_digest,
+        recipe_count=validation.recipe_count,
+        errors=list(validation.errors),
+        coverage=validation.coverage,
     )

--- a/src/api/schemas/response/admin_meal_catalog_responses.py
+++ b/src/api/schemas/response/admin_meal_catalog_responses.py
@@ -94,6 +94,13 @@ class AdminMealCatalogValidationResponse(BaseModel):
     coverage: dict[str, dict[str, int]]
 
 
+class AdminMealCatalogEnrichmentResponse(BaseModel):
+    validation: AdminMealCatalogValidationResponse
+    attempted: int
+    enriched: int
+    skipped_existing: int
+
+
 class AdminMealCatalogImportResponse(BaseModel):
     validation: AdminMealCatalogValidationResponse
     manifest_digest: str

--- a/src/app/services/catalog_meal_seed_import_service.py
+++ b/src/app/services/catalog_meal_seed_import_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import unicodedata
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from decimal import Decimal
 from difflib import SequenceMatcher
@@ -31,6 +32,8 @@ from src.domain.services.meal_suggestion.ingredient_name_normalizer import (
     normalize_food_name,
 )
 from src.observability import distribution_metric, increment_metric
+
+CatalogIngredientCandidateEnricher = Callable[[str], Awaitable[bool]]
 
 
 @dataclass(frozen=True)
@@ -117,6 +120,15 @@ class CatalogSeedReviewRequired:
 
 
 @dataclass(frozen=True)
+class CatalogSeedCandidateEnrichmentSummary:
+    """Outcome of caching provider candidates for later catalog review."""
+
+    attempted: int = 0
+    enriched: int = 0
+    skipped_existing: int = 0
+
+
+@dataclass(frozen=True)
 class CatalogSeedImportSummary:
     """Import outcome for CLI reporting and tests."""
 
@@ -184,6 +196,7 @@ class CatalogMealSeedImporter:
         approved_mappings: dict[str, int] | None = None,
         auto_resolve_threshold: float | None = 0.92,
         resolve_all_best_effort: bool = False,
+        candidate_enricher: CatalogIngredientCandidateEnricher | None = None,
         converter: IngredientQuantityConversionService | None = None,
     ) -> None:
         self._catalog_repository = catalog_repository
@@ -195,6 +208,8 @@ class CatalogMealSeedImporter:
         }
         self._auto_resolve_threshold = auto_resolve_threshold
         self._resolve_all_best_effort = resolve_all_best_effort
+        self._candidate_enricher = candidate_enricher
+        self._enriched_names: set[str] = set()
         self._converter = converter or IngredientQuantityConversionService(
             allow_unverified=resolve_all_best_effort,
             allow_unapproved_sources=resolve_all_best_effort,
@@ -220,6 +235,7 @@ class CatalogMealSeedImporter:
             approved_mappings=approved_mappings,
             auto_resolve_threshold=auto_resolve_threshold,
             resolve_all_best_effort=resolve_all_best_effort,
+            candidate_enricher=self._candidate_enricher,
         )
 
     async def import_manifest(self, manifest: dict[str, Any]) -> CatalogSeedImportSummary:
@@ -477,6 +493,55 @@ class CatalogMealSeedImporter:
             "needs_review",
             tuple(candidates[:5]),
         )
+
+    async def enrich_missing_candidates(
+        self,
+        manifest: dict[str, Any],
+    ) -> CatalogSeedCandidateEnrichmentSummary:
+        """Persist one unverified provider candidate per missing ingredient name."""
+
+        names = {
+            normalize_food_name(str(ingredient["name"]).strip()): str(
+                ingredient["name"]
+            ).strip()
+            for recipe in manifest.get("recipes", [])
+            if isinstance(recipe, dict)
+            for ingredient in recipe.get("ingredients", [])
+            if isinstance(ingredient, dict)
+            and ingredient.get("food_reference_id") is None
+            and str(ingredient.get("name", "")).strip()
+        }
+        attempted = 0
+        enriched = 0
+        skipped_existing = 0
+        for normalized, name in names.items():
+            if await self._find_reference_candidates_by_normalized_name(normalized):
+                skipped_existing += 1
+                continue
+            attempted += 1
+            if await self._enrich_missing_candidate(name, normalized):
+                enriched += 1
+        return CatalogSeedCandidateEnrichmentSummary(
+            attempted=attempted,
+            enriched=enriched,
+            skipped_existing=skipped_existing,
+        )
+
+    async def _enrich_missing_candidate(self, name: str, normalized: str) -> bool:
+        """Cache one provider candidate for review without bypassing publication gates."""
+
+        if (
+            self._candidate_enricher is None
+            or normalized in self._enriched_names
+        ):
+            return False
+        self._enriched_names.add(normalized)
+        try:
+            enriched = await self._candidate_enricher(name)
+        except Exception:
+            return False
+        self._candidate_rows = None
+        return enriched
 
     async def _find_existing(
         self,

--- a/tests/unit/api/test_admin_meal_catalog_import_route.py
+++ b/tests/unit/api/test_admin_meal_catalog_import_route.py
@@ -6,7 +6,10 @@ from fastapi.testclient import TestClient
 from src.api.base_dependencies import get_async_db
 from src.api.dependencies.auth import require_admin_or_local
 from src.api.routes.v1 import admin_meal_catalog_import as route_mod
-from src.app.services.catalog_meal_seed_import_service import CatalogSeedImportSummary
+from src.app.services.catalog_meal_seed_import_service import (
+    CatalogSeedCandidateEnrichmentSummary,
+    CatalogSeedImportSummary,
+)
 
 
 def test_resolve_catalog_manifest_is_dry_run_and_does_not_commit(monkeypatch):
@@ -62,11 +65,44 @@ def test_import_catalog_manifest_returns_validation_report_without_db_work():
     db.commit.assert_not_awaited()
 
 
-def _client(db):
+def test_enrich_catalog_candidates_commits_without_importing_recipes():
+    db = AsyncMock()
+
+    class Importer:
+        async def enrich_missing_candidates(self, manifest):
+            return CatalogSeedCandidateEnrichmentSummary(
+                attempted=4,
+                enriched=3,
+                skipped_existing=1,
+            )
+
+    client = _client(db, importer=Importer())
+
+    response = client.post("/v1/admin/meal-catalog/enrich", json=_request())
+
+    assert response.status_code == 200
+    assert response.json()["enriched"] == 3
+    assert response.json()["skipped_existing"] == 1
+    db.commit.assert_awaited_once()
+
+
+def test_enrich_catalog_candidates_rejects_invalid_manifest_without_commit():
+    db = AsyncMock()
+    payload = _request()
+    payload["manifest"]["recipes"][0]["meal_types"] = []
+    client = _client(db)
+
+    response = client.post("/v1/admin/meal-catalog/enrich", json=payload)
+
+    assert response.status_code == 422
+    db.commit.assert_not_awaited()
+
+
+def _client(db, importer=object):
     app = FastAPI()
     app.include_router(route_mod.router)
     app.dependency_overrides[get_async_db] = lambda: db
-    app.dependency_overrides[route_mod.get_catalog_meal_seed_importer] = object
+    app.dependency_overrides[route_mod.get_catalog_meal_seed_importer] = lambda: importer
     app.dependency_overrides[require_admin_or_local] = lambda: "admin@nutree.ai"
     return TestClient(app)
 

--- a/tests/unit/app/services/test_catalog_meal_seed_import_service.py
+++ b/tests/unit/app/services/test_catalog_meal_seed_import_service.py
@@ -100,6 +100,7 @@ class _Importer(CatalogMealSeedImporter):
         approved_mappings=None,
         auto_resolve_threshold=0.92,
         resolve_all_best_effort=False,
+        candidate_enricher=None,
     ):
         self.session = _Session()
         super().__init__(
@@ -108,6 +109,7 @@ class _Importer(CatalogMealSeedImporter):
             approved_mappings=approved_mappings,
             auto_resolve_threshold=auto_resolve_threshold,
             resolve_all_best_effort=resolve_all_best_effort,
+            candidate_enricher=candidate_enricher,
         )
         self.refs_by_id = refs_by_id or {}
         self.refs_by_name = refs_by_name or {}
@@ -331,6 +333,47 @@ async def test_import_reports_unverified_exact_match():
     assert summary.inserted == 0
     assert "exact_match_not_verified" in summary.errors[0]
     assert summary.resolution_issues[0].candidates[0].is_verified is False
+
+
+@pytest.mark.asyncio
+async def test_enrichment_caches_each_missing_name_once_without_importing_recipe():
+    calls = []
+
+    async def enrich(name):
+        calls.append(name)
+        return True
+
+    manifest = _manifest(food_reference_id=None)
+    duplicate = _manifest(food_reference_id=None)["recipes"][0]
+    duplicate["recipe_key"] = "vn-rice-lunch"
+    manifest["recipes"].append(duplicate)
+    importer = _Importer(
+        candidate_enricher=enrich,
+    )
+
+    summary = await importer.enrich_missing_candidates(manifest)
+
+    assert calls == ["Rice"]
+    assert summary.attempted == 1
+    assert summary.enriched == 1
+    assert importer.session.added == []
+
+
+@pytest.mark.asyncio
+async def test_import_does_not_enrich_missing_candidates():
+    calls = []
+
+    async def enrich(name):
+        calls.append(name)
+        return True
+
+    importer = _Importer(candidate_enricher=enrich)
+
+    summary = await importer.import_manifest(_manifest(food_reference_id=None))
+
+    assert summary.inserted == 0
+    assert "needs_review" in summary.errors[0]
+    assert calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an explicit admin-only catalog enrichment endpoint that stores FatSecret results as unverified candidates
- keep resolver preview and catalog import non-mutating/fail-closed until candidates are reviewed and mapped
- document the workflow and cover enrichment, validation, and no-side-effect guarantees

## Test plan
- [x] `.venv/bin/python -m pytest tests/unit/app/services/test_catalog_meal_seed_import_service.py tests/unit/api/test_admin_meal_catalog_import_route.py tests/unit/api/test_food_reference_dependency_wiring.py tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py tests/unit/domain/services/meal_suggestion/test_ingredient_nutrition_resolver.py -q`
- [x] `.venv/bin/ruff check` on changed Python files
- [x] repository pre-push unit suite (2,028 passed)