### PR TITLE
feat(billing): add Paddle fulfillment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,20 @@ REVENUECAT_SECRET_API_KEY=
 REVENUECAT_WEBHOOK_SECRET=
 
 # ---------------------------------------------------------------------------
+# Paddle (web subscriptions)
+# ---------------------------------------------------------------------------
+# Required explicitly. Use "production" for live or "sandbox" for sandbox.
+PADDLE_ENVIRONMENT=
+# Server-side Paddle API key. Never expose this to a browser/client bundle.
+PADDLE_API_KEY=
+# Backward-compatible server-side alias, if your deployment already uses it.
+PADDLE_LIVE_API_KEY=
+# Signing secret from the live notification destination, not the API key.
+PADDLE_WEBHOOK_SIGNING_SECRET=
+# Optional operational reference for the permanent notification destination.
+PADDLE_WEBHOOK_NOTIFICATION_DESTINATION_ID=
+
+# ---------------------------------------------------------------------------
 # PostHog (backend lifecycle analytics)
 # ---------------------------------------------------------------------------
 POSTHOG_API_KEY=

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,6 +1,6 @@
 # Backend API Endpoints Reference
 
-**Last Updated:** July 29, 2026
+**Last Updated:** July 31, 2026
 **Base URL:** `http://localhost:8000` (dev) or deployed host
 **API Docs:** `/docs` (Swagger UI)
 **Auth:** Firebase JWT — `Authorization: Bearer <firebase-id-token>`
@@ -326,12 +326,21 @@ Privileged endpoints require Firebase auth and an email in `ADMIN_EMAILS`.
 
 ## Webhooks
 
-Handles RevenueCat lifecycle events (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER). Signature verified via constant-time HMAC; events mirrored to PostHog when `POSTHOG_API_KEY` is set.
+Handles RevenueCat lifecycle events (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EXPIRATION, BILLING_ISSUE, PRODUCT_CHANGE, REFUND, TRANSFER). Signature verified via constant-time HMAC; events mirrored to PostHog when `POSTHOG_API_KEY` is set. Paddle deliveries use a distinct SDK-verified raw-body endpoint and are idempotent by event ID.
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/webhooks/revenuecat` | RevenueCat subscription webhook |
 | GET | `/v1/webhooks/revenuecat/health` | Webhook health check |
+| POST | `/v1/webhooks/paddle` | Verified Paddle customer, subscription, and transaction webhook |
+
+---
+
+## Billing
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/billing/paddle/customer-portal` | Authenticated redirect to a temporary Paddle-hosted billing portal session |
 
 ---
 

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -1,7 +1,7 @@
 # Backend External Services Integration
 
-**Last Updated:** July 29, 2026
-**Services:** Firebase, Cloudinary, OpenAI, Cloudflare Workers AI, RevenueCat, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, USDA FoodData Central, Brave Search, Pexels, Unsplash, Resend, Google Imagen, Pollinations, nutree-affiliate
+**Last Updated:** July 31, 2026
+**Services:** Firebase, Cloudinary, OpenAI, Cloudflare Workers AI, RevenueCat, Paddle, PostHog, Redis, Sentry, DeepL, FatSecret, OpenFoodFacts, USDA FoodData Central, Brave Search, Pexels, Unsplash, Resend, Google Imagen, Pollinations, nutree-affiliate
 **Failure handling:** Optional integrations degrade when safe. Firebase Auth and the primary DB fail fast. Redis optional caches degrade by bypassing cache; any Redis-backed required state must be documented and health-checked separately.
 
 ---
@@ -29,6 +29,18 @@
 - Cron push entrypoint (`src/cron/push.py`) owns all push scheduling: precompute notification rows, schedule trial-expiry rows, claim due rows, batch-send, mark sent, clean expired rows
 - Cron dispatch helper (`CronNotificationDispatchService`) uses database row claiming (`pending` → `processing`) plus stale-processing recovery instead of a background loop or leader lock
 - APNs diagnostics surfaced at `/v1/health/notifications` via `apns_diagnostics()` to verify `interruption-level` placement
+
+---
+
+## Paddle Web Subscriptions
+
+**Purpose:** Fulfill web checkout subscriptions and provide Paddle-hosted self-service billing.
+
+- `POST /v1/webhooks/paddle` verifies the unparsed request bytes using the Paddle Python SDK and `PADDLE_WEBHOOK_SIGNING_SECRET` before decoding the payload.
+- Verified customer and subscription events upsert existing provider-specific user and subscription records by Paddle ID; a transaction received before its subscription returns non-2xx so Paddle retries it.
+- The access helper grants paid access only for `active` or `trialing` Paddle subscriptions. Scheduled changes are retained for visibility and do not revoke access before the actual status changes.
+- `GET /v1/billing/paddle/customer-portal` requires Firebase authentication, resolves the Paddle customer server-side, and redirects to a temporary Paddle-hosted portal session.
+- `PADDLE_ENVIRONMENT` is required explicitly (`production` for live; `sandbox` for sandbox). `PADDLE_API_KEY` is server-only and distinct from the notification signing secret.
 
 ---
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -9,6 +9,13 @@
 
 ## Completed Phases
 
+### July 2026: Paddle Web Subscription Fulfillment
+- [x] Added verified, idempotent Paddle webhook handling for customer, subscription, and completed-transaction lifecycle events.
+- [x] Extended existing user and subscription records with provider-specific Paddle identifiers, preserving RevenueCat records alongside Paddle state.
+- [x] Paddle paid access grants only for `active` and `trialing` subscriptions; scheduled cancellation or pause is retained as state rather than revoking access early.
+- [x] Added authenticated Paddle customer-portal redirects that resolve the Paddle customer from the server-side user link.
+- [ ] Live rollout remains gated on the existing pending migration chain, the permanent notification destination, its signing secret, and deployed environment configuration.
+
 ### July 2026: Meal Catalog Phase 0 Production Foundation
 - [x] Four-table catalog recommendation foundation uses `meal_catalog`, `meal_catalog_ingredients`, `meal_recommendations`, and `meal_recommendation_operations`.
 - [x] Catalog import is additive, content-hash protected, serialized, and withholds near duplicates for explicit review.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,6 +1,6 @@
 # Backend System Architecture Overview
 
-**Last Updated:** July 29, 2026
+**Last Updated:** July 31, 2026
 **Architecture:** 4-Layer Clean + CQRS + Event-Driven
 **Event Bus:** PyMediator (singleton registry pattern)
 **Codebase:** 704 Python files, 65,423 LOC in `src/`
@@ -61,6 +61,18 @@ device, and purchase gates remain open.
 ---
 
 ## Key Architectural Patterns
+
+### Verified Subscription Fulfillment
+
+Paddle checkout is not an entitlement signal. The API accepts Paddle notifications at
+`/v1/webhooks/paddle`, verifies the exact raw body before decoding it, and upserts the
+provider-specific customer link or subscription in the same database transaction. Paddle
+state uses provider-specific fields on the existing user and subscription records, so
+RevenueCat state remains intact. Premium access is determined server-side from verified
+Paddle subscription status: `active` and `trialing` grant access; a scheduled change
+does not revoke access until Paddle reports an actual non-granting status.
+The API calls an application service through a domain port; its Paddle SDK and database
+adapter is assembled only in `src/bootstrap/paddle_billing.py`.
 
 ### Dependency Inversion
 Domain defines port interfaces; infrastructure implements them. Handlers depend on abstractions.

--- a/migrations/versions/20260731000001_add_paddle_fulfillment_provider_fields.py
+++ b/migrations/versions/20260731000001_add_paddle_fulfillment_provider_fields.py
@@ -1,0 +1,80 @@
+"""Add provider-neutral Paddle fields to existing user and subscription records.
+
+This forward-only migration preserves live billing and fulfillment state.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260731000001"
+down_revision: str | None = "20260730000004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("paddle_customer_id", sa.String(64), nullable=True))
+    op.create_unique_constraint(
+        "uq_users_paddle_customer_id", "users", ["paddle_customer_id"]
+    )
+
+    op.alter_column(
+        "subscriptions",
+        "user_id",
+        existing_type=sa.String(36),
+        nullable=True,
+    )
+    op.alter_column(
+        "subscriptions",
+        "revenuecat_subscriber_id",
+        existing_type=sa.String(255),
+        nullable=True,
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column(
+            "provider",
+            sa.String(32),
+            nullable=False,
+            server_default="revenuecat",
+        ),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("provider_customer_id", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("provider_subscription_id", sa.String(64), nullable=True),
+    )
+    op.add_column("subscriptions", sa.Column("price_id", sa.String(64), nullable=True))
+    op.add_column(
+        "subscriptions",
+        sa.Column("scheduled_change_action", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "subscriptions",
+        sa.Column("scheduled_change_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_subscriptions_provider_subscription_id",
+        "subscriptions",
+        ["provider_subscription_id"],
+    )
+    op.create_index(
+        "idx_subscriptions_provider_customer",
+        "subscriptions",
+        ["provider", "provider_customer_id"],
+    )
+    op.create_index(
+        "idx_subscriptions_provider_user_status",
+        "subscriptions",
+        ["provider", "user_id", "status"],
+    )
+    op.alter_column("subscriptions", "provider", server_default=None)
+
+
+def downgrade() -> None:
+    """Preserve live billing and fulfillment records on rollback."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "sentry-sdk[fastapi]==2.62.0",
     "resend==2.30.1",
     "jinja2==3.1.6",
+    "paddle-python-sdk==1.15.0",
     "langchain-openai>=1.3.0,<2.0.0",
     "langgraph==1.2.8",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ resend==2.30.1
 
 # Template rendering
 jinja2==3.1.6
+paddle-python-sdk==1.15.0

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -230,7 +230,9 @@ def get_catalog_image_generator() -> CloudflareWorkersImageGenerator:
         ) from exc
 
 
-def get_catalog_image_generator_factory() -> Callable[[], CloudflareWorkersImageGenerator]:
+def get_catalog_image_generator_factory() -> Callable[
+    [], CloudflareWorkersImageGenerator
+]:
     """Return a lazy generator factory so routes can finish cheap prechecks first."""
 
     return get_catalog_image_generator

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -50,6 +50,7 @@ from src.api.routes.app_download import router as app_download_router
 from src.api.routes.v1.activities import router as activities_router
 from src.api.routes.v1.admin_meal_catalog import router as admin_meal_catalog_router
 from src.api.routes.v1.admin_meal_catalog_import import router as admin_meal_catalog_import_router
+from src.api.routes.v1.billing import router as billing_router
 from src.api.routes.v1.cheat_days import router as cheat_days_router
 from src.api.routes.v1.codes import router as codes_router
 from src.api.routes.v1.feature_flags import router as feature_flags_router
@@ -65,6 +66,7 @@ from src.api.routes.v1.meals import router as meals_router
 from src.api.routes.v1.monitoring import router as monitoring_router
 from src.api.routes.v1.movement import router as movement_router
 from src.api.routes.v1.notifications import router as notifications_router
+from src.api.routes.v1.paddle_webhooks import router as paddle_webhooks_router
 from src.api.routes.v1.nutrition import router as nutrition_router
 from src.api.routes.v1.progress import router as progress_router
 from src.api.routes.v1.promo_codes import router as promo_codes_router
@@ -329,6 +331,8 @@ app.include_router(users_router)
 app.include_router(foods_router)
 app.include_router(monitoring_router)
 app.include_router(webhooks_router)
+app.include_router(paddle_webhooks_router)
+app.include_router(billing_router)
 app.include_router(notifications_router)
 app.include_router(hydration_router)
 app.include_router(ingredients_router)

--- a/src/api/middleware/premium_check.py
+++ b/src/api/middleware/premium_check.py
@@ -6,12 +6,13 @@ Uses RevenueCat as source of truth, with local cache for performance.
 
 import logging
 import os
-from typing import Optional
 
-from fastapi import Request, HTTPException, status
+from fastapi import HTTPException, Request, status
 
-from src.domain.ports.subscription_service_port import SubscriptionServicePort
 from src.api.base_dependencies import get_subscription_service
+from src.app.services.paddle_billing_service import PaddleBillingService
+from src.bootstrap.paddle_billing import get_paddle_billing_service
+from src.domain.ports.subscription_service_port import SubscriptionServicePort
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,10 @@ logger = logging.getLogger(__name__)
 def _get_subscription_service() -> SubscriptionServicePort:
     """Helper to get subscription service - can be overridden in tests."""
     return get_subscription_service()
+
+
+def _get_paddle_billing_service() -> PaddleBillingService:
+    return get_paddle_billing_service()
 
 
 async def require_subscription(request: Request):
@@ -44,6 +49,10 @@ async def require_subscription(request: Request):
     # Quick check: Local database cache
     if user.has_active_subscription():
         logger.debug(f"User {user.id} has cached subscription")
+        return
+
+    if await _user_has_paddle_access(str(user.id)):
+        logger.debug("User %s has active Paddle subscription", user.id)
         return
 
     # No local subscription - verify with RevenueCat (source of truth)
@@ -120,6 +129,23 @@ async def get_subscription_status(request: Request) -> dict:
             "source": "cache",
         }
 
+    paddle_subscription = await _get_active_paddle_subscription(str(user.id))
+    if paddle_subscription:
+        return {
+            "has_subscription": True,
+            "subscription": {
+                "product_id": paddle_subscription.product_id,
+                "expires_at": (
+                    paddle_subscription.expires_at.isoformat()
+                    if paddle_subscription.expires_at
+                    else None
+                ),
+                "price_id": paddle_subscription.price_id,
+                "status": paddle_subscription.status,
+            },
+            "source": "paddle_webhook",
+        }
+
     # Check RevenueCat if configured
     revenuecat_secret_key = os.getenv("REVENUECAT_SECRET_API_KEY", "")
     if revenuecat_secret_key:
@@ -134,3 +160,21 @@ async def get_subscription_status(request: Request) -> dict:
             }
 
     return {"has_subscription": False, "subscription": None, "source": "none"}
+
+
+async def _user_has_paddle_access(user_id: str) -> bool:
+    """Use the verified Paddle mirror without making an external API call."""
+    try:
+        return await _get_paddle_billing_service().user_has_access(user_id)
+    except Exception:
+        logger.exception("Paddle entitlement lookup failed for user %s", user_id)
+        return False
+
+
+async def _get_active_paddle_subscription(user_id: str):
+    """Read the active Paddle record for the non-blocking status dependency."""
+    try:
+        return await _get_paddle_billing_service().get_active_subscription(user_id)
+    except Exception:
+        logger.exception("Paddle subscription lookup failed for user %s", user_id)
+        return None

--- a/src/api/routes/v1/billing.py
+++ b/src/api/routes/v1/billing.py
@@ -1,0 +1,32 @@
+"""Authenticated Paddle customer billing routes."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import RedirectResponse
+
+from src.api.dependencies.auth import get_current_user_id
+from src.app.services.paddle_billing_service import PaddleBillingService
+from src.bootstrap.paddle_billing import get_paddle_billing_service
+from src.domain.exceptions.paddle_billing_exceptions import PaddleCustomerNotFoundError
+
+router = APIRouter(prefix="/v1/billing", tags=["Billing"])
+
+
+def _get_paddle_billing_service() -> PaddleBillingService:
+    return get_paddle_billing_service()
+
+
+@router.get("/paddle/customer-portal")
+async def redirect_to_paddle_customer_portal(
+    user_id: str = Depends(get_current_user_id),
+) -> RedirectResponse:
+    """Mint a Paddle-hosted customer portal session for the signed-in user."""
+    try:
+        portal_url = await _get_paddle_billing_service().create_customer_portal_url(
+            user_id
+        )
+    except PaddleCustomerNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No Paddle customer is linked to this account",
+        ) from exc
+    return RedirectResponse(portal_url, status_code=status.HTTP_303_SEE_OTHER)

--- a/src/api/routes/v1/paddle_webhooks.py
+++ b/src/api/routes/v1/paddle_webhooks.py
@@ -1,0 +1,61 @@
+"""Paddle webhook delivery endpoint."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from src.app.services.paddle_billing_service import PaddleBillingService
+from src.bootstrap.paddle_billing import get_paddle_billing_service
+from src.domain.exceptions.paddle_billing_exceptions import PaddleWebhookRetryError
+
+router = APIRouter(prefix="/v1/webhooks", tags=["Webhooks"])
+logger = logging.getLogger(__name__)
+
+
+def _get_paddle_billing_service() -> PaddleBillingService:
+    return get_paddle_billing_service()
+
+
+@router.post("/paddle", status_code=status.HTTP_200_OK)
+async def receive_paddle_webhook(request: Request) -> dict[str, str]:
+    """Verify and persist a Paddle event using its unparsed request body."""
+    raw_body = await request.body()
+    billing_service = _get_paddle_billing_service()
+
+    try:
+        signature_is_valid = billing_service.verify_webhook_signature(
+            raw_body, request.headers
+        )
+    except RuntimeError as exc:
+        logger.error("Paddle webhook is not configured: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Webhook verification is not configured",
+        ) from exc
+    except Exception:
+        logger.warning("Paddle webhook signature verification failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Paddle webhook signature",
+        ) from None
+
+    if not signature_is_valid:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Paddle webhook signature",
+        )
+
+    try:
+        return await billing_service.process_webhook(raw_body)
+    except PaddleWebhookRetryError as exc:
+        logger.info("Paddle webhook will be retried: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Paddle webhook dependency is not available yet",
+        ) from exc
+    except ValueError as exc:
+        logger.warning("Paddle webhook payload was invalid: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Paddle webhook payload",
+        ) from exc

--- a/src/app/services/paddle_billing_service.py
+++ b/src/app/services/paddle_billing_service.py
@@ -1,0 +1,32 @@
+"""Application boundary for Paddle billing and fulfillment."""
+
+from collections.abc import Mapping
+
+from src.domain.model.paddle_billing import PaddleSubscriptionStatus
+from src.domain.ports.paddle_billing_port import PaddleBillingPort
+
+
+class PaddleBillingService:
+    """Coordinates API requests through the Paddle billing port."""
+
+    def __init__(self, paddle_billing: PaddleBillingPort):
+        self._paddle_billing = paddle_billing
+
+    def verify_webhook_signature(
+        self, raw_body: bytes, headers: Mapping[str, str]
+    ) -> bool:
+        return self._paddle_billing.verify_webhook_signature(raw_body, headers)
+
+    async def process_webhook(self, raw_body: bytes) -> dict[str, str]:
+        return await self._paddle_billing.process_webhook(raw_body)
+
+    async def user_has_access(self, user_id: str) -> bool:
+        return await self._paddle_billing.user_has_access(user_id)
+
+    async def get_active_subscription(
+        self, user_id: str
+    ) -> PaddleSubscriptionStatus | None:
+        return await self._paddle_billing.get_active_subscription(user_id)
+
+    async def create_customer_portal_url(self, user_id: str) -> str:
+        return await self._paddle_billing.create_customer_portal_url(user_id)

--- a/src/bootstrap/paddle_billing.py
+++ b/src/bootstrap/paddle_billing.py
@@ -1,0 +1,9 @@
+"""Paddle billing composition root."""
+
+from src.app.services.paddle_billing_service import PaddleBillingService
+from src.infra.services.paddle_billing_gateway import PaddleBillingGateway
+
+
+def get_paddle_billing_service() -> PaddleBillingService:
+    """Construct the application service with its Paddle infrastructure adapter."""
+    return PaddleBillingService(PaddleBillingGateway())

--- a/src/domain/exceptions/paddle_billing_exceptions.py
+++ b/src/domain/exceptions/paddle_billing_exceptions.py
@@ -1,0 +1,9 @@
+"""Errors raised at the Paddle billing domain boundary."""
+
+
+class PaddleWebhookRetryError(Exception):
+    """A verified event needs a prerequisite delivery to be retried."""
+
+
+class PaddleCustomerNotFoundError(Exception):
+    """The authenticated application user has no linked Paddle customer."""

--- a/src/domain/model/paddle_billing.py
+++ b/src/domain/model/paddle_billing.py
@@ -1,0 +1,14 @@
+"""Provider-neutral values used by the Paddle billing boundary."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class PaddleSubscriptionStatus:
+    """The Paddle fields required by API entitlement responses."""
+
+    product_id: str
+    price_id: str | None
+    status: str
+    expires_at: datetime | None

--- a/src/domain/ports/paddle_billing_port.py
+++ b/src/domain/ports/paddle_billing_port.py
@@ -1,0 +1,34 @@
+"""Port for Paddle-specific billing operations."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+
+from src.domain.model.paddle_billing import PaddleSubscriptionStatus
+
+
+class PaddleBillingPort(ABC):
+    """Keeps Paddle SDK and persistence details outside the application layer."""
+
+    @abstractmethod
+    def verify_webhook_signature(
+        self, raw_body: bytes, headers: Mapping[str, str]
+    ) -> bool:
+        """Verify a raw Paddle webhook delivery."""
+
+    @abstractmethod
+    async def process_webhook(self, raw_body: bytes) -> dict[str, str]:
+        """Persist a verified Paddle webhook delivery."""
+
+    @abstractmethod
+    async def user_has_access(self, user_id: str) -> bool:
+        """Return whether a user has access from verified Paddle state."""
+
+    @abstractmethod
+    async def get_active_subscription(
+        self, user_id: str
+    ) -> PaddleSubscriptionStatus | None:
+        """Return a user's access-granting Paddle subscription."""
+
+    @abstractmethod
+    async def create_customer_portal_url(self, user_id: str) -> str:
+        """Create a Paddle-hosted portal URL for the authenticated user."""

--- a/src/infra/database/models/subscription.py
+++ b/src/infra/database/models/subscription.py
@@ -2,7 +2,7 @@
 Subscription model for tracking user subscriptions.
 """
 
-from sqlalchemy import Column, String, DateTime, Boolean, Enum, ForeignKey, Index
+from sqlalchemy import Boolean, Column, DateTime, Enum, ForeignKey, Index, String
 from sqlalchemy.orm import relationship
 
 from src.domain.utils.timezone_utils import utc_now
@@ -11,21 +11,22 @@ from src.infra.database.models.base import BaseMixin
 
 
 class Subscription(Base, BaseMixin):
-    """
-    Stores subscription records synced from RevenueCat.
-
-    RevenueCat is the source of truth - this table caches key data.
-    """
+    """Stores provider-specific subscription records for a user."""
 
     __tablename__ = "subscriptions"
 
     # User relationship
     user_id = Column(
-        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=True
     )
 
-    # RevenueCat data
-    revenuecat_subscriber_id = Column(String(255), nullable=False, index=True)
+    # Provider identifiers. RevenueCat rows keep revenuecat_subscriber_id;
+    # Paddle rows use the provider-specific IDs below.
+    provider = Column(String(32), nullable=False, default="revenuecat")
+    revenuecat_subscriber_id = Column(String(255), nullable=True, index=True)
+    provider_customer_id = Column(String(64), nullable=True)
+    provider_subscription_id = Column(String(64), nullable=True, unique=True)
+    price_id = Column(String(64), nullable=True)
     product_id = Column(
         String(255), nullable=False
     )  # "premium_monthly" or "premium_yearly"
@@ -39,6 +40,10 @@ class Subscription(Base, BaseMixin):
             "cancelled",
             "billing_issue",
             "refunded",
+            "trialing",
+            "paused",
+            "past_due",
+            "canceled",
             native_enum=False,
         ),
         nullable=False,
@@ -48,10 +53,11 @@ class Subscription(Base, BaseMixin):
     expires_at = Column(DateTime(timezone=True), nullable=True)
     cancelled_at = Column(DateTime(timezone=True), nullable=True)
 
-
     # Store metadata
     store_transaction_id = Column(String(255), nullable=True)
     is_sandbox = Column(Boolean, default=False, nullable=False)
+    scheduled_change_action = Column(String(64), nullable=True)
+    scheduled_change_at = Column(DateTime(timezone=True), nullable=True)
 
     # Relationships
     user = relationship("User", back_populates="subscriptions")
@@ -61,11 +67,20 @@ class Subscription(Base, BaseMixin):
         Index("idx_user_id_status", "user_id", "status"),
         Index("idx_expires_at", "expires_at"),
         Index("idx_revenuecat_subscriber_id", "revenuecat_subscriber_id"),
+        Index(
+            "idx_subscriptions_provider_customer", "provider", "provider_customer_id"
+        ),
+        Index(
+            "idx_subscriptions_provider_user_status", "provider", "user_id", "status"
+        ),
     )
 
     def is_active(self) -> bool:
         """Check if subscription is currently active."""
-        if self.status != "active":
+        access_statuses = (
+            {"active", "trialing"} if self.provider == "paddle" else {"active"}
+        )
+        if self.status not in access_statuses:
             return False
         if self.expires_at and utc_now() > self.expires_at:
             return False

--- a/src/infra/database/models/user/user.py
+++ b/src/infra/database/models/user/user.py
@@ -2,7 +2,7 @@
 Core user model for authentication and account management.
 """
 
-from sqlalchemy import Column, String, Boolean, DateTime, Text, Index, Enum
+from sqlalchemy import Boolean, Column, DateTime, Enum, Index, String, Text
 from sqlalchemy.orm import relationship
 
 from src.api.schemas.common.auth_enums import AuthProviderEnum
@@ -21,6 +21,7 @@ class User(Base, BaseMixin):
 
     # Basic Information
     email = Column(String(255), unique=True, nullable=False)
+    paddle_customer_id = Column(String(64), unique=True, nullable=True)
     username = Column(String(100), unique=True, nullable=False)
     first_name = Column(String(100), nullable=True)
     last_name = Column(String(100), nullable=True)

--- a/src/infra/repositories/subscription_repository_async.py
+++ b/src/infra/repositories/subscription_repository_async.py
@@ -54,7 +54,7 @@ class AsyncSubscriptionRepository(SubscriptionRepositoryPort):
             select(Subscription).where(
                 and_(
                     Subscription.user_id == user_id,
-                    Subscription.status == "active",
+                    Subscription.status.in_(("active", "trialing")),
                 )
             )
         )

--- a/src/infra/services/paddle_billing_gateway.py
+++ b/src/infra/services/paddle_billing_gateway.py
@@ -1,0 +1,101 @@
+"""Infrastructure implementation of the Paddle billing application port."""
+
+import asyncio
+from collections.abc import Mapping
+
+from sqlalchemy import select
+
+from src.domain.exceptions.paddle_billing_exceptions import PaddleCustomerNotFoundError
+from src.domain.model.paddle_billing import PaddleSubscriptionStatus
+from src.domain.ports.paddle_billing_port import PaddleBillingPort
+from src.infra.database.models.subscription import Subscription
+from src.infra.database.models.user.user import User
+from src.infra.database.uow_async import AsyncUnitOfWork
+from src.infra.services.paddle_client import build_paddle_client
+from src.infra.services.paddle_fulfillment_service import (
+    get_active_paddle_subscription,
+    process_verified_paddle_webhook,
+    user_has_paddle_access,
+    verify_paddle_webhook_signature,
+)
+
+
+class PaddleBillingGateway(PaddleBillingPort):
+    """Executes Paddle SDK calls and database work behind an application port."""
+
+    def verify_webhook_signature(
+        self, raw_body: bytes, headers: Mapping[str, str]
+    ) -> bool:
+        return verify_paddle_webhook_signature(raw_body, headers)
+
+    async def process_webhook(self, raw_body: bytes) -> dict[str, str]:
+        async with AsyncUnitOfWork() as uow:
+            if uow.session is None:
+                raise RuntimeError("Database session was not initialized")
+            return await process_verified_paddle_webhook(raw_body, uow.session)
+
+    async def user_has_access(self, user_id: str) -> bool:
+        async with AsyncUnitOfWork() as uow:
+            if uow.session is None:
+                return False
+            return await user_has_paddle_access(uow.session, user_id)
+
+    async def get_active_subscription(
+        self, user_id: str
+    ) -> PaddleSubscriptionStatus | None:
+        async with AsyncUnitOfWork() as uow:
+            if uow.session is None:
+                return None
+            subscription = await get_active_paddle_subscription(uow.session, user_id)
+        if subscription is None:
+            return None
+        return PaddleSubscriptionStatus(
+            product_id=subscription.product_id,
+            price_id=subscription.price_id,
+            status=subscription.status,
+            expires_at=subscription.expires_at,
+        )
+
+    async def create_customer_portal_url(self, user_id: str) -> str:
+        async with AsyncUnitOfWork() as uow:
+            if uow.session is None:
+                raise RuntimeError("Database session was not initialized")
+            customer_id = await uow.session.scalar(
+                select(User.paddle_customer_id).where(User.id == user_id)
+            )
+            if customer_id is None:
+                raise PaddleCustomerNotFoundError(
+                    "No Paddle customer is linked to this account"
+                )
+            result = await uow.session.execute(
+                select(Subscription.provider_subscription_id)
+                .where(
+                    Subscription.user_id == user_id,
+                    Subscription.provider == "paddle",
+                )
+                .order_by(Subscription.updated_at.desc())
+                .limit(25)
+            )
+            subscription_ids = list(result.scalars())
+
+        return await asyncio.to_thread(
+            _create_customer_portal_session, customer_id, subscription_ids
+        )
+
+
+def _create_customer_portal_session(
+    customer_id: str, subscription_ids: list[str]
+) -> str:
+    from paddle_billing.Resources.CustomerPortalSessions.Operations import (
+        CreateCustomerPortalSession,
+    )
+
+    operation = (
+        CreateCustomerPortalSession(subscription_ids=subscription_ids)
+        if subscription_ids
+        else CreateCustomerPortalSession()
+    )
+    session = build_paddle_client().customer_portal_sessions.create(
+        customer_id, operation
+    )
+    return session.urls.general.overview

--- a/src/infra/services/paddle_client.py
+++ b/src/infra/services/paddle_client.py
@@ -1,0 +1,34 @@
+"""Server-side Paddle SDK helpers."""
+
+import os
+
+
+def get_paddle_environment():
+    """Resolve Paddle environment from env without a silent default."""
+    raw_environment = os.getenv("PADDLE_ENVIRONMENT")
+    if not raw_environment:
+        raise RuntimeError("PADDLE_ENVIRONMENT must be set to 'production' or 'sandbox'")
+
+    from paddle_billing.Environment import Environment
+
+    normalized = raw_environment.strip().lower()
+    if normalized in {"production", "live"}:
+        return Environment.PRODUCTION
+    if normalized == "sandbox":
+        return Environment.SANDBOX
+    raise RuntimeError("PADDLE_ENVIRONMENT must be 'production', 'live', or 'sandbox'")
+
+
+def get_paddle_api_key() -> str:
+    """Read Paddle API key from env."""
+    api_key = os.getenv("PADDLE_API_KEY") or os.getenv("PADDLE_LIVE_API_KEY")
+    if not api_key:
+        raise RuntimeError("PADDLE_API_KEY must be set")
+    return api_key
+
+
+def build_paddle_client():
+    """Build the Paddle SDK client for server-side API calls."""
+    from paddle_billing import Client, Options
+
+    return Client(get_paddle_api_key(), options=Options(get_paddle_environment()))

--- a/src/infra/services/paddle_fulfillment_service.py
+++ b/src/infra/services/paddle_fulfillment_service.py
@@ -1,0 +1,274 @@
+"""Verified Paddle webhook fulfillment using the shared subscription records."""
+
+import json
+import logging
+import os
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.exceptions.paddle_billing_exceptions import PaddleWebhookRetryError
+from src.domain.utils.timezone_utils import ensure_utc, utc_now
+from src.infra.database.models.subscription import Subscription
+from src.infra.database.models.user.user import User
+
+logger = logging.getLogger(__name__)
+
+HANDLED_EVENT_TYPES = {
+    "subscription.created",
+    "subscription.updated",
+    "subscription.canceled",
+    "customer.created",
+    "customer.updated",
+    "transaction.completed",
+}
+
+
+@dataclass(frozen=True)
+class PaddleWebhookRequest:
+    """Minimal request adapter consumed by Paddle's Python verifier."""
+
+    body: bytes
+    headers: Mapping[str, str]
+
+
+def verify_paddle_webhook_signature(
+    raw_body: bytes, headers: Mapping[str, str]
+) -> bool:
+    """Verify a webhook before decoding its unparsed request body."""
+    secret = os.getenv("PADDLE_WEBHOOK_SIGNING_SECRET")
+    if not secret:
+        raise RuntimeError("PADDLE_WEBHOOK_SIGNING_SECRET must be set")
+
+    from paddle_billing.Notifications import Secret, Verifier
+
+    return bool(
+        Verifier().verify(PaddleWebhookRequest(raw_body, headers), Secret(secret))
+    )
+
+
+async def process_verified_paddle_webhook(
+    raw_body: bytes, session: AsyncSession
+) -> dict[str, str]:
+    """Route a signature-verified webhook to an idempotent persistence handler."""
+    event = json.loads(raw_body.decode("utf-8"))
+    event_id = _required_text(event, "event_id")
+    event_type = _required_text(event, "event_type")
+
+    if event_type not in HANDLED_EVENT_TYPES:
+        logger.info("Ignoring verified Paddle event type %s", event_type)
+        return {"status": "ignored", "event_type": event_type, "event_id": event_id}
+
+    data = event.get("data") or {}
+    if event_type.startswith("customer."):
+        await _handle_customer(session, data)
+    elif event_type.startswith("subscription."):
+        await _handle_subscription(session, data)
+    else:
+        await _handle_transaction_completed(session, data)
+
+    return {"status": "processed", "event_type": event_type, "event_id": event_id}
+
+
+async def user_has_paddle_access(session: AsyncSession, user_id: str) -> bool:
+    """Return whether an existing Paddle subscription currently grants access."""
+    return await get_active_paddle_subscription(session, user_id) is not None
+
+
+async def get_active_paddle_subscription(
+    session: AsyncSession, user_id: str
+) -> Subscription | None:
+    """Return the first access-granting Paddle subscription for a user."""
+    result = await session.execute(
+        select(Subscription).where(
+            Subscription.user_id == user_id,
+            Subscription.provider == "paddle",
+            Subscription.status.in_(("active", "trialing")),
+        )
+    )
+    return next((item for item in result.scalars() if item.is_active()), None)
+
+
+async def _handle_customer(session: AsyncSession, data: dict[str, object]) -> None:
+    customer_id = _required_text(data, "id")
+    email = _required_text(data, "email").lower()
+    result = await session.execute(
+        select(User.id).where(func.lower(User.email) == email)
+    )
+    user_id = result.scalar_one_or_none()
+    if user_id is None:
+        logger.info("Paddle customer %s has no matching application user", customer_id)
+        return
+
+    linked = await session.execute(
+        update(User)
+        .where(
+            User.id == user_id,
+            or_(
+                User.paddle_customer_id.is_(None),
+                User.paddle_customer_id == customer_id,
+            ),
+        )
+        .values(paddle_customer_id=customer_id, updated_at=utc_now())
+    )
+    if not linked.rowcount:
+        logger.warning("Refusing to replace Paddle customer link for user %s", user_id)
+        return
+
+    await session.execute(
+        update(Subscription)
+        .where(
+            Subscription.provider == "paddle",
+            Subscription.provider_customer_id == customer_id,
+            Subscription.user_id.is_(None),
+        )
+        .values(user_id=str(user_id), updated_at=utc_now())
+    )
+
+
+async def _handle_subscription(session: AsyncSession, data: dict[str, object]) -> None:
+    customer_id = _required_text(data, "customer_id")
+    user_id = await _find_user_id_by_customer_id(session, customer_id)
+    price_id, product_id = _extract_subscription_price(data)
+    scheduled_change = data.get("scheduled_change") or {}
+    if not isinstance(scheduled_change, dict):
+        scheduled_change = {}
+    updated_at = _parse_time(data.get("updated_at")) or utc_now()
+    created_at = _parse_time(data.get("created_at")) or updated_at
+    subscription_id = _required_text(data, "id")
+    status = _required_text(data, "status")
+
+    statement = insert(Subscription).values(
+        id=str(uuid.uuid4()),
+        user_id=user_id,
+        provider="paddle",
+        revenuecat_subscriber_id=None,
+        provider_customer_id=customer_id,
+        provider_subscription_id=subscription_id,
+        status=status,
+        price_id=price_id,
+        product_id=product_id,
+        platform="web",
+        purchased_at=created_at,
+        expires_at=_extract_period_end(data),
+        cancelled_at=updated_at if status in {"canceled", "cancelled"} else None,
+        scheduled_change_action=_optional_text(scheduled_change.get("action")),
+        scheduled_change_at=_parse_time(
+            scheduled_change.get("effective_at") or scheduled_change.get("resume_at")
+        ),
+        store_transaction_id=None,
+        is_sandbox=False,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+    await session.execute(
+        statement.on_conflict_do_update(
+            index_elements=["provider_subscription_id"],
+            set_={
+                "user_id": func.coalesce(
+                    Subscription.user_id, statement.excluded.user_id
+                ),
+                "provider_customer_id": customer_id,
+                "status": status,
+                "price_id": price_id,
+                "product_id": product_id,
+                "expires_at": _extract_period_end(data),
+                "cancelled_at": updated_at
+                if status in {"canceled", "cancelled"}
+                else None,
+                "scheduled_change_action": _optional_text(
+                    scheduled_change.get("action")
+                ),
+                "scheduled_change_at": _parse_time(
+                    scheduled_change.get("effective_at")
+                    or scheduled_change.get("resume_at")
+                ),
+                "updated_at": updated_at,
+            },
+            where=Subscription.updated_at <= updated_at,
+        )
+    )
+
+
+async def _handle_transaction_completed(
+    session: AsyncSession, data: dict[str, object]
+) -> None:
+    """Attach the completed Paddle transaction to its already-mirrored subscription."""
+    subscription_id = _optional_text(data.get("subscription_id"))
+    if subscription_id is None:
+        logger.info("Ignoring non-subscription Paddle transaction %s", data.get("id"))
+        return
+
+    price_id, product_id = _extract_transaction_price(data)
+    updated = await session.execute(
+        update(Subscription)
+        .where(
+            Subscription.provider == "paddle",
+            Subscription.provider_subscription_id == subscription_id,
+        )
+        .values(
+            store_transaction_id=_required_text(data, "id"),
+            price_id=func.coalesce(price_id, Subscription.price_id),
+            product_id=func.coalesce(product_id, Subscription.product_id),
+            updated_at=_parse_time(data.get("updated_at")) or utc_now(),
+        )
+    )
+    if not updated.rowcount:
+        raise PaddleWebhookRetryError(
+            f"Paddle subscription {subscription_id} has not been delivered yet"
+        )
+
+
+async def _find_user_id_by_customer_id(
+    session: AsyncSession, customer_id: str
+) -> str | None:
+    result = await session.execute(
+        select(User.id).where(User.paddle_customer_id == customer_id)
+    )
+    user_id = result.scalar_one_or_none()
+    return str(user_id) if user_id else None
+
+
+def _extract_subscription_price(data: dict[str, object]) -> tuple[str, str]:
+    items = data.get("items") or [{}]
+    first_item = items[0] if isinstance(items, list) and items else {}
+    price = first_item.get("price") if isinstance(first_item, dict) else None
+    return _required_text(price or {}, "id"), _required_text(price or {}, "product_id")
+
+
+def _extract_transaction_price(
+    data: dict[str, object],
+) -> tuple[str | None, str | None]:
+    details = data.get("details") or {}
+    line_items = details.get("line_items") if isinstance(details, dict) else None
+    first_item = line_items[0] if isinstance(line_items, list) and line_items else {}
+    return _optional_text(first_item.get("price_id")), _optional_text(
+        first_item.get("product_id")
+    )
+
+
+def _extract_period_end(data: dict[str, object]) -> datetime | None:
+    period = data.get("current_billing_period") or {}
+    return _parse_time(period.get("ends_at") if isinstance(period, dict) else None)
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return ensure_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
+def _optional_text(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _required_text(data: dict[str, object], key: str) -> str:
+    value = _optional_text(data.get(key))
+    if value is None:
+        raise ValueError(f"Paddle payload missing required field: {key}")
+    return value

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""MealTrack test package."""

--- a/tests/unit/api/routes/test_billing.py
+++ b/tests/unit/api/routes/test_billing.py
@@ -1,0 +1,63 @@
+"""Paddle customer portal SDK boundary tests."""
+
+import pytest
+
+from src.api.routes.v1 import billing
+from src.infra.services import paddle_billing_gateway
+
+
+def test_customer_portal_session_uses_paddle_customer_and_subscription_ids(monkeypatch):
+    received = {}
+
+    class FakeClient:
+        class customer_portal_sessions:
+            @staticmethod
+            def create(customer_id, operation):
+                received["customer_id"] = customer_id
+                received["subscription_ids"] = operation.subscription_ids
+                return type(
+                    "PortalSession",
+                    (),
+                    {
+                        "urls": type(
+                            "Urls",
+                            (),
+                            {
+                                "general": type(
+                                    "General",
+                                    (),
+                                    {"overview": "https://customer-portal.example"},
+                                )()
+                            },
+                        )()
+                    },
+                )()
+
+    monkeypatch.setattr(
+        paddle_billing_gateway, "build_paddle_client", lambda: FakeClient()
+    )
+
+    url = paddle_billing_gateway._create_customer_portal_session("ctm_123", ["sub_123"])
+
+    assert url == "https://customer-portal.example"
+    assert received == {"customer_id": "ctm_123", "subscription_ids": ["sub_123"]}
+
+
+@pytest.mark.asyncio
+async def test_customer_portal_route_uses_the_authenticated_user(monkeypatch):
+    received = {}
+
+    class FakeBillingService:
+        async def create_customer_portal_url(self, user_id):
+            received["user_id"] = user_id
+            return "https://customer-portal.example"
+
+    monkeypatch.setattr(
+        billing, "_get_paddle_billing_service", lambda: FakeBillingService()
+    )
+
+    response = await billing.redirect_to_paddle_customer_portal("user_123")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://customer-portal.example"
+    assert received == {"user_id": "user_123"}

--- a/tests/unit/api/routes/test_paddle_webhooks.py
+++ b/tests/unit/api/routes/test_paddle_webhooks.py
@@ -1,0 +1,82 @@
+"""Paddle webhook route contract tests."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes.v1 import paddle_webhooks
+from src.domain.exceptions.paddle_billing_exceptions import PaddleWebhookRetryError
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(paddle_webhooks.router)
+    return TestClient(app)
+
+
+def test_invalid_signature_is_rejected_before_payload_processing(monkeypatch):
+    class FakeBillingService:
+        def verify_webhook_signature(self, *_args):
+            return False
+
+        async def process_webhook(self, *_args):
+            raise AssertionError("unverified payload must never be processed")
+
+    monkeypatch.setattr(
+        paddle_webhooks, "_get_paddle_billing_service", lambda: FakeBillingService()
+    )
+
+    response = _client().post(
+        "/v1/webhooks/paddle",
+        content=b"not valid JSON",
+        headers={"Paddle-Signature": "invalid"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_valid_signature_dispatches_the_original_raw_body(monkeypatch):
+    raw_body = b'{"event_id":"evt_1","event_type":"customer.created"}'
+    received = {}
+
+    class FakeBillingService:
+        def verify_webhook_signature(self, *_args):
+            return True
+
+        async def process_webhook(self, body):
+            received["body"] = body
+            return {"status": "processed", "event_type": "customer.created"}
+
+    monkeypatch.setattr(
+        paddle_webhooks, "_get_paddle_billing_service", lambda: FakeBillingService()
+    )
+
+    response = _client().post(
+        "/v1/webhooks/paddle",
+        content=raw_body,
+        headers={"Paddle-Signature": "valid"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "processed"
+    assert received["body"] == raw_body
+
+
+def test_verified_event_with_missing_dependency_returns_non_2xx(monkeypatch):
+    class FakeBillingService:
+        def verify_webhook_signature(self, *_args):
+            return True
+
+        async def process_webhook(self, *_args):
+            raise PaddleWebhookRetryError("subscription delivery pending")
+
+    monkeypatch.setattr(
+        paddle_webhooks, "_get_paddle_billing_service", lambda: FakeBillingService()
+    )
+
+    response = _client().post(
+        "/v1/webhooks/paddle",
+        content=b'{"event_id":"evt_2","event_type":"transaction.completed"}',
+        headers={"Paddle-Signature": "valid"},
+    )
+
+    assert response.status_code == 409

--- a/tests/unit/api/test_premium_middleware.py
+++ b/tests/unit/api/test_premium_middleware.py
@@ -9,14 +9,28 @@ import pytest
 from fastapi import HTTPException, Request
 
 from src.api.middleware.premium_check import (
-    require_subscription,
     get_subscription_status,
+    require_subscription,
 )
 
 
 @pytest.mark.asyncio
 class TestSubscriptionMiddleware:
     """Test suite for subscription middleware."""
+
+    @pytest.fixture(autouse=True)
+    def no_paddle_subscription(self):
+        with (
+            patch(
+                "src.api.middleware.premium_check._user_has_paddle_access",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "src.api.middleware.premium_check._get_active_paddle_subscription",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            yield
 
     @pytest.fixture
     def mock_request(self):
@@ -94,6 +108,19 @@ class TestSubscriptionMiddleware:
                 mock_service.has_active_subscription.assert_called_once_with(
                     app_user_id="firebase_uid_456"
                 )
+
+    async def test_require_subscription_allows_verified_paddle_access(
+        self, mock_request, mock_user_without_subscription
+    ):
+        mock_request.state.user = mock_user_without_subscription
+
+        with patch(
+            "src.api.middleware.premium_check._user_has_paddle_access",
+            new=AsyncMock(return_value=True),
+        ):
+            result = await require_subscription(mock_request)
+
+        assert result is None
 
     async def test_require_subscription_denies_without_any_subscription(
         self, mock_request, mock_user_without_subscription

--- a/tests/unit/infra/models/test_paddle_subscription_model.py
+++ b/tests/unit/infra/models/test_paddle_subscription_model.py
@@ -1,0 +1,44 @@
+"""Paddle access-state tests."""
+
+from datetime import timedelta
+
+from src.domain.utils.timezone_utils import utc_now
+from src.infra.database.models.subscription import Subscription
+
+
+def _subscription(status: str, ends_in_days: int | None = 30) -> Subscription:
+    period_end = None
+    if ends_in_days is not None:
+        period_end = utc_now() + timedelta(days=ends_in_days)
+    return Subscription(
+        provider="paddle",
+        provider_subscription_id="sub_test",
+        provider_customer_id="ctm_test",
+        status=status,
+        price_id="pri_test",
+        product_id="pro_test",
+        platform="web",
+        purchased_at=utc_now(),
+        expires_at=period_end,
+    )
+
+
+def test_active_subscription_grants_access_with_scheduled_cancellation():
+    subscription = _subscription("active")
+    subscription.scheduled_change_action = "cancel"
+
+    assert subscription.is_active() is True
+
+
+def test_trialing_subscription_grants_access():
+    assert _subscription("trialing").is_active() is True
+
+
+def test_canceled_paused_and_past_due_subscriptions_do_not_grant_access():
+    assert _subscription("canceled").is_active() is False
+    assert _subscription("paused").is_active() is False
+    assert _subscription("past_due").is_active() is False
+
+
+def test_expired_active_subscription_does_not_grant_access():
+    assert _subscription("active", ends_in_days=-1).is_active() is False

--- a/tests/unit/infra/services/test_paddle_webhook_signature.py
+++ b/tests/unit/infra/services/test_paddle_webhook_signature.py
@@ -1,0 +1,44 @@
+"""Paddle SDK webhook verification tests."""
+
+import hashlib
+import hmac
+import time
+
+from src.infra.services.paddle_fulfillment_service import (
+    verify_paddle_webhook_signature,
+)
+
+
+def test_paddle_sdk_verifies_a_valid_raw_payload_signature(monkeypatch):
+    secret = "unit-test-webhook-secret"
+    raw_body = b'{"event_id":"evt_1","event_type":"customer.created"}'
+    timestamp = str(int(time.time()))
+    signature = hmac.new(
+        secret.encode(), f"{timestamp}:{raw_body.decode()}".encode(), hashlib.sha256
+    ).hexdigest()
+    monkeypatch.setenv("PADDLE_WEBHOOK_SIGNING_SECRET", secret)
+
+    assert (
+        verify_paddle_webhook_signature(
+            raw_body, {"Paddle-Signature": f"ts={timestamp};h1={signature}"}
+        )
+        is True
+    )
+
+
+def test_paddle_sdk_rejects_a_signature_for_different_raw_body(monkeypatch):
+    secret = "unit-test-webhook-secret"
+    timestamp = str(int(time.time()))
+    signed_body = b'{"event_id":"evt_1"}'
+    signature = hmac.new(
+        secret.encode(), f"{timestamp}:{signed_body.decode()}".encode(), hashlib.sha256
+    ).hexdigest()
+    monkeypatch.setenv("PADDLE_WEBHOOK_SIGNING_SECRET", secret)
+
+    assert (
+        verify_paddle_webhook_signature(
+            b'{"event_id":"evt_modified"}',
+            {"Paddle-Signature": f"ts={timestamp};h1={signature}"},
+        )
+        is False
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1310,6 +1310,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-langchain" },
+    { name = "paddle-python-sdk" },
     { name = "pgvector" },
     { name = "pillow" },
     { name = "posthog", extra = ["otel"] },
@@ -1377,6 +1378,7 @@ requires-dist = [
     { name = "langgraph", specifier = "==1.2.8" },
     { name = "openai", specifier = ">=2.14.0,<3.0.0" },
     { name = "opentelemetry-instrumentation-langchain", specifier = "==0.61.0" },
+    { name = "paddle-python-sdk", specifier = "==1.15.0" },
     { name = "pgvector", specifier = "==0.4.2" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "posthog", extras = ["otel"], specifier = "==7.18.3" },
@@ -1711,6 +1713,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "paddle-python-sdk"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/f2/b924002397c449cdcd1d0e39bbbb3791f7aed55a9df7802c3515c3d39029/paddle_python_sdk-1.15.0.tar.gz", hash = "sha256:2349490dd21754fab0f96b605109a38f208a1778be07121e881eacef02c87c79", size = 187424, upload-time = "2026-07-28T15:38:24.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/c8/2d8c93128a650d7e0a3fa6e410aaf681668bc91f2e172ccb7714fb40a66c/paddle_python_sdk-1.15.0-py3-none-any.whl", hash = "sha256:3250f3bcb6a4106c03512958533d25cca6a2c572e33004013dd6131b10329f06", size = 514761, upload-time = "2026-07-28T15:38:22.52Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add SDK-verified, raw-body Paddle webhook handling with idempotent customer, subscription, and transaction mirrors.
- Grant premium access from verified active or trialing Paddle subscriptions and add an authenticated Paddle customer-portal redirect.
- Add the forward-only delivery migration, Paddle SDK dependency, environment template, documentation, and webhook/portal/access tests.

## Test plan
- [x] `uv run python -m alembic heads`
- [x] `uv run python -m ruff check ...`
- [x] `uv run pytest tests/unit -q --cov=src --cov-fail-under=65` (2093 passed)