### PR TITLE
fix(meal-recommendations): attach image on log and remove diagnostics

### DIFF
--- a/migrations/versions/20260806000001_ensure_meal_image_id_nullable.py
+++ b/migrations/versions/20260806000001_ensure_meal_image_id_nullable.py
@@ -1,0 +1,43 @@
+"""Ensure meal.image_id is nullable for image-less materialization.
+
+Revision ID: 20260806000001
+Revises: 20260804000001
+
+Production evidence (2026-08-06): logging a meal recommendation failed with
+`NotNullViolationError` on meal.image_id. Code and migration 20260707000001
+already intend nullable image_id; this revision re-applies the alter
+idempotently for environments that still have NOT NULL.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260806000001"
+down_revision = "20260804000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {column["name"]: column for column in inspector.get_columns("meal")}
+    image_id = columns.get("image_id")
+    if image_id is None:
+        return
+    if image_id.get("nullable", False):
+        return
+    op.alter_column(
+        "meal",
+        "image_id",
+        existing_type=sa.String(length=36),
+        nullable=True,
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Do not re-tighten NOT NULL: historical rows may legitimately have no image.
+    pass

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -223,13 +223,6 @@ async def log_recommended_meal(
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
-    logger.info(
-        "meal_recommendation.log.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-    )
     try:
         result = await event_bus.send(
             LogRecommendedMealCommand(
@@ -241,42 +234,7 @@ async def log_recommended_meal(
         )
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
-        logger.warning(
-            "meal_recommendation.log.failed user_id=%s plan_id=%s slot_id=%s "
-            "request_id=%s status=%s detail=%s error_type=%s",
-            user_id,
-            plan_id,
-            slot_id,
-            body.request_id,
-            exc.status_code,
-            exc.public_detail,
-            type(exc).__name__,
-        )
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    except Exception:
-        logger.exception(
-            "meal_recommendation.log.unhandled user_id=%s plan_id=%s slot_id=%s "
-            "request_id=%s",
-            user_id,
-            plan_id,
-            slot_id,
-            body.request_id,
-        )
-        raise
-    logged_meal_id = (
-        result.slot.logged_meal_id
-        if result.slot is not None
-        else None
-    )
-    logger.info(
-        "meal_recommendation.log.materialized user_id=%s plan_id=%s slot_id=%s "
-        "request_id=%s logged_meal_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-        logged_meal_id,
-    )
     response = to_slot_detail_response(
         result.plan_id,
         await localize_meal_recommendation_slot(
@@ -294,15 +252,6 @@ async def log_recommended_meal(
     )
     metric_status = "success"
     record_operation_latency("log", started, metric_status)
-    logger.info(
-        "meal_recommendation.log.success user_id=%s plan_id=%s slot_id=%s "
-        "request_id=%s logged_meal_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-        logged_meal_id,
-    )
     return response
 
 

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -1,7 +1,5 @@
 """Handler for logging recommended meals through normal meal persistence."""
 
-import logging
-
 from src.app.commands.meal_recommendation import LogRecommendedMealCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.recommended_meal_materialization_service import (
@@ -10,8 +8,6 @@ from src.app.services.recommended_meal_materialization_service import (
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationSlotMutationResult,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @handles(LogRecommendedMealCommand)
@@ -32,13 +28,6 @@ class LogRecommendedMealCommandHandler(
     async def handle(
         self, command: LogRecommendedMealCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
-        logger.info(
-            "log_handler.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
-            command.user_id,
-            command.plan_id,
-            command.slot_id,
-            command.request_id,
-        )
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -46,64 +35,17 @@ class LogRecommendedMealCommandHandler(
                 slot_id=command.slot_id,
                 request_id=command.request_id,
             )
-            selected = slot.selected
-            logger.info(
-                "log_handler.claimed user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s replayed=%s slot_date=%s meal_type=%s "
-                "catalog_meal_id=%s has_catalog_meal=%s logged_meal_id=%s "
-                "skipped_at=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                replayed,
-                slot.slot_date,
-                slot.meal_type,
-                selected.catalog_meal_id if selected is not None else None,
-                bool(selected is not None and selected.catalog_meal is not None),
-                slot.logged_meal_id,
-                slot.skipped_at,
-            )
             if replayed:
-                logger.info(
-                    "log_handler.replay user_id=%s plan_id=%s slot_id=%s "
-                    "request_id=%s logged_meal_id=%s",
-                    command.user_id,
-                    command.plan_id,
-                    command.slot_id,
-                    command.request_id,
-                    slot.logged_meal_id,
-                )
                 return PersistedMealRecommendationSlotMutationResult(
                     plan_id=plan.id,
                     user_id=plan.user_id,
                     slot=slot,
                 )
             meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
-            logger.info(
-                "log_handler.materialized user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s meal_id=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                meal.meal_id,
-            )
-            result = await uow.meal_recommendation_plans.finalize_slot_logged(
+            return await uow.meal_recommendation_plans.finalize_slot_logged(
                 user_id=command.user_id,
                 plan_id=command.plan_id,
                 slot_id=command.slot_id,
                 request_id=command.request_id,
                 meal_id=meal.meal_id,
             )
-            logger.info(
-                "log_handler.finalized user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s meal_id=%s result_logged_meal_id=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                meal.meal_id,
-                result.slot.logged_meal_id,
-            )
-            return result

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -2,21 +2,22 @@
 
 from __future__ import annotations
 
-import logging
 from uuid import uuid4
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
     MealRecommendationNotFoundError,
 )
-from src.domain.model.meal import Meal, MealStatus
+from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_recommendation import (
+    CatalogMeal,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
 from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
-logger = logging.getLogger(__name__)
+# mealimage.url is VARCHAR(255); keep inserts valid when catalog URLs are longer.
+_MEAL_IMAGE_URL_MAX_LEN = 255
 
 
 class RecommendedMealMaterializationService:
@@ -30,31 +31,8 @@ class RecommendedMealMaterializationService:
         slot: PersistedMealRecommendationSlot,
     ) -> Meal:
         if slot.selected is None or slot.selected.catalog_meal is None:
-            logger.warning(
-                "materialize.missing_catalog_meal user_id=%s plan_id=%s "
-                "slot_id=%s selected_null=%s catalog_meal_id=%s",
-                plan.user_id,
-                plan.id,
-                slot.id,
-                slot.selected is None,
-                slot.selected.catalog_meal_id if slot.selected is not None else None,
-            )
             raise MealRecommendationNotFoundError
         catalog_meal = slot.selected.catalog_meal
-        ingredient_count = len(catalog_meal.ingredients)
-        logger.info(
-            "materialize.start user_id=%s plan_id=%s slot_id=%s "
-            "catalog_meal_id=%s ingredients=%s meal_type=%s "
-            "slot_date=%s timezone=%s",
-            plan.user_id,
-            plan.id,
-            slot.id,
-            catalog_meal.id,
-            ingredient_count,
-            slot.meal_type,
-            slot.slot_date,
-            plan.timezone,
-        )
 
         food_items = [
             FoodItem(
@@ -68,13 +46,16 @@ class RecommendedMealMaterializationService:
             for ingredient in catalog_meal.ingredients
         ]
         meal_time = noon_utc_for_date(slot.slot_date, plan.timezone)
+        # Always attach a MealImage row. Production still enforces NOT NULL on
+        # meal.image_id in some environments; image-less inserts 500 there.
+        # Matches manual / AI-suggestion materialization (placeholder image).
         meal = Meal(
             meal_id=str(uuid4()),
             user_id=plan.user_id,
             status=MealStatus.READY,
             created_at=meal_time,
             ready_at=meal_time,
-            image=None,
+            image=_meal_image_for_catalog(catalog_meal),
             dish_name=catalog_meal.name,
             nutrition=Nutrition(
                 macros=Macros(
@@ -88,14 +69,17 @@ class RecommendedMealMaterializationService:
             meal_type=slot.meal_type,
             source="meal_recommendation",
         )
-        saved = await uow.meals.save(meal)
-        logger.info(
-            "materialize.saved user_id=%s plan_id=%s slot_id=%s meal_id=%s "
-            "food_item_count=%s",
-            plan.user_id,
-            plan.id,
-            slot.id,
-            saved.meal_id,
-            len(food_items),
-        )
-        return saved
+        return await uow.meals.save(meal)
+
+
+def _meal_image_for_catalog(catalog_meal: CatalogMeal) -> MealImage:
+    """Build a mealimage row from catalog URL, or a placeholder when absent."""
+
+    raw_url = (catalog_meal.image_url or "").strip() or None
+    url = raw_url if raw_url and len(raw_url) <= _MEAL_IMAGE_URL_MAX_LEN else None
+    return MealImage(
+        image_id=str(uuid4()),
+        format="jpeg",
+        size_bytes=1,
+        url=url,
+    )

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -137,7 +137,42 @@ async def test_materializer_preserves_food_reference_ids_and_macro_snapshot():
     assert meal.nutrition is not None
     assert meal.nutrition.macros.protein == 30
     assert meal.nutrition.food_items[0].food_reference_id == 123
-    assert meal.image is None
+    # Placeholder image keeps inserts valid when meal.image_id is NOT NULL.
+    assert meal.image is not None
+    assert meal.image.url is None
+    assert meal.image.size_bytes == 1
+
+
+@pytest.mark.asyncio
+async def test_materializer_attaches_catalog_image_url_when_present():
+    plan, slot = _plan_and_slot()
+    catalog_meal = slot.selected.catalog_meal
+    assert catalog_meal is not None
+    slot = PersistedMealRecommendationSlot(
+        **{
+            **slot.__dict__,
+            "selected": PersistedMealRecommendationCandidate(
+                **{
+                    **slot.selected.__dict__,
+                    "catalog_meal": CatalogMeal(
+                        **{
+                            **catalog_meal.__dict__,
+                            "image_url": "https://cdn.example.com/meals/tuna.jpg",
+                        }
+                    ),
+                }
+            ),
+        }
+    )
+
+    meal = await RecommendedMealMaterializationService().materialize(
+        _Uow(),
+        plan=plan,
+        slot=slot,
+    )
+
+    assert meal.image is not None
+    assert meal.image.url == "https://cdn.example.com/meals/tuna.jpg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Remove** temporary diagnostic logging from #484 (route / handler / materializer).
- **Restore** the production log fix that was lost when #484 was squash-merged with only diagnostics: always attach a `MealImage` (catalog URL or placeholder) when materializing a recommended meal.
- **Migration** `20260806000001` idempotently makes `meal.image_id` nullable if still NOT NULL.

## Why
Production 500 on log: `NotNullViolationError` on `meal.image_id` with `image=None`. Staging had nullable `image_id`. #484 intended to ship the image attach + logs; only logs landed on main.

## Test plan
- [x] Unit materializer: placeholder image when no catalog URL
- [x] Unit materializer: catalog image URL when present
- [x] Unit log handler claim/materialize/finalize
- [ ] Deploy + `alembic upgrade head` on prod
- [ ] Log recommended meal → 200 (no image_id NOT NULL error)