### PR TITLE
fix(catalog): expose blocked ingredient references

### DIFF
--- a/src/api/routes/v1/admin_meal_catalog_import.py
+++ b/src/api/routes/v1/admin_meal_catalog_import.py
@@ -162,6 +162,7 @@ def _response(validation, summary, *, applied: bool) -> AdminMealCatalogImportRe
         applied=applied,
         errors=list(summary.errors),
         issues=report["issues"],
+        unverified_references=report["unverified_references"],
         review_required=report["review_required"],
     )
 

--- a/src/api/schemas/response/admin_meal_catalog_responses.py
+++ b/src/api/schemas/response/admin_meal_catalog_responses.py
@@ -79,6 +79,16 @@ class AdminMealCatalogResolutionIssue(BaseModel):
     candidates: list[AdminMealCatalogResolutionCandidate]
 
 
+class AdminMealCatalogUnverifiedReference(BaseModel):
+    recipe_index: int
+    recipe_key: str
+    ingredient_index: int
+    ingredient_name: str
+    food_reference_id: int
+    food_reference_name: str
+    source: str
+
+
 class AdminMealCatalogReviewRequired(BaseModel):
     recipe_index: int
     recipe_key: str
@@ -112,4 +122,5 @@ class AdminMealCatalogImportResponse(BaseModel):
     applied: bool
     errors: list[str]
     issues: list[AdminMealCatalogResolutionIssue]
+    unverified_references: list[AdminMealCatalogUnverifiedReference]
     review_required: list[AdminMealCatalogReviewRequired]

--- a/src/app/services/catalog_meal_seed_import_service.py
+++ b/src/app/services/catalog_meal_seed_import_service.py
@@ -129,6 +129,30 @@ class CatalogSeedCandidateEnrichmentSummary:
 
 
 @dataclass(frozen=True)
+class CatalogSeedUnverifiedReference:
+    """A pinned manifest reference blocked by the publication verification gate."""
+
+    recipe_index: int
+    recipe_key: str
+    ingredient_index: int
+    ingredient_name: str
+    food_reference_id: int
+    food_reference_name: str
+    source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "recipe_index": self.recipe_index,
+            "recipe_key": self.recipe_key,
+            "ingredient_index": self.ingredient_index,
+            "ingredient_name": self.ingredient_name,
+            "food_reference_id": self.food_reference_id,
+            "food_reference_name": self.food_reference_name,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
 class CatalogSeedImportSummary:
     """Import outcome for CLI reporting and tests."""
 
@@ -137,6 +161,9 @@ class CatalogSeedImportSummary:
     dry_run: bool = False
     errors: tuple[str, ...] = field(default_factory=tuple)
     resolution_issues: tuple[CatalogSeedResolutionIssue, ...] = field(
+        default_factory=tuple
+    )
+    unverified_references: tuple[CatalogSeedUnverifiedReference, ...] = field(
         default_factory=tuple
     )
     review_required: tuple[CatalogSeedReviewRequired, ...] = field(default_factory=tuple)
@@ -152,12 +179,27 @@ class CatalogSeedImportSummary:
             "dry_run": self.dry_run,
             "errors": list(self.errors),
             "issues": [issue.to_dict() for issue in self.resolution_issues],
+            "unverified_references": [
+                reference.to_dict() for reference in self.unverified_references
+            ],
             "review_required": [item.to_dict() for item in self.review_required],
         }
 
 
 class CatalogSeedImportError(ValueError):
     """Raised when a seed manifest cannot be imported safely."""
+
+
+class CatalogSeedUnverifiedReferenceError(CatalogSeedImportError):
+    """Raised when a manifest pins an unverified food reference."""
+
+    def __init__(self, issue: CatalogSeedUnverifiedReference) -> None:
+        self.issue = issue
+        super().__init__(
+            f"recipes[{issue.recipe_index}].ingredients[{issue.ingredient_index}] "
+            f"food_reference_not_verified: Food reference {issue.food_reference_id} "
+            "is not verified."
+        )
 
 
 class CatalogSeedResolutionError(CatalogSeedImportError):
@@ -243,6 +285,7 @@ class CatalogMealSeedImporter:
         skipped = 0
         errors: list[str] = []
         resolution_issues: list[CatalogSeedResolutionIssue] = []
+        unverified_references: list[CatalogSeedUnverifiedReference] = []
         review_required: list[CatalogSeedReviewRequired] = []
         prepared: list[_PreparedCatalogSeed] = []
         signatures = await self._catalog_repository.list_seed_signatures()
@@ -252,6 +295,10 @@ class CatalogMealSeedImporter:
             except CatalogSeedResolutionError as exc:
                 errors.append(str(exc))
                 resolution_issues.append(exc.issue)
+                continue
+            except CatalogSeedUnverifiedReferenceError as exc:
+                errors.append(str(exc))
+                unverified_references.append(exc.issue)
                 continue
             except CatalogSeedImportError as exc:
                 errors.append(str(exc))
@@ -272,6 +319,7 @@ class CatalogMealSeedImporter:
                 dry_run=self._dry_run,
                 errors=tuple(errors),
                 resolution_issues=tuple(resolution_issues),
+                unverified_references=tuple(unverified_references),
                 review_required=tuple(review_required),
             )
             _record_seed_import_metrics(summary, started)
@@ -408,6 +456,18 @@ class CatalogMealSeedImporter:
                     )
                 )
             except IngredientQuantityConversionError as exc:
+                if exc.code == "food_reference_not_verified":
+                    raise CatalogSeedUnverifiedReferenceError(
+                        CatalogSeedUnverifiedReference(
+                            recipe_index=recipe_index,
+                            recipe_key=str(recipe["recipe_key"]).strip(),
+                            ingredient_index=ingredient_index,
+                            ingredient_name=str(ingredient["name"]).strip(),
+                            food_reference_id=reference.id,
+                            food_reference_name=reference.name,
+                            source=reference.source,
+                        )
+                    ) from exc
                 raise CatalogSeedImportError(
                     f"recipes[{recipe_index}].ingredients[{ingredient_index}] "
                     f"{exc.code}: {exc}"

--- a/tests/unit/api/test_admin_meal_catalog_import_route.py
+++ b/tests/unit/api/test_admin_meal_catalog_import_route.py
@@ -9,6 +9,7 @@ from src.api.routes.v1 import admin_meal_catalog_import as route_mod
 from src.app.services.catalog_meal_seed_import_service import (
     CatalogSeedCandidateEnrichmentSummary,
     CatalogSeedImportSummary,
+    CatalogSeedUnverifiedReference,
 )
 
 
@@ -50,6 +51,33 @@ def test_import_catalog_manifest_previews_then_commits(monkeypatch):
     assert response.json()["inserted"] == 1
     assert calls == [True, False]
     db.commit.assert_awaited_once()
+
+
+def test_resolve_returns_structured_unverified_references(monkeypatch):
+    db = AsyncMock()
+
+    async def fake_run_importer(db_arg, request, *, dry_run):
+        return CatalogSeedImportSummary(
+            dry_run=dry_run,
+            errors=("food_reference_not_verified",),
+            unverified_references=(
+                CatalogSeedUnverifiedReference(
+                    recipe_index=0,
+                    recipe_key="pho-ga-001",
+                    ingredient_index=0,
+                    ingredient_name="Chicken breast",
+                    food_reference_id=1,
+                    food_reference_name="Chicken breast",
+                    source="seed",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(route_mod, "_run_importer", fake_run_importer)
+    response = _client(db).post("/v1/admin/meal-catalog/resolve", json=_request())
+
+    assert response.status_code == 200
+    assert response.json()["unverified_references"][0]["food_reference_id"] == 1
 
 
 def test_import_catalog_manifest_returns_validation_report_without_db_work():

--- a/tests/unit/app/services/test_catalog_meal_seed_import_service.py
+++ b/tests/unit/app/services/test_catalog_meal_seed_import_service.py
@@ -336,6 +336,18 @@ async def test_import_reports_unverified_exact_match():
 
 
 @pytest.mark.asyncio
+async def test_import_reports_pinned_unverified_reference_for_manifest_recovery():
+    importer = _Importer(refs_by_id={7: _reference(is_verified=False)})
+
+    summary = await importer.import_manifest(_manifest())
+
+    assert summary.inserted == 0
+    assert "food_reference_not_verified" in summary.errors[0]
+    assert summary.unverified_references[0].food_reference_id == 7
+    assert summary.resolution_report()["unverified_references"][0]["source"] == "catalog_seed"
+
+
+@pytest.mark.asyncio
 async def test_enrichment_caches_each_missing_name_once_without_importing_recipe():
     calls = []
 


### PR DESCRIPTION
## Final catalog import flow
1. Load a manifest in Nutree Web.
2. Resolve ingredients.
3. If pinned food references are unverified, the backend returns typed `unverified_references`.
4. Web groups the blocked IDs and offers **Remove blocked IDs and resolve again**. This preserves names and quantities, then permits verified-candidate review and resolver mappings.
5. Preview the clean manifest.
6. Apply the exact previewed manifest.

Best-effort mode remains explicit and is never enabled automatically.

## Verification
- `./.venv/bin/pytest -q tests/unit/app/services/test_catalog_meal_seed_import_service.py tests/unit/api/test_admin_meal_catalog_import_route.py`
- `./.venv/bin/ruff check ...`
- `lint-imports`

## Scope
- Excludes the pre-existing `migrations/utils.py` worktree change.