### PR TITLE
fix(migrations): merge Paddle and catalog heads

### DIFF
--- a/migrations/versions/20260731121600000000_merge_paddle_and_catalog_migration_heads.py
+++ b/migrations/versions/20260731121600000000_merge_paddle_and_catalog_migration_heads.py
@@ -1,0 +1,19 @@
+"""Merge Paddle fulfillment and catalog repair migration heads."""
+
+from collections.abc import Sequence
+
+revision: str = "20260731121600000000"
+down_revision: tuple[str, str] = (
+    "20260730110500000000",
+    "20260731000001",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Record that both independent migration branches have been applied."""
+
+
+def downgrade() -> None:
+    """Keep forward-only production schema changes intact on rollback."""


### PR DESCRIPTION
## Summary
- add a forward-only Alembic merge revision for the catalog repair and Paddle fulfillment heads
- restore one resolvable head for fresh database bootstrap without DDL or data changes

## Verification
- [x] `alembic heads` returns `20260731121600000000` only
- [x] `pytest tests/migrations -q` (46 passed)
- [x] scoped Ruff and Python compile checks
- [x] pre-push unit suite completed
- [ ] full `pytest` has 3 existing architecture failures from `delivery`; this branch does not modify the failing sources