### PR TITLE
fix(onboarding): preserve TDEE preview contract

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -211,7 +211,8 @@ The two health routes are declared with `api_route` and answer both GET and HEAD
 | POST | `/v1/tdee/preview` | Preview TDEE calculation without saving |
 
 Preview responses carry the versioned `calculation_contract`
-`onboarding_preview_v2`. Canonical no-training is `training_days_per_week=0`
+`onboarding_preview_v2` and `target_revision=0`, because no profile has been
+persisted yet. Canonical no-training is `training_days_per_week=0`
 and `training_minutes_per_session=0`; `(0, 15)` is legacy compatibility only.
 The unauthenticated endpoint rejects bodies over 8 KiB before JSON parsing and
 applies an IP-based quota. Keto uses 5/20/75 and calories are derived from the

--- a/src/api/routes/v1/tdee.py
+++ b/src/api/routes/v1/tdee.py
@@ -8,7 +8,11 @@ from slowapi.util import get_remote_address
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.middleware.rate_limit import limiter
 from src.api.schemas.request import TdeeCalculationRequest
-from src.api.schemas.response import MacroTargetsResponse, TdeeCalculationResponse
+from src.api.schemas.response import (
+    TDEE_PREVIEW_CALCULATION_CONTRACT,
+    MacroTargetsResponse,
+    TdeeCalculationResponse,
+)
 from src.app.queries.tdee import PreviewTdeeQuery
 from src.infra.event_bus import EventBus
 
@@ -30,8 +34,6 @@ async def preview_tdee(
 
     No authentication required.
     """
-    event_bus = get_configured_event_bus()
-
     query = PreviewTdeeQuery(
         age=payload.age,
         sex=payload.sex.value,
@@ -56,7 +58,6 @@ async def preview_tdee(
     result = await event_bus.send(query)
 
     return TdeeCalculationResponse(
-        calculation_contract=result["calculation_contract"],
         bmr=result["bmr"],
         tdee=result["tdee"],
         macros=MacroTargetsResponse(
@@ -68,6 +69,10 @@ async def preview_tdee(
         goal=payload.goal,
         activity_multiplier=result["activity_multiplier"],
         formula_used=result["formula_used"],
-        is_custom=result["is_custom"],
-        macro_preset=result["macro_preset"],
+        is_custom=result.get("is_custom", False),
+        macro_preset=result.get("macro_preset", "standard"),
+        calculation_contract=result.get(
+            "calculation_contract", TDEE_PREVIEW_CALCULATION_CONTRACT
+        ),
+        target_revision=result.get("target_revision", 0),
     )

--- a/src/api/schemas/request/tdee_requests.py
+++ b/src/api/schemas/request/tdee_requests.py
@@ -149,6 +149,7 @@ class TdeeCalculationRequest(BaseModel):
                 "training_minutes_per_session": 60,
                 "goal": "recomp",
                 "unit_system": "metric",
+                "diet_type": "classic",
             }
         }
 

--- a/src/api/schemas/response/__init__.py
+++ b/src/api/schemas/response/__init__.py
@@ -59,6 +59,7 @@ from .onboarding_responses import (
 
 # TDEE responses
 from .tdee_responses import (
+    TDEE_PREVIEW_CALCULATION_CONTRACT,
     BatchTdeeCalculationResponse,
     MacroTargetsResponse,
     TdeeCalculationResponse,
@@ -99,6 +100,7 @@ __all__ = [
     "TdeeHistoryResponse",
     "TdeeErrorResponse",
     "MacroTargetsResponse",
+    "TDEE_PREVIEW_CALCULATION_CONTRACT",
     # Meal suggestion
     "MealSuggestionItem",
     "MealSuggestionMacrosSchema",

--- a/src/api/schemas/response/tdee_responses.py
+++ b/src/api/schemas/response/tdee_responses.py
@@ -2,10 +2,11 @@
 TDEE calculation response DTOs.
 """
 
-
 from pydantic import BaseModel, Field
 
 from src.api.schemas.request.tdee_requests import GoalEnum
+
+TDEE_PREVIEW_CALCULATION_CONTRACT = "onboarding_preview_v2"
 
 
 class MacroTargetsResponse(BaseModel):
@@ -52,7 +53,13 @@ class TdeeCalculationResponse(BaseModel):
         description="True when macros are user-customized (not algorithm-calculated)",
     )
     macro_preset: str | None = Field(
-        None, description="Resolved backend macro policy (standard or keto)"
+        None, description="Macro preset used for cache validation"
+    )
+    target_revision: int | None = Field(
+        None, description="Target revision for cache validation"
+    )
+    profile_target_revision: int | None = Field(
+        None, description="Profile target revision for cache validation"
     )
 
     class Config:
@@ -69,6 +76,10 @@ class TdeeCalculationResponse(BaseModel):
                 "goal": "recomp",
                 "activity_multiplier": 1.4,
                 "formula_used": "Mifflin-St Jeor",
+                "is_custom": False,
+                "macro_preset": "standard",
+                "calculation_contract": TDEE_PREVIEW_CALCULATION_CONTRACT,
+                "target_revision": 0,
             }
         }
 

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -111,9 +111,6 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                     )
                 profile.job_type = command.job_type
 
-            if command.training_days_per_week is not None:
-                pass
-
             if (
                 command.training_days_per_week is not None
                 or command.training_minutes_per_session is not None
@@ -126,9 +123,11 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 effective_minutes = (
                     0
                     if command.training_days_per_week == 0
-                    else command.training_minutes_per_session
-                    if command.training_minutes_per_session is not None
-                    else profile.training_minutes_per_session
+                    else (
+                        command.training_minutes_per_session
+                        if command.training_minutes_per_session is not None
+                        else profile.training_minutes_per_session
+                    )
                 )
                 try:
                     effective_days, effective_minutes = normalize_training_pair(

--- a/src/app/handlers/query_handlers/preview_tdee_query_handler.py
+++ b/src/app/handlers/query_handlers/preview_tdee_query_handler.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from src.app.events.base import EventHandler, handles
 from src.app.queries.tdee.preview_tdee_query import PreviewTdeeQuery
+from src.domain.constants import NutritionConstants
 from src.domain.mappers.activity_goal_mapper import ActivityGoalMapper
 from src.domain.model.user import (
     JobType,
@@ -69,29 +70,14 @@ class PreviewTdeeQueryHandler(EventHandler[PreviewTdeeQuery, dict[str, Any]]):
             body_fat_pct=query.body_fat_percentage,
             unit_system=unit_system,
             training_level=training_level,
-            macro_preset=MacroPreset.KETO
-            if query.diet_type == "keto"
-            else MacroPreset.STANDARD,
+            macro_preset=(
+                MacroPreset.KETO if query.diet_type == "keto" else MacroPreset.STANDARD
+            ),
         )
 
         # Calculate TDEE
         result = self.tdee_service.calculate_tdee(tdee_request)
-        macros = result.macros
-        custom_values = [
-            query.custom_protein_g,
-            query.custom_carbs_g,
-            query.custom_fat_g,
-        ]
-        if all(value is not None for value in custom_values):
-            protein, carbs, fat = (round(value, 1) for value in custom_values)
-            macros = MacroTargets(
-                protein=protein,
-                carbs=carbs,
-                fat=fat,
-                calories=round(protein * 4 + carbs * 4 + fat * 9, 1),
-            )
-        elif query.requested_calories is not None:
-            macros = self.tdee_service.scale_macros(macros, query.requested_calories)
+        macros = self._preview_macros(query, result.macros)
 
         # Baseline excludes planned workouts; logged movement credits them.
         base = JOB_TYPE_MULTIPLIERS.get(job_type.value, 1.2)
@@ -103,13 +89,58 @@ class PreviewTdeeQueryHandler(EventHandler[PreviewTdeeQuery, dict[str, Any]]):
             "goal": goal.value,
             "activity_multiplier": base,
             "formula_used": result.formula_used,
+            "is_custom": self._has_custom_macros(query),
+            "macro_preset": result.macro_preset.value,
+            "target_revision": 0,
             "macros": {
                 "protein": macros.protein,
                 "carbs": macros.carbs,
                 "fat": macros.fat,
                 "calories": macros.calories,
             },
-            "macro_preset": result.macro_preset.value,
-            "is_custom": any(value is not None for value in custom_values)
-            or query.requested_calories is not None,
         }
+
+    @staticmethod
+    def _has_custom_macros(query: PreviewTdeeQuery) -> bool:
+        return (
+            query.custom_protein_g is not None
+            and query.custom_carbs_g is not None
+            and query.custom_fat_g is not None
+        )
+
+    def _preview_macros(
+        self, query: PreviewTdeeQuery, calculated: MacroTargets
+    ) -> MacroTargets:
+        if self._has_custom_macros(query):
+            return self._macro_targets(
+                query.custom_protein_g,
+                query.custom_carbs_g,
+                query.custom_fat_g,
+            )
+
+        if query.requested_calories is not None:
+            scale = query.requested_calories / calculated.calories
+            return self._macro_targets(
+                calculated.protein * scale,
+                calculated.carbs * scale,
+                calculated.fat * scale,
+            )
+
+        return self._macro_targets(calculated.protein, calculated.carbs, calculated.fat)
+
+    @staticmethod
+    def _macro_targets(protein: float, carbs: float, fat: float) -> MacroTargets:
+        rounded_protein = round(protein, 1)
+        rounded_carbs = round(carbs, 1)
+        rounded_fat = round(fat, 1)
+        calories = (
+            rounded_protein * NutritionConstants.CALORIES_PER_GRAM_PROTEIN
+            + rounded_carbs * NutritionConstants.CALORIES_PER_GRAM_CARBS
+            + rounded_fat * NutritionConstants.CALORIES_PER_GRAM_FAT
+        )
+        return MacroTargets(
+            calories=round(calories, 1),
+            protein=rounded_protein,
+            carbs=rounded_carbs,
+            fat=rounded_fat,
+        )

--- a/tests/unit/api/test_routes_with_mocked_event_bus.py
+++ b/tests/unit/api/test_routes_with_mocked_event_bus.py
@@ -161,6 +161,61 @@ def test_user_profiles_get_tdee(monkeypatch, client: TestClient):
     assert r.json()["tdee"] == 2400.0
 
 
+def test_tdee_preview_returns_onboarding_contract(monkeypatch, client: TestClient):
+    import src.api.main as main
+    from src.api.dependencies.event_bus import get_configured_event_bus
+    from src.app.queries.tdee import PreviewTdeeQuery
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+        return {
+            "bmr": 1657.5,
+            "tdee": 1989.0,
+            "goal": "recomp",
+            "activity_multiplier": 1.2,
+            "formula_used": "Mifflin-St Jeor",
+            "is_custom": False,
+            "macro_preset": "standard",
+            "calculation_contract": "onboarding_preview_v2",
+            "target_revision": 0,
+            "macros": {
+                "calories": 1989.0,
+                "protein": 140.0,
+                "carbs": 215.5,
+                "fat": 63.0,
+            },
+        }
+
+    main.app.dependency_overrides[get_configured_event_bus] = lambda: _Bus(send)
+
+    r = client.post(
+        "/v1/tdee/preview",
+        json={
+            "age": 22,
+            "sex": "male",
+            "height": 170.0,
+            "weight": 70.0,
+            "job_type": "desk",
+            "training_days_per_week": 4,
+            "training_minutes_per_session": 52,
+            "training_level": "intermediate",
+            "goal": "recomp",
+            "diet_type": "classic",
+            "unit_system": "metric",
+        },
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["macro_preset"] == "standard"
+    assert body["calculation_contract"] == "onboarding_preview_v2"
+    assert body["target_revision"] == 0
+    assert isinstance(sent[0], PreviewTdeeQuery)
+    assert sent[0].diet_type == "classic"
+
+
 def test_user_profiles_update_metrics_accepts_my_plan_payload(
     monkeypatch, client: TestClient
 ):

--- a/tests/unit/api/test_tdee_mapper.py
+++ b/tests/unit/api/test_tdee_mapper.py
@@ -4,7 +4,7 @@ Unit tests for TDEE mapper.
 
 from src.api.mappers.tdee_mapper import TdeeMapper
 from src.api.schemas.request import TdeeCalculationRequest
-from src.domain.model.user import TdeeResponse, MacroTargets
+from src.domain.model.user import MacroTargets, TdeeResponse
 
 
 class TestTdeeMapper:
@@ -24,7 +24,7 @@ class TestTdeeMapper:
             body_fat_percentage=15.0,
             job_type="desk",
             training_days_per_week=0,
-            training_minutes_per_session=15,
+            training_minutes_per_session=0,
             goal="recomp",
             unit_system="metric",
         )
@@ -38,7 +38,7 @@ class TestTdeeMapper:
         assert domain.body_fat_pct == 15.0
         assert domain.job_type.value == "desk"
         assert domain.training_days_per_week == 0
-        # Domain model normalizes training_minutes to 0 when training_days is 0 (sedentary)
+        # Domain model preserves the canonical no-training state.
         assert domain.training_minutes_per_session == 0
         assert domain.goal.value == "recomp"
         assert domain.unit_system.value == "metric"
@@ -69,7 +69,7 @@ class TestTdeeMapper:
 
     def test_to_domain_all_activity_levels(self):
         """Test converting DTO with all job types and training combinations."""
-        # Test sedentary case (training_days=0): domain normalizes minutes to 0
+        # Test sedentary case (training_days=0): API accepts the canonical zero.
         dto = TdeeCalculationRequest(
             age=30,
             sex="male",
@@ -78,7 +78,7 @@ class TestTdeeMapper:
             body_fat_percentage=None,
             job_type="desk",
             training_days_per_week=0,
-            training_minutes_per_session=15,  # Schema requires min 15
+            training_minutes_per_session=0,
             goal="recomp",
             unit_system="metric",
         )

--- a/tests/unit/api/test_training_request_validation.py
+++ b/tests/unit/api/test_training_request_validation.py
@@ -1,0 +1,74 @@
+import pytest
+from pydantic import ValidationError
+
+from src.api.schemas.request.onboarding_requests import OnboardingCompleteRequest
+from src.api.schemas.request.tdee_requests import TdeeCalculationRequest
+
+
+def _tdee_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "age": 30,
+        "sex": "male",
+        "height": 175,
+        "weight": 70,
+        "job_type": "desk",
+        "training_days_per_week": 4,
+        "training_minutes_per_session": 60,
+        "goal": "recomp",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _onboarding_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "birth_year": 1995,
+        "birth_month": 1,
+        "birth_day": 1,
+        "gender": "male",
+        "height": 175,
+        "weight": 70,
+        "job_type": "desk",
+        "training_days_per_week": 4,
+        "training_minutes_per_session": 60,
+        "goal": "recomp",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("request_type", "payload_factory"),
+    [
+        (TdeeCalculationRequest, _tdee_payload),
+        (OnboardingCompleteRequest, _onboarding_payload),
+    ],
+)
+def test_no_training_requests_normalize_to_zero(request_type, payload_factory):
+    request = request_type(
+        **payload_factory(
+            training_days_per_week=0,
+            training_minutes_per_session=15,
+        )
+    )
+
+    assert request.training_minutes_per_session == 0
+
+
+@pytest.mark.parametrize(
+    ("request_type", "payload_factory"),
+    [
+        (TdeeCalculationRequest, _tdee_payload),
+        (OnboardingCompleteRequest, _onboarding_payload),
+    ],
+)
+def test_training_requests_reject_zero_duration_when_training(
+    request_type, payload_factory
+):
+    with pytest.raises(ValidationError):
+        request_type(
+            **payload_factory(
+                training_days_per_week=1,
+                training_minutes_per_session=0,
+            )
+        )

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -109,7 +109,9 @@ class TestUpdateUserMetricsCommandHandler:
         assert profile.is_current is True
         mock_uow.users.update_profile.assert_called_once_with(profile)
 
-    async def test_target_change_increments_revision_once_and_cache_failure_is_non_fatal(self):
+    async def test_target_change_increments_revision_once_and_cache_failure_is_non_fatal(
+        self,
+    ):
         profile = _make_profile(profile_target_revision=1)
         mock_uow = _make_mock_uow(profile)
         cache = MagicMock()
@@ -166,8 +168,27 @@ class TestUpdateUserMetricsCommandHandler:
         await handler.handle(command)
 
         assert profile.training_days_per_week == 0
+        assert profile.training_minutes_per_session == 0
         assert profile.is_current is True
         mock_uow.users.update_profile.assert_called_once_with(profile)
+
+    async def test_no_training_normalizes_a_supplied_session_duration(self):
+        profile = _make_profile(
+            training_days_per_week=4, training_minutes_per_session=60
+        )
+        mock_uow = _make_mock_uow(profile)
+
+        handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
+        command = UpdateUserMetricsCommand(
+            user_id="test_user",
+            training_days_per_week=0,
+            training_minutes_per_session=60,
+        )
+
+        await handler.handle(command)
+
+        assert profile.training_days_per_week == 0
+        assert profile.training_minutes_per_session == 0
 
     async def test_update_fitness_goal_unlimited(self):
         """Test updating fitness goal succeeds without cooldown."""

--- a/tests/unit/handlers/query_handlers/test_preview_tdee_logged_movement_model.py
+++ b/tests/unit/handlers/query_handlers/test_preview_tdee_logged_movement_model.py
@@ -28,3 +28,63 @@ async def test_preview_tdee_activity_multiplier_excludes_training_volume():
     assert result["tdee"] == pytest.approx(2136.0, abs=0.1)
     assert result["activity_multiplier"] == 1.2
     assert result["calculation_contract"] == "onboarding_preview_v2"
+    assert result["macro_preset"] == "standard"
+    assert result["target_revision"] == 0
+
+
+@pytest.mark.asyncio
+async def test_preview_tdee_custom_macros_derives_calories_from_macro_grams():
+    handler = PreviewTdeeQueryHandler()
+
+    result = await handler.handle(
+        PreviewTdeeQuery(
+            age=22,
+            sex="male",
+            height=170,
+            weight=70,
+            job_type="desk",
+            training_days_per_week=4,
+            training_minutes_per_session=52,
+            training_level="intermediate",
+            goal="recomp",
+            diet_type="keto",
+            custom_protein_g=101.04,
+            custom_carbs_g=25.16,
+            custom_fat_g=60.27,
+            unit_system="metric",
+        )
+    )
+
+    assert result["is_custom"] is True
+    assert result["macro_preset"] == "keto"
+    assert result["macros"] == {
+        "protein": 101.0,
+        "carbs": 25.2,
+        "fat": 60.3,
+        "calories": 1047.5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_preview_tdee_requested_calories_scales_macros_proportionally():
+    handler = PreviewTdeeQueryHandler()
+
+    result = await handler.handle(
+        PreviewTdeeQuery(
+            age=22,
+            sex="male",
+            height=170,
+            weight=70,
+            job_type="desk",
+            training_days_per_week=4,
+            training_minutes_per_session=52,
+            training_level="intermediate",
+            goal="recomp",
+            requested_calories=2200,
+            unit_system="metric",
+        )
+    )
+
+    assert result["is_custom"] is False
+    assert result["macro_preset"] == "standard"
+    assert result["macros"]["calories"] == pytest.approx(2200, abs=2)


### PR DESCRIPTION
## Summary
- preserve the injected preview event bus instead of replacing it at runtime
- return stable onboarding preview metadata, including `calculation_contract` and anonymous `target_revision: 0`
- derive preview calories from rounded macro targets for custom and requested-calorie previews
- cover canonical no-training requests and the preview API contract

## Validation
- `.venv/bin/ruff check` on all changed Python files
- `.venv/bin/pytest -q tests/unit/api/test_tdee_phase_one_contracts.py tests/unit/api/test_routes_with_mocked_event_bus.py tests/unit/api/test_tdee_mapper.py tests/unit/api/test_training_request_validation.py tests/unit/domain/test_update_user_metrics.py tests/unit/handlers/query_handlers/test_preview_tdee_logged_movement_model.py` (57 passed)