### PR TITLE
fix: sync main migration repairs into delivery

### DIFF
--- a/migrations/versions/20260716000001_add_body_fat_visual_profiles.py
+++ b/migrations/versions/20260716000001_add_body_fat_visual_profiles.py
@@ -14,6 +14,10 @@ depends_on = None
 
 
 def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if inspector.has_table("body_fat_visual_profiles"):
+        return
+
     op.create_table(
         "body_fat_visual_profiles",
         sa.Column("id", sa.String(length=36), nullable=False),

--- a/migrations/versions/20260718000001_add_target_revisions.py
+++ b/migrations/versions/20260718000001_add_target_revisions.py
@@ -14,18 +14,27 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "user_profiles",
-        sa.Column(
-            "profile_target_revision", sa.Integer(), nullable=False, server_default="1"
-        ),
-    )
-    op.add_column(
-        "weekly_macro_budgets",
-        sa.Column("target_revision", sa.Integer(), nullable=False, server_default="1"),
-    )
-    op.alter_column("user_profiles", "profile_target_revision", server_default=None)
-    op.alter_column("weekly_macro_budgets", "target_revision", server_default=None)
+    inspector = sa.inspect(op.get_bind())
+    profile_columns = {column["name"] for column in inspector.get_columns("user_profiles")}
+    budget_columns = {
+        column["name"] for column in inspector.get_columns("weekly_macro_budgets")
+    }
+
+    if "profile_target_revision" not in profile_columns:
+        op.add_column(
+            "user_profiles",
+            sa.Column(
+                "profile_target_revision", sa.Integer(), nullable=False, server_default="1"
+            ),
+        )
+        op.alter_column("user_profiles", "profile_target_revision", server_default=None)
+
+    if "target_revision" not in budget_columns:
+        op.add_column(
+            "weekly_macro_budgets",
+            sa.Column("target_revision", sa.Integer(), nullable=False, server_default="1"),
+        )
+        op.alter_column("weekly_macro_budgets", "target_revision", server_default=None)
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260726000001_add_body_fat_visual_start_range.py
+++ b/migrations/versions/20260726000001_add_body_fat_visual_start_range.py
@@ -14,6 +14,13 @@ depends_on = None
 
 
 def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    columns = {
+        column["name"] for column in inspector.get_columns("body_fat_visual_profiles")
+    }
+    if "start_range_id" in columns:
+        return
+
     op.add_column(
         "body_fat_visual_profiles",
         sa.Column("start_range_id", sa.String(length=20), nullable=True),

--- a/migrations/versions/20260727000001_add_meal_recommendation_candidate_lifecycle.py
+++ b/migrations/versions/20260727000001_add_meal_recommendation_candidate_lifecycle.py
@@ -10,6 +10,10 @@ depends_on = None
 
 
 def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table("meal_recommendations"):
+        return
+
     op.add_column(
         "meal_recommendations",
         sa.Column("seen_at", sa.DateTime(timezone=True), nullable=True),

--- a/migrations/versions/20260730102158384558_ensure_food_item_allowed_units.py
+++ b/migrations/versions/20260730102158384558_ensure_food_item_allowed_units.py
@@ -24,10 +24,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    inspector = sa.inspect(op.get_bind())
-    if not inspector.has_table("food_item"):
-        return
-
-    columns = {column["name"] for column in inspector.get_columns("food_item")}
-    if "allowed_units" in columns:
-        op.drop_column("food_item", "allowed_units")
+    """Preserve a column that may have existed before this forward repair."""

--- a/migrations/versions/20260730102158384558_ensure_food_item_allowed_units.py
+++ b/migrations/versions/20260730102158384558_ensure_food_item_allowed_units.py
@@ -1,0 +1,33 @@
+"""Ensure legacy deployments expose food item allowed units."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260730102158384558"
+down_revision: str | None = "20260730000004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table("food_item"):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("food_item")}
+    if "allowed_units" in columns:
+        return
+
+    op.add_column("food_item", sa.Column("allowed_units", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table("food_item"):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("food_item")}
+    if "allowed_units" in columns:
+        op.drop_column("food_item", "allowed_units")

--- a/migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py
+++ b/migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py
@@ -1,0 +1,143 @@
+"""Restore catalog tables skipped by a legacy Alembic revision collision.
+
+The original catalog branch shares history with a revision identifier that was
+also used by the body-fat branch. Legacy deployments can therefore reach the
+merged head without creating any catalog tables. This is deliberately a
+forward-only repair: it preserves existing catalog data and only reconstructs
+the schema when every catalog table is absent.
+"""
+
+import importlib.util
+from collections.abc import Sequence
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260730110500000000"
+down_revision: str | None = "20260730102158384558"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+CATALOG_TABLES = frozenset(
+    {
+        "meal_catalog",
+        "meal_catalog_ingredients",
+        "meal_recommendations",
+        "meal_recommendation_operations",
+    }
+)
+
+
+def _run_catalog_baseline_upgrade() -> None:
+    """Run the immutable catalog baseline only for an entirely absent schema."""
+    baseline_path = Path(__file__).with_name(
+        "20260716000001_add_catalog_recipe_tables.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "catalog_recipe_tables_baseline", baseline_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Catalog baseline migration could not be loaded")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.upgrade()
+
+
+def _add_catalog_branch_follow_up_schema() -> None:
+    """Apply the additive catalog-branch migrations skipped with the baseline."""
+    op.add_column(
+        "meal_recommendations",
+        sa.Column("shown_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "meal_recommendations",
+        sa.Column("skipped_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_meal_recommendations_skip_terminal",
+        "meal_recommendations",
+        "skipped_at IS NULL OR (logged_at IS NULL AND logged_meal_id IS NULL)",
+    )
+    op.add_column(
+        "meal_recommendations",
+        sa.Column("seen_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "meal_recommendations",
+        sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        "UPDATE meal_recommendations SET seen_at = COALESCE(seen_at, created_at) "
+        "WHERE is_selected = TRUE"
+    )
+
+    op.drop_constraint(
+        "ck_meal_recommendation_operations_type",
+        "meal_recommendation_operations",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_meal_recommendation_operations_type",
+        "meal_recommendation_operations",
+        "operation_type IN ('swap', 'log', 'skip')",
+    )
+    op.drop_constraint(
+        "ck_meal_recommendation_operations_payload",
+        "meal_recommendation_operations",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_meal_recommendation_operations_payload",
+        "meal_recommendation_operations",
+        "("
+        "operation_type = 'swap' AND result_selection_version IS NOT NULL "
+        "AND result_catalog_meal_id IS NOT NULL AND result_logged_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'log' AND result_logged_meal_id IS NOT NULL "
+        "AND result_catalog_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'skip' AND result_selection_version IS NULL "
+        "AND result_catalog_meal_id IS NULL AND result_logged_meal_id IS NULL"
+        ")",
+    )
+
+
+def _ensure_food_reference_search_index(inspector: sa.Inspector) -> None:
+    if not inspector.has_table("food_reference"):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("food_reference")}
+    if "name_normalized" not in columns:
+        raise RuntimeError("food_reference.name_normalized is required for catalog search")
+
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_food_reference_name_normalized_trgm "
+        "ON food_reference USING gin (name_normalized gin_trgm_ops)"
+    )
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    existing_tables = {
+        table_name for table_name in CATALOG_TABLES if inspector.has_table(table_name)
+    }
+
+    if existing_tables and existing_tables != CATALOG_TABLES:
+        missing_tables = ", ".join(sorted(CATALOG_TABLES - existing_tables))
+        raise RuntimeError(
+            "Catalog schema is partially present; refusing automatic repair. "
+            f"Missing tables: {missing_tables}"
+        )
+
+    if not existing_tables:
+        _run_catalog_baseline_upgrade()
+        _add_catalog_branch_follow_up_schema()
+
+    _ensure_food_reference_search_index(inspector)
+
+
+def downgrade() -> None:
+    """Keep the forward repair schema intact if a release is rolled back."""

--- a/migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py
+++ b/migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py
@@ -112,6 +112,10 @@ def _ensure_food_reference_search_index(inspector: sa.Inspector) -> None:
     if "name_normalized" not in columns:
         raise RuntimeError("food_reference.name_normalized is required for catalog search")
 
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ux_food_reference_name_normalized "
+        "ON food_reference (name_normalized)"
+    )
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_food_reference_name_normalized_trgm "

--- a/src/domain/services/meal_recommendation/ingredient_quantity_conversion_service.py
+++ b/src/domain/services/meal_recommendation/ingredient_quantity_conversion_service.py
@@ -158,6 +158,7 @@ class IngredientQuantityConversionService:
             )
         if (
             reference.source.lower() not in self._approved_sources
+            and not reference.is_verified
             and not self._allow_unapproved_sources
         ):
             raise IngredientQuantityConversionError(
@@ -184,9 +185,8 @@ class IngredientQuantityConversionService:
             )
         fiber = reference.fiber_100g or 0.0
         sugar = reference.sugar_100g or 0.0
-        if (
-            not self._allow_implausible_macros
-            and (fiber > carbs_100g or sugar > carbs_100g or fiber + sugar > carbs_100g)
+        if not self._allow_implausible_macros and (
+            fiber > carbs_100g or sugar > carbs_100g or fiber + sugar > carbs_100g
         ):
             raise IngredientQuantityConversionError(
                 "implausible_macro_snapshot",
@@ -270,9 +270,11 @@ class IngredientQuantityConversionService:
         weights = {
             (
                 round(serving.grams, 6) if serving.grams is not None else None,
-                round(serving.milliliters, 6)
-                if serving.milliliters is not None
-                else None,
+                (
+                    round(serving.milliliters, 6)
+                    if serving.milliliters is not None
+                    else None
+                ),
             )
             for serving in matches
         }

--- a/src/domain/services/meal_recommendation/ingredient_quantity_conversion_service.py
+++ b/src/domain/services/meal_recommendation/ingredient_quantity_conversion_service.py
@@ -183,15 +183,6 @@ class IngredientQuantityConversionService:
                 "incomplete_macro_snapshot",
                 f"Food reference {reference.id} has invalid fiber or sugar.",
             )
-        fiber = reference.fiber_100g or 0.0
-        sugar = reference.sugar_100g or 0.0
-        if not self._allow_implausible_macros and (
-            fiber > carbs_100g or sugar > carbs_100g or fiber + sugar > carbs_100g
-        ):
-            raise IngredientQuantityConversionError(
-                "implausible_macro_snapshot",
-                f"Food reference {reference.id} fiber or sugar exceeds carbs.",
-            )
         macro_mass = protein_100g + carbs_100g + fat_100g
         if macro_mass > 110.0 and not self._allow_implausible_macros:
             raise IngredientQuantityConversionError(

--- a/tests/migrations/test_alembic_revision_graph.py
+++ b/tests/migrations/test_alembic_revision_graph.py
@@ -11,4 +11,4 @@ def test_alembic_revision_graph_has_single_head() -> None:
 
     assert heads == [current_head]
     assert current_head is not None
-    assert re.fullmatch(r"\d{3}|\d{14}", current_head)
+    assert re.fullmatch(r"\d{3}|\d{14}|\d{20}", current_head)

--- a/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
+++ b/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
@@ -23,6 +23,10 @@ MIGRATIONS = (
         "20260727000001_add_meal_recommendation_candidate_lifecycle.py",
         {},
     ),
+    (
+        "20260730102158384558_ensure_food_item_allowed_units.py",
+        {"food_item": {"allowed_units"}},
+    ),
 )
 
 
@@ -68,3 +72,26 @@ def test_upgrade_skips_ddl_when_legacy_body_fat_schema_exists(
     module.upgrade()
 
     assert operations.calls == []
+
+
+def test_allowed_units_repair_adds_missing_legacy_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filename = "20260730102158384558_ensure_food_item_allowed_units.py"
+    path = Path("migrations/versions") / filename
+    spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    operations = _Operations()
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector({"food_item": {"id"}}),
+    )
+
+    module.upgrade()
+
+    assert operations.calls == ["add_column"]

--- a/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
+++ b/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
@@ -95,3 +95,26 @@ def test_allowed_units_repair_adds_missing_legacy_column(
     module.upgrade()
 
     assert operations.calls == ["add_column"]
+
+
+def test_allowed_units_repair_downgrade_preserves_existing_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filename = "20260730102158384558_ensure_food_item_allowed_units.py"
+    path = Path("migrations/versions") / filename
+    spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    operations = _Operations()
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector({"food_item": {"id", "allowed_units"}}),
+    )
+
+    module.downgrade()
+
+    assert operations.calls == []

--- a/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
+++ b/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
@@ -1,0 +1,66 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MIGRATIONS = (
+    (
+        "20260716000001_add_body_fat_visual_profiles.py",
+        {"body_fat_visual_profiles": {"id"}},
+    ),
+    (
+        "20260718000001_add_target_revisions.py",
+        {
+            "user_profiles": {"profile_target_revision"},
+            "weekly_macro_budgets": {"target_revision"},
+        },
+    ),
+    (
+        "20260726000001_add_body_fat_visual_start_range.py",
+        {"body_fat_visual_profiles": {"start_range_id"}},
+    ),
+)
+
+
+class _Inspector:
+    def __init__(self, schema: dict[str, set[str]]) -> None:
+        self._schema = schema
+
+    def has_table(self, table_name: str) -> bool:
+        return table_name in self._schema
+
+    def get_columns(self, table_name: str) -> list[dict[str, str]]:
+        return [{"name": name} for name in self._schema[table_name]]
+
+
+class _Operations:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_bind(self) -> object:
+        return object()
+
+    def __getattr__(self, name: str):
+        def operation(*_args, **_kwargs) -> None:
+            self.calls.append(name)
+
+        return operation
+
+
+@pytest.mark.parametrize(("filename", "schema"), MIGRATIONS)
+def test_upgrade_skips_ddl_when_legacy_body_fat_schema_exists(
+    filename: str, schema: dict[str, set[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = Path("migrations/versions") / filename
+    spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    operations = _Operations()
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(module.sa, "inspect", lambda _bind: _Inspector(schema))
+
+    module.upgrade()
+
+    assert operations.calls == []

--- a/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
+++ b/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
@@ -19,6 +19,10 @@ MIGRATIONS = (
         "20260726000001_add_body_fat_visual_start_range.py",
         {"body_fat_visual_profiles": {"start_range_id"}},
     ),
+    (
+        "20260727000001_add_meal_recommendation_candidate_lifecycle.py",
+        {},
+    ),
 )
 
 

--- a/tests/migrations/test_catalog_recipe_tables_migration.py
+++ b/tests/migrations/test_catalog_recipe_tables_migration.py
@@ -34,9 +34,7 @@ def test_catalog_schema_has_one_head_and_no_stored_calories() -> None:
     text = MIGRATION.read_text()
     catalog_section = text.split('"meal_catalog_ingredients"')[0]
 
-    assert [
-        revision.revision for revision in script_dir.get_revisions("heads")
-    ] == ["20260730000004"]
+    assert len(script_dir.get_heads()) == 1
     assert '"calories"' not in catalog_section
 
 

--- a/tests/migrations/test_catalog_recipe_tables_migration.py
+++ b/tests/migrations/test_catalog_recipe_tables_migration.py
@@ -36,7 +36,7 @@ def test_catalog_schema_has_one_head_and_no_stored_calories() -> None:
 
     assert [
         revision.revision for revision in script_dir.get_revisions("heads")
-    ] == ["20260727000001"]
+    ] == ["20260730000004"]
     assert '"calories"' not in catalog_section
 
 

--- a/tests/migrations/test_restore_missing_meal_catalog_schema_migration.py
+++ b/tests/migrations/test_restore_missing_meal_catalog_schema_migration.py
@@ -1,0 +1,114 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MIGRATION = Path(
+    "migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py"
+)
+
+
+class _Inspector:
+    def __init__(self, tables: dict[str, set[str]]) -> None:
+        self.tables = tables
+
+    def has_table(self, table_name: str) -> bool:
+        return table_name in self.tables
+
+    def get_columns(self, table_name: str) -> list[dict[str, str]]:
+        return [{"name": name} for name in self.tables[table_name]]
+
+
+class _Operations:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_bind(self) -> object:
+        return object()
+
+    def __getattr__(self, name: str):
+        def operation(*_args, **_kwargs) -> None:
+            self.calls.append(name)
+
+        return operation
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("catalog_schema_repair", MIGRATION)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repair_creates_missing_catalog_branch_from_an_empty_catalog_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+    baseline_calls: list[bool] = []
+
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector({"food_reference": {"id", "name_normalized"}}),
+    )
+    monkeypatch.setattr(
+        module,
+        "_run_catalog_baseline_upgrade",
+        lambda: baseline_calls.append(True),
+    )
+
+    module.upgrade()
+
+    assert baseline_calls == [True]
+    assert operations.calls.count("add_column") == 4
+    assert operations.calls.count("create_check_constraint") == 3
+    assert operations.calls.count("drop_constraint") == 2
+    assert operations.calls.count("execute") == 3
+
+
+def test_repair_leaves_complete_catalog_schema_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+    catalog_tables = {name: {"id"} for name in module.CATALOG_TABLES}
+    catalog_tables["food_reference"] = {"id", "name_normalized"}
+
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(module.sa, "inspect", lambda _bind: _Inspector(catalog_tables))
+    monkeypatch.setattr(
+        module,
+        "_run_catalog_baseline_upgrade",
+        lambda: pytest.fail("baseline must not run for a complete catalog schema"),
+    )
+
+    module.upgrade()
+
+    assert operations.calls == ["execute", "execute"]
+
+
+def test_repair_fails_closed_for_a_partial_catalog_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector(
+            {
+                "food_reference": {"id", "name_normalized"},
+                "meal_catalog": {"id"},
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Catalog schema is partially present"):
+        module.upgrade()
+
+    assert operations.calls == []

--- a/tests/migrations/test_restore_missing_meal_catalog_schema_migration.py
+++ b/tests/migrations/test_restore_missing_meal_catalog_schema_migration.py
@@ -66,7 +66,7 @@ def test_repair_creates_missing_catalog_branch_from_an_empty_catalog_schema(
     assert operations.calls.count("add_column") == 4
     assert operations.calls.count("create_check_constraint") == 3
     assert operations.calls.count("drop_constraint") == 2
-    assert operations.calls.count("execute") == 3
+    assert operations.calls.count("execute") == 4
 
 
 def test_repair_leaves_complete_catalog_schema_unchanged(
@@ -87,7 +87,27 @@ def test_repair_leaves_complete_catalog_schema_unchanged(
 
     module.upgrade()
 
-    assert operations.calls == ["execute", "execute"]
+    assert operations.calls == ["execute", "execute", "execute"]
+
+
+def test_repair_restores_normalized_name_uniqueness_for_seed_upserts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector({"food_reference": {"id", "name_normalized"}}),
+    )
+
+    module._ensure_food_reference_search_index(
+        module.sa.inspect(operations.get_bind())
+    )
+
+    assert operations.calls == ["execute", "execute", "execute"]
 
 
 def test_repair_fails_closed_for_a_partial_catalog_schema(

--- a/tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py
+++ b/tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py
@@ -83,10 +83,31 @@ def test_rejects_unverified_food_reference():
     assert exc.value.code == "food_reference_not_verified"
 
 
-def test_rejects_unapproved_source():
+def test_rejects_unapproved_source_until_an_admin_verifies_that_reference():
     with pytest.raises(IngredientQuantityConversionError) as exc:
         IngredientQuantityConversionService().resolve(
-            reference=_reference(source="ai_estimate"),
+            reference=_reference(source="ai_estimate", is_verified=False),
+            quantity=100,
+            unit="g",
+        )
+
+    assert exc.value.code == "food_reference_not_verified"
+
+
+def test_accepts_admin_verified_reference_from_an_unapproved_source():
+    result = IngredientQuantityConversionService().resolve(
+        reference=_reference(source="ai_estimate", is_verified=True),
+        quantity=100,
+        unit="g",
+    )
+
+    assert result.food_reference_id == 42
+
+
+def test_review_mode_still_rejects_an_unapproved_unverified_source():
+    with pytest.raises(IngredientQuantityConversionError) as exc:
+        IngredientQuantityConversionService(allow_unverified=True).resolve(
+            reference=_reference(source="ai_estimate", is_verified=False),
             quantity=100,
             unit="g",
         )

--- a/tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py
+++ b/tests/unit/domain/services/meal_recommendation/test_ingredient_quantity_conversion_service.py
@@ -208,26 +208,24 @@ def test_rejects_implausible_macro_snapshot():
     assert exc.value.code == "implausible_macro_snapshot"
 
 
-def test_rejects_fiber_or_sugar_exceeding_carbs():
-    with pytest.raises(IngredientQuantityConversionError) as exc:
-        IngredientQuantityConversionService().resolve(
-            reference=_reference(carbs_100g=5, fiber_100g=6),
-            quantity=100,
-            unit="g",
-        )
+def test_accepts_verified_reference_when_fiber_exceeds_carbs():
+    result = IngredientQuantityConversionService().resolve(
+        reference=_reference(carbs_100g=5, fiber_100g=6),
+        quantity=100,
+        unit="g",
+    )
 
-    assert exc.value.code == "implausible_macro_snapshot"
+    assert result.food_reference_id == 42
 
 
-def test_rejects_combined_fiber_and_sugar_exceeding_carbs():
-    with pytest.raises(IngredientQuantityConversionError) as exc:
-        IngredientQuantityConversionService().resolve(
-            reference=_reference(carbs_100g=10, fiber_100g=6, sugar_100g=6),
-            quantity=100,
-            unit="g",
-        )
+def test_accepts_verified_reference_when_sugar_and_fiber_exceed_carbs():
+    result = IngredientQuantityConversionService().resolve(
+        reference=_reference(carbs_100g=10, fiber_100g=6, sugar_100g=6),
+        quantity=100,
+        unit="g",
+    )
 
-    assert exc.value.code == "implausible_macro_snapshot"
+    assert result.food_reference_id == 42
 
 
 def test_display_only_garnish_does_not_require_food_reference_or_macros():


### PR DESCRIPTION
## Scope\n\nPromotes the exact reviewed range from `main` into `delivery`.\n\n- Source SHA: `3d0dc6847ed1212292e8ac799aad622f64906709`\n- Base SHA: `4f3eaf17f5c3b35d91323710c80a302fbe26c57d`\n- Commits: 6\n- Changed paths: 12\n\n## Migration safety evidence\n\n- Fresh disposable PostgreSQL database: upgraded from base to `20260730110500000000`.\n- Delivery-head disposable database: upgraded from `20260730000004` to `20260730110500000000`.\n- Deliberately partial catalog schema: forward repair failed closed with the expected partial-schema error.\n- Focused migration checks: 20 passed using pytest importlib mode; `alembic heads` resolves one head.\n- `git diff --check` passed for the reviewed range.\n\n## Rollback\n\nThese are forward-only migration repairs. Roll back application code if needed; do not automatically downgrade the repair migrations.\n\n## Follow-up\n\nA separate delivery-targeted PR will enforce timestamped migration creation and an AST-only CI migration graph gate after this PR merges.\n\nMerge only while the source/base SHAs and six-commit range above still match.