### PR TITLE
fix: remove web redemption product allowlist

### DIFF
--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -112,14 +112,6 @@ def _require_legacy_claim_enabled() -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
 
 
-def _allowed_revenuecat_products() -> set[str]:
-    return {
-        product_id.strip()
-        for product_id in settings.WEB_FUNNEL_REVENUECAT_PRODUCT_IDS.split(",")
-        if product_id.strip()
-    }
-
-
 def _get_web_funnel_subscription_service():
     """Resolve RevenueCat through the API composition boundary."""
     return get_subscription_service()
@@ -246,12 +238,10 @@ async def correlate_revenuecat_customer(
     _require_bff_request(origin, bff_credential)
     if not settings.WEB_FUNNEL_REDEMPTION_ENABLED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    allowed_products = _allowed_revenuecat_products()
     if (
         not settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT
         or not settings.WEB_FUNNEL_REVENUECAT_PROJECT
         or not settings.WEB_FUNNEL_REVENUECAT_SECRET_API_KEY
-        or not allowed_products
     ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     lead = await db.get(WebFunnelLead, lead_id, with_for_update=True)
@@ -265,7 +255,6 @@ async def correlate_revenuecat_customer(
     verification = verify_bound_web_customer(
         subscriber,
         original_app_user_id=payload.app_user_id,
-        allowed_product_ids=allowed_products,
     )
     if verification.state is not RevenueCatVerificationState.VERIFIED:
         raise claim_not_found()
@@ -371,12 +360,10 @@ async def finalize_revenuecat_redemption(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid idempotency key"
         )
-    allowed_products = _allowed_revenuecat_products()
     if (
         not settings.WEB_FUNNEL_REVENUECAT_SECRET_API_KEY
         or not settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT
         or not settings.WEB_FUNNEL_REVENUECAT_PROJECT
-        or not allowed_products
     ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     subscriber = await _get_web_funnel_subscription_service().get_subscriber_info(uid)
@@ -386,7 +373,6 @@ async def finalize_revenuecat_redemption(
         or verify_redeemed_customer(
             subscriber,
             original_app_user_id=original_app_user_id,
-            allowed_product_ids=allowed_products,
         ).state
         is not RevenueCatVerificationState.VERIFIED
     ):

--- a/src/app/services/web_funnel_redemption_verification.py
+++ b/src/app/services/web_funnel_redemption_verification.py
@@ -24,7 +24,7 @@ def _verify(
     subscriber: dict | None,
     *,
     original_app_user_id: str,
-    allowed_product_ids: set[str],
+    allowed_product_ids: set[str] | None = None,
 ) -> RevenueCatVerification:
     customer = (subscriber or {}).get("subscriber")
     if (
@@ -38,8 +38,8 @@ def _verify(
     )
     if (
         not isinstance(product_id, str)
-        or product_id not in allowed_product_ids
         or not is_active_standard(subscriber)
+        or (allowed_product_ids is not None and product_id not in allowed_product_ids)
     ):
         return RevenueCatVerification(RevenueCatVerificationState.NOT_ENTITLED)
     return RevenueCatVerification(RevenueCatVerificationState.VERIFIED, product_id)
@@ -49,7 +49,7 @@ def verify_bound_web_customer(
     subscriber: dict | None,
     *,
     original_app_user_id: str,
-    allowed_product_ids: set[str],
+    allowed_product_ids: set[str] | None = None,
 ) -> RevenueCatVerification:
     """Verify the browser hint names the authoritative anonymous customer."""
     return _verify(
@@ -63,7 +63,7 @@ def verify_redeemed_customer(
     subscriber: dict | None,
     *,
     original_app_user_id: str,
-    allowed_product_ids: set[str],
+    allowed_product_ids: set[str] | None = None,
 ) -> RevenueCatVerification:
     """Verify a Firebase UID resolves to the previously bound web customer."""
     return _verify(

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -165,7 +165,6 @@ class Settings(BaseSettings):
     WEB_FUNNEL_REVENUECAT_ENVIRONMENT: str = Field(default="")
     WEB_FUNNEL_REVENUECAT_PROJECT: str = Field(default="")
     WEB_FUNNEL_REVENUECAT_SECRET_API_KEY: str | None = Field(default=None)
-    WEB_FUNNEL_REVENUECAT_PRODUCT_IDS: str = Field(default="")
     WEB_FUNNEL_REDEMPTION_ENABLED: bool = Field(default=False)
     WEB_FUNNEL_LEGACY_CLAIM_ENABLED: bool = Field(default=False)
     WEB_FUNNEL_CLAIM_LINK_BASE_URL: str = Field(default="")

--- a/tests/unit/api/routes/test_web_funnel_lead_routes.py
+++ b/tests/unit/api/routes/test_web_funnel_lead_routes.py
@@ -250,9 +250,6 @@ def _configure_redemption(monkeypatch):
     monkeypatch.setattr(
         web_funnel.settings, "WEB_FUNNEL_REVENUECAT_SECRET_API_KEY", "secret"
     )
-    monkeypatch.setattr(
-        web_funnel.settings, "WEB_FUNNEL_REVENUECAT_PRODUCT_IDS", "web_monthly"
-    )
 
 
 class VerifiedSubscriberService:


### PR DESCRIPTION
Removes the WEB_FUNNEL_REVENUECAT_PRODUCT_IDS runtime requirement. Web redemption still requires an active standard entitlement and provider-verified customer binding.