### PR TITLE
fix(catalog): resolve all ingredient review blockers

### DIFF
--- a/src/app/services/catalog_meal_seed_import_service.py
+++ b/src/app/services/catalog_meal_seed_import_service.py
@@ -219,6 +219,14 @@ class CatalogSeedResolutionError(CatalogSeedImportError):
         )
 
 
+class CatalogSeedResolutionErrors(CatalogSeedImportError):
+    """All ingredient-resolution decisions required for one recipe."""
+
+    def __init__(self, issues: list[CatalogSeedResolutionIssue]) -> None:
+        self.issues = tuple(issues)
+        super().__init__("; ".join(str(CatalogSeedResolutionError(issue)) for issue in issues))
+
+
 @dataclass(frozen=True)
 class _PreparedCatalogSeed:
     recipe_index: int
@@ -292,6 +300,10 @@ class CatalogMealSeedImporter:
         for index, recipe in enumerate(manifest.get("recipes", [])):
             try:
                 prepared_seed = await self._prepare_recipe(recipe, index)
+            except CatalogSeedResolutionErrors as exc:
+                errors.extend(str(CatalogSeedResolutionError(issue)) for issue in exc.issues)
+                resolution_issues.extend(exc.issues)
+                continue
             except CatalogSeedResolutionError as exc:
                 errors.append(str(exc))
                 resolution_issues.append(exc.issue)
@@ -439,13 +451,18 @@ class CatalogMealSeedImporter:
         recipe_index: int,
     ) -> list[ResolvedIngredientQuantity]:
         resolved: list[ResolvedIngredientQuantity] = []
+        issues: list[CatalogSeedResolutionIssue] = []
         for ingredient_index, ingredient in enumerate(recipe.get("ingredients", [])):
-            reference = await self._resolve_food_reference(
-                ingredient,
-                recipe_key=str(recipe["recipe_key"]).strip(),
-                recipe_index=recipe_index,
-                ingredient_index=ingredient_index,
-            )
+            try:
+                reference = await self._resolve_food_reference(
+                    ingredient,
+                    recipe_key=str(recipe["recipe_key"]).strip(),
+                    recipe_index=recipe_index,
+                    ingredient_index=ingredient_index,
+                )
+            except CatalogSeedResolutionError as exc:
+                issues.append(exc.issue)
+                continue
             try:
                 resolved.append(
                     self._converter.resolve(
@@ -472,6 +489,8 @@ class CatalogMealSeedImporter:
                     f"recipes[{recipe_index}].ingredients[{ingredient_index}] "
                     f"{exc.code}: {exc}"
                 ) from exc
+        if issues:
+            raise CatalogSeedResolutionErrors(issues)
         return resolved
 
     async def _resolve_food_reference(

--- a/tests/unit/app/services/test_catalog_meal_seed_import_service.py
+++ b/tests/unit/app/services/test_catalog_meal_seed_import_service.py
@@ -336,6 +336,31 @@ async def test_import_reports_unverified_exact_match():
 
 
 @pytest.mark.asyncio
+async def test_import_reports_every_unverified_exact_match_in_one_recipe():
+    manifest = _manifest(food_reference_id=None)
+    manifest["recipes"][0]["ingredients"].append(
+        {
+            "food_reference_id": None,
+            "name": "Egg",
+            "quantity": 1,
+            "unit": "each",
+        }
+    )
+    importer = _Importer(
+        refs_by_name={
+            "rice": [_reference(7, is_verified=False)],
+            "egg": [_reference(8, name="Egg", is_verified=False)],
+        }
+    )
+
+    summary = await importer.import_manifest(manifest)
+
+    assert summary.inserted == 0
+    assert [issue.normalized_name for issue in summary.resolution_issues] == ["rice", "egg"]
+    assert len(summary.errors) == 2
+
+
+@pytest.mark.asyncio
 async def test_import_reports_pinned_unverified_reference_for_manifest_recovery():
     importer = _Importer(refs_by_id={7: _reference(is_verified=False)})
 


### PR DESCRIPTION
## Summary
- report every unresolved ingredient in each recipe during a single resolve pass
- keep catalog imports fail-closed and non-mutating while review blockers remain
- add regression coverage for multiple unresolved exact matches in one recipe

## Verification
- .venv/bin/pytest tests/unit/app/services/test_catalog_meal_seed_import_service.py tests/unit/api/test_admin_meal_catalog_import_route.py tests/unit/app/services/test_catalog_food_reference_review_service.py -q
- lint-imports
- pre-push hook: 2035 passed