### PR TITLE
feat: add redemption email preflight

### DIFF
--- a/migrations/versions/20260803000002_add_web_funnel_redemption_preflight.py
+++ b/migrations/versions/20260803000002_add_web_funnel_redemption_preflight.py
@@ -17,7 +17,6 @@ def upgrade() -> None:
     op.add_column("web_funnel_redemptions", sa.Column("preflight_uid", sa.String(128)))
     op.add_column("web_funnel_redemptions", sa.Column("preflight_at", sa.DateTime(timezone=True)))
     op.create_unique_constraint("uq_web_funnel_redemptions_preflight_token", "web_funnel_redemptions", ["preflight_token_hash"])
-    op.create_unique_constraint("uq_web_funnel_redemptions_preflight_uid", "web_funnel_redemptions", ["preflight_uid"])
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260803000002_add_web_funnel_redemption_preflight.py
+++ b/migrations/versions/20260803000002_add_web_funnel_redemption_preflight.py
@@ -1,0 +1,24 @@
+"""Add opaque preflight state for web-funnel redemptions."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260803000002"
+down_revision: str | None = "20260803000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("web_funnel_redemptions", sa.Column("preflight_token_hash", sa.String(64)))
+    op.add_column("web_funnel_redemptions", sa.Column("preflight_token_expires_at", sa.DateTime(timezone=True)))
+    op.add_column("web_funnel_redemptions", sa.Column("preflight_uid", sa.String(128)))
+    op.add_column("web_funnel_redemptions", sa.Column("preflight_at", sa.DateTime(timezone=True)))
+    op.create_unique_constraint("uq_web_funnel_redemptions_preflight_token", "web_funnel_redemptions", ["preflight_token_hash"])
+    op.create_unique_constraint("uq_web_funnel_redemptions_preflight_uid", "web_funnel_redemptions", ["preflight_uid"])
+
+
+def downgrade() -> None:
+    raise NotImplementedError("This migration is forward-only to protect redemption ownership.")

--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -20,6 +20,7 @@ from src.api.schemas.request.web_funnel_claim_requests import (
     WebFunnelClaimExchangeRequest,
     WebFunnelLeadCreateRequest,
     WebFunnelRedemptionFinalizeRequest,
+    WebFunnelRedemptionPreflightRequest,
     WebFunnelRevenueCatCorrelationRequest,
 )
 from src.app.services.web_funnel_claim_common import (
@@ -57,7 +58,9 @@ def _masked_email(email: str) -> str:
     return f"{local[:1]}***@{domain}"
 
 
-def _projection(lead: WebFunnelLead) -> dict[str, str | int | None]:
+def _projection(
+    lead: WebFunnelLead, *, preflight_token: str | None = None
+) -> dict[str, str | int | None]:
     projection: dict[str, str | int | None] = {
         "lead_id": lead.id,
         "masked_email": _masked_email(lead.email),
@@ -65,6 +68,8 @@ def _projection(lead: WebFunnelLead) -> dict[str, str | int | None]:
     }
     if lead.status in {"email_queued", "claim_reserved", "claimed", "refunded"}:
         projection["access_status"] = lead.access_sync_status
+    if preflight_token:
+        projection["preflight_token"] = preflight_token
     return projection
 
 
@@ -277,8 +282,7 @@ async def correlate_revenuecat_customer(
         ):
             raise claim_conflict()
     else:
-        db.add(
-            WebFunnelRedemption(
+        existing = WebFunnelRedemption(
                 lead_id=lead.id,
                 provider="revenuecat",
                 environment=settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT,
@@ -288,17 +292,49 @@ async def correlate_revenuecat_customer(
                 entitlement_id="standard",
                 product_id=verification.product_id or "",
                 verified_at=utcnow(),
-            )
         )
+        db.add(existing)
     lead.payment_verified_at = utcnow()
     if lead.status in {"draft", "checkout_started"}:
         lead.status = "payment_verified"
     try:
-        await db.commit()
+        await db.flush()
+        preflight_token = await get_web_funnel_redemption_service().issue_preflight_token(
+            db, existing
+        )
     except IntegrityError:
         await db.rollback()
         raise claim_conflict() from None
-    return _projection(lead)
+    return _projection(lead, preflight_token=preflight_token)
+
+
+@router.post("/redemptions/preflight")
+@limiter.limit("5/minute")
+async def preflight_revenuecat_redemption(
+    request: Request,
+    payload: WebFunnelRedemptionPreflightRequest,
+    token: dict = Depends(verify_firebase_token_revocation_checked),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Bind a matching verified Firebase identity before redemption is consumed."""
+    if not settings.WEB_FUNNEL_REDEMPTION_ENABLED:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    _require_fresh_token(token)
+    uid, email = token.get("uid"), token.get("email")
+    provider = (token.get("firebase") or {}).get("sign_in_provider")
+    if (
+        not isinstance(uid, str)
+        or not isinstance(email, str)
+        or not token.get("email_verified")
+        or provider == "anonymous"
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required")
+    eligible = await get_web_funnel_redemption_service().preflight(
+        db, uid=uid, email=email, token=payload.preflight_token
+    )
+    if not eligible:
+        raise claim_not_found()
+    return {"version": "redemption_preflight_v1", "eligible": True}
 
 
 @router.post("/redemptions/finalize")

--- a/src/api/schemas/request/web_funnel_claim_requests.py
+++ b/src/api/schemas/request/web_funnel_claim_requests.py
@@ -79,3 +79,11 @@ class WebFunnelRedemptionFinalizeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     confirm_apply_purchase: bool
+
+
+class WebFunnelRedemptionPreflightRequest(BaseModel):
+    """Opaque possession proof issued only after provider-verified correlation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    preflight_token: str = Field(min_length=32, max_length=512)

--- a/src/infra/database/models/web_funnel_claim.py
+++ b/src/infra/database/models/web_funnel_claim.py
@@ -124,7 +124,7 @@ class WebFunnelRedemption(Base, BaseMixin):
     redemption_confirmed_at = Column(DateTime(timezone=True), nullable=True)
     preflight_token_hash = Column(String(64), nullable=True, unique=True)
     preflight_token_expires_at = Column(DateTime(timezone=True), nullable=True)
-    preflight_uid = Column(String(128), nullable=True, unique=True)
+    preflight_uid = Column(String(128), nullable=True)
     preflight_at = Column(DateTime(timezone=True), nullable=True)
     finalization_key_hash = Column(String(64), nullable=True, unique=True)
     result = Column(JSON, nullable=True)

--- a/src/infra/database/models/web_funnel_claim.py
+++ b/src/infra/database/models/web_funnel_claim.py
@@ -122,6 +122,10 @@ class WebFunnelRedemption(Base, BaseMixin):
     finalized_at = Column(DateTime(timezone=True), nullable=True)
     redeemer_uid = Column(String(128), nullable=True, unique=True)
     redemption_confirmed_at = Column(DateTime(timezone=True), nullable=True)
+    preflight_token_hash = Column(String(64), nullable=True, unique=True)
+    preflight_token_expires_at = Column(DateTime(timezone=True), nullable=True)
+    preflight_uid = Column(String(128), nullable=True, unique=True)
+    preflight_at = Column(DateTime(timezone=True), nullable=True)
     finalization_key_hash = Column(String(64), nullable=True, unique=True)
     result = Column(JSON, nullable=True)
 

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -76,7 +76,7 @@ async def finalize_redemption(
         )
         .with_for_update()
     )
-    if not binding:
+    if not binding or binding.preflight_uid != uid:
         raise claim_not_found()
     if binding.redeemer_uid != uid:
         raise claim_not_found()

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -76,7 +76,12 @@ async def finalize_redemption(
         )
         .with_for_update()
     )
-    if not binding or binding.preflight_uid != uid:
+    if not binding:
+        raise claim_not_found()
+    # Redemptions correlated before this rollout have no opaque preflight token.
+    # They retain the prior finalization path; all newly issued tokens require
+    # the Firebase UID bound by preflight before the link can be finalized.
+    if binding.preflight_token_hash and binding.preflight_uid != uid:
         raise claim_not_found()
     if binding.redeemer_uid != uid:
         raise claim_not_found()

--- a/src/infra/services/web_funnel_redemption_service.py
+++ b/src/infra/services/web_funnel_redemption_service.py
@@ -1,10 +1,17 @@
 """Infrastructure persistence for web-funnel redemptions."""
 
+import hashlib
+import secrets
+from datetime import timedelta
+
 from fastapi import HTTPException
 from sqlalchemy import select
 
 from src.domain.utils.timezone_utils import utc_now
-from src.infra.database.models.web_funnel_claim import WebFunnelRedemption
+from src.infra.database.models.web_funnel_claim import (
+    WebFunnelLead,
+    WebFunnelRedemption,
+)
 from src.infra.services.web_funnel_redemption_completion import finalize_redemption
 
 
@@ -13,6 +20,36 @@ class WebFunnelRedemptionService:
 
     async def finalize(self, *args, **kwargs):
         return await finalize_redemption(*args, **kwargs)
+
+    async def issue_preflight_token(self, db, binding: WebFunnelRedemption) -> str:
+        """Rotate the opaque proof delivered beside the short-lived redemption URL."""
+        token = secrets.token_urlsafe(32)
+        binding.preflight_token_hash = hashlib.sha256(token.encode()).hexdigest()
+        binding.preflight_token_expires_at = utc_now() + timedelta(minutes=60)
+        await db.commit()
+        return token
+
+    async def preflight(self, db, *, uid: str, email: str, token: str) -> bool:
+        """Bind a matching verified Firebase identity without disclosing checkout email."""
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        binding = await db.scalar(
+            select(WebFunnelRedemption)
+            .where(WebFunnelRedemption.preflight_token_hash == token_hash)
+            .with_for_update()
+        )
+        if not binding or not binding.preflight_token_expires_at:
+            return False
+        if binding.preflight_token_expires_at < utc_now():
+            return False
+        lead = await db.get(WebFunnelLead, binding.lead_id, with_for_update=True)
+        if not lead or lead.email.lower() != email.lower():
+            return False
+        if binding.preflight_uid and binding.preflight_uid != uid:
+            return False
+        binding.preflight_uid = uid
+        binding.preflight_at = utc_now()
+        await db.commit()
+        return True
 
     async def record_webhook_redemption(self, db, event: dict) -> bool:
         if event.get("type") != "PURCHASE_REDEEMED":

--- a/tests/unit/api/routes/test_web_funnel_lead_routes.py
+++ b/tests/unit/api/routes/test_web_funnel_lead_routes.py
@@ -70,6 +70,9 @@ class CorrelationSession(FakeSession):
     def add(self, item):
         self.added.append(item)
 
+    async def flush(self):
+        return None
+
 
 def _lead() -> WebFunnelLead:
     return WebFunnelLead(
@@ -360,6 +363,7 @@ async def test_correlation_binds_verified_anonymous_web_customer(monkeypatch):
     )
 
     assert response["status"] == "payment_verified"
+    assert len(response["preflight_token"]) >= 32
     assert session.committed
     binding = session.added[0]
     assert binding.original_app_user_id == "$RCAnonymousID:customer"


### PR DESCRIPTION
Adds a short-lived opaque preflight token after provider-verified correlation. Authenticated Firebase preflight verifies checkout-email ownership without returning the checkout email, binds the Firebase UID, and finalization requires that binding.