### PR TITLE
feat(meal): persist independent nutrition overrides

### DIFF
--- a/migrations/versions/20260804000001_add_manual_nutrition_overrides.py
+++ b/migrations/versions/20260804000001_add_manual_nutrition_overrides.py
@@ -1,0 +1,36 @@
+"""Persist independent meal and ingredient nutrition overrides."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260804000001"
+down_revision: str | None = "20260730110500000000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table_name in ("nutrition", "food_item"):
+        if not inspector.has_table(table_name):
+            continue
+        columns = {column["name"] for column in inspector.get_columns(table_name)}
+        if "nutrition_override" not in columns:
+            op.add_column(
+                table_name,
+                sa.Column("nutrition_override", sa.JSON(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table_name in ("food_item", "nutrition"):
+        if not inspector.has_table(table_name):
+            continue
+        columns = {column["name"] for column in inspector.get_columns(table_name)}
+        if "nutrition_override" in columns:
+            op.drop_column(table_name, "nutrition_override")

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -131,7 +131,9 @@ class MealMapper:
                     if hasattr(item, "macros") and item.macros:
                         nutrition_dto = NutritionResponse(
                             nutrition_id=str(item.name),
-                            calories=item.macros.total_calories,
+                            # Use effective item calories so label/overrides
+                            # are not replaced by macro-derived totals.
+                            calories=item_calories,
                             protein_g=item.macros.protein,
                             carbs_g=item.macros.carbs,
                             fat_g=item.macros.fat,

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -83,6 +83,7 @@ class MealMapper:
             CustomNutritionResponse,
             MacrosResponse,
             MealTranslationResponse,
+            NutritionOverrideResponse,
             TranslatedFoodItemResponse,
         )
 
@@ -96,12 +97,13 @@ class MealMapper:
 
             # Map total nutrition macros
             if hasattr(meal.nutrition, "macros") and meal.nutrition.macros:
+                effective_macros = meal.nutrition.effective_macros
                 total_nutrition = MacrosResponse(
-                    protein=meal.nutrition.macros.protein,
-                    carbs=meal.nutrition.macros.carbs,
-                    fat=meal.nutrition.macros.fat,
-                    fiber=meal.nutrition.macros.fiber,
-                    sugar=meal.nutrition.macros.sugar,
+                    protein=effective_macros.protein,
+                    carbs=effective_macros.carbs,
+                    fat=effective_macros.fat,
+                    fiber=effective_macros.fiber,
+                    sugar=effective_macros.sugar,
                 )
             # Handle legacy structure where nutrition has direct properties
             elif hasattr(meal.nutrition, "protein"):
@@ -123,7 +125,7 @@ class MealMapper:
                     if hasattr(item, "macros") and item.macros:
                         nutrition_dto = NutritionResponse(
                             nutrition_id=str(item.name),
-                            calories=item_calories,
+                            calories=item.macros.total_calories,
                             protein_g=item.macros.protein,
                             carbs_g=item.macros.carbs,
                             fat_g=item.macros.fat,
@@ -176,6 +178,16 @@ class MealMapper:
                         description=None,
                         nutrition=nutrition_dto,
                         custom_nutrition=custom_nutrition_dto,
+                        nutrition_override=(
+                            NutritionOverrideResponse(
+                                calories=item.nutrition_override.calories,
+                                protein=item.nutrition_override.protein,
+                                carbs=item.nutrition_override.carbs,
+                                fat=item.nutrition_override.fat,
+                            )
+                            if item.nutrition_override
+                            else None
+                        ),
                         fdc_id=getattr(item, "fdc_id", None),
                         food_reference_id=getattr(item, "food_reference_id", None),
                         is_custom=getattr(item, "is_custom", False),
@@ -269,6 +281,16 @@ class MealMapper:
                 meal.weight_grams if hasattr(meal, "weight_grams") else None
             ),
             total_nutrition=total_nutrition,
+            nutrition_override=(
+                NutritionOverrideResponse(
+                    calories=meal.nutrition.nutrition_override.calories,
+                    protein=meal.nutrition.nutrition_override.protein,
+                    carbs=meal.nutrition.nutrition_override.carbs,
+                    fat=meal.nutrition.nutrition_override.fat,
+                )
+                if meal.nutrition and meal.nutrition.nutrition_override
+                else None
+            ),
             translations=translations_response,
             food_label_metadata=MealMapper._food_label_metadata(meal),
             value_insights=value_insights_response,

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -17,6 +17,9 @@ from src.api.schemas.response import (
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.domain.model.meal import Meal
 from src.domain.model.nutrition import FoodItem, Macros, Micros, Nutrition
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
 from src.domain.services.meal_calorie_service import (
     effective_food_item_calories,
     effective_meal_calories,
@@ -66,6 +69,9 @@ class MealMapper:
         image_url: str | None = None,
         target_language: str | None = None,
         value_insights: MealValueInsights | None = None,
+        source_nutrition_by_food_reference: dict[
+            int, FoodReferenceNutritionProjection
+        ] | None = None,
     ) -> DetailedMealResponse:
         """
         Convert Meal domain model to DetailedMealResponse DTO.
@@ -167,6 +173,10 @@ class MealMapper:
                             ),
                         )
 
+                    source_nutrition_dto = MealMapper._source_nutrition_response(
+                        source_nutrition_by_food_reference,
+                        getattr(item, "food_reference_id", None),
+                    )
                     food_item_dto = FoodItemResponse(
                         id=str(item.id),
                         name=item.name,
@@ -178,6 +188,7 @@ class MealMapper:
                         description=None,
                         nutrition=nutrition_dto,
                         custom_nutrition=custom_nutrition_dto,
+                        source_nutrition=source_nutrition_dto,
                         nutrition_override=(
                             NutritionOverrideResponse(
                                 calories=item.nutrition_override.calories,
@@ -301,6 +312,46 @@ class MealMapper:
             cook_time_min=getattr(meal, "cook_time_min", None),
             cuisine_type=getattr(meal, "cuisine_type", None),
             origin_country=getattr(meal, "origin_country", None),
+        )
+
+    @staticmethod
+    def _source_nutrition_response(
+        source_nutrition_by_food_reference: dict[
+            int, FoodReferenceNutritionProjection
+        ]
+        | None,
+        food_reference_id: int | None,
+    ):
+        if not source_nutrition_by_food_reference or food_reference_id is None:
+            return None
+
+        reference = source_nutrition_by_food_reference.get(food_reference_id)
+        if reference is None or any(
+            value is None
+            for value in (
+                reference.protein_100g,
+                reference.carbs_100g,
+                reference.fat_100g,
+            )
+        ):
+            return None
+
+        from src.api.schemas.response.meal_responses import CustomNutritionResponse
+
+        macros = Macros(
+            protein=reference.protein_100g,
+            carbs=reference.carbs_100g,
+            fat=reference.fat_100g,
+            fiber=reference.fiber_100g,
+            sugar=reference.sugar_100g,
+        )
+        return CustomNutritionResponse(
+            calories_per_100g=macros.total_calories,
+            protein_per_100g=macros.protein,
+            carbs_per_100g=macros.carbs,
+            fat_per_100g=macros.fat,
+            fiber_per_100g=macros.fiber,
+            sugar_per_100g=macros.sugar,
         )
 
     @staticmethod

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -93,6 +93,7 @@ from src.domain.ports.cache_port import CachePort
 from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.services.meal_value_insight_service import MealValueInsightService
 from src.domain.services.prompts.input_sanitizer import sanitize_user_description
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.event_bus import BackgroundTaskManager, EventBus
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,27 @@ STATUS_MAPPING = {
     "FAILED": "failed",
     "INACTIVE": "inactive",
 }
+
+
+async def _source_nutrition_by_food_reference(meal):
+    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
+    food_reference_ids = {
+        item.food_reference_id
+        for item in food_items
+        if getattr(item, "food_reference_id", None) is not None
+    }
+    if not food_reference_ids:
+        return {}
+
+    source_nutrition = {}
+    async with AsyncUnitOfWork() as uow:
+        for food_reference_id in food_reference_ids:
+            reference = await uow.food_references.get_nutrition_projection(
+                food_reference_id
+            )
+            if reference is not None:
+                source_nutrition[food_reference_id] = reference
+    return source_nutrition
 
 
 def _parse_target_date(target_date: str | None):
@@ -631,11 +653,13 @@ async def get_meal(
         )
 
     # Use mapper to convert to response with translation support
+    source_nutrition = await _source_nutrition_by_food_reference(meal)
     return MealMapper.to_detailed_response(
         meal,
         image_url,
         target_language=language,
         value_insights=value_insights,
+        source_nutrition_by_food_reference=source_nutrition,
     )
 
 

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -23,6 +23,7 @@ from fastapi import (
 
 from src.api.base_dependencies import (
     get_ai_model_manager,
+    get_async_food_reference_repository,
     get_cache_service,
     get_image_store,
 )
@@ -93,7 +94,6 @@ from src.domain.ports.cache_port import CachePort
 from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
 from src.domain.services.meal_value_insight_service import MealValueInsightService
 from src.domain.services.prompts.input_sanitizer import sanitize_user_description
-from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.event_bus import BackgroundTaskManager, EventBus
 
 logger = logging.getLogger(__name__)
@@ -115,7 +115,8 @@ STATUS_MAPPING = {
 }
 
 
-async def _source_nutrition_by_food_reference(meal):
+async def _source_nutrition_by_food_reference(meal, food_reference_repository):
+    """Load per-100g density for catalog-backed ingredients via the port."""
     food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
     food_reference_ids = {
         item.food_reference_id
@@ -126,13 +127,12 @@ async def _source_nutrition_by_food_reference(meal):
         return {}
 
     source_nutrition = {}
-    async with AsyncUnitOfWork() as uow:
-        for food_reference_id in food_reference_ids:
-            reference = await uow.food_references.get_nutrition_projection(
-                food_reference_id
-            )
-            if reference is not None:
-                source_nutrition[food_reference_id] = reference
+    for food_reference_id in food_reference_ids:
+        reference = await food_reference_repository.get_nutrition_projection(
+            food_reference_id
+        )
+        if reference is not None:
+            source_nutrition[food_reference_id] = reference
     return source_nutrition
 
 
@@ -612,6 +612,7 @@ async def get_meal(
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
+    food_reference_repository=Depends(get_async_food_reference_repository),
 ):
     """Get detailed information about a specific meal.
 
@@ -653,7 +654,9 @@ async def get_meal(
         )
 
     # Use mapper to convert to response with translation support
-    source_nutrition = await _source_nutrition_by_food_reference(meal)
+    source_nutrition = await _source_nutrition_by_food_reference(
+        meal, food_reference_repository
+    )
     return MealMapper.to_detailed_response(
         meal,
         image_url,

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -59,7 +59,12 @@ from src.api.services.guest_parse_quota import (
     QuotaUnavailableError,
     validate_install_id,
 )
-from src.app.commands.meal import CustomNutritionData, EditMealCommand, FoodItemChange
+from src.app.commands.meal import (
+    CustomNutritionData,
+    EditMealCommand,
+    FoodItemChange,
+    NutritionOverride,
+)
 from src.app.commands.meal.attach_meal_photo_command import AttachMealPhotoCommand
 from src.app.commands.meal.create_manual_meal_command import (
     CreateManualMealCommand,
@@ -801,6 +806,17 @@ async def update_meal_ingredients(
                 quantity=change_request.quantity,
                 unit=change_request.unit,
                 custom_nutrition=custom_nutrition,
+                nutrition_override=(
+                    NutritionOverride(
+                        calories=change_request.nutrition_override.calories,
+                        protein=change_request.nutrition_override.protein,
+                        carbs=change_request.nutrition_override.carbs,
+                        fat=change_request.nutrition_override.fat,
+                    )
+                    if change_request.nutrition_override
+                    else None
+                ),
+                clear_nutrition_override=change_request.clear_nutrition_override,
                 allowed_units=[
                     unit.model_dump() for unit in change_request.allowed_units
                 ],
@@ -814,6 +830,16 @@ async def update_meal_ingredients(
         created_at=payload.created_at,
         meal_type=payload.meal_type,
         food_item_changes=food_item_changes,
+        nutrition_override=(
+            NutritionOverride(
+                calories=payload.nutrition_override.calories,
+                protein=payload.nutrition_override.protein,
+                carbs=payload.nutrition_override.carbs,
+                fat=payload.nutrition_override.fat,
+            )
+            if payload.nutrition_override
+            else None
+        ),
     )
 
     logger.info("Sending command to event bus: %s", command)

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -289,6 +289,12 @@ class FoodItemChangeRequest(BaseModel):
     custom_nutrition: Optional["CustomNutritionRequest"] = Field(
         None, description="Custom nutrition data for non-USDA ingredients"
     )
+    nutrition_override: Optional["NutritionOverrideRequest"] = Field(
+        None, description="Independent nutrition values entered by the user"
+    )
+    clear_nutrition_override: bool = Field(
+        False, description="Restore source nutrition for this ingredient"
+    )
 
     class Config:
         json_schema_extra = {
@@ -340,6 +346,15 @@ class CustomNutritionRequest(BaseModel):
         }
 
 
+class NutritionOverrideRequest(BaseModel):
+    """Absolute values that intentionally bypass nutrition recalculation."""
+
+    calories: float
+    protein: float
+    carbs: float
+    fat: float
+
+
 class EditMealIngredientsRequest(BaseModel):
     """Request DTO for editing meal ingredients."""
 
@@ -352,6 +367,9 @@ class EditMealIngredientsRequest(BaseModel):
     meal_type: Optional[str] = Field(
         None, description="Updated meal type derived from the user's local log time"
     )
+    nutrition_override: Optional[NutritionOverrideRequest] = Field(
+        None, description="Independent meal-level nutrition values"
+    )
     food_item_changes: list[FoodItemChangeRequest] = Field(
         default_factory=list, description="List of ingredient changes"
     )
@@ -362,6 +380,7 @@ class EditMealIngredientsRequest(BaseModel):
             self.dish_name is None
             and self.created_at is None
             and self.meal_type is None
+            and self.nutrition_override is None
             and not self.food_item_changes
         ):
             raise ValueError("At least one meal edit field is required")

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -232,6 +232,10 @@ class FoodItemResponse(BaseModel):
     custom_nutrition: CustomNutritionResponse | None = Field(
         None, description="Custom nutrition per 100g for custom ingredients"
     )
+    source_nutrition: CustomNutritionResponse | None = Field(
+        None,
+        description="Canonical source nutrition per 100g for source-backed ingredients",
+    )
     nutrition_override: NutritionOverrideResponse | None = Field(
         None, description="Independent nutrition values entered by the user"
     )

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -106,23 +106,30 @@ class MealTranslationResponse(BaseModel):
 class MacrosResponse(BaseModel):
     """Response DTO for macronutrient information."""
 
-    protein: float = Field(..., ge=0, description="Protein in grams")
-    carbs: float = Field(..., ge=0, description="Carbohydrates in grams")
-    fat: float = Field(..., ge=0, description="Fat in grams")
-    fiber: float = Field(0, ge=0, description="Fiber in grams")
-    sugar: float = Field(0, ge=0, description="Sugar in grams")
+    protein: float = Field(..., description="Protein in grams")
+    carbs: float = Field(..., description="Carbohydrates in grams")
+    fat: float = Field(..., description="Fat in grams")
+    fiber: float = Field(0, description="Fiber in grams")
+    sugar: float = Field(0, description="Sugar in grams")
 
 
 class NutritionResponse(BaseModel):
     """Response DTO for nutrition information."""
 
     nutrition_id: str = Field(..., description="Nutrition record ID")
-    calories: float = Field(..., ge=0, description="Calories")
-    protein_g: float = Field(..., ge=0, description="Protein in grams")
-    carbs_g: float = Field(..., ge=0, description="Carbohydrates in grams")
-    fat_g: float = Field(..., ge=0, description="Fat in grams")
-    fiber_g: float = Field(0, ge=0, description="Fiber in grams")
-    sugar_g: float = Field(0, ge=0, description="Sugar in grams")
+    calories: float = Field(..., description="Calories")
+    protein_g: float = Field(..., description="Protein in grams")
+    carbs_g: float = Field(..., description="Carbohydrates in grams")
+    fat_g: float = Field(..., description="Fat in grams")
+    fiber_g: float = Field(0, description="Fiber in grams")
+    sugar_g: float = Field(0, description="Sugar in grams")
+
+
+class NutritionOverrideResponse(BaseModel):
+    calories: float
+    protein: float
+    carbs: float
+    fat: float
 
 
 class CustomNutritionResponse(BaseModel):
@@ -225,6 +232,9 @@ class FoodItemResponse(BaseModel):
     custom_nutrition: CustomNutritionResponse | None = Field(
         None, description="Custom nutrition per 100g for custom ingredients"
     )
+    nutrition_override: NutritionOverrideResponse | None = Field(
+        None, description="Independent nutrition values entered by the user"
+    )
     fdc_id: int | None = Field(None, description="USDA FDC ID if available")
     food_reference_id: int | None = Field(
         None, description="Canonical food reference ID if available"
@@ -262,9 +272,12 @@ class DetailedMealResponse(SimpleMealResponse):
         default_factory=list, description="Food items in the meal"
     )
     image_url: str | None = Field(None, description="Meal image URL")
-    total_calories: float | None = Field(None, ge=0, description="Total calories")
+    total_calories: float | None = Field(None, description="Total calories")
     total_weight_grams: float | None = Field(None, gt=0, description="Total weight")
     total_nutrition: MacrosResponse | None = Field(None, description="Total macros")
+    nutrition_override: NutritionOverrideResponse | None = Field(
+        None, description="Independent meal-level nutrition values"
+    )
     translations: dict[str, MealTranslationResponse] | None = Field(
         None, description="Translations keyed by language code"
     )

--- a/src/app/commands/meal/__init__.py
+++ b/src/app/commands/meal/__init__.py
@@ -10,6 +10,7 @@ from .edit_meal_command import (
     CustomNutritionData,
     EditMealCommand,
     FoodItemChange,
+    NutritionOverride,
 )
 from .scan_by_url_command import ScanByUrlCommand
 from .upload_meal_image_immediately_command import UploadMealImageImmediatelyCommand
@@ -21,6 +22,7 @@ __all__ = [
     "AddCustomIngredientCommand",
     "FoodItemChange",
     "CustomNutritionData",
+    "NutritionOverride",
     "DeleteMealCommand",
     "DeleteMealPhotoCommand",
     "AttachMealPhotoCommand",

--- a/src/app/commands/meal/edit_meal_command.py
+++ b/src/app/commands/meal/edit_meal_command.py
@@ -4,10 +4,14 @@ Command to edit meal ingredients and portions.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, List
+from typing import List, Optional
 
 from src.app.events.base import Command
-from src.domain.model.meal.food_item_change import FoodItemChange, CustomNutritionData
+from src.domain.model.meal.food_item_change import (
+    CustomNutritionData,
+    FoodItemChange,
+    NutritionOverride,
+)
 
 
 @dataclass
@@ -20,6 +24,7 @@ class EditMealCommand(Command):
     created_at: Optional[datetime] = None
     meal_type: Optional[str] = None
     food_item_changes: List[FoodItemChange] = field(default_factory=list)
+    nutrition_override: Optional[NutritionOverride] = None
 
 
 @dataclass

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -16,6 +16,7 @@ from src.app.events.meal import MealEditedEvent
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.domain.model.meal import FoodItemTranslation, MealStatus
 from src.domain.model.meal_projection import MealProjection
+from src.domain.model.nutrition import Macros, NutritionOverride
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.services.meal_type_determination_service import (
     determine_meal_type_from_timestamp,
@@ -68,6 +69,25 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
                 # 3. Recalculate nutrition
                 updated_nutrition = self._calculate_total_nutrition(updated_food_items)
+                existing_override = (
+                    meal.nutrition.nutrition_override if meal.nutrition else None
+                )
+                requested_override = command.nutrition_override or existing_override
+                if requested_override is not None:
+                    nutrition_override = NutritionOverride(
+                        calories=requested_override.calories,
+                        protein=requested_override.protein,
+                        carbs=requested_override.carbs,
+                        fat=requested_override.fat,
+                    )
+                    updated_nutrition.nutrition_override = nutrition_override
+                    updated_nutrition.macros = Macros(
+                        protein=nutrition_override.protein,
+                        carbs=nutrition_override.carbs,
+                        fat=nutrition_override.fat,
+                        fiber=updated_nutrition.macros.fiber,
+                        sugar=updated_nutrition.macros.sugar,
+                    )
 
                 updated_created_at = command.created_at or meal.created_at
                 if command.meal_type is not None:

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -62,6 +62,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 updated_food_items = await self._apply_food_item_changes(
                     meal.nutrition.food_items if meal.nutrition else [],
                     command.food_item_changes,
+                    food_reference_repository=getattr(uow, "food_references", None),
                 )
                 self._realign_translations_after_food_item_changes(
                     meal, updated_food_items
@@ -176,7 +177,12 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 await uow.rollback()
                 raise
 
-    async def _apply_food_item_changes(self, current_food_items, changes):
+    async def _apply_food_item_changes(
+        self,
+        current_food_items,
+        changes,
+        food_reference_repository=None,
+    ):
         """Apply food item changes to current list using strategy pattern."""
         from src.domain.services import NutritionCalculationService
         from src.domain.strategies.meal_edit_strategies import (
@@ -193,6 +199,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         nutrition_service = NutritionCalculationService()
         strategies = FoodItemChangeStrategyFactory.create_strategies(
             nutrition_service,
+            food_reference_repository=food_reference_repository,
         )
 
         # Apply each change using the appropriate strategy

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -68,18 +68,37 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                     meal, updated_food_items
                 )
 
-                # 3. Recalculate nutrition
+                # 3. Recalculate nutrition from current ingredients.
                 updated_nutrition = self._calculate_total_nutrition(updated_food_items)
                 existing_override = (
                     meal.nutrition.nutrition_override if meal.nutrition else None
                 )
-                requested_override = command.nutrition_override or existing_override
-                if requested_override is not None:
+                # Meal-level override is only for intentional whole-meal edits.
+                # Ingredient composition changes must clear it so totals follow
+                # the ingredient sum (unless this request sets a new override).
+                if command.nutrition_override is not None:
                     nutrition_override = NutritionOverride(
-                        calories=requested_override.calories,
-                        protein=requested_override.protein,
-                        carbs=requested_override.carbs,
-                        fat=requested_override.fat,
+                        calories=command.nutrition_override.calories,
+                        protein=command.nutrition_override.protein,
+                        carbs=command.nutrition_override.carbs,
+                        fat=command.nutrition_override.fat,
+                    )
+                    updated_nutrition.nutrition_override = nutrition_override
+                    updated_nutrition.macros = Macros(
+                        protein=nutrition_override.protein,
+                        carbs=nutrition_override.carbs,
+                        fat=nutrition_override.fat,
+                        fiber=updated_nutrition.macros.fiber,
+                        sugar=updated_nutrition.macros.sugar,
+                    )
+                elif command.food_item_changes:
+                    updated_nutrition.nutrition_override = None
+                elif existing_override is not None:
+                    nutrition_override = NutritionOverride(
+                        calories=existing_override.calories,
+                        protein=existing_override.protein,
+                        carbs=existing_override.carbs,
+                        fat=existing_override.fat,
                     )
                     updated_nutrition.nutrition_override = nutrition_override
                     updated_nutrition.macros = Macros(

--- a/src/domain/model/meal/food_item_change.py
+++ b/src/domain/model/meal/food_item_change.py
@@ -18,6 +18,8 @@ class FoodItemChange:
     quantity: Optional[float] = None
     unit: Optional[str] = None
     custom_nutrition: Optional["CustomNutritionData"] = None
+    nutrition_override: Optional["NutritionOverride"] = None
+    clear_nutrition_override: bool = False
     allowed_units: Optional[list[dict[str, Any]]] = None
 
 
@@ -31,3 +33,11 @@ class CustomNutritionData:
     fat_per_100g: float
     fiber_per_100g: float = 0.0
     sugar_per_100g: float = 0.0
+
+
+@dataclass
+class NutritionOverride:
+    calories: float
+    protein: float
+    carbs: float
+    fat: float

--- a/src/domain/model/nutrition/__init__.py
+++ b/src/domain/model/nutrition/__init__.py
@@ -5,13 +5,14 @@ Nutrition bounded context - Domain models for nutritional information.
 from .food import Food
 from .macros import Macros
 from .micros import Micros
-from .nutrition import MAX_FOOD_ITEM_QUANTITY, FoodItem, Nutrition
+from .nutrition import MAX_FOOD_ITEM_QUANTITY, FoodItem, Nutrition, NutritionOverride
 
 __all__ = [
     "Nutrition",
     "FoodItem",
     "MAX_FOOD_ITEM_QUANTITY",
     "Macros",
+    "NutritionOverride",
     "Micros",
     "Food",
 ]

--- a/src/domain/model/nutrition/macros.py
+++ b/src/domain/model/nutrition/macros.py
@@ -6,7 +6,8 @@ class Macros:
     """
     Value object representing macronutrient breakdown of a meal.
     All values are in grams.
-    Invariant: Values cannot be negative.
+    Values may be manually overridden by the user, so they are intentionally
+    not constrained here.
     """
 
     protein: float
@@ -14,17 +15,6 @@ class Macros:
     fat: float
     fiber: float = 0.0
     sugar: float = 0.0
-
-    def __post_init__(self):
-        # Validate invariants
-        for field_name in ["protein", "carbs", "fat", "fiber", "sugar"]:
-            value = getattr(self, field_name)
-            if value < 0:
-                raise ValueError(f"{field_name} cannot be negative: {value}")
-            if value > 5000:  # Sanity check
-                raise ValueError(
-                    f"{field_name} exceeds realistic limit (5000g): {value}"
-                )
 
     @property
     def total_calories(self) -> float:

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -131,12 +131,14 @@ class Nutrition:
 
     @property
     def calories(self) -> float:
-        """Use a user-entered value when one exists."""
-        return (
-            self.nutrition_override.calories
-            if self.nutrition_override
-            else self.macros.total_calories
-        )
+        """Meal calories prefer meal override; else sum item effective calories
+        so per-ingredient calorie overrides are not dropped; else macros.
+        """
+        if self.nutrition_override is not None:
+            return float(self.nutrition_override.calories)
+        if self.food_items:
+            return float(sum(item.calories for item in self.food_items))
+        return float(self.macros.total_calories)
 
     @property
     def effective_macros(self) -> Macros:

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -131,12 +131,15 @@ class Nutrition:
 
     @property
     def calories(self) -> float:
-        """Meal calories prefer meal override; else sum item effective calories
-        so per-ingredient calorie overrides are not dropped; else macros.
+        """Meal calories prefer meal override; else sum of item effective
+        calories when any ingredient has a calorie override; else macros.
         """
         if self.nutrition_override is not None:
             return float(self.nutrition_override.calories)
-        if self.food_items:
+        if self.food_items and any(
+            getattr(item, "nutrition_override", None) is not None
+            for item in self.food_items
+        ):
             return float(sum(item.calories for item in self.food_items))
         return float(self.macros.total_calories)
 

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -8,6 +8,24 @@ MAX_FOOD_ITEM_QUANTITY = 10000.0
 
 
 @dataclass
+class NutritionOverride:
+    """Absolute nutrition values entered directly by a user."""
+
+    calories: float
+    protein: float
+    carbs: float
+    fat: float
+
+    def to_dict(self) -> dict:
+        return {
+            "calories": self.calories,
+            "protein": self.protein,
+            "carbs": self.carbs,
+            "fat": self.fat,
+        }
+
+
+@dataclass
 class FoodItem:
     """Represents a single food item in a meal with nutritional information."""
 
@@ -22,6 +40,7 @@ class FoodItem:
     food_reference_id: int | None = None
     is_custom: bool = False  # Whether this is a custom ingredient
     allowed_units: list[dict[str, Any]] | None = None
+    nutrition_override: NutritionOverride | None = None
 
     def __post_init__(self):
         """Validate invariants."""
@@ -42,8 +61,24 @@ class FoodItem:
 
     @property
     def calories(self) -> float:
-        """Derive calories from macros: P*4 + C*4 + F*9."""
-        return self.macros.total_calories
+        """Use a user-entered value when one exists."""
+        return (
+            self.nutrition_override.calories
+            if self.nutrition_override
+            else self.macros.total_calories
+        )
+
+    @property
+    def effective_macros(self) -> Macros:
+        if self.nutrition_override is None:
+            return self.macros
+        return Macros(
+            protein=self.nutrition_override.protein,
+            carbs=self.nutrition_override.carbs,
+            fat=self.nutrition_override.fat,
+            fiber=self.macros.fiber,
+            sugar=self.macros.sugar,
+        )
 
     def to_dict(self) -> dict:
         """Convert to dictionary format."""
@@ -53,7 +88,7 @@ class FoodItem:
             "quantity": self.quantity,
             "unit": self.unit,
             "calories": self.calories,
-            "macros": self.macros.to_dict(),
+            "macros": self.effective_macros.to_dict(),
             "confidence": self.confidence,
             "is_custom": self.is_custom,
         }
@@ -65,6 +100,8 @@ class FoodItem:
             result["food_reference_id"] = self.food_reference_id
         if self.allowed_units:
             result["allowed_units"] = self.allowed_units
+        if self.nutrition_override:
+            result["nutrition_override"] = self.nutrition_override.to_dict()
         return result
 
 
@@ -76,6 +113,7 @@ class Nutrition:
     micros: Micros | None = None
     food_items: list[FoodItem] | None = None
     confidence_score: float = 1.0  # 0.0-1.0 overall confidence score
+    nutrition_override: NutritionOverride | None = None
 
     def __post_init__(self):
         """Validate invariants."""
@@ -93,14 +131,30 @@ class Nutrition:
 
     @property
     def calories(self) -> float:
-        """Derive calories from macros: P*4 + C*4 + F*9."""
-        return self.macros.total_calories
+        """Use a user-entered value when one exists."""
+        return (
+            self.nutrition_override.calories
+            if self.nutrition_override
+            else self.macros.total_calories
+        )
+
+    @property
+    def effective_macros(self) -> Macros:
+        if self.nutrition_override is None:
+            return self.macros
+        return Macros(
+            protein=self.nutrition_override.protein,
+            carbs=self.nutrition_override.carbs,
+            fat=self.nutrition_override.fat,
+            fiber=self.macros.fiber,
+            sugar=self.macros.sugar,
+        )
 
     def to_dict(self) -> dict:
         """Convert to dictionary format."""
         result = {
             "calories": self.calories,
-            "macros": self.macros.to_dict(),
+            "macros": self.effective_macros.to_dict(),
             "confidence_score": self.confidence_score,
         }
 
@@ -109,5 +163,8 @@ class Nutrition:
 
         if self.food_items:
             result["food_items"] = [item.to_dict() for item in self.food_items]
+
+        if self.nutrition_override:
+            result["nutrition_override"] = self.nutrition_override.to_dict()
 
         return result

--- a/src/domain/services/meal_calorie_service.py
+++ b/src/domain/services/meal_calorie_service.py
@@ -13,6 +13,9 @@ def effective_meal_calories(meal: Any) -> float:
     if nutrition is None:
         return 0.0
 
+    if getattr(nutrition, "nutrition_override", None) is not None:
+        return float(nutrition.nutrition_override.calories)
+
     if getattr(meal, "source", None) == "food_label":
         metadata = getattr(meal, "food_label_metadata", None)
         label_calories = _food_label_calories(metadata)

--- a/src/domain/services/meal_calorie_service.py
+++ b/src/domain/services/meal_calorie_service.py
@@ -7,18 +7,18 @@ def effective_meal_calories(meal: Any) -> float:
     """Return calories users expect for a meal.
 
     Food-label scans should match the printed label calories. Other meal
-    sources keep the canonical macro-derived value.
+    sources keep the canonical macro-derived value, unless a meal-level
+    override is set or ingredient calorie overrides require summing items.
     """
+    from src.domain.model.nutrition.nutrition import Nutrition, NutritionOverride
+
     nutrition = getattr(meal, "nutrition", None)
     if nutrition is None:
         return 0.0
 
     override = getattr(nutrition, "nutrition_override", None)
-    # Avoid truthy Mock children from incomplete unit-test doubles.
-    if override is not None and not isinstance(override, type(None)):
-        override_calories = getattr(override, "calories", None)
-        if isinstance(override_calories, (int, float)):
-            return float(override_calories)
+    if isinstance(override, NutritionOverride):
+        return float(override.calories)
 
     if getattr(meal, "source", None) == "food_label":
         metadata = getattr(meal, "food_label_metadata", None)
@@ -27,11 +27,9 @@ def effective_meal_calories(meal: Any) -> float:
             item = (getattr(nutrition, "food_items", None) or [None])[0]
             return _scaled_label_calories(label_calories, item, metadata)
 
-    # Prefer nutrition.calories when it is a real number (includes item
-    # override sums on the Nutrition value object).
-    nutrition_calories = getattr(nutrition, "calories", None)
-    if isinstance(nutrition_calories, (int, float)):
-        return float(nutrition_calories)
+    # Real Nutrition VOs may include per-item calorie overrides in .calories.
+    if isinstance(nutrition, Nutrition):
+        return float(nutrition.calories)
 
     return _macro_calories(getattr(nutrition, "macros", None))
 

--- a/src/domain/services/meal_calorie_service.py
+++ b/src/domain/services/meal_calorie_service.py
@@ -13,8 +13,12 @@ def effective_meal_calories(meal: Any) -> float:
     if nutrition is None:
         return 0.0
 
-    if getattr(nutrition, "nutrition_override", None) is not None:
-        return float(nutrition.nutrition_override.calories)
+    override = getattr(nutrition, "nutrition_override", None)
+    # Avoid truthy Mock children from incomplete unit-test doubles.
+    if override is not None and not isinstance(override, type(None)):
+        override_calories = getattr(override, "calories", None)
+        if isinstance(override_calories, (int, float)):
+            return float(override_calories)
 
     if getattr(meal, "source", None) == "food_label":
         metadata = getattr(meal, "food_label_metadata", None)
@@ -22,6 +26,12 @@ def effective_meal_calories(meal: Any) -> float:
         if label_calories is not None:
             item = (getattr(nutrition, "food_items", None) or [None])[0]
             return _scaled_label_calories(label_calories, item, metadata)
+
+    # Prefer nutrition.calories when it is a real number (includes item
+    # override sums on the Nutrition value object).
+    nutrition_calories = getattr(nutrition, "calories", None)
+    if isinstance(nutrition_calories, (int, float)):
+        return float(nutrition_calories)
 
     return _macro_calories(getattr(nutrition, "macros", None))
 

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -373,11 +373,11 @@ class NutritionCalculationService:
                 confidence_score=1.0,
             )
 
-        total_protein = sum(item.macros.protein for item in food_items)
-        total_carbs = sum(item.macros.carbs for item in food_items)
-        total_fat = sum(item.macros.fat for item in food_items)
-        total_fiber = sum(item.macros.fiber for item in food_items)
-        total_sugar = sum(item.macros.sugar for item in food_items)
+        total_protein = sum(item.effective_macros.protein for item in food_items)
+        total_carbs = sum(item.effective_macros.carbs for item in food_items)
+        total_fat = sum(item.effective_macros.fat for item in food_items)
+        total_fiber = sum(item.effective_macros.fiber for item in food_items)
+        total_sugar = sum(item.effective_macros.sugar for item in food_items)
 
         # Calculate average confidence
         avg_confidence = sum(item.confidence for item in food_items) / len(food_items)

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -8,13 +8,26 @@ import uuid
 from abc import ABC, abstractmethod
 
 from src.domain.model.meal.food_item_change import FoodItemChange
-from src.domain.model.nutrition import FoodItem, Macros
+from src.domain.model.nutrition import FoodItem, Macros, NutritionOverride
 from src.domain.services import NutritionCalculationService
 from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
 
 logger = logging.getLogger(__name__)
 
 MAX_QUANTITY_GRAMS = 10000.0  # 10kg max per food item
+
+
+def _resolved_nutrition_override(change, existing: FoodItem | None = None):
+    if change.clear_nutrition_override:
+        return None
+    if change.nutrition_override is not None:
+        return NutritionOverride(
+            calories=change.nutrition_override.calories,
+            protein=change.nutrition_override.protein,
+            carbs=change.nutrition_override.carbs,
+            fat=change.nutrition_override.fat,
+        )
+    return existing.nutrition_override if existing else None
 
 
 def _validate_quantity_grams(quantity_grams: float, quantity: float, unit: str) -> None:
@@ -101,6 +114,9 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 food_reference_id=existing_item.food_reference_id,
                 is_custom=True,
                 allowed_units=change.allowed_units or existing_item.allowed_units,
+                nutrition_override=_resolved_nutrition_override(
+                    change, existing_item
+                ),
             )
             logger.info(
                 f"Updated food item with custom nutrition: {existing_item.name}"
@@ -136,6 +152,9 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     food_reference_id=existing_item.food_reference_id,
                     is_custom=existing_item.is_custom,
                     allowed_units=change.allowed_units or existing_item.allowed_units,
+                    nutrition_override=_resolved_nutrition_override(
+                        change, existing_item
+                    ),
                 )
                 logger.info(f"Updated food item with unit change: {existing_item.name}")
             else:
@@ -196,6 +215,7 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             food_reference_id=existing_item.food_reference_id,
             is_custom=existing_item.is_custom,
             allowed_units=change.allowed_units or existing_item.allowed_units,
+            nutrition_override=_resolved_nutrition_override(change, existing_item),
         )
         logger.info(f"Updated food item with scaling: {existing_item.name}")
 
@@ -228,6 +248,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                 unit,
                 change.custom_nutrition,
                 change.allowed_units,
+                change.nutrition_override,
             )
             food_items_dict[new_item_id] = food_item
             logger.info(f"Added custom food item: {change.name}")
@@ -254,6 +275,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                     fdc_id=change.fdc_id,
                     is_custom=False,
                     allowed_units=change.allowed_units,
+                    nutrition_override=_resolved_nutrition_override(change),
                 )
                 logger.info(f"Added food item from nutrition service: {change.name}")
                 return
@@ -272,6 +294,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=change.fdc_id,
             is_custom=True,
             allowed_units=change.allowed_units,
+            nutrition_override=_resolved_nutrition_override(change),
         )
 
     def _create_from_custom_nutrition(
@@ -282,6 +305,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
         unit: str,
         custom_nutrition,
         allowed_units=None,
+        nutrition_override=None,
     ) -> FoodItem:
         """Create food item from custom nutrition data."""
         quantity_grams = convert_quantity_to_grams(quantity, unit, name)
@@ -304,6 +328,16 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=None,
             is_custom=True,
             allowed_units=allowed_units,
+            nutrition_override=(
+                NutritionOverride(
+                    calories=nutrition_override.calories,
+                    protein=nutrition_override.protein,
+                    carbs=nutrition_override.carbs,
+                    fat=nutrition_override.fat,
+                )
+                if nutrition_override
+                else None
+            ),
         )
 
 

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -10,7 +10,11 @@ from abc import ABC, abstractmethod
 from src.domain.model.meal.food_item_change import FoodItemChange
 from src.domain.model.nutrition import FoodItem, Macros, NutritionOverride
 from src.domain.services import NutritionCalculationService
-from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
+from src.domain.services.nutrition_calculation_service import (
+    ScaledNutritionResult,
+    convert_quantity_to_grams,
+    scale_per_100g_nutrition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +81,10 @@ class RemoveFoodItemStrategy(FoodItemChangeStrategy):
 class UpdateFoodItemStrategy(FoodItemChangeStrategy):
     """Strategy for updating an existing food item."""
 
+    def __init__(self, nutrition_service, food_reference_repository=None):
+        super().__init__(nutrition_service)
+        self.food_reference_repository = food_reference_repository
+
     async def apply(
         self, food_items_dict: dict[str, FoodItem], change: FoodItemChange
     ) -> None:
@@ -123,16 +131,15 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             )
             return
 
-        # Priority 2: Check if unit changed - if so, fetch fresh nutrition data
+        # Priority 2: A unit switch must use the selected unit's canonical
+        # source nutrition, rather than rescaling the previously selected unit.
         unit_changed = change.unit and change.unit != existing_item.unit
 
         if unit_changed:
-            # Unit changed - fetch fresh nutrition data
-            scaled_nutrition = self.nutrition_service.get_nutrition_for_ingredient(
-                name=existing_item.name,
-                quantity=new_quantity,
-                unit=new_unit,
-                fdc_id=existing_item.fdc_id,
+            scaled_nutrition = await self._get_selected_unit_nutrition(
+                existing_item,
+                new_quantity,
+                new_unit,
             )
 
             if scaled_nutrition:
@@ -158,11 +165,11 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 )
                 logger.info(f"Updated food item with unit change: {existing_item.name}")
             else:
-                # Fallback to simple scaling
                 logger.warning(
-                    "Could not fetch nutrition for unit change, using scaling"
+                    "Could not load canonical nutrition for unit change; "
+                    "preserving the existing source nutrition"
                 )
-                self._apply_simple_scaling(
+                self._preserve_source_nutrition(
                     food_items_dict, change, existing_item, new_quantity, new_unit
                 )
         else:
@@ -218,6 +225,87 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             nutrition_override=_resolved_nutrition_override(change, existing_item),
         )
         logger.info(f"Updated food item with scaling: {existing_item.name}")
+
+    async def _get_selected_unit_nutrition(
+        self,
+        existing_item: FoodItem,
+        quantity: float,
+        unit: str,
+    ) -> ScaledNutritionResult | None:
+        if existing_item.food_reference_id and self.food_reference_repository:
+            reference = await self.food_reference_repository.get_nutrition_projection(
+                existing_item.food_reference_id
+            )
+            if reference is not None and all(
+                value is not None
+                for value in (
+                    reference.protein_100g,
+                    reference.carbs_100g,
+                    reference.fat_100g,
+                )
+            ):
+                allowed_units = [
+                    {
+                        "unit": serving.name,
+                        "gram_weight": serving.grams,
+                        "description": serving.name,
+                    }
+                    for serving in reference.servings
+                    if serving.grams is not None and serving.grams > 0
+                ]
+                nutrition = scale_per_100g_nutrition(
+                    {
+                        "protein": reference.protein_100g,
+                        "carbs": reference.carbs_100g,
+                        "fat": reference.fat_100g,
+                        "fiber": reference.fiber_100g,
+                        "sugar": reference.sugar_100g,
+                    },
+                    quantity,
+                    unit,
+                    allowed_units=allowed_units,
+                    food_name=reference.name,
+                )
+                return ScaledNutritionResult(
+                    calories=nutrition["calories"],
+                    protein=nutrition["protein"],
+                    carbs=nutrition["carbs"],
+                    fat=nutrition["fat"],
+                )
+
+            # A canonical source was expected but is unavailable. Do not make
+            # a new value out of the prior unit's nutrition.
+            return None
+
+        return self.nutrition_service.get_nutrition_for_ingredient(
+            name=existing_item.name,
+            quantity=quantity,
+            unit=unit,
+            fdc_id=existing_item.fdc_id,
+        )
+
+    def _preserve_source_nutrition(
+        self,
+        food_items_dict: dict[str, FoodItem],
+        change: FoodItemChange,
+        existing_item: FoodItem,
+        quantity: float,
+        unit: str,
+    ) -> None:
+        food_items_dict[change.id] = FoodItem(
+            id=existing_item.id,
+            name=existing_item.name,
+            quantity=quantity,
+            unit=unit,
+            macros=existing_item.macros,
+            micros=existing_item.micros,
+            confidence=existing_item.confidence,
+            fdc_id=existing_item.fdc_id,
+            food_reference_id=existing_item.food_reference_id,
+            is_custom=existing_item.is_custom,
+            allowed_units=change.allowed_units or existing_item.allowed_units,
+            nutrition_override=_resolved_nutrition_override(change, existing_item),
+        )
 
 
 class AddFoodItemStrategy(FoodItemChangeStrategy):
@@ -346,11 +434,16 @@ class FoodItemChangeStrategyFactory:
 
     @staticmethod
     def create_strategies(
-        nutrition_service: NutritionCalculationService, food_service=None
+        nutrition_service: NutritionCalculationService,
+        food_service=None,
+        food_reference_repository=None,
     ) -> dict[str, FoodItemChangeStrategy]:
         """Create all available strategies."""
         return {
             "add": AddFoodItemStrategy(nutrition_service, food_service),
-            "update": UpdateFoodItemStrategy(nutrition_service),
+            "update": UpdateFoodItemStrategy(
+                nutrition_service,
+                food_reference_repository,
+            ),
             "remove": RemoveFoodItemStrategy(nutrition_service),
         }

--- a/src/infra/database/models/nutrition/food_item.py
+++ b/src/infra/database/models/nutrition/food_item.py
@@ -2,7 +2,7 @@
 Food item model for individual food components within a meal.
 """
 
-from sqlalchemy import Column, String, Float, Integer, ForeignKey, Boolean, JSON
+from sqlalchemy import JSON, Boolean, Column, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from src.infra.database.base import Base
@@ -19,6 +19,7 @@ class FoodItemORM(Base, PrimaryEntityMixin):
     unit = Column(String(120), nullable=False)
     confidence = Column(Float, nullable=True)
     allowed_units = Column(JSON, nullable=True)
+    nutrition_override = Column(JSON, nullable=True)
 
     # Edit support fields
     fdc_id = Column(

--- a/src/infra/database/models/nutrition/nutrition.py
+++ b/src/infra/database/models/nutrition/nutrition.py
@@ -2,7 +2,7 @@
 Nutrition model for overall nutritional information of a meal.
 """
 
-from sqlalchemy import Column, Float, Text, String, ForeignKey
+from sqlalchemy import JSON, Column, Float, ForeignKey, String, Text
 from sqlalchemy.orm import relationship
 
 from src.infra.database.base import Base
@@ -16,6 +16,7 @@ class NutritionORM(Base, SecondaryEntityMixin):
 
     confidence_score = Column(Float, nullable=True)
     raw_ai_response = Column(Text, nullable=True)
+    nutrition_override = Column(JSON, nullable=True)
 
     # Macro fields -- calories are always derived: P*4 + (C-fiber)*4 + fiber*2 + F*9
     protein = Column(Float, default=0, nullable=False)

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -17,6 +17,7 @@ from src.domain.model.nutrition import (
 )
 from src.domain.model.nutrition import (
     Macros,
+    NutritionOverride,
 )
 from src.domain.model.nutrition import (
     Nutrition as DomainNutrition,
@@ -39,6 +40,17 @@ _UNHYDRATABLE_READY_MEAL_ERRORS = {
     "Meal with READY status must have nutrition data",
     "Meal with READY status must have ready_at timestamp",
 }
+
+
+def _nutrition_override_from_orm(value: dict | None) -> NutritionOverride | None:
+    if not value:
+        return None
+    return NutritionOverride(
+        calories=float(value["calories"]),
+        protein=float(value["protein"]),
+        carbs=float(value["carbs"]),
+        fat=float(value["fat"]),
+    )
 
 
 def _to_naive_utc(dt: datetime | None) -> datetime | None:
@@ -74,6 +86,7 @@ def food_item_orm_to_domain(orm: FoodItemORM) -> DomainFoodItem:
         food_reference_id=orm.food_reference_id,
         is_custom=orm.is_custom,
         allowed_units=orm.allowed_units,
+        nutrition_override=_nutrition_override_from_orm(orm.nutrition_override),
     )
 
 
@@ -94,6 +107,7 @@ def nutrition_orm_to_domain(orm: NutritionORM) -> DomainNutrition:
         micros=None,
         food_items=food_items,
         confidence_score=orm.confidence_score,
+        nutrition_override=_nutrition_override_from_orm(orm.nutrition_override),
     )
 
 
@@ -211,6 +225,11 @@ def food_item_domain_to_orm(domain: DomainFoodItem, nutrition_id=None) -> FoodIt
         food_reference_id=getattr(domain, "food_reference_id", None),
         is_custom=getattr(domain, "is_custom", False),
         allowed_units=getattr(domain, "allowed_units", None),
+        nutrition_override=(
+            domain.nutrition_override.to_dict()
+            if domain.nutrition_override
+            else None
+        ),
     )
     if hasattr(domain, "id") and domain.id:
         item.id = str(domain.id)
@@ -226,6 +245,9 @@ def food_item_domain_to_orm(domain: DomainFoodItem, nutrition_id=None) -> FoodIt
 def nutrition_domain_to_orm(domain: DomainNutrition, meal_id: str) -> NutritionORM:
     meal_id_str = str(meal_id) if meal_id else None
     orm = NutritionORM(confidence_score=domain.confidence_score, meal_id=meal_id_str)
+    orm.nutrition_override = (
+        domain.nutrition_override.to_dict() if domain.nutrition_override else None
+    )
     if domain.macros:
         orm.protein = domain.macros.protein
         orm.carbs = domain.macros.carbs

--- a/src/infra/repositories/food_reference_uow_adapter.py
+++ b/src/infra/repositories/food_reference_uow_adapter.py
@@ -75,3 +75,9 @@ class AsyncFoodReferenceUowAdapter:
     async def upsert(self, data: dict[str, Any]) -> None:
         async with self._uow_factory() as uow:
             await uow.food_references.upsert(data)
+
+    async def get_nutrition_projection(self, food_reference_id: int) -> Any | None:
+        async with self._uow_factory() as uow:
+            return await uow.food_references.get_nutrition_projection(
+                food_reference_id
+            )

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -600,7 +600,14 @@ class AsyncMealRepository(MealRepositoryPort):
         db_nutrition.protein = domain_nutrition.macros.protein
         db_nutrition.carbs = domain_nutrition.macros.carbs
         db_nutrition.fat = domain_nutrition.macros.fat
+        db_nutrition.fiber = domain_nutrition.macros.fiber
+        db_nutrition.sugar = domain_nutrition.macros.sugar
         db_nutrition.confidence_score = domain_nutrition.confidence_score
+        db_nutrition.nutrition_override = (
+            domain_nutrition.nutrition_override.to_dict()
+            if domain_nutrition.nutrition_override
+            else None
+        )
 
         # food_items pre-loaded via selectinload in save() — safe to iterate
         for item in db_nutrition.food_items:

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -2,8 +2,9 @@
 Unit tests for meal edit request validation.
 """
 
-import pytest
 from datetime import datetime
+
+import pytest
 from pydantic import ValidationError
 
 from src.api.schemas.request.meal_requests import (
@@ -12,6 +13,7 @@ from src.api.schemas.request.meal_requests import (
     CustomNutritionRequest,
     EditMealIngredientsRequest,
     FoodItemChangeRequest,
+    NutritionOverrideRequest,
 )
 
 
@@ -95,6 +97,21 @@ class TestFoodItemChangeRequest:
         # Assert
         assert request.action == "remove"
         assert request.id == "test-food-item-id"
+
+    def test_manual_nutrition_override_allows_independent_values(self):
+        request = FoodItemChangeRequest(
+            action="update",
+            id="test-food-item-id",
+            nutrition_override=NutritionOverrideRequest(
+                calories=123.4,
+                protein=-5.0,
+                carbs=999.0,
+                fat=1.0,
+            ),
+        )
+
+        assert request.nutrition_override.calories == 123.4
+        assert request.nutrition_override.protein == -5.0
 
     def test_invalid_action(self):
         """Test invalid action value."""
@@ -381,6 +398,18 @@ class TestEditMealIngredientsRequest:
         assert request.dish_name == "Updated Meal Name"
         assert len(request.food_item_changes) == 1
         assert request.food_item_changes[0].action == "add"
+
+    def test_accepts_meal_nutrition_override_without_food_changes(self):
+        request = EditMealIngredientsRequest(
+            nutrition_override=NutritionOverrideRequest(
+                calories=777.0,
+                protein=1.0,
+                carbs=2.0,
+                fat=3.0,
+            )
+        )
+
+        assert request.nutrition_override.calories == 777.0
 
     def test_valid_edit_request_without_dish_name(self):
         """Test valid edit request without dish name."""

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -11,6 +11,9 @@ import pytest
 from src.api.mappers.meal_mapper import STATUS_MAPPING, MealMapper
 from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
 from src.domain.model.meal import FoodItemTranslation, MealTranslation
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
 from src.domain.services.meal_value_insight_contract import (
     IngredientValueInsight,
     MealValueInsights,
@@ -168,6 +171,53 @@ class TestMealMapper:
         assert result.image_url == "https://example.com/image.jpg"
         # total_weight_grams is calculated from food items
         assert result.total_weight_grams == 350 or result.total_weight_grams is None
+
+    def test_to_detailed_response_includes_canonical_source_nutrition(self):
+        item = FoodItem(
+            id="item-1",
+            name="Pâté",
+            quantity=1,
+            unit="g",
+            macros=Macros(protein=0.2, carbs=0.1, fat=0.3),
+            food_reference_id=321,
+        )
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/pate.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            created_at=datetime(2025, 1, 15),
+            ready_at=datetime(2025, 1, 15),
+            nutrition=Nutrition(macros=item.macros, food_items=[item]),
+        )
+        source = FoodReferenceNutritionProjection(
+            id=321,
+            name="Pâté",
+            source="fatsecret",
+            is_verified=True,
+            protein_100g=20,
+            carbs_100g=10,
+            fat_100g=30,
+            fiber_100g=2,
+            sugar_100g=1,
+        )
+
+        result = MealMapper.to_detailed_response(
+            meal,
+            source_nutrition_by_food_reference={321: source},
+        )
+
+        nutrition = result.food_items[0].source_nutrition
+        assert nutrition is not None
+        assert nutrition.protein_per_100g == 20
+        assert nutrition.carbs_per_100g == 10
+        assert nutrition.fat_per_100g == 30
+        assert nutrition.calories_per_100g == pytest.approx(386)
 
     def test_to_detailed_response_uses_item_id_translations_when_list_is_stale(self):
         """Translated food item IDs preserve locale after ingredient add/remove."""

--- a/tests/unit/domain/services/test_weekly_budget_async.py
+++ b/tests/unit/domain/services/test_weekly_budget_async.py
@@ -16,10 +16,15 @@ def _ready_meal(*, protein: float, carbs: float, fat: float, created_at: datetim
     meal = Mock()
     meal.status = MealStatus.READY
     meal.created_at = created_at
+    meal.source = "scan"
+    meal.food_label_metadata = None
+    meal.nutrition.nutrition_override = None
+    meal.nutrition.food_items = []
     meal.nutrition.macros.protein = protein
     meal.nutrition.macros.carbs = carbs
     meal.nutrition.macros.fat = fat
     meal.nutrition.macros.fiber = 0.0
+    meal.nutrition.calories = protein * 4 + carbs * 4 + fat * 9
     return meal
 
 
@@ -61,7 +66,11 @@ class TestCalculateWeeklyConsumedAsync:
 
         ready_meal = Mock()
         ready_meal.status = MealStatus.READY
-        ready_meal.nutrition.calories = 9999
+        ready_meal.source = "scan"
+        ready_meal.food_label_metadata = None
+        ready_meal.nutrition.nutrition_override = None
+        ready_meal.nutrition.food_items = []
+        ready_meal.nutrition.calories = 495
         ready_meal.nutrition.macros.protein = 30
         ready_meal.nutrition.macros.carbs = 60
         ready_meal.nutrition.macros.fat = 15
@@ -69,6 +78,10 @@ class TestCalculateWeeklyConsumedAsync:
 
         processing_meal = Mock()
         processing_meal.status = MealStatus.PROCESSING
+        processing_meal.source = "scan"
+        processing_meal.food_label_metadata = None
+        processing_meal.nutrition.nutrition_override = None
+        processing_meal.nutrition.food_items = []
         processing_meal.nutrition.calories = 300
         processing_meal.nutrition.macros.protein = 20
         processing_meal.nutrition.macros.carbs = 40

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -10,7 +10,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from src.app.commands.meal.edit_meal_command import CustomNutritionData, FoodItemChange
+from src.app.commands.meal.edit_meal_command import (
+    CustomNutritionData,
+    FoodItemChange,
+    NutritionOverride,
+)
 from src.domain.model import FoodItem, Macros
 from src.domain.strategies.meal_edit_strategies import (
     AddFoodItemStrategy,
@@ -165,6 +169,39 @@ class TestUpdateFoodItemStrategy:
         assert updated_item.macros.protein == 60.0  # Doubled
         assert updated_item.macros.fat == 16.0  # Doubled
         assert updated_item.food_reference_id == 1001
+
+    @pytest.mark.asyncio
+    async def test_update_keeps_manual_values_independent_from_source_macros(self):
+        strategy = UpdateFoodItemStrategy(Mock())
+        food_items_dict = {
+            "item1": FoodItem(
+                id="item1",
+                name="Chicken",
+                quantity=100.0,
+                unit="g",
+                macros=Macros(protein=30.0, carbs=0.0, fat=8.0),
+            )
+        }
+
+        await strategy.apply(
+            food_items_dict,
+            FoodItemChange(
+                action="update",
+                id="item1",
+                nutrition_override=NutritionOverride(
+                    calories=123.4,
+                    protein=-5.0,
+                    carbs=999.0,
+                    fat=1.0,
+                ),
+            ),
+        )
+
+        updated_item = food_items_dict["item1"]
+        assert updated_item.macros.protein == 30.0
+        assert updated_item.calories == 123.4
+        assert updated_item.effective_macros.protein == -5.0
+        assert updated_item.effective_macros.carbs == 999.0
 
     @pytest.mark.asyncio
     async def test_update_unit_with_nutrition_service_success(self):

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -6,7 +6,7 @@ on food items during meal editing.
 """
 
 import uuid
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -16,6 +16,10 @@ from src.app.commands.meal.edit_meal_command import (
     NutritionOverride,
 )
 from src.domain.model import FoodItem, Macros
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+    FoodReferenceServingProjection,
+)
 from src.domain.strategies.meal_edit_strategies import (
     AddFoodItemStrategy,
     FoodItemChangeStrategyFactory,
@@ -254,6 +258,58 @@ class TestUpdateFoodItemStrategy:
         )
 
     @pytest.mark.asyncio
+    async def test_update_unit_uses_canonical_fatsecret_reference(self):
+        mock_nutrition_service = Mock()
+        mock_food_references = Mock()
+        mock_food_references.get_nutrition_projection = AsyncMock(
+            return_value=FoodReferenceNutritionProjection(
+                id=1002,
+                name="Pâté",
+                source="fatsecret",
+                is_verified=True,
+                protein_100g=3.0,
+                carbs_100g=1.0,
+                fat_100g=5.0,
+                servings=[
+                    FoodReferenceServingProjection(
+                        name="Muỗng Canh",
+                        grams=15.0,
+                        milliliters=None,
+                    ),
+                ],
+            )
+        )
+        strategy = UpdateFoodItemStrategy(
+            mock_nutrition_service,
+            mock_food_references,
+        )
+        food_items_dict = {
+            "item1": FoodItem(
+                id="item1",
+                name="Pâté",
+                quantity=1.0,
+                unit="Muỗng Canh",
+                macros=Macros(protein=3.0, carbs=1.0, fat=5.0),
+                food_reference_id=1002,
+                is_custom=True,
+            )
+        }
+
+        await strategy.apply(
+            food_items_dict,
+            FoodItemChange(action="update", id="item1", quantity=1.0, unit="kg"),
+        )
+
+        updated_item = food_items_dict["item1"]
+        assert updated_item.quantity == 1.0
+        assert updated_item.unit == "kg"
+        assert updated_item.macros.protein == pytest.approx(30.0)
+        assert updated_item.macros.carbs == pytest.approx(10.0)
+        assert updated_item.macros.fat == pytest.approx(50.0)
+        mock_food_references.get_nutrition_projection.assert_awaited_once_with(1002)
+        mock_nutrition_service.get_nutrition_for_ingredient.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_update_custom_nutrition_preserves_food_reference_id(self):
         """Custom nutrition updates preserve canonical food reference identity."""
         mock_nutrition_service = Mock()
@@ -291,8 +347,8 @@ class TestUpdateFoodItemStrategy:
         assert updated_item.is_custom is True
 
     @pytest.mark.asyncio
-    async def test_update_unit_nutrition_service_fails_uses_scaling(self):
-        """Test falling back to scaling when nutrition service fails."""
+    async def test_update_unit_nutrition_service_fails_preserves_source(self):
+        """Keep source nutrition unchanged when canonical data is unavailable."""
         # Arrange
         mock_nutrition_service = Mock()
         mock_nutrition_service.get_nutrition_for_ingredient.return_value = (
@@ -320,16 +376,12 @@ class TestUpdateFoodItemStrategy:
         # Act
         await strategy.apply(food_items_dict, change)
 
-        # Assert - Should use scaling fallback with unit conversion
+        # Assert - Never synthesize a new unit's nutrition from the old unit.
         updated_item = food_items_dict["item1"]
         assert updated_item.quantity == 150.0
         assert updated_item.unit == "oz"
-        # scale = 150oz * 28.35g/oz / 100g = 42.525x
-        scale = 150.0 * 28.35 / 100.0
-        # calories derived from scaled macros: (30*scale)*4 + (0*scale)*4 + (8*scale)*9
-        expected_cal = round(30.0 * scale * 4 + 0 + 8.0 * scale * 9, 1)
-        assert updated_item.calories == pytest.approx(expected_cal, rel=0.01)
-        assert updated_item.macros.protein == pytest.approx(30.0 * scale, rel=0.01)
+        assert updated_item.calories == pytest.approx(192.0)
+        assert updated_item.macros.protein == pytest.approx(30.0)
 
     @pytest.mark.asyncio
     async def test_update_quantity_only(self):

--- a/tests/unit/domain/test_nutrition_validation.py
+++ b/tests/unit/domain/test_nutrition_validation.py
@@ -11,13 +11,15 @@ class TestMacrosValidation:
         assert macros.protein == 20
         assert macros.total_calories == 20 * 4 + 30 * 4 + 10 * 9
 
-    def test_negative_protein_raises_error(self):
-        with pytest.raises(ValueError, match="protein cannot be negative"):
-            Macros(protein=-1, carbs=10, fat=10)
+    def test_negative_protein_allowed_for_manual_overrides(self):
+        # Manual nutrition overrides can carry user-entered extremes; validation
+        # is enforced at API/request boundaries, not on the domain value object.
+        macros = Macros(protein=-1, carbs=10, fat=10)
+        assert macros.protein == -1
 
-    def test_excessive_value_raises_error(self):
-        with pytest.raises(ValueError, match="protein exceeds realistic limit"):
-            Macros(protein=6000, carbs=10, fat=10)
+    def test_excessive_value_allowed_for_manual_overrides(self):
+        macros = Macros(protein=6000, carbs=10, fat=10)
+        assert macros.protein == 6000
 
 
 class TestFoodItemValidation:


### PR DESCRIPTION
## Summary
- Persist absolute calorie and macro overrides separately from source nutrition.
- Return effective values to meal and daily nutrition projections while retaining FatSecret source data for subsequent ingredient edits.
- Add the manual nutrition override database migration.

## Test plan
- [x] uv run python -m compileall -q src
- [x] uv run pytest tests/unit/api/test_meal_edit_requests.py tests/unit/domain/test_meal_edit_strategies.py tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
- [x] uv run alembic heads