### PR TITLE
fix(meal-recommendations): persist locale when logging recommended meals

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -619,7 +619,11 @@ def get_configured_event_bus() -> EventBus:
     )
     event_bus.register_handler(
         LogRecommendedMealCommand,
-        LogRecommendedMealCommandHandler(uow=AsyncUnitOfWork()),
+        LogRecommendedMealCommandHandler(
+            uow=AsyncUnitOfWork(),
+            meal_translation_service=meal_translation_service,
+            cache_invalidation=cache_invalidation_service,
+        ),
     )
     event_bus.register_handler(
         SkipMealRecommendationSlotCommand,

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -230,6 +230,7 @@ async def log_recommended_meal(
                 plan_id=plan_id,
                 slot_id=slot_id,
                 request_id=body.request_id,
+                language=get_request_language(request),
             )
         )
     except MealRecommendationCreationError as exc:

--- a/src/app/commands/meal_recommendation/log_recommended_meal_command.py
+++ b/src/app/commands/meal_recommendation/log_recommended_meal_command.py
@@ -11,3 +11,5 @@ class LogRecommendedMealCommand(Command):
     plan_id: str
     slot_id: str
     request_id: str
+    # ISO 639-1 request language; used to persist meal_translation after materialize.
+    language: str = "en"

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -1,13 +1,24 @@
 """Handler for logging recommended meals through normal meal persistence."""
 
+from __future__ import annotations
+
+import logging
+
 from src.app.commands.meal_recommendation import LogRecommendedMealCommand
 from src.app.events.base import EventHandler, handles
+from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.recommended_meal_materialization_service import (
     RecommendedMealMaterializationService,
 )
+from src.domain.model.meal import Meal
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationSlotMutationResult,
 )
+from src.domain.services.meal_analysis.deepl_meal_translation_service import (
+    DeepLMealTranslationService,
+)
+
+logger = logging.getLogger(__name__)
 
 
 @handles(LogRecommendedMealCommand)
@@ -21,13 +32,20 @@ class LogRecommendedMealCommandHandler(
         self,
         uow,
         materializer: RecommendedMealMaterializationService | None = None,
+        meal_translation_service: DeepLMealTranslationService | None = None,
+        cache_invalidation: CacheInvalidationService | None = None,
     ):
         self.uow = uow
         self.materializer = materializer or RecommendedMealMaterializationService()
+        self.meal_translation_service = meal_translation_service
+        self.cache_invalidation = cache_invalidation
 
     async def handle(
         self, command: LogRecommendedMealCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
+        saved_meal: Meal | None = None
+        meal_date = None
+
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -36,16 +54,67 @@ class LogRecommendedMealCommandHandler(
                 request_id=command.request_id,
             )
             if replayed:
-                return PersistedMealRecommendationSlotMutationResult(
+                result = PersistedMealRecommendationSlotMutationResult(
                     plan_id=plan.id,
                     user_id=plan.user_id,
                     slot=slot,
                 )
-            meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
-            return await uow.meal_recommendation_plans.finalize_slot_logged(
-                user_id=command.user_id,
-                plan_id=command.plan_id,
-                slot_id=command.slot_id,
-                request_id=command.request_id,
-                meal_id=meal.meal_id,
+            else:
+                meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
+                result = await uow.meal_recommendation_plans.finalize_slot_logged(
+                    user_id=command.user_id,
+                    plan_id=command.plan_id,
+                    slot_id=command.slot_id,
+                    request_id=command.request_id,
+                    meal_id=meal.meal_id,
+                )
+                saved_meal = meal
+                meal_date = slot.slot_date
+
+        # meal_translation uses its own DB session; parent meal must be committed first.
+        if saved_meal is not None:
+            await self._persist_request_language_translation(command, saved_meal)
+            if self.cache_invalidation is not None and meal_date is not None:
+                await self.cache_invalidation.after_meal_write(
+                    command.user_id, meal_date
+                )
+
+        return result
+
+    async def _persist_request_language_translation(
+        self,
+        command: LogRecommendedMealCommand,
+        meal: Meal,
+    ) -> None:
+        """Persist DeepL meal_translation so Today's Meals can show localized titles."""
+
+        language = (command.language or "en").strip().lower()
+        if language == "en" or self.meal_translation_service is None:
+            return
+
+        nutrition = getattr(meal, "nutrition", None)
+        food_items = list(getattr(nutrition, "food_items", None) or [])
+        dish_name = getattr(meal, "dish_name", None) or ""
+        if not dish_name and not food_items:
+            return
+
+        try:
+            await self.meal_translation_service.translate_meal(
+                meal=meal,
+                dish_name=dish_name,
+                food_items=food_items,
+                target_language=language,
+            )
+            logger.info(
+                "recommended meal translated meal=%s language=%s",
+                meal.meal_id,
+                language,
+            )
+        except Exception as exc:
+            # Logging must succeed even when translation is unavailable.
+            logger.warning(
+                "recommended meal translation failed meal=%s language=%s error=%s",
+                meal.meal_id,
+                language,
+                exc,
             )

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -317,8 +317,29 @@ async def test_log_route_sends_recommended_meal_command():
         item for item in event_bus.commands if isinstance(item, LogRecommendedMealCommand)
     )
     assert command.request_id == "log-1"
+    assert command.language == "en"
     assert response.plan_id == "plan-1"
     assert response.slot.id == "slot-1"
+
+
+@pytest.mark.asyncio
+async def test_log_route_forwards_request_language_to_command():
+    event_bus = _EventBus()
+
+    await log_recommended_meal(
+        request=_request(language="vi"),
+        plan_id="plan-1",
+        slot_id="slot-1",
+        body=LogRecommendedMealRequest(request_id="log-1"),
+        user_id="user-1",
+        event_bus=event_bus,
+        analytics_service=_Analytics(),
+    )
+
+    command = next(
+        item for item in event_bus.commands if isinstance(item, LogRecommendedMealCommand)
+    )
+    assert command.language == "vi"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/handlers/test_meal_recommendation_handlers.py
+++ b/tests/unit/app/handlers/test_meal_recommendation_handlers.py
@@ -104,10 +104,23 @@ class _SkipPlanRepo(_PlanRepo):
 
 
 class _Materializer:
-    def __init__(self):
-        self.materialize = AsyncMock(
-            return_value=type("Meal", (), {"meal_id": "meal-1"})()
-        )
+    def __init__(self, meal=None):
+        food_item = type(
+            "FoodItem",
+            (),
+            {"id": "food-1", "name": "Rice"},
+        )()
+        nutrition = type("Nutrition", (), {"food_items": [food_item]})()
+        self.meal = meal or type(
+            "Meal",
+            (),
+            {
+                "meal_id": "meal-1",
+                "dish_name": "Rice Bowl",
+                "nutrition": nutrition,
+            },
+        )()
+        self.materialize = AsyncMock(return_value=self.meal)
 
 
 class _Uow:
@@ -183,12 +196,13 @@ def _catalog_meal(meal_id: str) -> CatalogMeal:
     )
 
 
-def _log_command() -> LogRecommendedMealCommand:
+def _log_command(*, language: str = "en") -> LogRecommendedMealCommand:
     return LogRecommendedMealCommand(
         user_id="user-1",
         plan_id="plan-1",
         slot_id="slot-1",
         request_id="log-1",
+        language=language,
     )
 
 
@@ -314,6 +328,80 @@ async def test_log_handler_claims_materializes_then_finalizes():
         request_id="log-1",
         meal_id="meal-1",
     )
+
+
+@pytest.mark.asyncio
+async def test_log_handler_translates_and_invalidates_cache_for_non_english():
+    plans = _LogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    translation_service = type(
+        "TranslationService",
+        (),
+        {"translate_meal": AsyncMock(return_value=None)},
+    )()
+    cache_invalidation = type(
+        "CacheInvalidation",
+        (),
+        {"after_meal_write": AsyncMock()},
+    )()
+    handler = LogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_translation_service=translation_service,
+        cache_invalidation=cache_invalidation,
+    )
+
+    await handler.handle(_log_command(language="vi"))
+
+    translation_service.translate_meal.assert_awaited_once()
+    kwargs = translation_service.translate_meal.await_args.kwargs
+    assert kwargs["target_language"] == "vi"
+    assert kwargs["dish_name"] == "Rice Bowl"
+    assert kwargs["food_items"][0].name == "Rice"
+    cache_invalidation.after_meal_write.assert_awaited_once_with(
+        "user-1", _plan().slots[0].slot_date
+    )
+
+
+@pytest.mark.asyncio
+async def test_log_handler_skips_translation_for_english():
+    plans = _LogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    translation_service = type(
+        "TranslationService",
+        (),
+        {"translate_meal": AsyncMock(return_value=None)},
+    )()
+    handler = LogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_translation_service=translation_service,
+    )
+
+    await handler.handle(_log_command(language="en"))
+
+    translation_service.translate_meal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_log_handler_does_not_fail_when_translation_raises():
+    plans = _LogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    translation_service = type(
+        "TranslationService",
+        (),
+        {"translate_meal": AsyncMock(side_effect=RuntimeError("deepl down"))},
+    )()
+    handler = LogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_translation_service=translation_service,
+    )
+
+    result = await handler.handle(_log_command(language="vi"))
+
+    assert result.plan_id == "plan-1"
+    translation_service.translate_meal.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Pass `Accept-Language` into `LogRecommendedMealCommand` when logging a recommendation slot.
- After materializing the English catalog meal, persist a `meal_translation` via DeepL for non-English request languages.
- Invalidate activity/nutrition caches after log so Today's Meals refreshes with the localized title.

## Why
Recommendation responses were localized on the fly (Vietnamese UI), but logging stored only English catalog `dish_name` with no `meal_translation`. Today's Meals / activities then fell back to English.

## Test plan
- [x] `pytest tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/api/test_meal_recommendations_route.py -q`
- [ ] With Vietnamese app language: open recommendation → confirm name is Vietnamese → log meal → confirm Today's Meals title stays Vietnamese
- [ ] With English language: log still works; no translation write required
- [ ] Open meal detail after log and confirm ingredient names localize when language is non-English