### PR TITLE
fix(catalog): harden image generation workflow

### DIFF
--- a/.github/workflows/generate-catalog-meal-images.yml
+++ b/.github/workflows/generate-catalog-meal-images.yml
@@ -74,6 +74,7 @@ jobs:
             test -n "$CLOUDINARY_CLOUD_NAME" || (echo "CLOUDINARY_CLOUD_NAME secret is required" && exit 1)
             test -n "$CLOUDINARY_API_KEY" || (echo "CLOUDINARY_API_KEY secret is required" && exit 1)
             test -n "$CLOUDINARY_API_SECRET" || (echo "CLOUDINARY_API_SECRET secret is required" && exit 1)
+            echo "Cloudinary signature failures require CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET to be replaced as one matching production account set."
           fi
 
       - name: Generate image URLs

--- a/docs/journals/260801-0027-catalog-image-generation-reliability.md
+++ b/docs/journals/260801-0027-catalog-image-generation-reliability.md
@@ -1,0 +1,36 @@
+# Catalog Image Generation Reliability Fix
+
+**Date**: 2026-08-01
+**Severity**: High
+**Component**: Catalog image generation workflow
+**Status**: Resolved
+
+## What Happened
+
+The catalog image job was failing in two different ways. Cloudinary uploads were coming back with invalid signatures, and the script was also holding one async database transaction open while each remote generation/upload could take a long time. That was a bad combination: the job could fail on the external call, then still trip over the database commit path on the way out.
+
+## The Brutal Truth
+
+This was self-inflicted. We tried to keep the whole workflow inside one unit of work and paid for it with fragile transaction scope, noisy failures, and useless retries. The embarrassing part is that the signature problem was not even a code-path mystery in the end, it was an operational mismatch between the GitHub production Cloudinary secret trio and the target account.
+
+## Technical Details
+
+The fix split read and write concerns. `scripts/generate_catalog_meal_images.py` now loads catalog rows in a short-lived `AsyncUnitOfWork`, closes it before any Cloudflare or Cloudinary I/O, and opens a fresh unit of work only for conditional persistence. Failures are categorized with safe error codes, so `invalid signature` is surfaced as `cloudinary_signature_invalid` without leaking secrets or payload data. `src/infra/adapters/cloudinary_image_store.py` now logs only the exception type, not the exception string.
+
+Verification covered 57 focused tests, `py_compile`, Ruff, and reviewer approval. The workflow also now prints a safe reminder that `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, and `CLOUDINARY_API_SECRET` must be replaced together as one matching production set.
+
+## What We Tried
+
+We first treated the final commit failure as the bug. That was wrong. Retrying the commit would have hidden the real issue and kept the database connection hostage during remote work. We also rejected changing the Cloudinary request shape, because the signed upload parameters were already correct.
+
+## Root Cause Analysis
+
+Two root causes overlapped. First, we violated transaction boundaries by stretching a DB unit of work across unbounded network I/O. Second, production rollout was using a mismatched Cloudinary credential set, so the upload signature could never verify.
+
+## Lessons Learned
+
+External I/O and database lifetimes need to be separated by default. Also, secret drift must be treated as a deployment failure, not as an application bug that code can paper over.
+
+## Next Steps
+
+Reconcile the GitHub `production` Cloudinary secret trio as one matching set, with no value changes in code or docs. Keep the new tests and safe diagnostics in place, and treat any future signature error as a rollout check before touching the workflow again.

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -1,0 +1,7 @@
+# Project Changelog
+
+## 2026-08-01
+
+### Fixed
+
+- Catalog image generation reliability: catalog-job DB transactions are now short-lived, Cloudinary error logging and job output are sanitized, and the GitHub Actions production Cloudinary secret trio must be reconciled before the workflow is expected to run cleanly.

--- a/plans/260801-0008-catalog-image-generation-reliability/phase-01-transaction-boundaries.md
+++ b/plans/260801-0008-catalog-image-generation-reliability/phase-01-transaction-boundaries.md
@@ -1,0 +1,49 @@
+---
+phase: 1
+title: "Transaction Boundaries"
+status: completed
+priority: P1
+effort: "1.5h"
+dependencies: []
+---
+
+# Phase 1: Transaction Boundaries
+
+## Overview
+
+Separate catalog reads and per-image writes from Cloudflare/Cloudinary calls, avoiding an idle Neon transaction during remote I/O.
+
+## Requirements
+
+- Functional: select target meal projections before generation; generate with no active UoW; use a fresh UoW for each conditional update and commit.
+- Functional: a provider exception increments `failed`, continues to the next meal, and returns a summary without an exit-time commit attempt.
+- Non-functional: retain bounded memory and current update race protection; no public contract change.
+
+## Architecture
+
+`select targets (short UoW) -> close DB session -> generate externally -> conditional update + commit (fresh short UoW per success)`. The existing `image_url IS NULL OR trim(image_url) = ''` predicate remains the concurrency fence.
+
+## Related Code Files
+
+- Modify: `scripts/generate_catalog_meal_images.py` — transaction scoping and result flow.
+- Modify: `tests/unit/scripts/test_generate_catalog_meal_images.py` — script lifecycle tests.
+
+## Implementation Steps
+
+1. Extract lightweight target data needed for prompt construction before closing the read UoW.
+2. Iterate external generation after the read UoW exits.
+3. Persist each successful URL through a dedicated helper that opens, conditionally updates, commits, and closes its own UoW.
+4. Treat a lost conditional update as `skipped`; do not retry or overwrite an image created concurrently.
+5. Ensure all error paths roll back/close their fresh session and preserve accurate selected/updated/skipped/failed counts.
+6. Replace raw prompt and generated URL output with safe catalog identity and outcome fields.
+
+## Success Criteria
+
+- [x] No UoW spans `generator.generate_url`.
+- [x] Cloudinary failure cannot trigger the prior exit-time `Transaction.commit()` error.
+- [x] Existing per-row conditional persistence behavior remains intact.
+
+## Risk Assessment
+
+- Detached ORM relationships may lazy-load after the read UoW closes. Mitigate by retaining eager loading or converting to a prompt-ready projection before exit.
+- A duplicate generation can occur if another worker writes first. The conditional update intentionally prevents overwrite; the generated remote asset is an acceptable orphan under current behavior.

--- a/plans/260801-0008-catalog-image-generation-reliability/phase-02-credential-diagnostics-and-workflow-validation.md
+++ b/plans/260801-0008-catalog-image-generation-reliability/phase-02-credential-diagnostics-and-workflow-validation.md
@@ -1,0 +1,42 @@
+---
+phase: 2
+title: "Credential Diagnostics and Workflow Validation"
+status: completed
+priority: P1
+effort: "1h"
+dependencies: [1]
+---
+
+# Phase 2: Credential Diagnostics and Workflow Validation
+
+## Overview
+
+Provide safe failure context and validate the workflow configuration boundary without disclosing Cloudinary credentials.
+
+## Requirements
+
+- Functional: distinguish configuration validation failures from provider upload failures in job output using fixed safe messages only.
+- Functional: document/check that GitHub Actions uses a matching cloud name, API key, and API secret in the `production` environment.
+- Non-functional: never log secrets, API keys, URLs, prompts, image bytes, or raw Cloudflare responses.
+
+## Related Code Files
+
+- Modify: `.github/workflows/generate-catalog-meal-images.yml` — safe preflight checks and operational guidance.
+- Read: `src/infra/adapters/cloudinary_image_store.py` — preserve its upload and direct-upload signature contracts unchanged.
+
+## Implementation Steps
+
+1. Preserve non-empty secret validation and add no key/secret fingerprints or hashes.
+2. Add a failure message that names the expected corrective action: replace the three `production` Cloudinary secrets as a matching account set.
+3. Do not change the upload parameters or signature algorithm; Cloudinary SDK signing is correct for the logged request string.
+4. Keep the direct-upload token endpoint and Cloudinary adapter public methods backward compatible.
+
+## Success Criteria
+
+- [x] Workflow errors direct operators to reconcile the three Cloudinary secrets without printing their values.
+- [x] A signature failure retains enough safe context to distinguish it from Cloudflare generation and DB persistence failures.
+- [x] Existing upload-token response remains unchanged.
+
+## Security Considerations
+
+Credential values must not enter logs, hashes, fingerprints, or output. Prefer presence-only validation plus fixed remediation guidance.

--- a/plans/260801-0008-catalog-image-generation-reliability/phase-03-regression-tests-and-verification.md
+++ b/plans/260801-0008-catalog-image-generation-reliability/phase-03-regression-tests-and-verification.md
@@ -1,0 +1,37 @@
+---
+phase: 3
+title: "Regression Tests and Verification"
+status: completed
+priority: P1
+effort: "1.5h"
+dependencies: [1, 2]
+---
+
+# Phase 3: Regression Tests and Verification
+
+## Overview
+
+Characterize the broken paths, run targeted validation, and verify no catalog/admin/direct-upload behavior regresses.
+
+## Related Code Files
+
+- Modify: `tests/unit/scripts/test_generate_catalog_meal_images.py`.
+- Read: `tests/unit/infra/test_cloudinary_image_store.py`, `tests/unit/api/test_admin_meal_catalog_route.py`, and direct-upload signature tests.
+
+## Implementation Steps
+
+1. Add async tests that prove the generator runs after the read UoW exits and persistence opens a separate UoW only after a successful URL.
+2. Cover provider failure, conditional-update skip, successful update, and persistence failure cleanup/counts.
+3. Run script, Cloudinary adapter, Cloudflare generator, admin endpoint, and direct-upload signature tests.
+4. Run compile, targeted Ruff, mypy on touched modules when feasible, and `git diff --check`.
+5. Reviewer verifies error handling, log privacy, transaction boundaries, public-contract stability, and operational remediation.
+
+## Success Criteria
+
+- [x] Targeted tests pass with no live external calls.
+- [x] Python compilation and touched-file quality checks pass.
+- [x] Review finds no security or contract regression.
+
+## Risk Assessment
+
+- Unit tests must not encode `AsyncUnitOfWork` internals so tightly that normal refactors break them. Assert observable ordering and summaries with fakes instead.

--- a/plans/260801-0008-catalog-image-generation-reliability/plan.md
+++ b/plans/260801-0008-catalog-image-generation-reliability/plan.md
@@ -1,0 +1,52 @@
+---
+title: "Catalog Image Generation Reliability"
+description: "Make catalog image backfills resilient to external-provider latency and safely diagnose stale Cloudinary workflow credentials."
+status: completed
+priority: P1
+effort: "4h"
+branch: "fix/catalog-image-generation"
+tags: [bugfix, backend, database, infra]
+blockedBy: []
+blocks: []
+created: "2026-07-31T17:08:22.503Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Catalog Image Generation Reliability
+
+## Overview
+
+Repair the catalog-image GitHub Actions job without changing the working client direct-upload or admin endpoint contracts. External Cloudflare/Cloudinary work must run outside database transactions; failed uploads must not cause a stale-session commit error; the workflow must offer safe evidence for mismatched Cloudinary credentials.
+
+## Scope
+
+- Keep: catalog selection semantics, per-row conditional update, image prompt/model, and existing API contracts.
+- Add: short-lived persistence boundaries, safe configuration error guidance, private job output, and targeted regression coverage.
+- Exclude: automatic secret rotation, retry queues, changing Cloudinary upload fields, and direct-upload endpoint changes.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Transaction Boundaries](./phase-01-transaction-boundaries.md) | Completed |
+| 2 | [Credential Diagnostics and Workflow Validation](./phase-02-credential-diagnostics-and-workflow-validation.md) | Completed |
+| 3 | [Regression Tests and Verification](./phase-03-regression-tests-and-verification.md) | Completed |
+
+## Dependencies
+
+- Approved diagnosis: [catalog image generation brainstorm](../reports/260801-0000-catalog-image-generation-brainstorm.md).
+- No blocking plan dependency. Operational rollout requires replacing GitHub `production` environment Cloudinary secrets as one matching account set.
+
+## Success Criteria
+
+- External image generation never holds an open async SQLAlchemy transaction.
+- Upload failure finishes with the catalog-job failure summary, not a closed-connection commit traceback.
+- Successful persistence remains conditional and race-safe.
+- Workflow output contains no secret, API key, prompt, raw provider payload, or image URL.
+- Direct upload and admin catalog image generation contracts remain unchanged.
+
+## Completion Record
+
+- Verified: 57 focused tests passed; Python compilation, Ruff, and independent code review passed.
+- External rollout: replace the GitHub Actions `production` Cloudinary cloud name, API key, and API secret as one matching account set before a non-dry-run execution.

--- a/plans/260801-0008-catalog-image-generation-reliability/reports/pm-260801-0015-catalog-image-generation-reliability.md
+++ b/plans/260801-0008-catalog-image-generation-reliability/reports/pm-260801-0015-catalog-image-generation-reliability.md
@@ -1,0 +1,31 @@
+---
+title: "Catalog Image Generation Reliability Completion"
+status: completed
+created: 2026-08-01
+---
+
+# Catalog Image Generation Reliability Completion
+
+## Summary
+
+All three plan phases completed. The job no longer holds a database transaction during Cloudflare or Cloudinary work; failure output is safe; direct-upload/admin contracts remain unchanged.
+
+## Verification
+
+- Focused tests: 57 passed, 1 warning.
+- Python compile: passed.
+- Ruff: passed.
+- Independent code review: approved after Cloudinary exception-log sanitization and persistence-failure coverage.
+
+## Documentation
+
+- Changelog updated.
+- Roadmap unchanged; no matching roadmap item.
+
+## External Rollout
+
+- Replace the GitHub Actions `production` Cloudinary cloud name, API key, and API secret as one matching account set before retrying the non-dry-run workflow.
+
+## Unresolved Questions
+
+None.

--- a/plans/reports/260801-0000-catalog-image-generation-brainstorm.md
+++ b/plans/reports/260801-0000-catalog-image-generation-brainstorm.md
@@ -1,0 +1,46 @@
+---
+title: "Catalog Image Generation Failure Diagnosis"
+status: approved
+created: 2026-08-01
+branch: fix/catalog-image-generation
+tags: [bugfix, backend, cloudinary, database]
+---
+
+# Catalog Image Generation Failure Diagnosis
+
+## Summary
+
+The catalog-image workflow has two separate failures. The Cloudinary signature is invalid because the GitHub Actions credential set is inconsistent with the target Cloudinary account. The database failure follows because the script holds one async transaction open while each remote generation/upload may take 120 seconds, then the unit of work attempts a final commit after its connection has been closed.
+
+## Evidence
+
+- `.github/workflows/generate-catalog-meal-images.yml` injects repository/environment secrets independently of the deployed API runtime.
+- `CloudinaryImageStore.save()` passes the SDK ordinary signed-upload fields: `format`, `overwrite`, `public_id`, and `timestamp`. Cloudinary signs these fields automatically. The reported string is therefore valid request shape; the account rejects the secret used to sign it.
+- `scripts/generate_catalog_meal_images.py` opens `AsyncUnitOfWork` before selecting rows, retains it during Cloudflare + Cloudinary calls, and leaves the context to commit even when all attempts failed.
+- `CloudflareWorkersImageGenerator` sends the configured Flux model through the base64 path, which necessarily uploads returned bytes to Cloudinary. This can differ from a working endpoint invocation only if it used a URL-returning model or different deployment credentials.
+
+## Options Considered
+
+1. Retry/reconnect the final DB commit. Rejected: it treats the symptom and still holds a database transaction during unbounded external I/O.
+2. Change Cloudinary upload parameters. Rejected: the reported signed string matches Cloudinary's normal SDK contract; changing fields cannot repair a mismatched secret.
+3. Short-lived database units plus safe configuration identity diagnostics. Selected: separates remote generation from persistence, preserves the endpoint contract, and directs the operational correction without exposing secrets.
+
+## Approved Design
+
+- Read catalog targets in a short-lived DB session, then close it before image generation.
+- For each successful generation, open a new UoW only for conditional update and commit; retain the existing race-safe missing-image predicate.
+- Make workflow startup validate non-empty secrets and emit only safe account/config fingerprints or metadata needed to distinguish mismatched Actions credentials; never print API keys, secrets, prompts, or URLs.
+- Add unit coverage for failed generation, conditional persistence, and transaction scoping. Preserve the direct-upload endpoint and public contracts.
+- Reconcile or rotate the GitHub Actions `production` environment's `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, and `CLOUDINARY_API_SECRET` as one matching set. This is a required operational action outside repository code.
+
+## Success Criteria
+
+- A failing Cloudinary upload increments `failed` and exits cleanly without a second DB commit error.
+- A successful image is persisted only when the row still has no image URL.
+- Database connections are never held during Cloudflare or Cloudinary requests.
+- Signature mismatch diagnostics identify configuration mismatch safely, without disclosing sensitive values.
+- The existing admin endpoint and signed direct-upload response contracts remain unchanged.
+
+## Unresolved Questions
+
+None. The production environment secret set must be corrected during rollout.

--- a/scripts/generate_catalog_meal_images.py
+++ b/scripts/generate_catalog_meal_images.py
@@ -79,47 +79,79 @@ async def _run(args) -> dict[str, int]:
             catalog_keys=tuple(args.catalog_key),
             include_existing=args.include_existing,
         )
-        selected = len(meals)
-        for meal in meals:
-            prompt = build_catalog_meal_image_prompt(meal)
-            print(f"meal={meal.catalog_key} name={meal.name}")
-            print(f"prompt={prompt}")
-            if args.dry_run:
-                continue
-            try:
-                if generator is None:
-                    raise RuntimeError("Cloudflare image generator is not initialized")
-                image_url = await generator.generate_url(
-                    prompt,
-                    quality=args.quality,
-                    size=args.size,
-                    output_format=args.output_format,
-                )
-            except Exception as exc:  # noqa: BLE001
-                failed += 1
-                print(
-                    f"image_generation_failed catalog_key={meal.catalog_key}: {exc}",
-                    file=sys.stderr,
-                )
-                continue
-            persisted = await _set_image_url(
-                uow.session,
+    selected = len(meals)
+
+    for meal in meals:
+        prompt = build_catalog_meal_image_prompt(meal)
+        print(f"meal={meal.catalog_key} name={meal.name}")
+        if args.dry_run:
+            continue
+        try:
+            if generator is None:
+                raise RuntimeError("Cloudflare image generator is not initialized")
+            image_url = await generator.generate_url(
+                prompt,
+                quality=args.quality,
+                size=args.size,
+                output_format=args.output_format,
+            )
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print(
+                f"image_generation_failed catalog_key={meal.catalog_key} "
+                f"error={_error_code(exc)}",
+                file=sys.stderr,
+            )
+            continue
+        try:
+            persisted = await _persist_image_url(
                 str(meal.id),
                 image_url,
                 include_existing=args.include_existing,
             )
-            if persisted:
-                await uow.commit()
-                updated += 1
-                print(f"image_url={image_url}")
-            else:
-                await uow.rollback()
-                skipped += 1
-                print(
-                    f"image_generation_skipped catalog_key={meal.catalog_key}: image_url already set",
-                    file=sys.stderr,
-                )
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print(
+                f"image_persistence_failed catalog_key={meal.catalog_key} "
+                f"error={_error_code(exc)}",
+                file=sys.stderr,
+            )
+            continue
+        if persisted:
+            updated += 1
+            print(f"image_generation_updated catalog_key={meal.catalog_key}")
+        else:
+            skipped += 1
+            print(
+                f"image_generation_skipped catalog_key={meal.catalog_key}: image_url already set",
+                file=sys.stderr,
+            )
     return {"selected": selected, "updated": updated, "skipped": skipped, "failed": failed}
+
+
+async def _persist_image_url(
+    catalog_id: str,
+    image_url: str,
+    *,
+    include_existing: bool,
+) -> bool:
+    """Persist one generated URL without keeping a DB transaction open during I/O."""
+    async with AsyncUnitOfWork() as uow:
+        if uow.session is None:
+            raise RuntimeError("AsyncUnitOfWork did not initialize a database session")
+        return await _set_image_url(
+            uow.session,
+            catalog_id,
+            image_url,
+            include_existing=include_existing,
+        )
+
+
+def _error_code(exc: Exception) -> str:
+    """Return an actionable error category without exposing provider details."""
+    if "invalid signature" in str(exc).lower():
+        return "cloudinary_signature_invalid"
+    return type(exc).__name__
 
 
 async def _load_target_meals(

--- a/src/infra/adapters/cloudinary_image_store.py
+++ b/src/infra/adapters/cloudinary_image_store.py
@@ -109,8 +109,8 @@ class CloudinaryImageStore(ImageStorePort):
                 )
                 return image_id
 
-        except Exception as e:
-            logger.error(f"Error uploading to Cloudinary: {str(e)}")
+        except Exception as exc:
+            logger.error("Cloudinary upload failed error_type=%s", type(exc).__name__)
             raise
 
     def load(self, image_id: str) -> bytes | None:

--- a/tests/unit/infra/test_cloudinary_image_store.py
+++ b/tests/unit/infra/test_cloudinary_image_store.py
@@ -175,13 +175,17 @@ class TestSaveImage:
                 # Should return the UUID when secure_url is missing
                 assert result == "12345678-1234-5678-1234-567812345678"
 
-    def test_save_upload_error(self, cloudinary_store, sample_image_bytes):
+    def test_save_upload_error(self, cloudinary_store, sample_image_bytes, caplog):
         """Test save handles upload errors."""
         with patch("cloudinary.uploader.upload") as mock_upload:
-            mock_upload.side_effect = Exception("Upload failed")
+            mock_upload.side_effect = Exception("Upload failed secret-detail")
 
-            with pytest.raises(Exception, match="Upload failed"):
-                cloudinary_store.save(sample_image_bytes, "image/jpeg")
+            with pytest.raises(Exception, match="Upload failed secret-detail"):
+                with caplog.at_level("ERROR"):
+                    cloudinary_store.save(sample_image_bytes, "image/jpeg")
+
+        assert "Cloudinary upload failed error_type=Exception" in caplog.text
+        assert "secret-detail" not in caplog.text
 
     def test_save_generates_unique_ids(self, cloudinary_store, sample_image_bytes):
         """Test that save generates unique IDs for different uploads."""

--- a/tests/unit/scripts/test_generate_catalog_meal_images.py
+++ b/tests/unit/scripts/test_generate_catalog_meal_images.py
@@ -1,6 +1,9 @@
 import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 
 _SCRIPT_PATH = (
     Path(__file__).resolve().parents[3] / "scripts" / "generate_catalog_meal_images.py"
@@ -32,3 +35,198 @@ def test_build_catalog_meal_image_prompt_includes_meal_and_ingredients():
     assert "Chicken" in prompt
     assert "Rice noodles" in prompt
     assert "no text" in prompt
+
+
+class _FakeUnitOfWork:
+    def __init__(self, events: list[str]):
+        self.events = events
+        self.session = object()
+        self.exit_exception_types: list[type[BaseException] | None] = []
+
+    async def __aenter__(self):
+        self.events.append("uow_enter")
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.events.append("uow_exit")
+        self.exit_exception_types.append(exc_type)
+
+
+def _args(*, dry_run: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        dry_run=dry_run,
+        model="model",
+        timeout=120,
+        limit=1,
+        catalog_key=[],
+        include_existing=False,
+        quality="medium",
+        size="1024x1024",
+        output_format="jpeg",
+    )
+
+
+def _meal() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="catalog-1",
+        catalog_key="pho-ga",
+        name="Pho Ga",
+        cuisine="vietnamese",
+        ingredients=[SimpleNamespace(display_name="Chicken")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_closes_read_uow_before_remote_generation(monkeypatch):
+    events: list[str] = []
+    generator = SimpleNamespace(generate_url=AsyncMock(return_value="https://image"))
+
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _FakeUnitOfWork(events))
+
+    async def load_targets(*args, **kwargs):
+        events.append("load")
+        return [_meal()]
+
+    async def persist(*args, **kwargs):
+        events.append("persist")
+        return True
+
+    async def generate(*args, **kwargs):
+        assert events == ["uow_enter", "load", "uow_exit"]
+        events.append("generate")
+        return "https://image"
+
+    generator.generate_url.side_effect = generate
+    monkeypatch.setattr(_MODULE, "_load_target_meals", load_targets)
+    monkeypatch.setattr(_MODULE, "_persist_image_url", persist)
+    monkeypatch.setattr(_MODULE, "CloudinaryImageStore", lambda: object())
+    monkeypatch.setattr(_MODULE, "CloudflareWorkersImageGenerator", lambda **kwargs: generator)
+
+    summary = await _MODULE._run(_args())
+
+    assert summary == {"selected": 1, "updated": 1, "skipped": 0, "failed": 0}
+    assert events == ["uow_enter", "load", "uow_exit", "generate", "persist"]
+
+
+@pytest.mark.asyncio
+async def test_run_generation_failure_does_not_open_persistence_uow(monkeypatch, capsys):
+    events: list[str] = []
+    generator = SimpleNamespace(
+        generate_url=AsyncMock(side_effect=RuntimeError("Invalid Signature secret"))
+    )
+
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _FakeUnitOfWork(events))
+    monkeypatch.setattr(
+        _MODULE,
+        "_load_target_meals",
+        AsyncMock(return_value=[_meal()]),
+    )
+    monkeypatch.setattr(_MODULE, "CloudinaryImageStore", lambda: object())
+    monkeypatch.setattr(_MODULE, "CloudflareWorkersImageGenerator", lambda **kwargs: generator)
+    persist = AsyncMock(return_value=True)
+    monkeypatch.setattr(_MODULE, "_persist_image_url", persist)
+
+    summary = await _MODULE._run(_args())
+
+    assert summary == {"selected": 1, "updated": 0, "skipped": 0, "failed": 1}
+    assert events == ["uow_enter", "uow_exit"]
+    persist.assert_not_awaited()
+    assert "cloudinary_signature_invalid" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_run_counts_lost_conditional_update_as_skipped(monkeypatch):
+    events: list[str] = []
+    generator = SimpleNamespace(generate_url=AsyncMock(return_value="https://image"))
+
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _FakeUnitOfWork(events))
+    monkeypatch.setattr(
+        _MODULE,
+        "_load_target_meals",
+        AsyncMock(return_value=[_meal()]),
+    )
+    monkeypatch.setattr(_MODULE, "CloudinaryImageStore", lambda: object())
+    monkeypatch.setattr(_MODULE, "CloudflareWorkersImageGenerator", lambda **kwargs: generator)
+    monkeypatch.setattr(_MODULE, "_persist_image_url", AsyncMock(return_value=False))
+
+    summary = await _MODULE._run(_args())
+
+    assert summary == {"selected": 1, "updated": 0, "skipped": 1, "failed": 0}
+
+
+@pytest.mark.asyncio
+async def test_persist_image_url_uses_a_fresh_short_lived_uow(monkeypatch):
+    events: list[str] = []
+    seen_sessions: list[object] = []
+
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _FakeUnitOfWork(events))
+
+    async def set_image_url(session, *args, **kwargs):
+        seen_sessions.append(session)
+        events.append("set")
+        return True
+
+    monkeypatch.setattr(_MODULE, "_set_image_url", set_image_url)
+
+    persisted = await _MODULE._persist_image_url(
+        "catalog-1",
+        "https://image",
+        include_existing=False,
+    )
+
+    assert persisted is True
+    assert len(seen_sessions) == 1
+    assert events == ["uow_enter", "set", "uow_exit"]
+
+
+@pytest.mark.asyncio
+async def test_run_persistence_failure_exits_fresh_uow_and_counts_failure(monkeypatch):
+    events: list[str] = []
+    units_of_work: list[_FakeUnitOfWork] = []
+    generator = SimpleNamespace(generate_url=AsyncMock(return_value="https://image"))
+
+    def make_uow() -> _FakeUnitOfWork:
+        uow = _FakeUnitOfWork(events)
+        units_of_work.append(uow)
+        return uow
+
+    async def fail_persistence(*args, **kwargs):
+        events.append("set")
+        raise RuntimeError("database connection lost")
+
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", make_uow)
+    monkeypatch.setattr(
+        _MODULE,
+        "_load_target_meals",
+        AsyncMock(return_value=[_meal()]),
+    )
+    monkeypatch.setattr(_MODULE, "CloudinaryImageStore", lambda: object())
+    monkeypatch.setattr(_MODULE, "CloudflareWorkersImageGenerator", lambda **kwargs: generator)
+    monkeypatch.setattr(_MODULE, "_set_image_url", fail_persistence)
+
+    summary = await _MODULE._run(_args())
+
+    assert summary == {"selected": 1, "updated": 0, "skipped": 0, "failed": 1}
+    assert events == ["uow_enter", "uow_exit", "uow_enter", "set", "uow_exit"]
+    assert units_of_work[1].exit_exception_types == [RuntimeError]
+
+
+@pytest.mark.asyncio
+async def test_run_dry_run_does_not_initialize_remote_generator(monkeypatch):
+    events: list[str] = []
+
+    monkeypatch.setattr(_MODULE, "AsyncUnitOfWork", lambda: _FakeUnitOfWork(events))
+    monkeypatch.setattr(
+        _MODULE,
+        "_load_target_meals",
+        AsyncMock(return_value=[_meal()]),
+    )
+    monkeypatch.setattr(
+        _MODULE,
+        "CloudflareWorkersImageGenerator",
+        lambda **kwargs: pytest.fail("generator must not initialize for dry-run"),
+    )
+
+    summary = await _MODULE._run(_args(dry_run=True))
+
+    assert summary == {"selected": 1, "updated": 0, "skipped": 0, "failed": 0}


### PR DESCRIPTION
Harden catalog image generation workflow.

- Scope: transaction-scoped image generation, sanitized logs, and rollback-safe handling.
- Validation: 57 focused tests passed, `python -m py_compile`, and Ruff.
- Safety check: dry-run on main run `30652541714` verified the flow without claiming live fixed-branch execution.
- Rollout: reconcile the GitHub production Cloudinary secret trio after merge.

Notes:
- Logs are sanitized; no credential values are included.
- This PR does not claim live execution on the fixed branch.