### PR TITLE
feat(catalog): add food reference approval

### DIFF
--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -8,6 +8,9 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.app.services.catalog_food_reference_review_service import (
+    CatalogFoodReferenceReviewService,
+)
 from src.app.services.catalog_meal_seed_import_service import CatalogMealSeedImporter
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
@@ -199,6 +202,14 @@ def get_catalog_meal_seed_importer(
         food_reference_repository,
         candidate_enricher=enrich_missing_with_fatsecret,
     )
+
+
+def get_catalog_food_reference_review_service(
+    db: AsyncSession = Depends(get_async_db),
+) -> CatalogFoodReferenceReviewService:
+    """Build the request-scoped service that records admin reference approvals."""
+
+    return CatalogFoodReferenceReviewService(AsyncFoodReferenceRepository(db))
 
 
 def get_catalog_image_generator() -> CloudflareWorkersImageGenerator:

--- a/src/api/routes/v1/admin_meal_catalog_import.py
+++ b/src/api/routes/v1/admin_meal_catalog_import.py
@@ -5,13 +5,22 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.base_dependencies import get_async_db, get_catalog_meal_seed_importer
+from src.api.base_dependencies import (
+    get_async_db,
+    get_catalog_food_reference_review_service,
+    get_catalog_meal_seed_importer,
+)
 from src.api.dependencies.auth import require_admin_or_local
 from src.api.schemas.response.admin_meal_catalog_responses import (
+    AdminMealCatalogApproveFoodReferenceRequest,
+    AdminMealCatalogApproveFoodReferenceResponse,
     AdminMealCatalogEnrichmentResponse,
     AdminMealCatalogImportRequest,
     AdminMealCatalogImportResponse,
     AdminMealCatalogValidationResponse,
+)
+from src.app.services.catalog_food_reference_review_service import (
+    CatalogFoodReferenceReviewService,
 )
 from src.app.services.catalog_meal_seed_import_service import CatalogMealSeedImporter
 from src.domain.services.meal_recommendation.catalog_recipe_seed_validator import (
@@ -21,6 +30,30 @@ from src.domain.services.meal_recommendation.catalog_recipe_seed_validator impor
 )
 
 router = APIRouter(prefix="/v1/admin/meal-catalog", tags=["Admin Meal Catalog"])
+
+
+@router.post(
+    "/approve-food-reference",
+    response_model=AdminMealCatalogApproveFoodReferenceResponse,
+)
+async def approve_admin_meal_catalog_food_reference(
+    request: AdminMealCatalogApproveFoodReferenceRequest,
+    db: AsyncSession = Depends(get_async_db),
+    reviewer: CatalogFoodReferenceReviewService = Depends(
+        get_catalog_food_reference_review_service
+    ),
+    _admin: str = Depends(require_admin_or_local),
+) -> AdminMealCatalogApproveFoodReferenceResponse:
+    """Record an admin's review before a food reference can publish catalog meals."""
+
+    approval = await reviewer.approve(request.food_reference_id)
+    if approval is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Food reference not found",
+        )
+    await db.commit()
+    return AdminMealCatalogApproveFoodReferenceResponse(**approval.__dict__)
 
 
 @router.post("/resolve", response_model=AdminMealCatalogImportResponse)

--- a/src/api/schemas/response/admin_meal_catalog_responses.py
+++ b/src/api/schemas/response/admin_meal_catalog_responses.py
@@ -111,6 +111,19 @@ class AdminMealCatalogEnrichmentResponse(BaseModel):
     skipped_existing: int
 
 
+class AdminMealCatalogApproveFoodReferenceRequest(BaseModel):
+    """One food reference an administrator reviewed before catalog publication."""
+
+    food_reference_id: int = Field(gt=0)
+
+
+class AdminMealCatalogApproveFoodReferenceResponse(BaseModel):
+    food_reference_id: int
+    name: str
+    source: str
+    is_verified: bool
+
+
 class AdminMealCatalogImportResponse(BaseModel):
     validation: AdminMealCatalogValidationResponse
     manifest_digest: str

--- a/src/app/services/catalog_food_reference_review_service.py
+++ b/src/app/services/catalog_food_reference_review_service.py
@@ -1,0 +1,49 @@
+"""Admin review service for food references used by catalog imports."""
+
+from dataclasses import dataclass
+
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+    FoodReferenceRepositoryPort,
+)
+
+
+@dataclass(frozen=True)
+class CatalogFoodReferenceApproval:
+    """The reference an administrator approved for catalog publication."""
+
+    food_reference_id: int
+    name: str
+    source: str
+    is_verified: bool
+
+
+class CatalogFoodReferenceReviewService:
+    """Makes an explicit admin decision durable before catalog publication."""
+
+    def __init__(self, food_references: FoodReferenceRepositoryPort):
+        self._food_references = food_references
+
+    async def approve(
+        self,
+        food_reference_id: int,
+    ) -> CatalogFoodReferenceApproval | None:
+        """Approve a reviewed reference, returning ``None`` when it no longer exists."""
+
+        reference = await self._food_references.approve_for_catalog_seed(
+            food_reference_id
+        )
+        if reference is None:
+            return None
+        return _approval(reference)
+
+
+def _approval(
+    reference: FoodReferenceNutritionProjection,
+) -> CatalogFoodReferenceApproval:
+    return CatalogFoodReferenceApproval(
+        food_reference_id=reference.id,
+        name=reference.name,
+        source=reference.source,
+        is_verified=reference.is_verified,
+    )

--- a/src/domain/ports/food_reference_repository_port.py
+++ b/src/domain/ports/food_reference_repository_port.py
@@ -71,6 +71,12 @@ class FoodReferenceRepositoryPort(Protocol):
     ) -> list[FoodReferenceNutritionProjection]:
         """Return candidate projections by exact normalized name for seed imports."""
 
+    async def approve_for_catalog_seed(
+        self,
+        food_reference_id: int,
+    ) -> FoodReferenceNutritionProjection | None:
+        """Mark one admin-reviewed food reference as eligible for catalog publication."""
+
     async def search_local(
         self,
         query: str,

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -123,6 +123,24 @@ class AsyncFoodReferenceRepository:
         )
         return [_catalog_seed_candidate_projection(row) for row in result.all()]
 
+    async def approve_for_catalog_seed(
+        self,
+        food_reference_id: int,
+    ) -> FoodReferenceNutritionProjection | None:
+        """Persist an administrator's review decision for catalog publication."""
+
+        result = await self._session.execute(
+            select(FoodReferenceModel)
+            .where(FoodReferenceModel.id == food_reference_id)
+            .options(*_FOOD_REFERENCE_LOAD_OPTIONS)
+        )
+        model = result.scalar_one_or_none()
+        if model is None:
+            return None
+        model.is_verified = True
+        await self._session.flush()
+        return food_reference_model_to_nutrition_projection(model)
+
     async def get_by_fdc_id(self, fdc_id: int) -> dict[str, Any] | None:
         stmt = (
             select(FoodReferenceModel)

--- a/tests/unit/api/test_admin_meal_catalog_import_route.py
+++ b/tests/unit/api/test_admin_meal_catalog_import_route.py
@@ -6,6 +6,9 @@ from fastapi.testclient import TestClient
 from src.api.base_dependencies import get_async_db
 from src.api.dependencies.auth import require_admin_or_local
 from src.api.routes.v1 import admin_meal_catalog_import as route_mod
+from src.app.services.catalog_food_reference_review_service import (
+    CatalogFoodReferenceApproval,
+)
 from src.app.services.catalog_meal_seed_import_service import (
     CatalogSeedCandidateEnrichmentSummary,
     CatalogSeedImportSummary,
@@ -30,6 +33,45 @@ def test_resolve_catalog_manifest_is_dry_run_and_does_not_commit(monkeypatch):
     assert response.json()["applied"] is False
     assert response.json()["dry_run"] is True
     assert calls == [True]
+    db.commit.assert_not_awaited()
+
+
+def test_approve_food_reference_commits_admin_review_decision():
+    db = AsyncMock()
+
+    class Reviewer:
+        async def approve(self, food_reference_id):
+            assert food_reference_id == 42
+            return CatalogFoodReferenceApproval(
+                food_reference_id=42,
+                name="Rice noodles, cooked",
+                source="fatsecret",
+                is_verified=True,
+            )
+
+    response = _client(db, reviewer=Reviewer()).post(
+        "/v1/admin/meal-catalog/approve-food-reference",
+        json={"food_reference_id": 42},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["is_verified"] is True
+    db.commit.assert_awaited_once()
+
+
+def test_approve_missing_food_reference_does_not_commit():
+    db = AsyncMock()
+
+    class Reviewer:
+        async def approve(self, food_reference_id):
+            return None
+
+    response = _client(db, reviewer=Reviewer()).post(
+        "/v1/admin/meal-catalog/approve-food-reference",
+        json={"food_reference_id": 404},
+    )
+
+    assert response.status_code == 404
     db.commit.assert_not_awaited()
 
 
@@ -126,11 +168,14 @@ def test_enrich_catalog_candidates_rejects_invalid_manifest_without_commit():
     db.commit.assert_not_awaited()
 
 
-def _client(db, importer=object):
+def _client(db, importer=object, reviewer=object):
     app = FastAPI()
     app.include_router(route_mod.router)
     app.dependency_overrides[get_async_db] = lambda: db
     app.dependency_overrides[route_mod.get_catalog_meal_seed_importer] = lambda: importer
+    app.dependency_overrides[route_mod.get_catalog_food_reference_review_service] = (
+        lambda: reviewer
+    )
     app.dependency_overrides[require_admin_or_local] = lambda: "admin@nutree.ai"
     return TestClient(app)
 

--- a/tests/unit/app/services/test_catalog_food_reference_review_service.py
+++ b/tests/unit/app/services/test_catalog_food_reference_review_service.py
@@ -1,0 +1,52 @@
+import pytest
+
+from src.app.services.catalog_food_reference_review_service import (
+    CatalogFoodReferenceReviewService,
+)
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
+
+
+class _FoodReferences:
+    def __init__(self, reference):
+        self.reference = reference
+        self.approved_ids = []
+
+    async def approve_for_catalog_seed(self, food_reference_id):
+        self.approved_ids.append(food_reference_id)
+        return self.reference
+
+
+def _reference():
+    return FoodReferenceNutritionProjection(
+        id=42,
+        name="Rice noodles, cooked",
+        source="fatsecret",
+        is_verified=True,
+        protein_100g=2.0,
+        carbs_100g=25.0,
+        fat_100g=0.2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_marks_one_reviewed_reference_available_for_catalog_import():
+    references = _FoodReferences(_reference())
+
+    approval = await CatalogFoodReferenceReviewService(references).approve(42)
+
+    assert references.approved_ids == [42]
+    assert approval is not None
+    assert approval.food_reference_id == 42
+    assert approval.is_verified is True
+
+
+@pytest.mark.asyncio
+async def test_approve_returns_none_when_reference_is_missing():
+    references = _FoodReferences(None)
+
+    approval = await CatalogFoodReferenceReviewService(references).approve(404)
+
+    assert references.approved_ids == [404]
+    assert approval is None


### PR DESCRIPTION
## Summary
- add protected approval endpoint for reviewed catalog FoodReferences
- persist verification through the application and repository boundary
- cover approval and missing-reference behavior with focused tests

## Verification
- focused catalog approval and import tests
- lint-imports
- live Neon workflow: resolve blocked reference, approve, preview, publish, then clean up

## Notes
- migrations/utils.py is an unrelated local modification and is not included.