### PR TITLE
fix(catalog): honor explicit food reference review

### DIFF
--- a/src/domain/services/meal_recommendation/ingredient_quantity_conversion_service.py
+++ b/src/domain/services/meal_recommendation/ingredient_quantity_conversion_service.py
@@ -158,6 +158,7 @@ class IngredientQuantityConversionService:
             )
         if (
             reference.source.lower() not in self._approved_sources
+            and not reference.is_verified
             and not self._allow_unapproved_sources
         ):
             raise IngredientQuantityConversionError(
@@ -184,9 +185,8 @@ class IngredientQuantityConversionService:
             )
         fiber = reference.fiber_100g or 0.0
         sugar = reference.sugar_100g or 0.0
-        if (
-            not self._allow_implausible_macros
-            and (fiber > carbs_100g or sugar > carbs_100g or fiber + sugar > carbs_100g)
+        if not self._allow_implausible_macros and (
+            fiber > carbs_100g or sugar > carbs_100g or fiber + sugar > carbs_100g
         ):
             raise IngredientQuantityConversionError(
                 "implausible_macro_snapshot",
@@ -270,9 +270,11 @@ class IngredientQuantityConversionService:
         weights = {
             (
                 round(serving.grams, 6) if serving.grams is not None else None,
-                round(serving.milliliters, 6)
-                if serving.milliliters is not None
-                else None,
+                (
+                    round(serving.milliliters, 6)
+                    if serving.milliliters is not None
+                    else None
+                ),
             )
             for serving in matches
         }

--- a/tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py
+++ b/tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py
@@ -83,10 +83,31 @@ def test_rejects_unverified_food_reference():
     assert exc.value.code == "food_reference_not_verified"
 
 
-def test_rejects_unapproved_source():
+def test_rejects_unapproved_source_until_an_admin_verifies_that_reference():
     with pytest.raises(IngredientQuantityConversionError) as exc:
         IngredientQuantityConversionService().resolve(
-            reference=_reference(source="ai_estimate"),
+            reference=_reference(source="ai_estimate", is_verified=False),
+            quantity=100,
+            unit="g",
+        )
+
+    assert exc.value.code == "food_reference_not_verified"
+
+
+def test_accepts_admin_verified_reference_from_an_unapproved_source():
+    result = IngredientQuantityConversionService().resolve(
+        reference=_reference(source="ai_estimate", is_verified=True),
+        quantity=100,
+        unit="g",
+    )
+
+    assert result.food_reference_id == 42
+
+
+def test_review_mode_still_rejects_an_unapproved_unverified_source():
+    with pytest.raises(IngredientQuantityConversionError) as exc:
+        IngredientQuantityConversionService(allow_unverified=True).resolve(
+            reference=_reference(source="ai_estimate", is_verified=False),
             quantity=100,
             unit="g",
         )


### PR DESCRIPTION
## Summary
- let an explicitly reviewed food reference pass the catalog source gate without adding its source to the global allowlist
- retain strict rejection for unverified references and review-mode source checks
- cover both paths with converter regression tests

## Verification
- focused catalog tests: 45 passed
- pre-push full unit suite: 2085 passed
- ruff and black checks passed

## Follow-up
Pair with Nutree Web PR that adds the review action for pinned references.