### PR TITLE
fix(meals): allow deleting meals logged from recommendations

### DIFF
--- a/migrations/versions/20260806000001_ensure_meal_image_id_nullable.py
+++ b/migrations/versions/20260806000001_ensure_meal_image_id_nullable.py
@@ -1,0 +1,43 @@
+"""Ensure meal.image_id is nullable for image-less materialization.
+
+Revision ID: 20260806000001
+Revises: 20260804000001
+
+Production evidence (2026-08-06): logging a meal recommendation failed with
+`NotNullViolationError` on meal.image_id. Code and migration 20260707000001
+already intend nullable image_id; this revision re-applies the alter
+idempotently for environments that still have NOT NULL.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260806000001"
+down_revision = "20260804000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {column["name"]: column for column in inspector.get_columns("meal")}
+    image_id = columns.get("image_id")
+    if image_id is None:
+        return
+    if image_id.get("nullable", False):
+        return
+    op.alter_column(
+        "meal",
+        "image_id",
+        existing_type=sa.String(length=36),
+        nullable=True,
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Do not re-tighten NOT NULL: historical rows may legitimately have no image.
+    pass

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -223,13 +223,6 @@ async def log_recommended_meal(
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
-    logger.info(
-        "meal_recommendation.log.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-    )
     try:
         result = await event_bus.send(
             LogRecommendedMealCommand(
@@ -241,42 +234,7 @@ async def log_recommended_meal(
         )
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
-        logger.warning(
-            "meal_recommendation.log.failed user_id=%s plan_id=%s slot_id=%s "
-            "request_id=%s status=%s detail=%s error_type=%s",
-            user_id,
-            plan_id,
-            slot_id,
-            body.request_id,
-            exc.status_code,
-            exc.public_detail,
-            type(exc).__name__,
-        )
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    except Exception:
-        logger.exception(
-            "meal_recommendation.log.unhandled user_id=%s plan_id=%s slot_id=%s "
-            "request_id=%s",
-            user_id,
-            plan_id,
-            slot_id,
-            body.request_id,
-        )
-        raise
-    logged_meal_id = (
-        result.slot.logged_meal_id
-        if result.slot is not None
-        else None
-    )
-    logger.info(
-        "meal_recommendation.log.materialized user_id=%s plan_id=%s slot_id=%s "
-        "request_id=%s logged_meal_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-        logged_meal_id,
-    )
     response = to_slot_detail_response(
         result.plan_id,
         await localize_meal_recommendation_slot(
@@ -294,15 +252,6 @@ async def log_recommended_meal(
     )
     metric_status = "success"
     record_operation_latency("log", started, metric_status)
-    logger.info(
-        "meal_recommendation.log.success user_id=%s plan_id=%s slot_id=%s "
-        "request_id=%s logged_meal_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-        logged_meal_id,
-    )
     return response
 
 

--- a/src/app/handlers/command_handlers/delete_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/delete_meal_command_handler.py
@@ -41,6 +41,12 @@ class DeleteMealCommandHandler(EventHandler[DeleteMealCommand, dict[str, Any]]):
                     raise AuthorizationException(
                         "You do not have permission to delete this meal"
                     )
+                # Recommended-meal logs set meal_recommendations.logged_meal_id
+                # with ON DELETE SET NULL. Clearing only the FK leaves logged_at
+                # set and violates ck_meal_recommendations_logged_coherent.
+                plans = getattr(uow, "meal_recommendation_plans", None)
+                if plans is not None:
+                    await plans.clear_links_for_deleted_meal(meal_id=command.meal_id)
                 await uow.meals.delete(command.meal_id)
                 log_date = (meal.created_at or utc_now()).date()
             else:

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -1,7 +1,5 @@
 """Handler for logging recommended meals through normal meal persistence."""
 
-import logging
-
 from src.app.commands.meal_recommendation import LogRecommendedMealCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.recommended_meal_materialization_service import (
@@ -10,8 +8,6 @@ from src.app.services.recommended_meal_materialization_service import (
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationSlotMutationResult,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @handles(LogRecommendedMealCommand)
@@ -32,13 +28,6 @@ class LogRecommendedMealCommandHandler(
     async def handle(
         self, command: LogRecommendedMealCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
-        logger.info(
-            "log_handler.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
-            command.user_id,
-            command.plan_id,
-            command.slot_id,
-            command.request_id,
-        )
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -46,64 +35,17 @@ class LogRecommendedMealCommandHandler(
                 slot_id=command.slot_id,
                 request_id=command.request_id,
             )
-            selected = slot.selected
-            logger.info(
-                "log_handler.claimed user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s replayed=%s slot_date=%s meal_type=%s "
-                "catalog_meal_id=%s has_catalog_meal=%s logged_meal_id=%s "
-                "skipped_at=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                replayed,
-                slot.slot_date,
-                slot.meal_type,
-                selected.catalog_meal_id if selected is not None else None,
-                bool(selected is not None and selected.catalog_meal is not None),
-                slot.logged_meal_id,
-                slot.skipped_at,
-            )
             if replayed:
-                logger.info(
-                    "log_handler.replay user_id=%s plan_id=%s slot_id=%s "
-                    "request_id=%s logged_meal_id=%s",
-                    command.user_id,
-                    command.plan_id,
-                    command.slot_id,
-                    command.request_id,
-                    slot.logged_meal_id,
-                )
                 return PersistedMealRecommendationSlotMutationResult(
                     plan_id=plan.id,
                     user_id=plan.user_id,
                     slot=slot,
                 )
             meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
-            logger.info(
-                "log_handler.materialized user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s meal_id=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                meal.meal_id,
-            )
-            result = await uow.meal_recommendation_plans.finalize_slot_logged(
+            return await uow.meal_recommendation_plans.finalize_slot_logged(
                 user_id=command.user_id,
                 plan_id=command.plan_id,
                 slot_id=command.slot_id,
                 request_id=command.request_id,
                 meal_id=meal.meal_id,
             )
-            logger.info(
-                "log_handler.finalized user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s meal_id=%s result_logged_meal_id=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                meal.meal_id,
-                result.slot.logged_meal_id,
-            )
-            return result

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -2,21 +2,22 @@
 
 from __future__ import annotations
 
-import logging
 from uuid import uuid4
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
     MealRecommendationNotFoundError,
 )
-from src.domain.model.meal import Meal, MealStatus
+from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_recommendation import (
+    CatalogMeal,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
 from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
-logger = logging.getLogger(__name__)
+# mealimage.url is VARCHAR(255); keep inserts valid when catalog URLs are longer.
+_MEAL_IMAGE_URL_MAX_LEN = 255
 
 
 class RecommendedMealMaterializationService:
@@ -30,31 +31,8 @@ class RecommendedMealMaterializationService:
         slot: PersistedMealRecommendationSlot,
     ) -> Meal:
         if slot.selected is None or slot.selected.catalog_meal is None:
-            logger.warning(
-                "materialize.missing_catalog_meal user_id=%s plan_id=%s "
-                "slot_id=%s selected_null=%s catalog_meal_id=%s",
-                plan.user_id,
-                plan.id,
-                slot.id,
-                slot.selected is None,
-                slot.selected.catalog_meal_id if slot.selected is not None else None,
-            )
             raise MealRecommendationNotFoundError
         catalog_meal = slot.selected.catalog_meal
-        ingredient_count = len(catalog_meal.ingredients)
-        logger.info(
-            "materialize.start user_id=%s plan_id=%s slot_id=%s "
-            "catalog_meal_id=%s ingredients=%s meal_type=%s "
-            "slot_date=%s timezone=%s",
-            plan.user_id,
-            plan.id,
-            slot.id,
-            catalog_meal.id,
-            ingredient_count,
-            slot.meal_type,
-            slot.slot_date,
-            plan.timezone,
-        )
 
         food_items = [
             FoodItem(
@@ -68,13 +46,16 @@ class RecommendedMealMaterializationService:
             for ingredient in catalog_meal.ingredients
         ]
         meal_time = noon_utc_for_date(slot.slot_date, plan.timezone)
+        # Always attach a MealImage row. Production still enforces NOT NULL on
+        # meal.image_id in some environments; image-less inserts 500 there.
+        # Matches manual / AI-suggestion materialization (placeholder image).
         meal = Meal(
             meal_id=str(uuid4()),
             user_id=plan.user_id,
             status=MealStatus.READY,
             created_at=meal_time,
             ready_at=meal_time,
-            image=None,
+            image=_meal_image_for_catalog(catalog_meal),
             dish_name=catalog_meal.name,
             nutrition=Nutrition(
                 macros=Macros(
@@ -88,14 +69,17 @@ class RecommendedMealMaterializationService:
             meal_type=slot.meal_type,
             source="meal_recommendation",
         )
-        saved = await uow.meals.save(meal)
-        logger.info(
-            "materialize.saved user_id=%s plan_id=%s slot_id=%s meal_id=%s "
-            "food_item_count=%s",
-            plan.user_id,
-            plan.id,
-            slot.id,
-            saved.meal_id,
-            len(food_items),
-        )
-        return saved
+        return await uow.meals.save(meal)
+
+
+def _meal_image_for_catalog(catalog_meal: CatalogMeal) -> MealImage:
+    """Build a mealimage row from catalog URL, or a placeholder when absent."""
+
+    raw_url = (catalog_meal.image_url or "").strip() or None
+    url = raw_url if raw_url and len(raw_url) <= _MEAL_IMAGE_URL_MAX_LEN else None
+    return MealImage(
+        image_id=str(uuid4()),
+        format="jpeg",
+        size_bytes=1,
+        url=url,
+    )

--- a/src/domain/ports/meal_recommendation_plan_repository_port.py
+++ b/src/domain/ports/meal_recommendation_plan_repository_port.py
@@ -137,3 +137,10 @@ class MealRecommendationPlanRepositoryPort(ABC):
         meal_id: str,
     ) -> PersistedMealRecommendationSlotMutationResult:
         """Attach a materialized meal to a claimed slot log and return the slot."""
+
+    async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
+        """Clear recommendation links before a normal meal is hard-deleted.
+
+        Default no-op for lightweight fakes; production repos must implement.
+        """
+        return None

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -525,7 +525,9 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
                 MealRecommendationOperationORM.result_logged_meal_id == meal_id
             )
         )
-        await self._flush_operations()
+        # Plain flush — do not use _flush_operations(), which remaps IntegrityError
+        # into meal-recommendation swap/idempotency domain errors (wrong for delete).
+        await self._session.flush()
 
     async def _load_batch(
         self, *, user_id: str, batch_id: str

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -8,7 +8,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import cast
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -505,6 +505,27 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             user_id=user_id,
             slot=_rows_to_slot_detail(anchor, rows),
         )
+
+    async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
+        """Detach recommendation state from a meal about to be hard-deleted.
+
+        ``logged_meal_id`` FKs use ON DELETE SET NULL. That leaves ``logged_at``
+        set and breaks ``ck_meal_recommendations_logged_coherent``. Log operation
+        rows also require ``result_logged_meal_id`` non-null, so SET NULL there
+        violates ``ck_meal_recommendation_operations_payload``. Clear both sides
+        before the meal row is removed.
+        """
+        await self._session.execute(
+            update(MealRecommendationORM)
+            .where(MealRecommendationORM.logged_meal_id == meal_id)
+            .values(logged_meal_id=None, logged_at=None)
+        )
+        await self._session.execute(
+            delete(MealRecommendationOperationORM).where(
+                MealRecommendationOperationORM.result_logged_meal_id == meal_id
+            )
+        )
+        await self._flush_operations()
 
     async def _load_batch(
         self, *, user_id: str, batch_id: str

--- a/tests/unit/app/handlers/test_handler_with_fake_uow.py
+++ b/tests/unit/app/handlers/test_handler_with_fake_uow.py
@@ -47,6 +47,9 @@ class TestDeleteMealWithFakeUoW:
         mock_uow = MagicMock()
         mock_uow.meals.find_by_id = AsyncMock(return_value=meal)
         mock_uow.meals.delete = AsyncMock(return_value=None)
+        mock_uow.meal_recommendation_plans.clear_links_for_deleted_meal = AsyncMock(
+            return_value=None
+        )
         mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
         mock_uow.__aexit__ = AsyncMock(return_value=False)
 
@@ -59,7 +62,58 @@ class TestDeleteMealWithFakeUoW:
         # Assert
         assert result["meal_id"] == meal.meal_id
         assert "deleted" in result["message"].lower()
+        mock_uow.meal_recommendation_plans.clear_links_for_deleted_meal.assert_awaited_once_with(
+            meal_id=meal.meal_id
+        )
         mock_uow.meals.delete.assert_called_once_with(meal.meal_id)
+
+
+    @pytest.mark.asyncio
+    async def test_delete_meal_clears_recommendation_links_before_delete(self):
+        """Recommended-meal FK clear must run before hard-deleting the meal."""
+        user_id = str(uuid4())
+        meal = Meal.create_new_processing(
+            user_id=user_id,
+            image=MealImage(
+                image_id=str(uuid4()),
+                format="jpeg",
+                size_bytes=100000,
+                url="https://example.com/image.jpg",
+            ),
+        )
+        from src.domain.model.nutrition import Nutrition, Macros
+
+        meal = meal.mark_ready(
+            nutrition=Nutrition(
+                macros=Macros(protein=30, carbs=50, fat=20), food_items=[]
+            ),
+            dish_name="Recommended meal",
+        )
+        meal = meal.__class__(
+            **{**meal.__dict__, "source": "meal_recommendation"}
+        )
+
+        call_order: list[str] = []
+
+        async def clear_links(*, meal_id: str) -> None:
+            call_order.append(f"clear:{meal_id}")
+
+        async def delete_meal(meal_id: str) -> None:
+            call_order.append(f"delete:{meal_id}")
+
+        mock_uow = MagicMock()
+        mock_uow.meals.find_by_id = AsyncMock(return_value=meal)
+        mock_uow.meals.delete = AsyncMock(side_effect=delete_meal)
+        mock_uow.meal_recommendation_plans.clear_links_for_deleted_meal = AsyncMock(
+            side_effect=clear_links
+        )
+        mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+        mock_uow.__aexit__ = AsyncMock(return_value=False)
+
+        handler = DeleteMealCommandHandler(uow=mock_uow)
+        await handler.handle(DeleteMealCommand(meal_id=meal.meal_id, user_id=user_id))
+
+        assert call_order == [f"clear:{meal.meal_id}", f"delete:{meal.meal_id}"]
 
 
 # Removed TestSyncUserWithFakeUoW - SyncUserCommand not in scope for this demo

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -137,7 +137,42 @@ async def test_materializer_preserves_food_reference_ids_and_macro_snapshot():
     assert meal.nutrition is not None
     assert meal.nutrition.macros.protein == 30
     assert meal.nutrition.food_items[0].food_reference_id == 123
-    assert meal.image is None
+    # Placeholder image keeps inserts valid when meal.image_id is NOT NULL.
+    assert meal.image is not None
+    assert meal.image.url is None
+    assert meal.image.size_bytes == 1
+
+
+@pytest.mark.asyncio
+async def test_materializer_attaches_catalog_image_url_when_present():
+    plan, slot = _plan_and_slot()
+    catalog_meal = slot.selected.catalog_meal
+    assert catalog_meal is not None
+    slot = PersistedMealRecommendationSlot(
+        **{
+            **slot.__dict__,
+            "selected": PersistedMealRecommendationCandidate(
+                **{
+                    **slot.selected.__dict__,
+                    "catalog_meal": CatalogMeal(
+                        **{
+                            **catalog_meal.__dict__,
+                            "image_url": "https://cdn.example.com/meals/tuna.jpg",
+                        }
+                    ),
+                }
+            ),
+        }
+    )
+
+    meal = await RecommendedMealMaterializationService().materialize(
+        _Uow(),
+        plan=plan,
+        slot=slot,
+    )
+
+    assert meal.image is not None
+    assert meal.image.url == "https://cdn.example.com/meals/tuna.jpg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fix production IntegrityError when deleting a meal that was created by logging a meal recommendation.

## Root cause (Sentry PYTHON-F8 / 7651179067)
`meal_recommendations.logged_meal_id` FK is `ON DELETE SET NULL`, but:
- `ck_meal_recommendations_logged_coherent` requires `logged_at` and `logged_meal_id` to be both null or both non-null
- `meal_recommendation_operations` log rows require `result_logged_meal_id IS NOT NULL`

Deleting the meal only nulls the FK id → check violation → transaction rolls back.

## Fix
Before hard-deleting the meal:
1. Set `logged_meal_id = NULL` and `logged_at = NULL` on matching recommendation rows (slot becomes unlogged again)
2. Delete `meal_recommendation_operations` rows with `result_logged_meal_id = meal_id` (cannot null without breaking the operations payload check)

## Test plan
- [x] Unit: delete handler clears recommendation links before meal delete
- [ ] Production: log a recommended meal, then `DELETE /v1/meals/{id}` → 200
- [ ] Plan deck shows the slot as unlogged again after delete