### PR TITLE
fix(billing): mark sandbox Paddle subscriptions

### DIFF
--- a/src/api/routes/v1/paddle_webhooks.py
+++ b/src/api/routes/v1/paddle_webhooks.py
@@ -47,6 +47,12 @@ async def receive_paddle_webhook(request: Request) -> dict[str, str]:
 
     try:
         return await billing_service.process_webhook(raw_body)
+    except RuntimeError as exc:
+        logger.error("Paddle webhook processing is not configured: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Webhook processing is not configured",
+        ) from exc
     except PaddleWebhookRetryError as exc:
         logger.info("Paddle webhook will be retried: %s", exc)
         raise HTTPException(

--- a/src/infra/services/paddle_client.py
+++ b/src/infra/services/paddle_client.py
@@ -27,6 +27,13 @@ def get_paddle_api_key() -> str:
     return api_key
 
 
+def is_paddle_sandbox() -> bool:
+    """Return whether the configured Paddle SDK target is the sandbox."""
+    from paddle_billing.Environment import Environment
+
+    return get_paddle_environment() == Environment.SANDBOX
+
+
 def build_paddle_client():
     """Build the Paddle SDK client for server-side API calls."""
     from paddle_billing import Client, Options

--- a/src/infra/services/paddle_fulfillment_service.py
+++ b/src/infra/services/paddle_fulfillment_service.py
@@ -16,6 +16,7 @@ from src.domain.exceptions.paddle_billing_exceptions import PaddleWebhookRetryEr
 from src.domain.utils.timezone_utils import ensure_utc, utc_now
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
+from src.infra.services.paddle_client import is_paddle_sandbox
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +163,7 @@ async def _handle_subscription(session: AsyncSession, data: dict[str, object]) -
             scheduled_change.get("effective_at") or scheduled_change.get("resume_at")
         ),
         store_transaction_id=None,
-        is_sandbox=False,
+        is_sandbox=is_paddle_sandbox(),
         created_at=created_at,
         updated_at=updated_at,
     )
@@ -174,6 +175,7 @@ async def _handle_subscription(session: AsyncSession, data: dict[str, object]) -
                     Subscription.user_id, statement.excluded.user_id
                 ),
                 "provider_customer_id": customer_id,
+                "is_sandbox": statement.excluded.is_sandbox,
                 "status": status,
                 "price_id": price_id,
                 "product_id": product_id,

--- a/tests/unit/api/routes/test_paddle_webhooks.py
+++ b/tests/unit/api/routes/test_paddle_webhooks.py
@@ -80,3 +80,25 @@ def test_verified_event_with_missing_dependency_returns_non_2xx(monkeypatch):
     )
 
     assert response.status_code == 409
+
+
+def test_verified_event_with_missing_runtime_configuration_returns_500(monkeypatch):
+    class FakeBillingService:
+        def verify_webhook_signature(self, *_args):
+            return True
+
+        async def process_webhook(self, *_args):
+            raise RuntimeError("PADDLE_ENVIRONMENT must be set")
+
+    monkeypatch.setattr(
+        paddle_webhooks, "_get_paddle_billing_service", lambda: FakeBillingService()
+    )
+
+    response = _client().post(
+        "/v1/webhooks/paddle",
+        content=b'{"event_id":"evt_3","event_type":"subscription.updated"}',
+        headers={"Paddle-Signature": "valid"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Webhook processing is not configured"

--- a/tests/unit/infra/services/test_paddle_client.py
+++ b/tests/unit/infra/services/test_paddle_client.py
@@ -1,0 +1,59 @@
+"""Paddle server environment and webhook persistence tests."""
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from src.infra.services.paddle_client import is_paddle_sandbox
+from src.infra.services.paddle_fulfillment_service import _handle_subscription
+
+
+def test_sandbox_environment_is_marked_as_sandbox(monkeypatch):
+    monkeypatch.setenv("PADDLE_ENVIRONMENT", "sandbox")
+
+    assert is_paddle_sandbox() is True
+
+
+def test_live_environment_is_not_marked_as_sandbox(monkeypatch):
+    monkeypatch.setenv("PADDLE_ENVIRONMENT", "production")
+
+    assert is_paddle_sandbox() is False
+
+
+class _UnlinkedUserResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _CapturingSession:
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        if len(self.statements) == 1:
+            return _UnlinkedUserResult()
+        return None
+
+
+@pytest.mark.asyncio
+async def test_subscription_upsert_persists_sandbox_flag_on_conflict(monkeypatch):
+    monkeypatch.setenv("PADDLE_ENVIRONMENT", "sandbox")
+    session = _CapturingSession()
+
+    await _handle_subscription(
+        session,
+        {
+            "id": "sub_test",
+            "customer_id": "ctm_test",
+            "status": "active",
+            "created_at": "2026-07-31T00:00:00Z",
+            "updated_at": "2026-07-31T00:00:00Z",
+            "items": [{"price": {"id": "pri_test", "product_id": "pro_test"}}],
+        },
+    )
+
+    statement = session.statements[-1]
+    compiled = statement.compile(dialect=postgresql.dialect())
+
+    assert compiled.params["is_sandbox"] is True
+    assert "is_sandbox = excluded.is_sandbox" in str(compiled)


### PR DESCRIPTION
## Summary
- derive the mirrored Paddle subscription sandbox flag from the configured SDK environment
- preserve live behavior and add sandbox/live unit coverage

## Verification
- .venv/bin/pytest tests/unit/infra/services/test_paddle_client.py tests/unit/infra/services/test_paddle_webhook_signature.py tests/unit/infra/models/test_paddle_subscription_model.py tests/unit/api/routes/test_paddle_webhooks.py tests/unit/api/routes/test_billing.py -q
- .venv/bin/ruff check src/infra/services/paddle_client.py src/infra/services/paddle_fulfillment_service.py tests/unit/infra/services/test_paddle_client.py