### PR TITLE
fix: use dedicated web funnel RevenueCat key

### DIFF
--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -591,3 +591,12 @@ def get_web_funnel_redemption_service():
     )
 
     return factory()
+
+
+def get_web_funnel_subscription_service():
+    """Resolve the web-funnel RevenueCat client through the composition root."""
+    from src.bootstrap.web_funnel_redemption import (
+        get_web_funnel_subscription_service as factory,
+    )
+
+    return factory()

--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -10,8 +10,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.base_dependencies import (
-    get_subscription_service,
     get_web_funnel_redemption_service,
+    get_web_funnel_subscription_service,
 )
 from src.api.dependencies.auth import verify_firebase_token_revocation_checked
 from src.api.middleware.rate_limit import limiter
@@ -117,7 +117,7 @@ def _allowed_revenuecat_products() -> set[str]:
 
 def _get_web_funnel_subscription_service():
     """Resolve RevenueCat through the API composition boundary."""
-    return get_subscription_service()
+    return get_web_funnel_subscription_service()
 
 
 def _subscriber_original_app_user_id(subscriber: dict | None) -> str | None:

--- a/src/bootstrap/web_funnel_redemption.py
+++ b/src/bootstrap/web_funnel_redemption.py
@@ -1,7 +1,14 @@
 """Composition root for web-funnel redemption persistence."""
 
+from src.infra.adapters.revenuecat_adapter import RevenueCatAdapter
+from src.infra.config.settings import settings
 from src.infra.services.web_funnel_redemption_service import WebFunnelRedemptionService
 
 
 def get_web_funnel_redemption_service() -> WebFunnelRedemptionService:
     return WebFunnelRedemptionService()
+
+
+def get_web_funnel_subscription_service() -> RevenueCatAdapter:
+    """Use the dedicated key for the configured web-funnel RevenueCat project."""
+    return RevenueCatAdapter(api_key=settings.WEB_FUNNEL_REVENUECAT_SECRET_API_KEY or "")


### PR DESCRIPTION
Ensures redemption verification uses WEB_FUNNEL_REVENUECAT_SECRET_API_KEY rather than the generic RevenueCat client key.