### PR TITLE
fix(migrations): preserve repair schema invariants

### DIFF
--- a/migrations/versions/20260730102158384558_ensure_food_item_allowed_units.py
+++ b/migrations/versions/20260730102158384558_ensure_food_item_allowed_units.py
@@ -24,10 +24,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    inspector = sa.inspect(op.get_bind())
-    if not inspector.has_table("food_item"):
-        return
-
-    columns = {column["name"] for column in inspector.get_columns("food_item")}
-    if "allowed_units" in columns:
-        op.drop_column("food_item", "allowed_units")
+    """Preserve a column that may have existed before this forward repair."""

--- a/migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py
+++ b/migrations/versions/20260730110500000000_restore_missing_meal_catalog_schema.py
@@ -112,6 +112,10 @@ def _ensure_food_reference_search_index(inspector: sa.Inspector) -> None:
     if "name_normalized" not in columns:
         raise RuntimeError("food_reference.name_normalized is required for catalog search")
 
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ux_food_reference_name_normalized "
+        "ON food_reference (name_normalized)"
+    )
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_food_reference_name_normalized_trgm "

--- a/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
+++ b/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
@@ -95,3 +95,26 @@ def test_allowed_units_repair_adds_missing_legacy_column(
     module.upgrade()
 
     assert operations.calls == ["add_column"]
+
+
+def test_allowed_units_repair_downgrade_preserves_existing_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filename = "20260730102158384558_ensure_food_item_allowed_units.py"
+    path = Path("migrations/versions") / filename
+    spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    operations = _Operations()
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector({"food_item": {"id", "allowed_units"}}),
+    )
+
+    module.downgrade()
+
+    assert operations.calls == []

--- a/tests/migrations/test_restore_missing_meal_catalog_schema_migration.py
+++ b/tests/migrations/test_restore_missing_meal_catalog_schema_migration.py
@@ -66,7 +66,7 @@ def test_repair_creates_missing_catalog_branch_from_an_empty_catalog_schema(
     assert operations.calls.count("add_column") == 4
     assert operations.calls.count("create_check_constraint") == 3
     assert operations.calls.count("drop_constraint") == 2
-    assert operations.calls.count("execute") == 3
+    assert operations.calls.count("execute") == 4
 
 
 def test_repair_leaves_complete_catalog_schema_unchanged(
@@ -87,7 +87,27 @@ def test_repair_leaves_complete_catalog_schema_unchanged(
 
     module.upgrade()
 
-    assert operations.calls == ["execute", "execute"]
+    assert operations.calls == ["execute", "execute", "execute"]
+
+
+def test_repair_restores_normalized_name_uniqueness_for_seed_upserts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector({"food_reference": {"id", "name_normalized"}}),
+    )
+
+    module._ensure_food_reference_search_index(
+        module.sa.inspect(operations.get_bind())
+    )
+
+    assert operations.calls == ["execute", "execute", "execute"]
 
 
 def test_repair_fails_closed_for_a_partial_catalog_schema(


### PR DESCRIPTION
Fixes two blockers found while reviewing #451:\n\n- restores the unique `food_reference.name_normalized` index required by seed upserts when catalog schema is repaired;\n- makes the allowed-units forward repair downgrade a no-op so it cannot remove a pre-existing column.\n\nValidation: `pytest --import-mode=importlib -q tests/migrations/test_alembic_revision_graph.py tests/migrations/test_body_fat_visual_profile_migration_compatibility.py tests/migrations/test_catalog_recipe_tables_migration.py tests/migrations/test_restore_missing_meal_catalog_schema_migration.py` (22 passed); targeted Ruff; `git diff --check`.