### PR TITLE
fix(auth): resume interrupted web claims

### DIFF
--- a/src/app/services/web_funnel_claim_completion.py
+++ b/src/app/services/web_funnel_claim_completion.py
@@ -8,8 +8,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.app.services.web_funnel_claim_common import (
+    EXCHANGE_TTL,
     claim_conflict,
     claim_not_found,
+    hash_secret,
+    new_secret,
     utcnow,
 )
 from src.app.services.web_funnel_claim_exchange import reservation_is_bound
@@ -34,19 +37,44 @@ def _age(snapshot: dict) -> int:
 def _result(snapshot: dict, revenuecat_customer_id: str) -> dict:
     age = _age(snapshot)
     request = TdeeRequest(
-        age=age, sex=Sex(snapshot["gender"]), height=snapshot["height"], weight=snapshot["weight"],
-        body_fat_pct=snapshot.get("body_fat_percentage"), job_type=JobType(snapshot["job_type"]),
+        age=age,
+        sex=Sex(snapshot["gender"]),
+        height=snapshot["height"],
+        weight=snapshot["weight"],
+        body_fat_pct=snapshot.get("body_fat_percentage"),
+        job_type=JobType(snapshot["job_type"]),
         training_days_per_week=snapshot["training_days_per_week"],
-        training_minutes_per_session=snapshot["training_minutes_per_session"], goal=Goal(snapshot["goal"]),
-        training_level=TrainingLevel(snapshot["training_level"]) if snapshot.get("training_level") else None,
+        training_minutes_per_session=snapshot["training_minutes_per_session"],
+        goal=Goal(snapshot["goal"]),
+        training_level=(
+            TrainingLevel(snapshot["training_level"])
+            if snapshot.get("training_level")
+            else None
+        ),
     )
     calculation = TdeeCalculationService().calculate_tdee(request)
     macros = calculation.macros
-    if all(snapshot.get(key) is not None for key in ("custom_protein_g", "custom_carbs_g", "custom_fat_g")):
-        protein, carbs, fat = (float(snapshot[key]) for key in ("custom_protein_g", "custom_carbs_g", "custom_fat_g"))
-        macro_data = {"protein": protein, "carbs": carbs, "fat": fat, "calories": protein * 4 + carbs * 4 + fat * 9}
+    if all(
+        snapshot.get(key) is not None
+        for key in ("custom_protein_g", "custom_carbs_g", "custom_fat_g")
+    ):
+        protein, carbs, fat = (
+            float(snapshot[key])
+            for key in ("custom_protein_g", "custom_carbs_g", "custom_fat_g")
+        )
+        macro_data = {
+            "protein": protein,
+            "carbs": carbs,
+            "fat": fat,
+            "calories": protein * 4 + carbs * 4 + fat * 9,
+        }
     else:
-        macro_data = {"protein": macros.protein, "carbs": macros.carbs, "fat": macros.fat, "calories": macros.calories}
+        macro_data = {
+            "protein": macros.protein,
+            "carbs": macros.carbs,
+            "fat": macros.fat,
+            "calories": macros.calories,
+        }
     return {
         "version": "claim_result_v1",
         "onboarding_completed": True,
@@ -66,36 +94,95 @@ def _week_start(today: date) -> date:
     return date.fromordinal(today.toordinal() - today.weekday())
 
 
-async def complete_claim(db: AsyncSession, uid: str, email: str | None, exchange_token: str) -> dict:
+async def complete_claim(
+    db: AsyncSession, uid: str, email: str | None, exchange_token: str
+) -> dict:
     """Create all local effects under the request's one transaction and commit once."""
-    claim = await db.scalar(select(WebFunnelClaim).where(WebFunnelClaim.exchange_token_hash == hashlib.sha256(exchange_token.encode()).hexdigest()).with_for_update())
+    claim = await db.scalar(
+        select(WebFunnelClaim)
+        .where(
+            WebFunnelClaim.exchange_token_hash
+            == hashlib.sha256(exchange_token.encode()).hexdigest()
+        )
+        .with_for_update()
+    )
     if not claim:
         raise claim_not_found()
     lead = await db.get(WebFunnelLead, claim.lead_id, with_for_update=True)
-    if not lead or lead.status in {"refunded", "revoked", "conflict"} or claim.revoked_at or claim.expires_at <= utcnow():
+    if (
+        not lead
+        or lead.status in {"refunded", "revoked", "conflict"}
+        or claim.revoked_at
+        or claim.expires_at <= utcnow()
+    ):
         raise claim_not_found()
     if claim.consumed_at:
         if claim.consumed_uid == uid:
-            return claim.result or {"version": "claim_result_v1", "access_status": lead.access_sync_status}
+            return claim.result or {
+                "version": "claim_result_v1",
+                "access_status": lead.access_sync_status,
+            }
         raise claim_conflict()
-    if not reservation_is_bound(claim, uid, exchange_token) or (email or "").lower() != lead.email.lower():
+    if (
+        not reservation_is_bound(claim, uid, exchange_token)
+        or (email or "").lower() != lead.email.lower()
+    ):
         raise claim_conflict()
-    user = await db.scalar(select(User).where(User.firebase_uid == uid).with_for_update())
-    email_owner = await db.scalar(select(User).where(User.email == lead.email).with_for_update())
+    user = await db.scalar(
+        select(User).where(User.firebase_uid == uid).with_for_update()
+    )
+    email_owner = await db.scalar(
+        select(User).where(User.email == lead.email).with_for_update()
+    )
     if email_owner and email_owner.firebase_uid != uid:
         raise claim_conflict()
     if not user:
-        user = User(firebase_uid=uid, email=lead.email, username=_username(lead.email), password_hash="", provider=AuthProvider.EMAIL_LINK, onboarding_completed=True)
+        user = User(
+            firebase_uid=uid,
+            email=lead.email,
+            username=_username(lead.email),
+            password_hash="",
+            provider=AuthProvider.EMAIL_LINK,
+            onboarding_completed=True,
+        )
         db.add(user)
         await db.flush()
     elif user.email != lead.email:
         raise claim_conflict()
     user.onboarding_completed = True
     user.revenuecat_customer_id = lead.id
-    profile = await db.scalar(select(UserProfile).where(UserProfile.user_id == user.id, UserProfile.is_current.is_(True)).with_for_update())
+    profile = await db.scalar(
+        select(UserProfile)
+        .where(UserProfile.user_id == user.id, UserProfile.is_current.is_(True))
+        .with_for_update()
+    )
     snapshot = lead.snapshot
     if profile is None:
-        profile = UserProfile(user_id=user.id, age=_age(snapshot), gender=snapshot["gender"], height_cm=snapshot["height"], weight_kg=snapshot["weight"], body_fat_percentage=snapshot.get("body_fat_percentage"), date_of_birth=date(snapshot["birth_year"], snapshot["birth_month"], snapshot["birth_day"]), job_type=snapshot["job_type"], training_days_per_week=snapshot["training_days_per_week"], training_minutes_per_session=snapshot["training_minutes_per_session"], fitness_goal=snapshot["goal"], meals_per_day=snapshot.get("meals_per_day", 3), pain_points=snapshot.get("pain_points", []), dietary_preferences=snapshot.get("dietary_preferences", []), training_level=snapshot.get("training_level"), challenge_duration=snapshot.get("challenge_duration"), training_types=snapshot.get("training_types"), custom_protein_g=snapshot.get("custom_protein_g"), custom_carbs_g=snapshot.get("custom_carbs_g"), custom_fat_g=snapshot.get("custom_fat_g"), target_weight_kg=snapshot.get("target_weight_kg"))
+        profile = UserProfile(
+            user_id=user.id,
+            age=_age(snapshot),
+            gender=snapshot["gender"],
+            height_cm=snapshot["height"],
+            weight_kg=snapshot["weight"],
+            body_fat_percentage=snapshot.get("body_fat_percentage"),
+            date_of_birth=date(
+                snapshot["birth_year"], snapshot["birth_month"], snapshot["birth_day"]
+            ),
+            job_type=snapshot["job_type"],
+            training_days_per_week=snapshot["training_days_per_week"],
+            training_minutes_per_session=snapshot["training_minutes_per_session"],
+            fitness_goal=snapshot["goal"],
+            meals_per_day=snapshot.get("meals_per_day", 3),
+            pain_points=snapshot.get("pain_points", []),
+            dietary_preferences=snapshot.get("dietary_preferences", []),
+            training_level=snapshot.get("training_level"),
+            challenge_duration=snapshot.get("challenge_duration"),
+            training_types=snapshot.get("training_types"),
+            custom_protein_g=snapshot.get("custom_protein_g"),
+            custom_carbs_g=snapshot.get("custom_carbs_g"),
+            custom_fat_g=snapshot.get("custom_fat_g"),
+            target_weight_kg=snapshot.get("target_weight_kg"),
+        )
         db.add(profile)
     else:
         profile.age = _age(snapshot)
@@ -103,7 +190,9 @@ async def complete_claim(db: AsyncSession, uid: str, email: str | None, exchange
         profile.height_cm = snapshot["height"]
         profile.weight_kg = snapshot["weight"]
         profile.body_fat_percentage = snapshot.get("body_fat_percentage")
-        profile.date_of_birth = date(snapshot["birth_year"], snapshot["birth_month"], snapshot["birth_day"])
+        profile.date_of_birth = date(
+            snapshot["birth_year"], snapshot["birth_month"], snapshot["birth_day"]
+        )
         profile.job_type = snapshot["job_type"]
         profile.training_days_per_week = snapshot["training_days_per_week"]
         profile.training_minutes_per_session = snapshot["training_minutes_per_session"]
@@ -111,10 +200,12 @@ async def complete_claim(db: AsyncSession, uid: str, email: str | None, exchange
     result = _result(lead.snapshot, lead.id)
     current_week = _week_start(date.today())
     budget = await db.scalar(
-        select(WeeklyMacroBudgetORM).where(
+        select(WeeklyMacroBudgetORM)
+        .where(
             WeeklyMacroBudgetORM.user_id == user.id,
             WeeklyMacroBudgetORM.week_start_date == current_week,
-        ).with_for_update()
+        )
+        .with_for_update()
     )
     if budget is None:
         macros = result["macros"]
@@ -135,13 +226,39 @@ async def complete_claim(db: AsyncSession, uid: str, email: str | None, exchange
     return result
 
 
-async def recover_claim(db: AsyncSession, uid: str, reservation_id: str | None, generation: int | None) -> dict:
+async def recover_claim(
+    db: AsyncSession, uid: str, reservation_id: str | None, generation: int | None
+) -> dict:
     """Return only the caller's completed result or a safe completion-required state."""
-    claim = await db.scalar(select(WebFunnelClaim).where(WebFunnelClaim.reservation_uid == uid).order_by(WebFunnelClaim.created_at.desc()))
+    claim = await db.scalar(
+        select(WebFunnelClaim)
+        .where(WebFunnelClaim.reservation_uid == uid)
+        .order_by(WebFunnelClaim.created_at.desc())
+        .with_for_update()
+    )
     if not claim:
         raise claim_not_found()
     if claim.consumed_uid == uid:
-        return claim.result or {"version": "claim_result_v1", "access_status": "pending"}
-    if reservation_id == claim.reservation_id and generation == claim.generation and reservation_is_bound(claim, uid, None):
-        return {"version": "claim_result_v1", "status": "completion_required"}
+        return {
+            **(
+                claim.result
+                or {"version": "claim_result_v1", "access_status": "pending"}
+            ),
+            "lead_id": claim.lead_id,
+        }
+    if (
+        reservation_id == claim.reservation_id
+        and generation == claim.generation
+        and reservation_is_bound(claim, uid, None)
+    ):
+        exchange_token = new_secret()
+        claim.exchange_token_hash = hash_secret(exchange_token)
+        claim.exchange_expires_at = utcnow() + EXCHANGE_TTL
+        await db.commit()
+        return {
+            "version": "claim_result_v1",
+            "status": "completion_required",
+            "lead_id": claim.lead_id,
+            "exchange_token": exchange_token,
+        }
     raise claim_not_found()

--- a/tests/unit/app/services/test_web_funnel_claim_complete_flow.py
+++ b/tests/unit/app/services/test_web_funnel_claim_complete_flow.py
@@ -38,9 +38,42 @@ class FakeCompletionSession:
 @pytest.mark.asyncio
 async def test_bound_completion_persists_lead_customer_id_in_user_and_result():
     token = "x" * 48
-    snapshot = {"birth_year": 1995, "birth_month": 4, "birth_day": 20, "gender": "female", "height": 168, "weight": 62, "job_type": "desk", "training_days_per_week": 3, "training_minutes_per_session": 45, "goal": "recomp"}
-    lead = WebFunnelLead(id="lead-1", email="buyer@example.com", access_key_hash="key", request_id="request", snapshot_version="v1", snapshot=snapshot, snapshot_hash="snapshot", status="claim_reserved", revision=1, access_sync_status="pending")
-    claim = WebFunnelClaim(id="claim-1", lead_id="lead-1", generation=1, magic_token_hash="magic", expires_at=utcnow() + timedelta(hours=1), reservation_id="reservation-1", reservation_uid="uid-1", reservation_expires_at=utcnow() + timedelta(minutes=5), exchange_token_hash=hash_secret(token), exchange_expires_at=utcnow() + timedelta(minutes=2))
+    snapshot = {
+        "birth_year": 1995,
+        "birth_month": 4,
+        "birth_day": 20,
+        "gender": "female",
+        "height": 168,
+        "weight": 62,
+        "job_type": "desk",
+        "training_days_per_week": 3,
+        "training_minutes_per_session": 45,
+        "goal": "recomp",
+    }
+    lead = WebFunnelLead(
+        id="lead-1",
+        email="buyer@example.com",
+        access_key_hash="key",
+        request_id="request",
+        snapshot_version="v1",
+        snapshot=snapshot,
+        snapshot_hash="snapshot",
+        status="claim_reserved",
+        revision=1,
+        access_sync_status="pending",
+    )
+    claim = WebFunnelClaim(
+        id="claim-1",
+        lead_id="lead-1",
+        generation=1,
+        magic_token_hash="magic",
+        expires_at=utcnow() + timedelta(hours=1),
+        reservation_id="reservation-1",
+        reservation_uid="uid-1",
+        reservation_expires_at=utcnow() + timedelta(minutes=5),
+        exchange_token_hash=hash_secret(token),
+        exchange_expires_at=utcnow() + timedelta(minutes=2),
+    )
     session = FakeCompletionSession(claim, lead)
     result = await complete_claim(session, "uid-1", "buyer@example.com", token)
     assert result["version"] == "claim_result_v1"
@@ -50,7 +83,10 @@ async def test_bound_completion_persists_lead_customer_id_in_user_and_result():
     user = next(item for item in session.added if isinstance(item, User))
     assert user.revenuecat_customer_id == lead.id
     assert any(hasattr(item, "weekly_budget_id") for item in session.added)
-    assert not any(getattr(item, "job_type", None) == "revenuecat_association" for item in session.added)
+    assert not any(
+        getattr(item, "job_type", None) == "revenuecat_association"
+        for item in session.added
+    )
     assert session.committed
 
 
@@ -58,30 +94,124 @@ async def test_bound_completion_persists_lead_customer_id_in_user_and_result():
 async def test_same_uid_completion_replay_returns_immutable_result():
     token = "x" * 48
     result = {"version": "claim_result_v1", "access_status": "pending"}
-    lead = WebFunnelLead(id="lead-1", email="buyer@example.com", access_key_hash="key", request_id="request", snapshot_version="v1", snapshot={}, snapshot_hash="snapshot", status="claimed", revision=1, access_sync_status="pending")
-    claim = WebFunnelClaim(id="claim-1", lead_id="lead-1", generation=1, magic_token_hash="magic", expires_at=utcnow() + timedelta(hours=1), exchange_token_hash=hash_secret(token), consumed_uid="uid-1", consumed_at=utcnow(), result=result)
-    assert await complete_claim(FakeCompletionSession(claim, lead), "uid-1", "buyer@example.com", token) == result
+    lead = WebFunnelLead(
+        id="lead-1",
+        email="buyer@example.com",
+        access_key_hash="key",
+        request_id="request",
+        snapshot_version="v1",
+        snapshot={},
+        snapshot_hash="snapshot",
+        status="claimed",
+        revision=1,
+        access_sync_status="pending",
+    )
+    claim = WebFunnelClaim(
+        id="claim-1",
+        lead_id="lead-1",
+        generation=1,
+        magic_token_hash="magic",
+        expires_at=utcnow() + timedelta(hours=1),
+        exchange_token_hash=hash_secret(token),
+        consumed_uid="uid-1",
+        consumed_at=utcnow(),
+        result=result,
+    )
+    assert (
+        await complete_claim(
+            FakeCompletionSession(claim, lead), "uid-1", "buyer@example.com", token
+        )
+        == result
+    )
 
 
 @pytest.mark.asyncio
 async def test_other_uid_cannot_replay_consumed_claim():
     token = "x" * 48
-    lead = WebFunnelLead(id="lead-1", email="buyer@example.com", access_key_hash="key", request_id="request", snapshot_version="v1", snapshot={}, snapshot_hash="snapshot", status="claimed", revision=1, access_sync_status="pending")
-    claim = WebFunnelClaim(id="claim-1", lead_id="lead-1", generation=1, magic_token_hash="magic", expires_at=utcnow() + timedelta(hours=1), exchange_token_hash=hash_secret(token), consumed_uid="uid-1", consumed_at=utcnow(), result={"version": "claim_result_v1"})
+    lead = WebFunnelLead(
+        id="lead-1",
+        email="buyer@example.com",
+        access_key_hash="key",
+        request_id="request",
+        snapshot_version="v1",
+        snapshot={},
+        snapshot_hash="snapshot",
+        status="claimed",
+        revision=1,
+        access_sync_status="pending",
+    )
+    claim = WebFunnelClaim(
+        id="claim-1",
+        lead_id="lead-1",
+        generation=1,
+        magic_token_hash="magic",
+        expires_at=utcnow() + timedelta(hours=1),
+        exchange_token_hash=hash_secret(token),
+        consumed_uid="uid-1",
+        consumed_at=utcnow(),
+        result={"version": "claim_result_v1"},
+    )
     with pytest.raises(HTTPException) as error:
-        await complete_claim(FakeCompletionSession(claim, lead), "uid-2", "buyer@example.com", token)
+        await complete_claim(
+            FakeCompletionSession(claim, lead), "uid-2", "buyer@example.com", token
+        )
     assert error.value.status_code == 409
 
 
 @pytest.mark.asyncio
 async def test_recovery_returns_only_same_uid_committed_result():
     result = {"version": "claim_result_v1", "access_status": "pending"}
-    claim = WebFunnelClaim(id="claim-1", lead_id="lead-1", generation=1, magic_token_hash="magic", expires_at=utcnow() + timedelta(hours=1), reservation_uid="uid-1", consumed_uid="uid-1", consumed_at=utcnow(), result=result)
+    claim = WebFunnelClaim(
+        id="claim-1",
+        lead_id="lead-1",
+        generation=1,
+        magic_token_hash="magic",
+        expires_at=utcnow() + timedelta(hours=1),
+        reservation_uid="uid-1",
+        consumed_uid="uid-1",
+        consumed_at=utcnow(),
+        result=result,
+    )
 
     class RecoverySession:
         async def scalar(self, _statement):
             return claim
 
-    assert await recover_claim(RecoverySession(), "uid-1", None, None) == result
+    assert await recover_claim(RecoverySession(), "uid-1", None, None) == {
+        **result,
+        "lead_id": "lead-1",
+    }
     with pytest.raises(HTTPException):
         await recover_claim(RecoverySession(), "uid-2", None, None)
+
+
+@pytest.mark.asyncio
+async def test_recovery_mints_a_completion_token_for_the_bound_reservation():
+    claim = WebFunnelClaim(
+        id="claim-1",
+        lead_id="lead-1",
+        generation=1,
+        magic_token_hash="magic",
+        expires_at=utcnow() + timedelta(hours=1),
+        reservation_id="reservation-1",
+        reservation_uid="uid-1",
+        reservation_expires_at=utcnow() + timedelta(minutes=5),
+    )
+
+    class RecoverySession:
+        committed = False
+
+        async def scalar(self, _statement):
+            return claim
+
+        async def commit(self):
+            self.committed = True
+
+    session = RecoverySession()
+    result = await recover_claim(session, "uid-1", "reservation-1", 1)
+
+    assert result["status"] == "completion_required"
+    assert result["lead_id"] == "lead-1"
+    assert len(result["exchange_token"]) >= 32
+    assert hash_secret(result["exchange_token"]) == claim.exchange_token_hash
+    assert session.committed


### PR DESCRIPTION
## Summary
- return the bound lead ID with claim recovery results
- mint a short-lived completion token for a valid authenticated reservation
- allow the mobile app to finish an interrupted claim without re-exchanging its magic link

## Validation
- .venv/bin/pytest tests/unit/app/services/test_web_funnel_claim_complete_flow.py
- .venv/bin/ruff check src/app/services/web_funnel_claim_completion.py tests/unit/app/services/test_web_funnel_claim_complete_flow.py
- .venv/bin/black --check src/app/services/web_funnel_claim_completion.py tests/unit/app/services/test_web_funnel_claim_complete_flow.py