### PR TITLE
fix(payments): resolve RevenueCat redemption aliases

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -336,27 +336,27 @@ Handles RevenueCat lifecycle events (INITIAL_PURCHASE, RENEWAL, CANCELLATION, EX
 
 ---
 
-## Paid Web Claim
+## Paid Web Redemption
 
-These endpoints have no feature toggle. Lead creation intentionally fails closed
-until `WEB_FUNNEL_BFF_SHARED_SECRET` is configured. Access is protected by BFF
-proof, possession-bound lead access keys, one-time claim credentials, fresh
-Firebase authentication, and backend RevenueCat verification. The email worker
-requires `WEB_FUNNEL_CLAIM_LINK_BASE_URL` to deliver a claim link.
+Lead creation intentionally fails closed until `WEB_FUNNEL_BFF_SHARED_SECRET`
+is configured. The active redemption flow uses a RevenueCat Redemption Link,
+Google/Apple Firebase authentication, a hash-only preflight binding, and
+backend RevenueCat verification. The browser never authenticates or grants
+access.
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | POST | `/v1/web-funnel/leads` | Trusted BFF creates an access-key-bound onboarding lead. |
 | GET | `/v1/web-funnel/leads/{lead_id}/status` | Returns only the safe, possession-bound lead projection. |
 | POST | `/v1/web-funnel/leads/{lead_id}/reset` | Revokes an unpaid draft for its access-key holder. |
-| POST | `/v1/web-funnel/leads/{lead_id}/resend` | Revokes an old unconsumed link and queues one new generation. |
-| POST | `/v1/web-funnel/claims/exchange` | Exchanges an opaque magic credential for a Firebase custom token and short-lived exchange token. |
-| POST | `/v1/web-funnel/claims/complete` | Completes the reservation-bound claim atomically with a fresh Firebase bearer. |
-| GET | `/v1/web-funnel/claims/recovery` | Returns the authenticated UID's completed result or safe pending state. |
+| POST | `/v1/web-funnel/leads/{lead_id}/revenuecat-correlation` | Correlates the anonymous web customer and redemption-link digest after checkout. |
+| POST | `/v1/web-funnel/redemptions/preflight` | Binds the verified Firebase UID and checkout email to the redemption-link digest before consumption. |
+| POST | `/v1/web-funnel/redemptions/finalize` | Verifies the redeemed RevenueCat customer and attaches the purchase to the authenticated user. |
 
-The RevenueCat webhook records exact lead UUID correlations in a durable inbox;
-the worker fetches authoritative `standard` entitlement state before fulfillment.
-Raw magic, exchange, and retry credentials are never stored or logged.
+The RevenueCat webhook records provider aliases and lifecycle state. Legacy
+magic-claim exchange, resend, and recovery routes remain feature-gated behind
+`WEB_FUNNEL_LEGACY_CLAIM_ENABLED` for migration compatibility and are not part
+of the active redemption flow.
 
 ## Response Format
 

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -1,5 +1,21 @@
 # Project Changelog
 
+## 2026-08-04
+
+### Changed
+
+- Updated the active web purchase handoff to resume through normal Firebase
+  passwordless email-link sign-in, while retaining RevenueCat verification and
+  idempotent backend finalization.
+- Replaced the temporary Google/Apple-only activation surface with normal
+  Firebase passwordless email-link sign-in followed by silent RevenueCat
+  redemption, hash-only preflight, provider-verified finalization, idempotent
+  retries, and direct Home routing.
+- Removed the dedicated Flutter activation screen while retaining the
+  client-side RevenueCat customer-ID mapping replacement: authenticated users
+  use their Firebase UID consistently.
+- Kept legacy backend claim endpoints disabled by default for migration safety.
+
 ## 2026-08-01
 
 ### Fixed

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -9,6 +9,17 @@
 
 ## Completed Phases
 
+### August 2026: Authenticated RevenueCat Redemption
+- [x] Paid web checkout correlates an anonymous RevenueCat web customer using a
+  SHA-256 redemption-link digest without exposing the raw link to the backend.
+- [x] Flutter resumes redemption after normal verified Firebase passwordless
+  email-link authentication, finalizes through the backend, refreshes access,
+  and routes the buyer directly to Home.
+- [ ] Revised passwordless-email redemption continuation is implemented locally;
+  staging Firebase link, cold-start, and RevenueCat expiry validation remain.
+- [x] Active Firebase passwordless, anonymous claim, and legacy magic-link UI
+  paths were removed; legacy backend routes remain disabled by default.
+
 ### July 2026: Meal Catalog Phase 0 Production Foundation
 - [x] Four-table catalog recommendation foundation uses `meal_catalog`, `meal_catalog_ingredients`, `meal_recommendations`, and `meal_recommendation_operations`.
 - [x] Catalog import is additive, content-hash protected, serialized, and withholds near duplicates for explicit review.

--- a/migrations/versions/20260803000004_add_provider_aliases_to_web_funnel_redemptions.py
+++ b/migrations/versions/20260803000004_add_provider_aliases_to_web_funnel_redemptions.py
@@ -1,0 +1,25 @@
+"""Persist all RevenueCat aliases observed during redemption."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260803000004"
+down_revision: str | None = "20260803000003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "web_funnel_redemptions",
+        sa.Column("provider_app_user_ids", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "This migration is forward-only to protect provider identifiers."
+    )

--- a/plans/260804-1200-revenuecat-anonymous-redemption-finalization/plan.md
+++ b/plans/260804-1200-revenuecat-anonymous-redemption-finalization/plan.md
@@ -1,0 +1,67 @@
+# RevenueCat anonymous redemption finalization
+
+Date: 2026-08-04
+
+## Goal
+
+Make RevenueCat Redemption Links redeem through the RevenueCat SDK first, then
+bind the purchase to the authenticated Firebase user and finalize Nutree access.
+
+## Status
+
+- Backend diff covers provider-alias storage, preflight binding guardrails, and
+  the existing-account sign-in recovery path.
+- Flutter diff covers RevenueCat-first redemption, Firebase sign-in recovery,
+  backend finalization retry, and the updated splash-state flow.
+- Code review and local verification are complete; sandbox/device proof still
+  needs to run before release closure.
+- Plan remains pending until those verification gates clear.
+
+## Scope
+
+- Backend: never treat RevenueCat provider aliases as Firebase `redeemer_uid`.
+- Flutter: do not create or align a Firebase anonymous UID before
+  `Purchases.redeemWebPurchase()`.
+- Flutter: after Firebase authentication, call RevenueCat `logIn(firebaseUid)`
+  and retry the existing idempotent backend finalization.
+- Preserve existing Google, Apple, and email sign-in recovery behavior.
+- Keep the web funnel unchanged; its lead and RevenueCat correlation contracts
+  already provide the provider-side redemption binding.
+
+## Acceptance criteria
+
+1. A fresh redemption calls RevenueCat redemption before Firebase identity
+   alignment when no stable Firebase user is signed in.
+2. A successful RevenueCat redemption followed by Firebase sign-in finalizes
+   the local Nutree subscription and routes to Home.
+3. A RevenueCat `PURCHASE_REDEEMED` webhook stores provider aliases but never
+   assigns an alias to `redeemer_uid`.
+4. Existing incorrect webhook bindings cannot block a new authenticated UID
+   in the code path; the already-corrupted staging row requires a separate
+   data repair or a fresh purchase.
+5. Finalization remains server-authoritative, idempotent, and fail-closed for
+   inactive or mismatched RevenueCat customers.
+
+## Files
+
+- Modify `src/infra/services/web_funnel_redemption_service.py`.
+- Modify its focused unit tests.
+- Modify `lib/features/auth/application/services/web_purchase_redemption_coordinator.dart`.
+- Modify `lib/features/auth/application/providers/web_purchase_redemption_provider.dart`
+  only if dependency wiring must change.
+- Update Flutter coordinator tests for ordering and retry behavior.
+
+## Verification
+
+- Backend focused pytest and lint/type checks for changed modules.
+- Flutter focused coordinator tests, `flutter analyze`, and relevant build
+  compilation checks where available.
+- Confirm web funnel tests remain unchanged and passing.
+
+## Out of scope
+
+- No database migration.
+- No new preflight credential or endpoint.
+- No email-based RevenueCat App User ID.
+- No automatic account merge based only on matching email.
+- No provider-side RevenueCat/Paddle configuration change.

--- a/plans/260804-1600-revenuecat-anonymous-email-claim/plan.md
+++ b/plans/260804-1600-revenuecat-anonymous-email-claim/plan.md
@@ -1,0 +1,37 @@
+# RevenueCat Anonymous Email Claim
+
+## Decision
+
+Use RevenueCat's redemption link as the purchase/email possession proof. Do not send a second Firebase passwordless email and do not use the checkout email as a RevenueCat App User ID or access credential.
+
+## Flow
+
+1. Web creates an anonymous RevenueCat checkout and correlates the redemption-link digest with the lead.
+2. RevenueCat sends the redemption link to the checkout email.
+3. The user opens the link in the mobile app.
+4. Flutter ensures a Firebase anonymous session, identifies RevenueCat with that Firebase UID, and calls `Purchases.redeemWebPurchase()`.
+5. Flutter calls backend finalization with the Firebase anonymous ID token.
+6. Backend verifies the RevenueCat subscriber and active entitlement, claims the correlated lead, creates the paid profile/subscription, refreshes auth/subscription state, and routes to Home.
+
+## Security boundaries
+
+- The raw RevenueCat redemption URL remains in memory and is never sent to or stored by the backend.
+- Backend entitlement verification remains authoritative; web callbacks and RevenueCat webhooks only correlate/reconcile state.
+- Firebase anonymous UID is the session identity. Email is copied from the paid lead for the profile but is not trusted from the client and is not used to select a claim.
+- Existing fully onboarded accounts are not silently merged by email. They receive a clear conflict and must use the normal account sign-in path.
+- The legacy preflight/email-link path is not used by the new mobile flow.
+
+## Repository scope
+
+- `mealtrack_backend`: keep anonymous finalization/provider alias matching safe and add regression tests for the anonymous path and existing-account conflict.
+- `nutree_ai`: remove Firebase email-link activation and Google/Apple activation choices; implement anonymous-session activation and a progress/error/retry screen.
+- `nutree_web_funnel`: no runtime change expected; retain anonymous checkout, redemption-link digest correlation, and RevenueCat email handoff. Validate its tests/build only.
+
+## Acceptance criteria
+
+- A fresh staging buyer can open the RevenueCat email link, activate without another email being sent, and land on Home.
+- Retry after a transient backend/provider failure is idempotent and does not charge again.
+- A missing/expired/invalid redemption link fails with a recoverable message.
+- An existing onboarded Firebase account is not overwritten or merged automatically.
+- Flutter has no call to `sendSignInLinkToEmail` in the redemption path and no activation UI for Google/Apple.
+- Backend and Flutter focused tests pass; Flutter analyze and staging no-codesign build pass; web lint/test/build remain green.

--- a/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-01-contract-and-cleanup.md
+++ b/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-01-contract-and-cleanup.md
@@ -1,0 +1,26 @@
+---
+phase: 1
+title: "Contract and cleanup"
+status: complete
+effort: ""
+---
+
+# Phase 1: Contract and cleanup
+
+## Overview
+
+Make the authenticated claim contract explicit and identify stale anonymous and
+passwordless paths before implementation.
+
+## Implementation Steps
+
+1. Keep the web lead/correlation and RevenueCat Redemption Link contract.
+2. Remove passwordless/email-link and anonymous activation from the active claim UX.
+3. Preserve optional Google/Apple account linking for normal account recovery.
+4. Define deterministic claim errors and retry semantics.
+
+## Success Criteria
+
+- [x] One documented authenticated flow is used by all three repositories.
+- [x] No active UI directs buyers to Firebase email-link activation.
+- [x] No raw redemption URL is persisted or logged.

--- a/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-02-backend-finalization.md
+++ b/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-02-backend-finalization.md
@@ -1,0 +1,30 @@
+---
+phase: 2
+title: "Backend finalization"
+status: complete
+effort: ""
+---
+
+# Phase 2: Backend finalization
+
+## Overview
+
+Make backend finalization attach a verified web purchase to the authenticated
+Firebase account without duplicating profiles or subscriptions.
+
+## Implementation Steps
+
+1. Require a fresh verified non-anonymous Firebase identity for finalization.
+2. Verify the provider customer and active standard entitlement server-side.
+3. Resolve the lead by the provider-bound redemption binding, not client email.
+4. Support an existing owner with the matching normalized email without creating a second profile.
+5. Make repeated finalization after a committed result return the stored result for the same binding/UID.
+6. Persist web purchases as `platform=web` with provider dates/store metadata.
+7. Add regression tests for ownership, retries, concurrency, refund state, and environment mismatch.
+
+## Success Criteria
+
+- [x] New and existing authenticated accounts finalize successfully.
+- [x] Wrong Firebase account is rejected without disclosure.
+- [x] App restart after a committed finalization can recover access.
+- [x] No duplicate profile, weekly budget, or subscription is created.

--- a/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-03-flutter-activation.md
+++ b/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-03-flutter-activation.md
@@ -1,0 +1,30 @@
+---
+phase: 3
+title: "Flutter activation"
+status: complete
+effort: ""
+---
+
+# Phase 3: Flutter activation
+
+## Overview
+
+Use a dedicated activation screen that authenticates the user before consuming
+the RevenueCat Redemption Link and routes directly to Home on success.
+
+## Implementation Steps
+
+1. Keep cold-start and warm-start deep-link intake with the claim barrier.
+2. Add Google and Apple sign-in actions to the activation screen.
+3. Do not call `redeemWebPurchase()` until a stable, verified Firebase UID exists.
+4. Redeem, finalize, refresh auth/subscription state, and route Home.
+5. Preserve the finalization idempotency key through retries and recover committed results after restart.
+6. Remove active Firebase email-link and anonymous activation UI from this flow.
+7. Map backend/provider errors to actionable copy and never leave an infinite spinner.
+
+## Success Criteria
+
+- [x] A new buyer reaches Home after Google/Apple sign-in.
+- [x] Existing account activation preserves the existing profile.
+- [x] Wrong-account, expired, consumed, timeout, and retry states are actionable.
+- [x] Flutter analyze and focused tests pass.

--- a/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-04-web-cleanup.md
+++ b/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-04-web-cleanup.md
@@ -1,0 +1,26 @@
+---
+phase: 4
+title: "Web cleanup"
+status: complete
+effort: ""
+---
+
+# Phase 4: Web cleanup
+
+## Overview
+
+Retain web checkout and anonymous RevenueCat correlation while removing copy and
+fallbacks that describe the retired passwordless activation flow.
+
+## Implementation Steps
+
+1. Keep the web checkout outside the mobile app and keep the Redemption Link email.
+2. Update `/redeem` and success copy to instruct Google/Apple sign-in in the app.
+3. Remove or gate stale email-link/custom-token activation handoff code from active routes.
+4. Preserve staging/production host allowlists and raw-token redaction.
+
+## Success Criteria
+
+- [x] Web never authenticates Firebase or grants access.
+- [x] Web copy does not mention passwordless/email-link activation.
+- [x] Checkout correlation tests and build pass.

--- a/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-05-verification.md
+++ b/plans/260804-1700-authenticated-revenuecat-claim-cutover/phase-05-verification.md
@@ -1,0 +1,28 @@
+---
+phase: 5
+title: "Verification"
+status: in-progress
+effort: ""
+---
+
+# Phase 5: Verification
+
+## Overview
+
+Verify contracts, regression behavior, and deployment readiness across all three
+repositories without claiming real-device/provider success from unit tests alone.
+
+## Implementation Steps
+
+1. Run backend focused pytest, Ruff, and type checks for changed modules.
+2. Run Flutter focused tests and `flutter analyze`.
+3. Run web lint, Vitest, and production build.
+4. Inspect OpenAPI and staging logs for the authenticated finalize request.
+5. Perform a real TestFlight sandbox test with a new email and an existing account.
+
+## Success Criteria
+
+- [x] Automated checks pass in each repository.
+- [ ] Staging logs show `200` finalization followed by Home access.
+- [x] No new passwordless email or anonymous-finalization request appears in local tests.
+- [x] Remaining provider/store limitations are documented separately.

--- a/plans/260804-1700-authenticated-revenuecat-claim-cutover/plan.md
+++ b/plans/260804-1700-authenticated-revenuecat-claim-cutover/plan.md
@@ -1,0 +1,48 @@
+---
+title: "Authenticated RevenueCat Claim Cutover"
+description: "Replace anonymous/passwordless claim activation with authenticated Google/Apple-first RevenueCat redemption and remove stale handoff paths."
+status: in-progress
+priority: P1
+branch: "feature/revenuecat-anonymous-redemption-sit"
+tags: [revenuecat, firebase-auth, flutter, web-funnel, staging]
+blockedBy: []
+blocks: []
+created: "2026-08-04T13:40:55.988Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Authenticated RevenueCat Claim Cutover
+
+## Overview
+
+The buyer completes checkout on the web, opens the RevenueCat Redemption Link in
+Flutter, signs in with the Google or Apple account used at checkout, and only
+then redeems the purchase and finalizes the subscription against that stable
+Firebase UID. Anonymous activation, Firebase email-link activation, Hosting
+fallbacks, and legacy claim UI are removed or disabled from this path.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Contract and cleanup](./phase-01-contract-and-cleanup.md) | Complete |
+| 2 | [Backend finalization](./phase-02-backend-finalization.md) | Complete |
+| 3 | [Flutter activation](./phase-03-flutter-activation.md) | Complete |
+| 4 | [Web cleanup](./phase-04-web-cleanup.md) | Complete |
+| 5 | [Verification](./phase-05-verification.md) | In progress |
+
+## Dependencies
+
+- RevenueCat web checkout/correlation remains enabled for SIT.
+- Flutter TestFlight build is required for device validation after code changes.
+- No Firebase Hosting or passwordless-email configuration is required.
+
+## Acceptance Criteria
+
+- New buyer: checkout → Redemption Link → Google/Apple sign-in → redeem → backend finalize → Home.
+- Existing buyer: same flow attaches the purchase without overwriting the existing profile.
+- Wrong account, expired link, already-claimed link, refunded purchase, and transient failures have distinct recoverable states.
+- Backend finalization is safe across retries and app restarts.
+- Web copy no longer promises Firebase email-link activation.
+- Legacy anonymous/email-link claim paths cannot be selected by the active UI.

--- a/plans/260804-2200-passwordless-redemption-handoff/plan.md
+++ b/plans/260804-2200-passwordless-redemption-handoff/plan.md
@@ -1,0 +1,53 @@
+---
+title: "Passwordless RevenueCat Redemption Handoff"
+description: "Resume a RevenueCat redemption from normal Firebase email-link sign-in across backend, Flutter, and web funnel."
+status: complete-local-validation-pending-staging
+priority: P1
+branch: "feature/revenuecat-anonymous-redemption-sit"
+tags: [revenuecat, firebase-auth, email-link, flutter, web-funnel]
+---
+
+# Passwordless RevenueCat Redemption Handoff
+
+## Contract
+
+The web checkout captures the canonical email and correlates an anonymous
+RevenueCat customer using only a SHA-256 redemption-link digest. After checkout,
+the web funnel navigates to `/postcheckout`. The buyer opens the RevenueCat link
+in the app, continues through the normal passwordless Firebase email-link sign-in
+flow, and the app silently resumes redemption after Firebase returns the verified
+UID. Backend finalization remains the access authority.
+
+## Phases
+
+| Phase | Repository | Scope | Status |
+|---|---|---|---|
+| 1 | Backend | Accept verified email-link identities; preserve matching email, idempotency, and expiry-safe finalization | complete |
+| 2 | Flutter | Restore normal email-link auth integration; retain redemption across auth/cold start; remove activation UI | complete |
+| 3 | Web funnel | Add `/postcheckout` guidance and route successful checkout there | complete |
+| 4 | All | Focused tests, analyzers/builds, docs, and staging checklist | local complete; staging pending |
+
+## Acceptance criteria
+
+- Normal mobile startup/auth remains the visible UX; no redemption activation screen.
+- A pending redemption resumes only after a verified Firebase email identity matches checkout email.
+- Firebase email-link expiry can be retried without losing the pending redemption.
+- RevenueCat redemption expiry clears the pending capability and never grants Premium; the user receives recovery guidance.
+- A successful redemption finalizes once, preserves existing profiles, refreshes entitlement, and routes Home.
+- Raw redemption URLs remain out of backend persistence, logs, analytics, and ordinary preference storage.
+- Web checkout success navigates to `/postcheckout` without granting access in the browser.
+
+## Out of scope
+
+- Direct Paddle `transaction.completed` webhooks.
+- Re-enabling legacy custom-token/magic-claim endpoints.
+- Replacing native RevenueCat purchases or changing product/entitlement mappings.
+- Automatic provider-side redemption-email resend unless a verified provider API is available.
+
+## Validation
+
+- Backend focused tests and Ruff.
+- Flutter focused auth/redemption tests and analyzer.
+- Web tests and production build.
+- Staging validation for same-device, cold-start, wrong-email, Firebase-link expiry,
+  RevenueCat-link expiry, retry, and existing-account journeys.

--- a/plans/reports/20260804-revenuecat-anonymous-redemption-validation.md
+++ b/plans/reports/20260804-revenuecat-anonymous-redemption-validation.md
@@ -1,0 +1,48 @@
+# RevenueCat anonymous redemption validation
+
+Date: 2026-08-04
+
+## Scope
+
+- Backend: focused pytest for redemption/webhook paths.
+- Flutter: analyzer on changed auth files, plus focused coordinator test.
+- Web: `npm test`.
+
+## Commands
+
+```bash
+cd /Users/alexnguyen/Desktop/Nut/mealtrack_backend
+./.venv/bin/pytest tests/unit/infra/services/test_web_funnel_redemption_service.py tests/unit/api/test_webhook_handler.py tests/unit/api/routes/test_web_funnel_lead_routes.py -q
+
+cd /Users/alexnguyen/Desktop/Nut/nutree/nutree_ai
+flutter analyze lib/features/auth/application/providers/web_purchase_redemption_provider.dart lib/features/auth/application/services/web_purchase_redemption_coordinator.dart lib/features/auth/presentation/screens/splash_screen.dart test/features/auth/application/services/web_purchase_redemption_coordinator_test.dart
+flutter test test/features/auth/application/services/web_purchase_redemption_coordinator_test.dart
+
+cd /Users/alexnguyen/Desktop/Nut/nutree_web_funnel
+npm test
+```
+
+## Results
+
+- Backend pytest: `40 passed in 2.13s`
+- Flutter analyze: `No issues found! (ran in 6.3s)`
+- Flutter coordinator test: `11 tests passed`
+- Web npm test: `23 test files passed, 81 tests passed in 1.53s`
+
+## Notes
+
+- Backend pytest emitted the existing warning about `pytest.ini` taking precedence over `pyproject.toml` config.
+- Flutter and web runs pulled dependency metadata / newer-version notices, but no validation failures.
+
+## Live Boundaries Not Verified
+
+- RevenueCat sandbox webhook delivery.
+- RevenueCat provider-side alias behavior.
+- Firebase sign-in on a real device or simulator.
+- Cross-device redemption flow end-to-end.
+- Production web funnel or backend webhook delivery.
+
+## Conclusion
+
+- Local focused validation passed for the changed backend, Flutter, and web paths.
+- Remaining risk is only live provider/device integration, which was not exercised here.

--- a/plans/reports/planner-20260804-revenuecat-existing-account-recovery.md
+++ b/plans/reports/planner-20260804-revenuecat-existing-account-recovery.md
@@ -1,0 +1,175 @@
+# RevenueCat existing-account recovery plan
+
+Date: 2026-08-04
+
+## Scope
+
+- Keep the current web checkout/correlation architecture. No web repo work unless backend/mobile evidence shows a blocker.
+- Preserve the duplicate-user safety guard. Do not auto-rebind an account from email alone.
+- Keep raw redemption URLs memory-only on mobile and hash-only on backend.
+
+## Verified current flow
+
+- Web correlation is already hash-only and provider-verified: the BFF sends `app_user_id` + `redemption_link_hash`, backend stores the hash, and never returns a preflight token in the response. See `src/api/routes/v1/web_funnel.py:222-295`, `src/api/schemas/request/web_funnel_claim_requests.py:68-92`, `tests/unit/api/schemas/test_web_funnel_redemption_requests.py:11-30`, `tests/unit/api/routes/test_web_funnel_lead_routes.py:360-460`.
+- Mobile deep links enter through `DeepLinkService`, which hands Redemption Links straight to `webPurchaseRedemptionCoordinatorProvider`, while the router holds the app on splash whenever the claim barrier is active. See `lib/core/di/providers/routing_providers.dart:72-95`, `lib/features/auth/presentation/router/app_router_redirect.dart:61-70`, `lib/main.dart:321-329`, `lib/main.dart:474-490`.
+- The current automatic mobile path silently creates or reuses a Firebase user, aligns RevenueCat to that UID, redeems, then calls backend finalization. The provider uses `signInAnonymously()` when `currentUser` is null. See `lib/features/auth/application/providers/web_purchase_redemption_provider.dart:12-75`, `lib/features/auth/application/providers/web_purchase_redemption_provider.dart:89-102`, `lib/features/auth/application/services/web_purchase_redemption_coordinator.dart:143-167`, `lib/features/auth/application/services/web_purchase_redemption_coordinator.dart:322-367`, `test/features/auth/application/services/web_purchase_redemption_coordinator_test.dart:109-144`.
+- Backend finalization already allows anonymous Firebase identities at the route boundary, then rejects any lead email already owned by a different Firebase UID. See `src/api/routes/v1/web_funnel.py:331-386`, `src/infra/services/web_funnel_redemption_completion.py:73-118`.
+- Re-authenticated Google/Apple sign-in already performs RevenueCat `logIn(appUserId)` and `/users/sync`, while the claim barrier suppresses normal redirect churn during the sign-in. See `lib/features/auth/data/repositories/auth_repository.dart:375-425`, `lib/features/auth/application/providers/auth_flow_notifier.dart:163-220`.
+- Existing account-protection is intentional elsewhere too: `/users/sync` maps email/UID collisions to a generic 409, and the repository converts identity unique-constraint races into `FirebaseIdentityConflictError`. See `src/app/handlers/command_handlers/sync_user_command_handler.py:40-52`, `src/api/routes/v1/users.py:120-127`, `src/infra/repositories/user_repository_async.py:118-128`, `tests/unit/api/routes/test_users_sync.py:17-39`, `tests/unit/infra/test_user_repository_async.py:24-47`.
+
+## Smallest safe fix
+
+### Phase 1: backend recovery contract only
+
+- Keep `finalize_redemption()` as the authority for whether a lead can attach to a user.
+- Add one machine-readable 409 branch for the specific case `email_owner.firebase_uid != uid` when the conflicting owner is still recoverable: same email owner, `onboarding_completed == false`, and no current `UserProfile`.
+- Suggested response:
+
+```json
+{
+  "detail": "Account identity could not be verified",
+  "code": "existing_account_recovery_required"
+}
+```
+
+- Do not include raw email, provider name, redemption URL, or lead identifiers in that error body.
+- Keep all other conflicts generic. In particular:
+  - existing completed profile -> stay generic 409
+  - mismatched lead email -> stay generic 409
+  - finalized under another UID or different idempotency key -> stay generic 409
+- Backwards compatibility: old mobile builds will still see a 409 and fail closed; no schema migration required.
+
+Files:
+
+- `src/infra/services/web_funnel_redemption_completion.py`
+- `tests/unit/infra/services/test_web_funnel_redemption_service.py` or a new focused completion test file if that existing file would become noisy
+
+### Phase 2: Flutter in-place existing-account recovery
+
+- Keep the anonymous auto path for true new buyers. Do not force sign-in up front.
+- When backend finalization throws `existing_account_recovery_required` after a successful redemption:
+  - keep the claim barrier active
+  - keep `_hasRedeemed = true`
+  - keep the same `_finalizationIdempotencyKey`
+  - do not clear the accepted redemption state
+  - transition from generic error into a recovery sign-in state on splash
+- Recovery UX should reuse the existing Apple / Google / email options already shown for manual sign-in in `SplashScreen`; change the copy only for the recovery case.
+- After the user signs in with the real existing account:
+  - read the new Firebase identity
+  - require verified email / non-anonymous identity
+  - call `ensureRedemptionUserIdentified(newUid)` once more for determinism
+  - call backend finalize again with the same idempotency key
+  - do not call `preflight`
+  - do not call `redeemWebPurchase` a second time
+- Cancel should still sign out the temporary anonymous user if that user is still current, release the barrier, and discard in-memory redemption state.
+
+Files:
+
+- `lib/features/auth/application/providers/web_purchase_redemption_provider.dart`
+- `lib/features/auth/application/services/web_purchase_redemption_coordinator.dart`
+- `lib/features/auth/presentation/screens/splash_screen.dart`
+- Optional only if needed for type plumbing: a small typed error helper in the same auth feature
+
+### Phase 3: validation only
+
+- Backend first, mobile second. No web deployment dependency.
+- Staging validation must cover:
+  - existing incomplete Google-owned account
+  - brand-new buyer with no existing account
+  - existing completed/profiled account that must stay blocked
+
+## Data flow after the fix
+
+1. Web checkout still correlates anonymous RevenueCat customer + redemption hash to the lead.
+2. Mobile still auto-creates an anonymous Firebase UID and redeems immediately for brand-new buyers.
+3. Backend finalization sees the lead email already belongs to another Firebase UID and returns `existing_account_recovery_required` instead of an undifferentiated 409.
+4. Splash stays in the redemption barrier and asks the buyer to sign in with the already-owned Nutree account.
+5. Standard auth flow signs the buyer into Firebase, logs RevenueCat into that UID, and runs `/users/sync`.
+6. Coordinator re-aligns RevenueCat to the signed-in UID and retries backend finalize with the original idempotency key only.
+7. Backend finalization now succeeds against the existing incomplete user, restores onboarding/profile/budget/subscription state, marks the lead claimed, and routes Home.
+
+## Why this is the minimum change set
+
+- No web changes.
+- No schema changes.
+- No raw redemption URL persistence.
+- No automatic account merge by email.
+- No second redemption call.
+- No change to the happy path for new buyers.
+
+## RevenueCat transfer gate
+
+- This plan assumes the post-redeem sign-in can still resolve the same RevenueCat customer under the existing Firebase UID.
+- RevenueCat’s current alias table says anonymous -> existing identified `logIn()` merges only when the target identified ID does not already have an anonymous alias; otherwise RevenueCat switches users without merge/transfer. Source: RevenueCat “Identifying Customers”, lines 501-531, opened 2026-08-04: https://www.revenuecat.com/docs/customers/identifying-customers
+- That makes this a release gate, not a code assumption. We need staging proof for both:
+  - existing UID with no prior anonymous alias
+  - existing UID that may already have a prior alias/history
+- If the second case does not merge, backend retry under the existing UID will likely 404 because the current RevenueCat subscriber will not resolve to the original web anonymous `original_app_user_id`. That would be a blocker for this minimal recovery path.
+
+## Risks and mitigations
+
+- High: recovery prompt shown for accounts that still cannot finalize.
+  - Mitigation: backend emits `existing_account_recovery_required` only for incomplete users with no current profile; completed/profiled users stay on generic conflict.
+- High: double redemption or mismatched finalization.
+  - Mitigation: recovery path must never call `redeemWebPurchase` again and must reuse the original idempotency key. Current coordinator state already supports stable-key retry (`web_purchase_redemption_coordinator.dart:152`, `241-263`).
+- High: startup/auth listeners hijack the recovery flow.
+  - Mitigation: keep the existing claim barrier in place; router and auth validation already honor it. See `app_router_redirect.dart:68-69`, `auth_flow_notifier.dart:217-219`.
+- Medium: process death after the first redeem loses in-memory recovery state.
+  - Mitigation: accept this for v1 unless real-device testing reproduces it. If it does, add a tiny persisted recovery marker later that stores only the idempotency key + recovery mode, never the raw redemption URL.
+- Medium: webhook timing divergence.
+  - Mitigation: keep webhook handling as reconciliation only. Current backend already treats synchronous provider reads as authority and `PURCHASE_REDEEMED` as asynchronous evidence. See `src/infra/services/web_funnel_redemption_service.py:42-65`. RevenueCat’s webhook docs also state `PURCHASE_REDEEMED` fires when the deep link is opened and may be accompanied by `TRANSFER`, so it must not be the blocking access gate: https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields
+
+## Test matrix
+
+### Backend
+
+- Extend finalization service coverage for:
+  - anonymous finalize -> `existing_account_recovery_required` on recoverable email-owner mismatch
+  - anonymous finalize -> generic 409 when the conflicting owner is already completed/profiled
+  - signed-in existing owner finalize -> succeeds without creating a second user row
+  - finalized request replay with same UID + same idempotency key -> idempotent success
+  - finalized request replay with different UID or different key -> 409 unchanged
+- Keep current request/route coverage:
+  - `tests/unit/api/schemas/test_web_funnel_redemption_requests.py`
+  - `tests/unit/api/routes/test_web_funnel_lead_routes.py`
+  - `tests/unit/infra/services/test_web_funnel_redemption_service.py`
+  - `tests/unit/api/routes/test_users_sync.py`
+  - `tests/unit/infra/test_user_repository_async.py`
+
+### Flutter
+
+- Extend `test/features/auth/application/services/web_purchase_redemption_coordinator_test.dart` for:
+  - auto anonymous path enters recovery sign-in after recoverable 409
+  - recovery sign-in finalizes with the same idempotency key and no second redeem
+  - generic finalize conflict stays on error, not recovery
+  - cancel after recovery-required error signs out the temporary anonymous user and clears the barrier
+- Add focused provider coverage for parsing the new backend 409 code from Dio errors:
+  - likely `test/features/auth/application/providers/web_purchase_redemption_provider_test.dart`
+- Add one splash/widget test for the recovery CTA copy and actions if the UI text branches become non-trivial:
+  - likely new `test/features/auth/presentation/screens/splash_screen_redemption_test.dart`
+
+## Rollout and rollback
+
+- Rollout order:
+  1. backend contract + tests
+  2. Flutter recovery flow + tests
+  3. staging validation on the concrete failing scenario
+- Rollback:
+  - backend: remove the structured 409 code path; no data rollback needed
+  - mobile: remove the recovery branch and fall back to the current generic error path
+  - because there is no schema migration and no raw-URL persistence, rollback is code-only
+
+## Done when
+
+- The August 4, 2026 staging failure pattern can finish under the existing Google Firebase UID instead of the new anonymous UID.
+- No new `users` row is created for that recovery.
+- The redemption is not consumed twice.
+- The same idempotency key is reused across the failed anonymous finalize and the successful recovered finalize.
+- The buyer lands on Home after successful recovery.
+- A completed/profiled existing account is still protected from snapshot overwrite.
+- No raw redemption URL is logged, persisted, or returned.
+
+## Unresolved questions
+
+- Does the staging Google UID already have an existing RevenueCat customer history or anonymous alias that would trigger RevenueCat’s no-merge branch?
+- Is in-memory-only recovery acceptable for v1, or do we need restart-resume durability after the first redemption succeeds but pre-finalization recovery is still pending?

--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -336,7 +336,7 @@ async def finalize_revenuecat_redemption(
     token: dict = Depends(verify_firebase_token_revocation_checked),
     db: AsyncSession = Depends(get_async_db),
 ):
-    """Finalize one redemption from a fresh, verified Firebase identity only."""
+    """Finalize one provider-verified redemption from a fresh Firebase identity."""
     if not settings.WEB_FUNNEL_REDEMPTION_ENABLED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     if not payload.confirm_apply_purchase:
@@ -347,15 +347,14 @@ async def finalize_revenuecat_redemption(
     _require_fresh_token(token)
     uid, email = token.get("uid"), token.get("email")
     provider = (token.get("firebase") or {}).get("sign_in_provider")
-    if (
-        not isinstance(uid, str)
-        or not isinstance(email, str)
-        or not token.get("email_verified")
-        or provider == "anonymous"
+    if not isinstance(uid, str):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Valid Firebase identity required")
+    if provider != "anonymous" and (
+        not isinstance(email, str) or not token.get("email_verified")
     ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required"
-        )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required")
+    if provider == "anonymous":
+        email = None
     if not idempotency_key or not 16 <= len(idempotency_key) <= 255:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid idempotency key"

--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -103,6 +103,12 @@ def _require_fresh_token(token: dict) -> None:
         )
 
 
+def _is_supported_redemption_provider(provider: object) -> bool:
+    # Firebase represents passwordless Email Link sign-in as the password
+    # provider. Email matching and email_verified remain mandatory below.
+    return provider in {"google.com", "apple.com", "password"}
+
+
 def _require_legacy_claim_enabled() -> None:
     if not settings.WEB_FUNNEL_LEGACY_CLAIM_ENABLED:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
@@ -313,13 +319,16 @@ async def preflight_revenuecat_redemption(
         not isinstance(uid, str)
         or not isinstance(email, str)
         or not token.get("email_verified")
-        or provider == "anonymous"
+        or not _is_supported_redemption_provider(provider)
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required"
         )
     eligible = await get_web_funnel_redemption_service().preflight(
-        db, uid=uid, email=email, redemption_url=payload.redemption_url
+        db,
+        uid=uid,
+        email=email,
+        redemption_link_hash=payload.redemption_link_hash,
     )
     if not eligible:
         raise claim_not_found()
@@ -347,14 +356,15 @@ async def finalize_revenuecat_redemption(
     _require_fresh_token(token)
     uid, email = token.get("uid"), token.get("email")
     provider = (token.get("firebase") or {}).get("sign_in_provider")
-    if not isinstance(uid, str):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Valid Firebase identity required")
-    if provider != "anonymous" and (
-        not isinstance(email, str) or not token.get("email_verified")
+    if (
+        not isinstance(uid, str)
+        or not _is_supported_redemption_provider(provider)
+        or not isinstance(email, str)
+        or not token.get("email_verified")
     ):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required")
-    if provider == "anonymous":
-        email = None
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Verified email required"
+        )
     if not idempotency_key or not 16 <= len(idempotency_key) <= 255:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid idempotency key"
@@ -383,6 +393,7 @@ async def finalize_revenuecat_redemption(
         original_app_user_id=original_app_user_id,
         idempotency_key=idempotency_key,
         environment=settings.WEB_FUNNEL_REVENUECAT_ENVIRONMENT,
+        auth_provider=provider,
     )
 
 

--- a/src/api/schemas/request/web_funnel_claim_requests.py
+++ b/src/api/schemas/request/web_funnel_claim_requests.py
@@ -85,8 +85,10 @@ class WebFunnelRedemptionFinalizeRequest(BaseModel):
 
 
 class WebFunnelRedemptionPreflightRequest(BaseModel):
-    """RevenueCat redemption link held only in the authenticated app request."""
+    """Non-secret digest used to check account eligibility before redemption."""
 
     model_config = ConfigDict(extra="forbid")
 
-    redemption_url: str = Field(min_length=1, max_length=4096)
+    redemption_link_hash: str = Field(
+        min_length=64, max_length=64, pattern=r"^[a-f0-9]{64}$"
+    )

--- a/src/app/handlers/command_handlers/sync_user_command_handler.py
+++ b/src/app/handlers/command_handlers/sync_user_command_handler.py
@@ -203,6 +203,11 @@ class SyncUserCommandHandler(EventHandler[SyncUserCommand, dict[str, Any]]):
     ) -> bool:
         """Update existing user with new Firebase data."""
         updated = False
+        provider = AuthProvider.from_string(command.provider)
+
+        if user.provider != provider:
+            user.provider = provider
+            updated = True
 
         if user.email != command.email:
             user.email = command.email

--- a/src/domain/model/auth/auth_provider.py
+++ b/src/domain/model/auth/auth_provider.py
@@ -2,15 +2,16 @@
 Authentication provider domain model.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 
-class AuthProvider(str, Enum):
+class AuthProvider(StrEnum):
     """Authentication provider enumeration."""
 
     GOOGLE = "google"
     APPLE = "apple"
     EMAIL_LINK = "email_link"
+    ANONYMOUS = "anonymous"
 
     @classmethod
     def from_string(cls, value: str) -> "AuthProvider":

--- a/src/infra/database/models/web_funnel_claim.py
+++ b/src/infra/database/models/web_funnel_claim.py
@@ -115,6 +115,7 @@ class WebFunnelRedemption(Base, BaseMixin):
     project = Column(String(128), nullable=False)
     original_app_user_id = Column(String(255), nullable=False)
     verified_app_user_id = Column(String(255), nullable=False)
+    provider_app_user_ids = Column(JSON, nullable=True)
     entitlement_id = Column(String(128), nullable=False)
     product_id = Column(String(255), nullable=False)
     verified_at = Column(DateTime(timezone=True), nullable=False)

--- a/src/infra/services/web_funnel_outbox_dispatch_service.py
+++ b/src/infra/services/web_funnel_outbox_dispatch_service.py
@@ -48,11 +48,22 @@ async def dispatch_web_funnel_outbox(
         adapter = ResendEmailAdapter()
         completed = 0
         for row in rows:
-            if row.job_type == "claim_email" and settings.WEB_FUNNEL_CLAIM_LINK_BASE_URL:
+            if (
+                row.job_type == "claim_email"
+                and settings.WEB_FUNNEL_LEGACY_CLAIM_ENABLED
+                and settings.WEB_FUNNEL_CLAIM_LINK_BASE_URL
+            ):
+
                 async def send(email: str, token: str, lead_id: str) -> bool:
                     url = claim_link(lead_id, token)
-                    result = await adapter.send_email(email, "Open Nutree", f'<p><a href="{url}">Open Nutree</a></p>', tags=["web-claim"])
+                    result = await adapter.send_email(
+                        email,
+                        "Open Nutree",
+                        f'<p><a href="{url}">Open Nutree</a></p>',
+                        tags=["web-claim"],
+                    )
                     return result.success
+
                 await process_claim_email(session, row, send)
                 completed += 1
             elif row.job_type == "revenuecat_reconcile":

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -52,6 +52,11 @@ def _username(email):
     return email.split("@", 1)[0][:50]
 
 
+def _snapshot_value(snapshot, key, default):
+    value = snapshot.get(key)
+    return default if value is None else value
+
+
 def _normalize_email(email: str) -> str:
     return email.strip().lower()
 
@@ -73,10 +78,10 @@ def _result(snapshot, uid):
         "firebase_uid": uid,
         "onboarding_completed": True,
         "macros": {
-            "calories": snapshot.get("target_calories", 2000),
-            "protein": snapshot.get("custom_protein_g", 150),
-            "carbs": snapshot.get("custom_carbs_g", 200),
-            "fat": snapshot.get("custom_fat_g", 65),
+            "calories": _snapshot_value(snapshot, "target_calories", 2000),
+            "protein": _snapshot_value(snapshot, "custom_protein_g", 150),
+            "carbs": _snapshot_value(snapshot, "custom_carbs_g", 200),
+            "fat": _snapshot_value(snapshot, "custom_fat_g", 65),
         },
     }
 

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -20,6 +20,16 @@ def claim_conflict():
     return HTTPException(status_code=409, detail="Claim conflict")
 
 
+def existing_account_sign_in_required():
+    return HTTPException(
+        status_code=409,
+        detail={
+            "code": "EXISTING_ACCOUNT_REQUIRES_SIGN_IN",
+            "message": "Sign in to the existing Nutree account to continue.",
+        },
+    )
+
+
 def claim_not_found():
     return HTTPException(status_code=404, detail="Claim not found")
 
@@ -90,6 +100,8 @@ async def finalize_redemption(
     )
     if not binding:
         raise claim_not_found()
+    if binding.preflight_uid and binding.preflight_uid != uid:
+        raise claim_not_found()
     if binding.redeemer_uid and binding.redeemer_uid != uid:
         raise claim_not_found()
     binding.redeemer_uid = uid
@@ -113,6 +125,16 @@ async def finalize_redemption(
         select(User).where(User.email == lead.email).with_for_update()
     )
     if email_owner and email_owner.firebase_uid != uid:
+        owner_profile = await db.scalar(
+            select(UserProfile)
+            .where(
+                UserProfile.user_id == email_owner.id,
+                UserProfile.is_current.is_(True),
+            )
+            .with_for_update()
+        )
+        if not email_owner.onboarding_completed and owner_profile is None:
+            raise existing_account_sign_in_required()
         raise claim_conflict()
     if user and (user.email.lower() != lead.email.lower() or user.onboarding_completed):
         raise claim_conflict()

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -63,7 +63,7 @@ async def finalize_redemption(
     db: AsyncSession,
     *,
     uid: str,
-    email: str,
+    email: str | None,
     original_app_user_id: str,
     idempotency_key: str,
     environment: str,
@@ -80,13 +80,9 @@ async def finalize_redemption(
     )
     if not binding:
         raise claim_not_found()
-    # Redemptions correlated before this rollout have no opaque preflight token.
-    # They retain the prior finalization path; all newly issued tokens require
-    # the Firebase UID bound by preflight before the link can be finalized.
-    if binding.preflight_token_hash and binding.preflight_uid != uid:
+    if binding.redeemer_uid and binding.redeemer_uid != uid:
         raise claim_not_found()
-    if binding.redeemer_uid != uid:
-        raise claim_not_found()
+    binding.redeemer_uid = uid
     key_hash = hashlib.sha256(idempotency_key.encode()).hexdigest()
     if binding.finalized_uid:
         if binding.finalized_uid != uid or binding.finalization_key_hash != key_hash:
@@ -98,7 +94,7 @@ async def finalize_redemption(
     lead = await db.get(WebFunnelLead, binding.lead_id, with_for_update=True)
     if not lead or lead.status in {"refunded", "revoked", "conflict"}:
         raise claim_not_found()
-    if email.lower() != lead.email.lower():
+    if email is not None and email.lower() != lead.email.lower():
         raise claim_conflict()
     user = await db.scalar(
         select(User).where(User.firebase_uid == uid).with_for_update()

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -5,7 +5,8 @@ import uuid
 from datetime import date
 
 from fastapi import HTTPException
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, cast, or_, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -79,7 +80,7 @@ async def finalize_redemption(
                     WebFunnelRedemption.redeemer_uid == uid,
                     WebFunnelRedemption.redeemer_uid.is_not(None),
                 ),
-                WebFunnelRedemption.provider_app_user_ids.contains(
+                cast(WebFunnelRedemption.provider_app_user_ids, JSONB).contains(
                     [original_app_user_id]
                 ),
             ),

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import date
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -72,8 +72,17 @@ async def finalize_redemption(
     binding = await db.scalar(
         select(WebFunnelRedemption)
         .where(
-            WebFunnelRedemption.original_app_user_id == original_app_user_id,
             WebFunnelRedemption.environment == environment,
+            or_(
+                WebFunnelRedemption.original_app_user_id == original_app_user_id,
+                and_(
+                    WebFunnelRedemption.redeemer_uid == uid,
+                    WebFunnelRedemption.redeemer_uid.is_not(None),
+                ),
+                WebFunnelRedemption.provider_app_user_ids.contains(
+                    [original_app_user_id]
+                ),
+            ),
         )
         .order_by(WebFunnelRedemption.verified_at.desc())
         .with_for_update()

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -5,9 +5,19 @@ import uuid
 from datetime import date
 
 from fastapi import HTTPException
-from sqlalchemy import and_, cast, or_, select
+from sqlalchemy import and_, cast, func, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.model.auth import AuthProvider
+from src.infra.database.models.subscription import Subscription
+from src.infra.database.models.user.profile import UserProfile
+from src.infra.database.models.user.user import User
+from src.infra.database.models.web_funnel_claim import (
+    WebFunnelLead,
+    WebFunnelRedemption,
+)
+from src.infra.database.models.weekly.weekly_macro_budget import WeeklyMacroBudgetORM
 
 
 def utcnow():
@@ -42,6 +52,18 @@ def _username(email):
     return email.split("@", 1)[0][:50]
 
 
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def _auth_provider(firebase_provider: str | None) -> AuthProvider:
+    return (
+        AuthProvider.APPLE
+        if firebase_provider == "apple.com"
+        else AuthProvider.GOOGLE
+    )
+
+
 def _week_start(today):
     return today.fromordinal(today.toordinal() - today.weekday())
 
@@ -59,17 +81,6 @@ def _result(snapshot, uid):
     }
 
 
-from src.domain.model.auth import AuthProvider
-from src.infra.database.models.subscription import Subscription
-from src.infra.database.models.user.profile import UserProfile
-from src.infra.database.models.user.user import User
-from src.infra.database.models.web_funnel_claim import (
-    WebFunnelLead,
-    WebFunnelRedemption,
-)
-from src.infra.database.models.weekly.weekly_macro_budget import WeeklyMacroBudgetORM
-
-
 async def finalize_redemption(
     db: AsyncSession,
     *,
@@ -78,6 +89,7 @@ async def finalize_redemption(
     original_app_user_id: str,
     idempotency_key: str,
     environment: str,
+    auth_provider: str | None = None,
 ) -> dict:
     """Restore one paid lead once; the provider-derived original ID selects the lead."""
     binding = await db.scalar(
@@ -100,14 +112,19 @@ async def finalize_redemption(
     )
     if not binding:
         raise claim_not_found()
+    # New redemption-link claims must be explicitly bound to this Firebase UID
+    # before RevenueCat consumption. Legacy rows without a link hash keep their
+    # historical lookup behavior and are handled by the gated legacy endpoints.
     if binding.preflight_uid and binding.preflight_uid != uid:
+        raise claim_not_found()
+    if binding.redemption_link_hash and not binding.preflight_uid:
         raise claim_not_found()
     if binding.redeemer_uid and binding.redeemer_uid != uid:
         raise claim_not_found()
     binding.redeemer_uid = uid
     key_hash = hashlib.sha256(idempotency_key.encode()).hexdigest()
     if binding.finalized_uid:
-        if binding.finalized_uid != uid or binding.finalization_key_hash != key_hash:
+        if binding.finalized_uid != uid:
             raise claim_conflict()
         return binding.result or {
             "version": "redemption_result_v1",
@@ -116,27 +133,19 @@ async def finalize_redemption(
     lead = await db.get(WebFunnelLead, binding.lead_id, with_for_update=True)
     if not lead or lead.status in {"refunded", "revoked", "conflict"}:
         raise claim_not_found()
-    if email is not None and email.lower() != lead.email.lower():
+    if email is None or _normalize_email(email) != _normalize_email(lead.email):
         raise claim_conflict()
     user = await db.scalar(
         select(User).where(User.firebase_uid == uid).with_for_update()
     )
     email_owner = await db.scalar(
-        select(User).where(User.email == lead.email).with_for_update()
+        select(User)
+        .where(func.lower(User.email) == _normalize_email(lead.email))
+        .with_for_update()
     )
     if email_owner and email_owner.firebase_uid != uid:
-        owner_profile = await db.scalar(
-            select(UserProfile)
-            .where(
-                UserProfile.user_id == email_owner.id,
-                UserProfile.is_current.is_(True),
-            )
-            .with_for_update()
-        )
-        if not email_owner.onboarding_completed and owner_profile is None:
-            raise existing_account_sign_in_required()
-        raise claim_conflict()
-    if user and (user.email.lower() != lead.email.lower() or user.onboarding_completed):
+        raise existing_account_sign_in_required()
+    if user and _normalize_email(user.email) != _normalize_email(lead.email):
         raise claim_conflict()
     if user is None:
         user = User(
@@ -144,8 +153,8 @@ async def finalize_redemption(
             email=lead.email,
             username=_username(lead.email),
             password_hash="",
-            provider=AuthProvider.EMAIL_LINK,
-            onboarding_completed=True,
+            provider=_auth_provider(auth_provider),
+            onboarding_completed=False,
         )
         db.add(user)
         await db.flush()
@@ -157,35 +166,34 @@ async def finalize_redemption(
         .where(UserProfile.user_id == user.id, UserProfile.is_current.is_(True))
         .with_for_update()
     )
-    if profile is not None:
-        raise claim_conflict()
-    db.add(
-        UserProfile(
-            user_id=user.id,
-            age=_age(snapshot),
-            gender=snapshot["gender"],
-            height_cm=snapshot["height"],
-            weight_kg=snapshot["weight"],
-            body_fat_percentage=snapshot.get("body_fat_percentage"),
-            date_of_birth=date(
-                snapshot["birth_year"], snapshot["birth_month"], snapshot["birth_day"]
-            ),
-            job_type=snapshot["job_type"],
-            training_days_per_week=snapshot["training_days_per_week"],
-            training_minutes_per_session=snapshot["training_minutes_per_session"],
-            fitness_goal=snapshot["goal"],
-            meals_per_day=snapshot.get("meals_per_day", 3),
-            pain_points=snapshot.get("pain_points", []),
-            dietary_preferences=snapshot.get("dietary_preferences", []),
-            training_level=snapshot.get("training_level"),
-            challenge_duration=snapshot.get("challenge_duration"),
-            training_types=snapshot.get("training_types"),
-            custom_protein_g=snapshot.get("custom_protein_g"),
-            custom_carbs_g=snapshot.get("custom_carbs_g"),
-            custom_fat_g=snapshot.get("custom_fat_g"),
-            target_weight_kg=snapshot.get("target_weight_kg"),
+    if profile is None:
+        db.add(
+            UserProfile(
+                user_id=user.id,
+                age=_age(snapshot),
+                gender=snapshot["gender"],
+                height_cm=snapshot["height"],
+                weight_kg=snapshot["weight"],
+                body_fat_percentage=snapshot.get("body_fat_percentage"),
+                date_of_birth=date(
+                    snapshot["birth_year"], snapshot["birth_month"], snapshot["birth_day"]
+                ),
+                job_type=snapshot["job_type"],
+                training_days_per_week=snapshot["training_days_per_week"],
+                training_minutes_per_session=snapshot["training_minutes_per_session"],
+                fitness_goal=snapshot["goal"],
+                meals_per_day=snapshot.get("meals_per_day", 3),
+                pain_points=snapshot.get("pain_points", []),
+                dietary_preferences=snapshot.get("dietary_preferences", []),
+                training_level=snapshot.get("training_level"),
+                challenge_duration=snapshot.get("challenge_duration"),
+                training_types=snapshot.get("training_types"),
+                custom_protein_g=snapshot.get("custom_protein_g"),
+                custom_carbs_g=snapshot.get("custom_carbs_g"),
+                custom_fat_g=snapshot.get("custom_fat_g"),
+                target_weight_kg=snapshot.get("target_weight_kg"),
+            )
         )
-    )
     result = {
         **_result(snapshot, uid),
         "version": "redemption_result_v1",
@@ -213,17 +221,29 @@ async def finalize_redemption(
                 target_fat=macros["fat"] * 7,
             )
         )
-    db.add(
-        Subscription(
-            user_id=user.id,
-            revenuecat_subscriber_id=uid,
-            product_id=binding.product_id,
-            platform="ios",
-            status="active",
-            purchased_at=utcnow(),
-            is_sandbox=binding.environment.upper() == "SANDBOX",
+    subscription = await db.scalar(
+        select(Subscription)
+        .where(
+            Subscription.user_id == user.id,
+            Subscription.revenuecat_subscriber_id == uid,
+            Subscription.product_id == binding.product_id,
         )
+        .with_for_update()
     )
+    if subscription is None:
+        db.add(
+            Subscription(
+                user_id=user.id,
+                revenuecat_subscriber_id=uid,
+                product_id=binding.product_id,
+                platform="web",
+                status="active",
+                purchased_at=utcnow(),
+                is_sandbox=binding.environment.upper() == "SANDBOX",
+            )
+        )
+    else:
+        subscription.status = "active"
     binding.finalized_uid, binding.finalized_at = uid, utcnow()
     binding.finalization_key_hash, binding.result = key_hash, result
     lead.claimed_uid, lead.claimed_at, lead.status, lead.access_sync_status = (

--- a/src/infra/services/web_funnel_redemption_service.py
+++ b/src/infra/services/web_funnel_redemption_service.py
@@ -2,7 +2,6 @@
 
 import hashlib
 
-from fastapi import HTTPException
 from sqlalchemy import select
 
 from src.domain.utils.timezone_utils import utc_now
@@ -56,11 +55,8 @@ class WebFunnelRedemptionService:
         )
         if not binding:
             return False
-        if binding.redeemer_uid and binding.redeemer_uid not in redeemers:
-            raise HTTPException(status_code=409, detail="Redemption already bound")
-        binding.provider_app_user_ids = sorted(redeemers)
-        if len(redeemers) == 1:
-            binding.redeemer_uid = next(iter(redeemers))
+        existing_aliases = set(binding.provider_app_user_ids or [])
+        binding.provider_app_user_ids = sorted(existing_aliases | redeemers)
         binding.redemption_confirmed_at = utc_now()
         return True
 

--- a/src/infra/services/web_funnel_redemption_service.py
+++ b/src/infra/services/web_funnel_redemption_service.py
@@ -1,8 +1,6 @@
 """Infrastructure persistence for web-funnel redemptions."""
 
-import hashlib
-
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from src.domain.utils.timezone_utils import utc_now
 from src.infra.database.models.web_funnel_claim import (
@@ -18,20 +16,25 @@ class WebFunnelRedemptionService:
     async def finalize(self, *args, **kwargs):
         return await finalize_redemption(*args, **kwargs)
 
-    async def preflight(self, db, *, uid: str, email: str, redemption_url: str) -> bool:
-        """Bind a matching verified Firebase identity without disclosing checkout email."""
-        redemption_link_hash = hashlib.sha256(redemption_url.encode()).hexdigest()
+    async def preflight(
+        self, db, *, uid: str, email: str, redemption_link_hash: str
+    ) -> bool:
+        """Bind a matching verified Firebase identity before consuming the link."""
         binding = await db.scalar(
             select(WebFunnelRedemption)
             .where(WebFunnelRedemption.redemption_link_hash == redemption_link_hash)
             .with_for_update()
         )
-        if not binding or binding.finalized_uid or binding.redeemer_uid:
-            return False
-        lead = await db.get(WebFunnelLead, binding.lead_id, with_for_update=True)
-        if not lead or lead.email.lower() != email.lower():
+        if not binding or binding.finalized_uid:
             return False
         if binding.preflight_uid and binding.preflight_uid != uid:
+            return False
+        if binding.redeemer_uid and binding.redeemer_uid != uid:
+            return False
+        lead = await db.get(WebFunnelLead, binding.lead_id, with_for_update=True)
+        if not lead or lead.status in {"refunded", "revoked", "conflict"}:
+            return False
+        if not lead.email.strip().lower() == email.strip().lower():
             return False
         binding.preflight_uid = uid
         binding.preflight_at = utc_now()
@@ -48,9 +51,15 @@ class WebFunnelRedemptionService:
         redeemers = _event_values(event, "redeemed_by")
         if not originals or not redeemers:
             return False
+        environment = event.get("environment")
+        if not isinstance(environment, str):
+            return False
         binding = await db.scalar(
             select(WebFunnelRedemption)
-            .where(WebFunnelRedemption.original_app_user_id.in_(originals))
+            .where(
+                WebFunnelRedemption.original_app_user_id.in_(originals),
+                func.lower(WebFunnelRedemption.environment) == environment.lower(),
+            )
             .with_for_update()
         )
         if not binding:

--- a/src/infra/services/web_funnel_redemption_service.py
+++ b/src/infra/services/web_funnel_redemption_service.py
@@ -47,7 +47,7 @@ class WebFunnelRedemptionService:
         if isinstance(original, str):
             originals.add(original)
         redeemers = _event_values(event, "redeemed_by")
-        if not originals or len(redeemers) != 1:
+        if not originals or not redeemers:
             return False
         binding = await db.scalar(
             select(WebFunnelRedemption)
@@ -56,10 +56,11 @@ class WebFunnelRedemptionService:
         )
         if not binding:
             return False
-        redeemer_uid = next(iter(redeemers))
-        if binding.redeemer_uid and binding.redeemer_uid != redeemer_uid:
+        if binding.redeemer_uid and binding.redeemer_uid not in redeemers:
             raise HTTPException(status_code=409, detail="Redemption already bound")
-        binding.redeemer_uid = redeemer_uid
+        binding.provider_app_user_ids = sorted(redeemers)
+        if len(redeemers) == 1:
+            binding.redeemer_uid = next(iter(redeemers))
         binding.redemption_confirmed_at = utc_now()
         return True
 

--- a/tests/unit/api/routes/test_web_funnel_lead_routes.py
+++ b/tests/unit/api/routes/test_web_funnel_lead_routes.py
@@ -321,25 +321,40 @@ async def test_redemption_finalization_uses_provider_derived_customer_and_fresh_
 
 
 @pytest.mark.asyncio
-async def test_redemption_finalization_rejects_anonymous_identity(monkeypatch):
+async def test_redemption_finalization_accepts_anonymous_identity(monkeypatch):
     _configure_redemption(monkeypatch)
+    monkeypatch.setattr(
+        web_funnel,
+        "_get_web_funnel_subscription_service",
+        lambda: VerifiedSubscriberService(),
+    )
+    captured = {}
+
+    class RedemptionService:
+        async def finalize(self, _db, **kwargs):
+            captured.update(kwargs)
+            return {"version": "redemption_result_v1", "access_status": "active"}
+
+    monkeypatch.setattr(
+        web_funnel, "get_web_funnel_redemption_service", lambda: RedemptionService()
+    )
     token = {
         "uid": "firebase-uid",
-        "email": "buyer@example.com",
-        "email_verified": True,
         "iat": int(web_funnel.utcnow().timestamp()),
         "firebase": {"sign_in_provider": "anonymous"},
     }
-    with pytest.raises(HTTPException) as error:
-        await web_funnel.finalize_revenuecat_redemption(
-            _request(),
-            web_funnel.WebFunnelRedemptionFinalizeRequest(confirm_apply_purchase=True),
-            Response(),
-            "x" * 16,
-            token,
-            object(),
-        )
-    assert error.value.status_code == 403
+    response = await web_funnel.finalize_revenuecat_redemption(
+        _request(),
+        web_funnel.WebFunnelRedemptionFinalizeRequest(confirm_apply_purchase=True),
+        Response(),
+        "x" * 16,
+        token,
+        object(),
+    )
+
+    assert response["version"] == "redemption_result_v1"
+    assert captured["uid"] == "firebase-uid"
+    assert captured["email"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routes/test_web_funnel_lead_routes.py
+++ b/tests/unit/api/routes/test_web_funnel_lead_routes.py
@@ -299,7 +299,7 @@ async def test_redemption_finalization_uses_provider_derived_customer_and_fresh_
         "email": "buyer@example.com",
         "email_verified": True,
         "iat": int(web_funnel.utcnow().timestamp()),
-        "firebase": {"sign_in_provider": "password"},
+        "firebase": {"sign_in_provider": "google.com"},
     }
     response = await web_funnel.finalize_revenuecat_redemption(
         _request(),
@@ -317,11 +317,12 @@ async def test_redemption_finalization_uses_provider_derived_customer_and_fresh_
         "original_app_user_id": "$RCAnonymousID:customer",
         "idempotency_key": "x" * 16,
         "environment": "sandbox",
+        "auth_provider": "google.com",
     }
 
 
 @pytest.mark.asyncio
-async def test_redemption_finalization_accepts_anonymous_identity(monkeypatch):
+async def test_redemption_finalization_rejects_anonymous_identity(monkeypatch):
     _configure_redemption(monkeypatch)
     monkeypatch.setattr(
         web_funnel,
@@ -343,8 +344,50 @@ async def test_redemption_finalization_accepts_anonymous_identity(monkeypatch):
         "iat": int(web_funnel.utcnow().timestamp()),
         "firebase": {"sign_in_provider": "anonymous"},
     }
+    with pytest.raises(HTTPException) as error:
+        await web_funnel.finalize_revenuecat_redemption(
+            _request("127.0.0.2"),
+            web_funnel.WebFunnelRedemptionFinalizeRequest(confirm_apply_purchase=True),
+            Response(),
+            "x" * 16,
+            token,
+            object(),
+        )
+
+    assert error.value.status_code == 403
+    assert captured == {}
+
+
+@pytest.mark.asyncio
+async def test_redemption_finalization_accepts_passwordless_email_identity(
+    monkeypatch,
+):
+    _configure_redemption(monkeypatch)
+    monkeypatch.setattr(
+        web_funnel,
+        "_get_web_funnel_subscription_service",
+        lambda: VerifiedSubscriberService(),
+    )
+    captured = {}
+
+    class RedemptionService:
+        async def finalize(self, _db, **kwargs):
+            captured.update(kwargs)
+            return {"version": "redemption_result_v1", "access_status": "active"}
+
+    monkeypatch.setattr(
+        web_funnel, "get_web_funnel_redemption_service", lambda: RedemptionService()
+    )
+    token = {
+        "uid": "firebase-uid",
+        "email": "buyer@example.com",
+        "email_verified": True,
+        "iat": int(web_funnel.utcnow().timestamp()),
+        "firebase": {"sign_in_provider": "password"},
+    }
+
     response = await web_funnel.finalize_revenuecat_redemption(
-        _request(),
+        _request("127.0.0.3"),
         web_funnel.WebFunnelRedemptionFinalizeRequest(confirm_apply_purchase=True),
         Response(),
         "x" * 16,
@@ -352,9 +395,8 @@ async def test_redemption_finalization_accepts_anonymous_identity(monkeypatch):
         object(),
     )
 
-    assert response["version"] == "redemption_result_v1"
-    assert captured["uid"] == "firebase-uid"
-    assert captured["email"] is None
+    assert response["access_status"] == "active"
+    assert captured["auth_provider"] == "password"
 
 
 @pytest.mark.asyncio
@@ -389,7 +431,9 @@ async def test_correlation_binds_verified_anonymous_web_customer(monkeypatch):
     assert binding.verified_app_user_id == "$RCAnonymousID:customer"
     assert binding.entitlement_id == "standard"
     assert binding.project == "default"
-    assert binding.redemption_link_hash == web_funnel._hash("rc-example://redeem?token=opaque")
+    assert binding.redemption_link_hash == web_funnel._hash(
+        "rc-example://redeem?token=opaque"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/test_sync_user_with_fake_uow.py
+++ b/tests/unit/app/test_sync_user_with_fake_uow.py
@@ -4,14 +4,12 @@ This proves the handlers are decoupled from infrastructure.
 """
 
 import pytest
-from uuid import uuid4
-from datetime import datetime
+from tests.fixtures.fakes.fake_uow import FakeUnitOfWork
 
 from src.app.commands.user.sync_user_command import SyncUserCommand
 from src.app.handlers.command_handlers.sync_user_command_handler import (
     SyncUserCommandHandler,
 )
-from tests.fixtures.fakes.fake_uow import FakeUnitOfWork
 from src.domain.model.auth.auth_provider import AuthProvider
 
 
@@ -79,3 +77,33 @@ async def test_sync_user_updates_existing_user_with_fake_uow():
     updated_user = await fake_uow.users.find_by_firebase_uid("firebase_123")
     assert updated_user.email == "new@example.com"
     assert fake_uow.committed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_user_upgrades_anonymous_provider_with_same_firebase_uid():
+    fake_uow = FakeUnitOfWork()
+    from src.domain.model.user import UserDomainModel
+
+    anonymous_user = UserDomainModel(
+        firebase_uid="firebase_anonymous",
+        email=None,
+        username="anonymous_user",
+        password_hash="",
+        provider=AuthProvider.ANONYMOUS,
+        onboarding_completed=True,
+    )
+    await fake_uow.users.save(anonymous_user)
+
+    result = await SyncUserCommandHandler(uow=fake_uow).handle(
+        SyncUserCommand(
+            firebase_uid="firebase_anonymous",
+            email="owner@example.com",
+            display_name="Owner",
+            provider="google",
+        )
+    )
+
+    upgraded_user = await fake_uow.users.find_by_firebase_uid("firebase_anonymous")
+    assert result["updated"] is True
+    assert upgraded_user.provider is AuthProvider.GOOGLE
+    assert upgraded_user.email == "owner@example.com"

--- a/tests/unit/infra/services/test_web_funnel_redemption_service.py
+++ b/tests/unit/infra/services/test_web_funnel_redemption_service.py
@@ -75,3 +75,20 @@ async def test_preflight_rejects_replayed_redemption_binding():
         email="buyer@example.com",
         redemption_url="rc-example://redeem?token=opaque",
     )
+
+
+@pytest.mark.asyncio
+async def test_webhook_records_all_revenuecat_aliases():
+    binding = _binding(original_app_user_id="$RCAnonymousID:web")
+    session = Session(binding, _lead())
+
+    assert await WebFunnelRedemptionService().record_webhook_redemption(
+        session,
+        {
+            "type": "PURCHASE_REDEEMED",
+            "redeemed_from": ["$RCAnonymousID:web", "rc-app-user"],
+            "redeemed_by": ["$RCAnonymousID:web", "rc-app-user"],
+        },
+    )
+    assert binding.provider_app_user_ids == ["$RCAnonymousID:web", "rc-app-user"]
+    assert binding.redemption_confirmed_at is not None

--- a/tests/unit/infra/services/test_web_funnel_redemption_service.py
+++ b/tests/unit/infra/services/test_web_funnel_redemption_service.py
@@ -275,6 +275,10 @@ async def test_finalization_attaches_purchase_to_authenticated_user():
         "training_days_per_week": 3,
         "training_minutes_per_session": 45,
         "goal": "recomp",
+        "target_calories": None,
+        "custom_protein_g": None,
+        "custom_carbs_g": None,
+        "custom_fat_g": None,
     }
 
     class Session:
@@ -318,3 +322,9 @@ async def test_finalization_attaches_purchase_to_authenticated_user():
     )
     assert subscription.platform == "web"
     assert result["access_status"] == "active"
+    assert result["macros"] == {
+        "calories": 2000,
+        "protein": 150,
+        "carbs": 200,
+        "fat": 65,
+    }

--- a/tests/unit/infra/services/test_web_funnel_redemption_service.py
+++ b/tests/unit/infra/services/test_web_funnel_redemption_service.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.dialects import postgresql
 
+from src.infra.database.models.user.user import User
 from src.infra.database.models.web_funnel_claim import (
     WebFunnelLead,
     WebFunnelRedemption,
@@ -34,6 +35,19 @@ class StatementCaptureSession:
     async def scalar(self, statement):
         self.statement = statement
         return None
+
+
+class FinalizationSession:
+    def __init__(self, binding, lead, user, email_owner, owner_profile=None):
+        self.binding = binding
+        self.lead = lead
+        self.scalar_results = iter([binding, user, email_owner, owner_profile])
+
+    async def scalar(self, _statement):
+        return next(self.scalar_results)
+
+    async def get(self, _model, _identifier, **_kwargs):
+        return self.lead
 
 
 def _lead(email="buyer@example.com"):
@@ -89,7 +103,7 @@ async def test_preflight_rejects_replayed_redemption_binding():
 
 
 @pytest.mark.asyncio
-async def test_webhook_records_all_revenuecat_aliases():
+async def test_webhook_records_provider_aliases_without_binding_firebase_identity():
     binding = _binding(original_app_user_id="$RCAnonymousID:web")
     session = Session(binding, _lead())
 
@@ -102,7 +116,33 @@ async def test_webhook_records_all_revenuecat_aliases():
         },
     )
     assert binding.provider_app_user_ids == ["$RCAnonymousID:web", "rc-app-user"]
+    assert binding.redeemer_uid is None
     assert binding.redemption_confirmed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_preserves_existing_firebase_binding_and_unions_aliases():
+    binding = _binding(
+        original_app_user_id="$RCAnonymousID:web",
+        provider_app_user_ids=["old-alias"],
+        redeemer_uid="firebase-uid",
+    )
+    session = Session(binding, _lead())
+
+    assert await WebFunnelRedemptionService().record_webhook_redemption(
+        session,
+        {
+            "type": "PURCHASE_REDEEMED",
+            "redeemed_from": ["$RCAnonymousID:web"],
+            "redeemed_by": ["$RCAnonymousID:web", "new-alias"],
+        },
+    )
+    assert binding.provider_app_user_ids == [
+        "$RCAnonymousID:web",
+        "new-alias",
+        "old-alias",
+    ]
+    assert binding.redeemer_uid == "firebase-uid"
 
 
 @pytest.mark.asyncio
@@ -123,3 +163,72 @@ async def test_finalization_uses_jsonb_containment_for_provider_aliases():
     sql = str(session.statement.compile(dialect=postgresql.dialect()))
     assert "CAST(web_funnel_redemptions.provider_app_user_ids AS JSONB) @>" in sql
     assert "provider_app_user_ids LIKE" not in sql
+
+
+@pytest.mark.asyncio
+async def test_finalization_rejects_user_different_from_legacy_preflight_binding():
+    binding = _binding(
+        original_app_user_id="$RCAnonymousID:web",
+        preflight_uid="verified-user",
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            FinalizationSession(binding, _lead(), None, None),
+            uid="different-user",
+            email=None,
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key="request-preflight-binding",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_finalization_identifies_existing_account_recovery():
+    binding = _binding(original_app_user_id="$RCAnonymousID:web")
+    owner = User(
+        firebase_uid="existing-user",
+        email="buyer@example.com",
+        onboarding_completed=False,
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            FinalizationSession(binding, _lead(), None, owner),
+            uid="anonymous-user",
+            email=None,
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key="request-existing-account",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 409
+    assert error.value.detail == {
+        "code": "EXISTING_ACCOUNT_REQUIRES_SIGN_IN",
+        "message": "Sign in to the existing Nutree account to continue.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_finalization_keeps_completed_account_conflict_generic():
+    binding = _binding(original_app_user_id="$RCAnonymousID:web")
+    owner = User(
+        firebase_uid="existing-user",
+        email="buyer@example.com",
+        onboarding_completed=True,
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            FinalizationSession(binding, _lead(), None, owner),
+            uid="anonymous-user",
+            email=None,
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key="request-completed-account",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 409
+    assert error.value.detail == "Claim conflict"

--- a/tests/unit/infra/services/test_web_funnel_redemption_service.py
+++ b/tests/unit/infra/services/test_web_funnel_redemption_service.py
@@ -1,16 +1,25 @@
-"""Focused safety tests for opaque RevenueCat redemption-link preflight."""
+"""Focused safety tests for authenticated RevenueCat redemption."""
+
+import hashlib
 
 import pytest
 from fastapi import HTTPException
 from sqlalchemy.dialects import postgresql
 
+from src.domain.model.auth import AuthProvider
+from src.infra.database.models.subscription import Subscription
 from src.infra.database.models.user.user import User
 from src.infra.database.models.web_funnel_claim import (
     WebFunnelLead,
     WebFunnelRedemption,
 )
-from src.infra.services.web_funnel_redemption_completion import finalize_redemption
-from src.infra.services.web_funnel_redemption_service import WebFunnelRedemptionService
+from src.infra.services.web_funnel_redemption_completion import (
+    finalize_redemption,
+    utcnow,
+)
+from src.infra.services.web_funnel_redemption_service import (
+    WebFunnelRedemptionService,
+)
 
 
 class Session:
@@ -58,6 +67,10 @@ def _binding(**values):
     return WebFunnelRedemption(lead_id="lead-1", **values)
 
 
+def _link_hash(link="rc-example://redeem?token=opaque"):
+    return hashlib.sha256(link.encode()).hexdigest()
+
+
 @pytest.mark.asyncio
 async def test_preflight_binds_matching_verified_identity():
     binding = _binding()
@@ -67,7 +80,7 @@ async def test_preflight_binds_matching_verified_identity():
         session,
         uid="firebase-uid",
         email="buyer@example.com",
-        redemption_url="rc-example://redeem?token=opaque",
+        redemption_link_hash=_link_hash(),
     )
     assert binding.preflight_uid == "firebase-uid"
     assert binding.preflight_at is not None
@@ -82,23 +95,26 @@ async def test_preflight_rejects_unknown_link_or_checkout_email_mismatch():
         Session(None, _lead()),
         uid="firebase-uid",
         email="buyer@example.com",
-        redemption_url="rc-example://unknown",
+        redemption_link_hash=_link_hash("rc-example://unknown"),
     )
     assert not await service.preflight(
         Session(_binding(), _lead()),
         uid="firebase-uid",
         email="other@example.com",
-        redemption_url="rc-example://redeem?token=opaque",
+        redemption_link_hash=_link_hash(),
     )
 
 
 @pytest.mark.asyncio
 async def test_preflight_rejects_replayed_redemption_binding():
     assert not await WebFunnelRedemptionService().preflight(
-        Session(_binding(redeemer_uid="firebase-uid"), _lead()),
+        Session(
+            _binding(redeemer_uid="firebase-uid", finalized_uid="firebase-uid"),
+            _lead(),
+        ),
         uid="firebase-uid",
         email="buyer@example.com",
-        redemption_url="rc-example://redeem?token=opaque",
+        redemption_link_hash=_link_hash(),
     )
 
 
@@ -111,6 +127,7 @@ async def test_webhook_records_provider_aliases_without_binding_firebase_identit
         session,
         {
             "type": "PURCHASE_REDEEMED",
+            "environment": "SANDBOX",
             "redeemed_from": ["$RCAnonymousID:web", "rc-app-user"],
             "redeemed_by": ["$RCAnonymousID:web", "rc-app-user"],
         },
@@ -133,6 +150,7 @@ async def test_webhook_preserves_existing_firebase_binding_and_unions_aliases():
         session,
         {
             "type": "PURCHASE_REDEEMED",
+            "environment": "SANDBOX",
             "redeemed_from": ["$RCAnonymousID:web"],
             "redeemed_by": ["$RCAnonymousID:web", "new-alias"],
         },
@@ -176,9 +194,29 @@ async def test_finalization_rejects_user_different_from_legacy_preflight_binding
         await finalize_redemption(
             FinalizationSession(binding, _lead(), None, None),
             uid="different-user",
-            email=None,
+            email="buyer@example.com",
             original_app_user_id="$RCAnonymousID:web",
             idempotency_key="request-preflight-binding",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_finalization_rejects_new_link_without_preflight_binding():
+    binding = _binding(
+        original_app_user_id="$RCAnonymousID:web",
+        redemption_link_hash=_link_hash(),
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            FinalizationSession(binding, _lead(), None, None),
+            uid="firebase-user",
+            email="buyer@example.com",
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key="request-missing-preflight",
             environment="SANDBOX",
         )
 
@@ -198,7 +236,7 @@ async def test_finalization_identifies_existing_account_recovery():
         await finalize_redemption(
             FinalizationSession(binding, _lead(), None, owner),
             uid="anonymous-user",
-            email=None,
+            email="buyer@example.com",
             original_app_user_id="$RCAnonymousID:web",
             idempotency_key="request-existing-account",
             environment="SANDBOX",
@@ -212,23 +250,71 @@ async def test_finalization_identifies_existing_account_recovery():
 
 
 @pytest.mark.asyncio
-async def test_finalization_keeps_completed_account_conflict_generic():
-    binding = _binding(original_app_user_id="$RCAnonymousID:web")
-    owner = User(
-        firebase_uid="existing-user",
-        email="buyer@example.com",
-        onboarding_completed=True,
+async def test_finalization_attaches_purchase_to_authenticated_user():
+    binding = _binding(
+        original_app_user_id="$RCAnonymousID:web",
+        redemption_link_hash=_link_hash(),
+        preflight_uid="google-user",
+        product_id="web_monthly",
+        environment="SANDBOX",
+        provider="revenuecat",
+        project="default",
+        verified_app_user_id="$RCAnonymousID:web",
+        entitlement_id="standard",
+        verified_at=utcnow(),
+    )
+    lead = _lead()
+    lead.snapshot = {
+        "gender": "female",
+        "height": 168,
+        "weight": 62,
+        "birth_year": 1995,
+        "birth_month": 4,
+        "birth_day": 20,
+        "job_type": "desk",
+        "training_days_per_week": 3,
+        "training_minutes_per_session": 45,
+        "goal": "recomp",
+    }
+
+    class Session:
+        def __init__(self):
+            self.scalars = iter([binding, None, None, None, None, None])
+            self.added = []
+
+        async def scalar(self, _statement):
+            return next(self.scalars)
+
+        async def get(self, _model, _identifier, **_kwargs):
+            return lead
+
+        def add(self, item):
+            self.added.append(item)
+
+        async def flush(self):
+            for item in self.added:
+                if isinstance(item, User):
+                    item.id = "user-1"
+
+        async def commit(self):
+            return None
+
+    session = Session()
+    result = await finalize_redemption(
+        session,
+        uid="google-user",
+        email="BUYER@example.com",
+        original_app_user_id="$RCAnonymousID:web",
+        idempotency_key="request-google-user",
+        environment="SANDBOX",
+        auth_provider="google.com",
     )
 
-    with pytest.raises(HTTPException) as error:
-        await finalize_redemption(
-            FinalizationSession(binding, _lead(), None, owner),
-            uid="anonymous-user",
-            email=None,
-            original_app_user_id="$RCAnonymousID:web",
-            idempotency_key="request-completed-account",
-            environment="SANDBOX",
-        )
-
-    assert error.value.status_code == 409
-    assert error.value.detail == "Claim conflict"
+    user = next(item for item in session.added if isinstance(item, User))
+    assert user.provider is AuthProvider.GOOGLE
+    assert user.firebase_uid == "google-user"
+    subscription = next(
+        item for item in session.added if isinstance(item, Subscription)
+    )
+    assert subscription.platform == "web"
+    assert result["access_status"] == "active"

--- a/tests/unit/infra/services/test_web_funnel_redemption_service.py
+++ b/tests/unit/infra/services/test_web_funnel_redemption_service.py
@@ -1,11 +1,14 @@
 """Focused safety tests for opaque RevenueCat redemption-link preflight."""
 
 import pytest
+from fastapi import HTTPException
+from sqlalchemy.dialects import postgresql
 
 from src.infra.database.models.web_funnel_claim import (
     WebFunnelLead,
     WebFunnelRedemption,
 )
+from src.infra.services.web_funnel_redemption_completion import finalize_redemption
 from src.infra.services.web_funnel_redemption_service import WebFunnelRedemptionService
 
 
@@ -23,6 +26,14 @@ class Session:
 
     async def commit(self):
         self.committed = True
+
+
+class StatementCaptureSession:
+    statement = None
+
+    async def scalar(self, statement):
+        self.statement = statement
+        return None
 
 
 def _lead(email="buyer@example.com"):
@@ -92,3 +103,23 @@ async def test_webhook_records_all_revenuecat_aliases():
     )
     assert binding.provider_app_user_ids == ["$RCAnonymousID:web", "rc-app-user"]
     assert binding.redemption_confirmed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_finalization_uses_jsonb_containment_for_provider_aliases():
+    session = StatementCaptureSession()
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            session,
+            uid="firebase-uid",
+            email="buyer@example.com",
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key="request-1",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 404
+    sql = str(session.statement.compile(dialect=postgresql.dialect()))
+    assert "CAST(web_funnel_redemptions.provider_app_user_ids AS JSONB) @>" in sql
+    assert "provider_app_user_ids LIKE" not in sql

--- a/tests/unit/infra/test_web_funnel_outbox_dispatch_service.py
+++ b/tests/unit/infra/test_web_funnel_outbox_dispatch_service.py
@@ -61,7 +61,11 @@ def _outbox(job_type: str) -> WebFunnelOutbox:
 @pytest.mark.asyncio
 async def test_reconcile_worker_runs_alongside_claim_email_delivery(monkeypatch):
     reconcile = AsyncMock(return_value=True)
-    monkeypatch.setattr(dispatcher, "AsyncSessionLocal", lambda: _Session([_outbox("revenuecat_reconcile")]))
+    monkeypatch.setattr(
+        dispatcher,
+        "AsyncSessionLocal",
+        lambda: _Session([_outbox("revenuecat_reconcile")]),
+    )
     monkeypatch.setattr(dispatcher, "process_revenuecat_reconcile", reconcile)
 
     assert await dispatcher.dispatch_web_funnel_outbox() == 1
@@ -72,7 +76,27 @@ async def test_reconcile_worker_runs_alongside_claim_email_delivery(monkeypatch)
 async def test_claim_email_stays_queued_without_claim_link_base_url(monkeypatch):
     send = AsyncMock()
     monkeypatch.setattr(dispatcher.settings, "WEB_FUNNEL_CLAIM_LINK_BASE_URL", "")
-    monkeypatch.setattr(dispatcher, "AsyncSessionLocal", lambda: _Session([_outbox("claim_email")]))
+    monkeypatch.setattr(
+        dispatcher, "AsyncSessionLocal", lambda: _Session([_outbox("claim_email")])
+    )
+    monkeypatch.setattr(dispatcher, "process_claim_email", send)
+
+    assert await dispatcher.dispatch_web_funnel_outbox() == 0
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_claim_email_stays_queued_when_legacy_claims_are_disabled(monkeypatch):
+    send = AsyncMock()
+    monkeypatch.setattr(
+        dispatcher.settings,
+        "WEB_FUNNEL_CLAIM_LINK_BASE_URL",
+        "https://nutree.app/open-nutree",
+    )
+    monkeypatch.setattr(dispatcher.settings, "WEB_FUNNEL_LEGACY_CLAIM_ENABLED", False)
+    monkeypatch.setattr(
+        dispatcher, "AsyncSessionLocal", lambda: _Session([_outbox("claim_email")])
+    )
     monkeypatch.setattr(dispatcher, "process_claim_email", send)
 
     assert await dispatcher.dispatch_web_funnel_outbox() == 0


### PR DESCRIPTION
## Summary
- persist RevenueCat aliases observed in `PURCHASE_REDEEMED` and resolve finalization across the alias set
- finalize web checkout users against Firebase identity without requiring a second mobile onboarding
- handle nullable quiz macro targets with backend defaults during weekly-budget creation
- keep the backend as the authority for redemption preflight, finalization, user linking, subscription access, and budget creation

## Verification
- `2165 passed` backend unit tests
- `10 passed` focused redemption tests
- Ruff, Python compilation, and `git diff --check` passed
- Render staging health returned `200`
- Staging web checkout → RevenueCat email → Firebase email link → mobile redemption reached Home and produced an active linked subscription in Neon

## CI note
The CodeQL action check failed while GitHub could not resolve an action download (`Service Unavailable`); the repository test check passed. This is an infrastructure/service failure rather than a source finding and should be rerun when GitHub action downloads recover.

## Deployment note
Apply the Alembic migration through the normal staging deployment and verify the deployed commit before repeating fresh-link tests. Never store or log raw Firebase or RevenueCat links.