### PR TITLE
fix: reuse shared RevenueCat configuration

### DIFF
--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -240,8 +240,7 @@ async def correlate_revenuecat_customer(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     if (
         not settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT
-        or not settings.WEB_FUNNEL_REVENUECAT_PROJECT
-        or not settings.WEB_FUNNEL_REVENUECAT_SECRET_API_KEY
+        or not settings.REVENUECAT_SECRET_API_KEY
     ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     lead = await db.get(WebFunnelLead, lead_id, with_for_update=True)
@@ -267,20 +266,19 @@ async def correlate_revenuecat_customer(
         if (
             existing.original_app_user_id != payload.app_user_id
             or existing.environment != settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT
-            or existing.project != settings.WEB_FUNNEL_REVENUECAT_PROJECT
         ):
             raise claim_conflict()
     else:
         existing = WebFunnelRedemption(
-                lead_id=lead.id,
-                provider="revenuecat",
-                environment=settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT,
-                project=settings.WEB_FUNNEL_REVENUECAT_PROJECT,
-                original_app_user_id=payload.app_user_id,
-                verified_app_user_id=payload.app_user_id,
-                entitlement_id="standard",
-                product_id=verification.product_id or "",
-                verified_at=utcnow(),
+            lead_id=lead.id,
+            provider="revenuecat",
+            environment=settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT,
+            project="default",
+            original_app_user_id=payload.app_user_id,
+            verified_app_user_id=payload.app_user_id,
+            entitlement_id="standard",
+            product_id=verification.product_id or "",
+            verified_at=utcnow(),
         )
         db.add(existing)
     lead.payment_verified_at = utcnow()
@@ -288,8 +286,10 @@ async def correlate_revenuecat_customer(
         lead.status = "payment_verified"
     try:
         await db.flush()
-        preflight_token = await get_web_funnel_redemption_service().issue_preflight_token(
-            db, existing
+        preflight_token = (
+            await get_web_funnel_redemption_service().issue_preflight_token(
+                db, existing
+            )
         )
     except IntegrityError:
         await db.rollback()
@@ -317,7 +317,9 @@ async def preflight_revenuecat_redemption(
         or not token.get("email_verified")
         or provider == "anonymous"
     ):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required"
+        )
     eligible = await get_web_funnel_redemption_service().preflight(
         db, uid=uid, email=email, token=payload.preflight_token
     )
@@ -361,9 +363,8 @@ async def finalize_revenuecat_redemption(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid idempotency key"
         )
     if (
-        not settings.WEB_FUNNEL_REVENUECAT_SECRET_API_KEY
+        not settings.REVENUECAT_SECRET_API_KEY
         or not settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT
-        or not settings.WEB_FUNNEL_REVENUECAT_PROJECT
     ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     subscriber = await _get_web_funnel_subscription_service().get_subscriber_info(uid)
@@ -385,7 +386,6 @@ async def finalize_revenuecat_redemption(
         original_app_user_id=original_app_user_id,
         idempotency_key=idempotency_key,
         environment=settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT,
-        project=settings.WEB_FUNNEL_REVENUECAT_PROJECT,
     )
 
 

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -163,8 +163,6 @@ class Settings(BaseSettings):
     REVENUECAT_SECRET_API_KEY: str | None = Field(default=None)
     REVENUECAT_WEBHOOK_SECRET: str | None = Field(default=None)
     WEB_FUNNEL_REVENUECAT_ENVIRONMENT: str = Field(default="")
-    WEB_FUNNEL_REVENUECAT_PROJECT: str = Field(default="")
-    WEB_FUNNEL_REVENUECAT_SECRET_API_KEY: str | None = Field(default=None)
     WEB_FUNNEL_REDEMPTION_ENABLED: bool = Field(default=False)
     WEB_FUNNEL_LEGACY_CLAIM_ENABLED: bool = Field(default=False)
     WEB_FUNNEL_CLAIM_LINK_BASE_URL: str = Field(default="")

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def utcnow():
     from datetime import UTC, datetime
+
     return datetime.now(UTC)
 
 
@@ -45,6 +46,8 @@ def _result(snapshot, uid):
             "fat": snapshot.get("custom_fat_g", 65),
         },
     }
+
+
 from src.domain.model.auth import AuthProvider
 from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.profile import UserProfile
@@ -64,7 +67,6 @@ async def finalize_redemption(
     original_app_user_id: str,
     idempotency_key: str,
     environment: str,
-    project: str,
 ) -> dict:
     """Restore one paid lead once; the provider-derived original ID selects the lead."""
     binding = await db.scalar(
@@ -72,8 +74,8 @@ async def finalize_redemption(
         .where(
             WebFunnelRedemption.original_app_user_id == original_app_user_id,
             WebFunnelRedemption.environment == environment,
-            WebFunnelRedemption.project == project,
         )
+        .order_by(WebFunnelRedemption.verified_at.desc())
         .with_for_update()
     )
     if not binding:

--- a/tests/unit/api/routes/test_web_funnel_lead_routes.py
+++ b/tests/unit/api/routes/test_web_funnel_lead_routes.py
@@ -7,7 +7,10 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from src.api.routes.v1 import web_funnel
-from src.infra.database.models.web_funnel_claim import WebFunnelLead
+from src.infra.database.models.web_funnel_claim import (
+    WebFunnelLead,
+    WebFunnelRedemption,
+)
 
 
 class FakeSession:
@@ -109,14 +112,14 @@ def _payload():
     )
 
 
-def _request() -> Request:
+def _request(client_host: str = "127.0.0.1") -> Request:
     return Request(
         {
             "type": "http",
             "method": "POST",
             "path": "/",
             "headers": [],
-            "client": ("127.0.0.1", 1),
+            "client": (client_host, 1),
         }
     )
 
@@ -246,10 +249,7 @@ def _configure_redemption(monkeypatch):
     monkeypatch.setattr(
         web_funnel.settings, "WEB_FUNNEL_REVENUECAT_ENVIRONMENT", "sandbox"
     )
-    monkeypatch.setattr(web_funnel.settings, "WEB_FUNNEL_REVENUECAT_PROJECT", "nutree")
-    monkeypatch.setattr(
-        web_funnel.settings, "WEB_FUNNEL_REVENUECAT_SECRET_API_KEY", "secret"
-    )
+    monkeypatch.setattr(web_funnel.settings, "REVENUECAT_SECRET_API_KEY", "secret")
 
 
 class VerifiedSubscriberService:
@@ -310,7 +310,6 @@ async def test_redemption_finalization_uses_provider_derived_customer_and_fresh_
         "original_app_user_id": "$RCAnonymousID:customer",
         "idempotency_key": "x" * 16,
         "environment": "sandbox",
-        "project": "nutree",
     }
 
 
@@ -366,7 +365,46 @@ async def test_correlation_binds_verified_anonymous_web_customer(monkeypatch):
     assert binding.original_app_user_id == "$RCAnonymousID:customer"
     assert binding.verified_app_user_id == "$RCAnonymousID:customer"
     assert binding.entitlement_id == "standard"
-    assert binding.project == "nutree"
+    assert binding.project == "default"
+
+
+@pytest.mark.asyncio
+async def test_correlation_accepts_existing_binding_with_legacy_project_label(
+    monkeypatch,
+):
+    _configure_redemption(monkeypatch)
+    monkeypatch.setattr(
+        web_funnel,
+        "_get_web_funnel_subscription_service",
+        lambda: VerifiedSubscriberService(),
+    )
+    existing = WebFunnelRedemption(
+        lead_id="lead-1",
+        provider="revenuecat",
+        environment="sandbox",
+        project="nutree",
+        original_app_user_id="$RCAnonymousID:customer",
+        verified_app_user_id="$RCAnonymousID:customer",
+        entitlement_id="standard",
+        product_id="web_monthly",
+        verified_at=web_funnel.utcnow(),
+    )
+    session = CorrelationSession(_lead(), existing=existing)
+
+    response = await web_funnel.correlate_revenuecat_customer(
+        _request("127.0.0.2"),
+        "lead-1",
+        web_funnel.WebFunnelRevenueCatCorrelationRequest(
+            app_user_id="$RCAnonymousID:customer"
+        ),
+        "a" * 32,
+        "https://web.example",
+        "bff-secret",
+        session,
+    )
+
+    assert response["status"] == "payment_verified"
+    assert not session.added
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the redundant web-funnel RevenueCat project and secret-key settings
- reuse the shared `REVENUECAT_SECRET_API_KEY`
- preserve redemption records written with the former project label

## Validation
- `.venv/bin/pytest --import-mode=importlib tests/unit/api/routes/test_web_funnel_lead_routes.py tests/unit/app/services/test_web_funnel_redemption_verification.py -q` (16 passed)
- `ruff`, `black --check`, and `lint-imports`
- repository pre-push unit-test hook