### PR TITLE
fix(meal-recommendations): include selected meal ingredients

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -118,7 +118,7 @@ The two health routes are declared with `api_route` and answer both GET and HEAD
 
 ### Meal Recommendation Contract
 
-- `create` and `get` return the compact summary contract: selected slots only, with no slot-level ingredients, alternatives, or scores in the plan payload.
+- `create` and `get` return the compact summary contract: selected slots only, with ingredients for each selected meal. Alternatives, scores, and full meal details remain available from slot detail responses.
 - Slot detail hydrates exactly one selected slot plus its alternatives. Mutation responses reuse the same changed-slot shape so clients can patch cached plans in place.
 - `swap`, `log`, and `skip` are owner-scoped, idempotent by request ID, and reject already terminal selected slots.
 - `shown_at`, `skipped_at`, and `logged_at` are backend-owned outcome fields. Clients must not infer terminal state by recalculating recommendation logic.

--- a/docs/meal-recommendation-mobile-handoff.md
+++ b/docs/meal-recommendation-mobile-handoff.md
@@ -86,7 +86,7 @@ Authorization: Bearer <firebase-jwt>
 Behavior:
 
 - Returns the compact plan summary for the owner-scoped plan.
-- The response includes selected slots only. Slot ingredients, alternatives, and scores are omitted from the summary payload.
+- The response includes selected slots only. Each selected meal includes its ingredients; alternatives, scores, and full meal details are omitted from the summary payload.
 
 ### Swap Slot
 
@@ -156,7 +156,8 @@ The plan summary is compact:
 
 - plan metadata: `id`, `status`, `timezone`, `start_date`, `daily_calories`, `allergy_evaluated`
 - slot summary: `id`, `slot_date`, `day_index`, `meal_type`, `catalog_meal_id`, compact `catalog_meal`, `target_calories`, `position`, `selection_version`, `logged_meal_id`, `shown_at`, `skipped_at`
-- omitted from plan summary: `score`, `alternatives`, and `catalog_meal.ingredients`
+- included in the compact `catalog_meal`: selected meal ingredients
+- omitted from plan summary: `score`, `alternatives`, and full meal-detail fields such as `description`
 
 Use `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` for the hydrated selected slot payload when the user needs details or alternatives.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -164,7 +164,7 @@ downloading Cloudinary bytes. Graph nodes must not import provider SDKs,
 ## Data Flow Example: Meal Recommendation Plan
 
 1. `POST /v1/meal-recommendations/three-day` resolves timezone and daily calories, then builds or replays a durable recommendation plan.
-2. The plan-level response is compact: it includes only the selected slots. Slot ingredients, alternatives, and scores stay out of the summary payload.
+2. The plan-level response is compact: it includes only the selected slots, with ingredients for each selected meal. Alternatives, scores, and full meal-detail fields stay out of the summary payload.
 3. `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` hydrates one selected slot and its alternatives when the client needs drill-down data.
 4. `swap`, `log`, and `skip` return the changed-slot detail shape so the mobile client can patch its cached plan without reloading everything.
 5. Recommendation analytics are scheduled through `BackgroundTaskManager` when available. Catalog meals are read from the process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback. Meal-history affinity is projected from aggregate linked ingredient buckets instead of loading the full meal graph, and logging a recommended meal reuses the already loaded selected catalog projection without fabricating image data.

--- a/src/api/routes/v1/meal_recommendation_route_support.py
+++ b/src/api/routes/v1/meal_recommendation_route_support.py
@@ -273,15 +273,7 @@ def _catalog_meal_response(catalog_meal: CatalogMeal) -> MealRecommendationCatal
             fiber_g=float(catalog_meal.fiber_g),
             sugar_g=float(catalog_meal.sugar_g),
         ),
-        ingredients=[
-            MealRecommendationIngredientResponse(
-                food_reference_id=ingredient.food_reference_id,
-                display_name=ingredient.display_name,
-                quantity=float(ingredient.quantity),
-                unit=ingredient.unit,
-            )
-            for ingredient in catalog_meal.ingredients
-        ],
+        ingredients=_catalog_meal_ingredients(catalog_meal),
     )
 
 
@@ -301,4 +293,19 @@ def _catalog_meal_summary_response(
             fiber_g=float(catalog_meal.fiber_g),
             sugar_g=float(catalog_meal.sugar_g),
         ),
+        ingredients=_catalog_meal_ingredients(catalog_meal),
     )
+
+
+def _catalog_meal_ingredients(
+    catalog_meal: CatalogMeal,
+) -> list[MealRecommendationIngredientResponse]:
+    return [
+        MealRecommendationIngredientResponse(
+            food_reference_id=ingredient.food_reference_id,
+            display_name=ingredient.display_name,
+            quantity=float(ingredient.quantity),
+            unit=ingredient.unit,
+        )
+        for ingredient in catalog_meal.ingredients
+    ]

--- a/src/api/schemas/response/meal_recommendation_responses.py
+++ b/src/api/schemas/response/meal_recommendation_responses.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MealRecommendationMacrosResponse(BaseModel):
@@ -40,6 +40,12 @@ class MealRecommendationCatalogMealSummaryResponse(BaseModel):
     image_url: str | None = None
     calories: int
     macros: MealRecommendationMacrosResponse
+    # Selected meals are rendered with their ingredients in the plan deck.
+    # Alternatives remain omitted from the summary and are returned by the
+    # hydrated slot-detail endpoint only.
+    ingredients: list[MealRecommendationIngredientResponse] = Field(
+        default_factory=list
+    )
 
 
 class MealRecommendationAlternativeResponse(BaseModel):

--- a/tests/unit/api/test_meal_recommendation_http_contract.py
+++ b/tests/unit/api/test_meal_recommendation_http_contract.py
@@ -79,7 +79,7 @@ def test_current_openapi_schema_exposes_full_plan_fields():
     assert "macros" in meal_fields
 
 
-def test_summary_openapi_schema_omits_full_plan_fields():
+def test_summary_openapi_schema_keeps_selected_ingredients_compact():
     schema = MealRecommendationPlanSummaryResponse.model_json_schema()
     definitions = schema["$defs"]
 
@@ -88,7 +88,7 @@ def test_summary_openapi_schema_omits_full_plan_fields():
 
     assert "alternatives" not in slot_fields
     assert "score" not in slot_fields
-    assert "ingredients" not in meal_fields
+    assert "ingredients" in meal_fields
     assert "description" not in meal_fields
     assert "macros" in meal_fields
 

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -175,7 +175,7 @@ async def test_create_three_day_recommendations_snapshots_target_and_timezone():
     )
     assert response.id == "plan-1"
     assert not hasattr(response.slots[0], "alternatives")
-    assert not hasattr(response.slots[0].catalog_meal, "ingredients")
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "Rice"
     assert command.idempotency_key == "key-1"
     assert command.timezone == "Asia/Ho_Chi_Minh"
     assert command.daily_calories == 2150
@@ -219,7 +219,7 @@ async def test_get_plan_returns_owner_scoped_compact_summary():
     assert response.slots[0].catalog_meal.name == "Breakfast Rice"
     assert response.slots[0].catalog_meal.calories == 380
     assert not hasattr(response.slots[0], "alternatives")
-    assert not hasattr(response.slots[0].catalog_meal, "ingredients")
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "Rice"
 
 
 @pytest.mark.asyncio
@@ -255,6 +255,7 @@ async def test_get_plan_translates_catalog_text_from_request_language():
     assert response.slots[0].catalog_meal.name == "vi:Breakfast Rice"
     assert response.slots[0].catalog_meal.cuisine == "vi:vietnamese"
     assert response.slots[0].catalog_meal.calories == 380
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "vi:Rice"
     assert translator.calls == [
         (
             [


### PR DESCRIPTION
## Summary

- Include ingredients in compact selected-meal plan summaries.
- Keep alternatives, scores, and full meal details in slot-detail responses.
- Add contract/route regression coverage and update API handoff documentation.

## Test plan

- [x] uv run pytest -q tests/unit/api/test_meal_recommendation_http_contract.py tests/unit/api/test_meal_recommendations_route.py
- [x] uv run ruff check on modified backend files
- [x] No related GitHub issue found.