### PR TITLE
fix(users): lower minimum age to 12 for App Store alignment

### DIFF
--- a/migrations/versions/20260807000001_lower_min_age_to_12.py
+++ b/migrations/versions/20260807000001_lower_min_age_to_12.py
@@ -1,0 +1,32 @@
+"""Lower user profile minimum age from 13 to 12 (App Store 12+).
+
+Revision ID: 20260807000001
+Revises: 20260806000001
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260807000001"
+down_revision = "20260806000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("check_age_range", "user_profiles", type_="check")
+    op.create_check_constraint(
+        "check_age_range",
+        "user_profiles",
+        "age >= 12 AND age <= 120",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("check_age_range", "user_profiles", type_="check")
+    op.create_check_constraint(
+        "check_age_range",
+        "user_profiles",
+        "age >= 13 AND age <= 120",
+    )

--- a/src/api/schemas/request/tdee_requests.py
+++ b/src/api/schemas/request/tdee_requests.py
@@ -55,7 +55,7 @@ class UnitSystemEnum(StrEnum):
 class TdeeCalculationRequest(BaseModel):
     """Request DTO for TDEE calculation matching Flutter OnboardingData."""
 
-    age: int = Field(..., ge=13, le=120, description="User age")
+    age: int = Field(..., ge=12, le=120, description="User age")
     sex: SexEnum = Field(..., description="User biological sex")
     height: float = Field(..., gt=0, description="Height in user's preferred units")
     weight: float = Field(..., gt=0, description="Weight in user's preferred units")

--- a/src/api/schemas/request/user_profile_update_requests.py
+++ b/src/api/schemas/request/user_profile_update_requests.py
@@ -35,7 +35,7 @@ class UpdateMetricsRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    age: int | None = Field(None, ge=13, le=120, description="User age")
+    age: int | None = Field(None, ge=12, le=120, description="User age")
     height_cm: float | None = Field(None, ge=100, le=272, description="Height in cm")
     weight_kg: float | None = Field(None, description="Weight in kg", gt=0)
     biological_sex: str | None = Field(

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -85,8 +85,8 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
 
             # Update provided fields only
             if command.age is not None:
-                if command.age < 13 or command.age > 120:
-                    raise ValidationException("Age must be between 13 and 120")
+                if command.age < 12 or command.age > 120:
+                    raise ValidationException("Age must be between 12 and 120")
                 profile.age = command.age
 
             if command.height_cm is not None:

--- a/src/domain/constants/meal_constants.py
+++ b/src/domain/constants/meal_constants.py
@@ -174,7 +174,7 @@ class TDEEConstants:
     MIN_CALORIES_MALE = 1500
 
     # Validation ranges
-    MIN_AGE = 13
+    MIN_AGE = 12
     MAX_AGE = 120
     MIN_WEIGHT_KG = 30
     MAX_WEIGHT_KG = 300

--- a/src/domain/model/user/tdee.py
+++ b/src/domain/model/user/tdee.py
@@ -64,8 +64,8 @@ class TdeeRequest:
 
     def __post_init__(self):
         """Validate invariants."""
-        if not (13 <= self.age <= 120):
-            raise ValueError(f"Age must be between 13 and 120: {self.age}")
+        if not (12 <= self.age <= 120):
+            raise ValueError(f"Age must be between 12 and 120: {self.age}")
 
         if self.unit_system == UnitSystem.METRIC:
             if not (100 <= self.height <= 272):

--- a/src/infra/database/models/user/profile.py
+++ b/src/infra/database/models/user/profile.py
@@ -97,7 +97,7 @@ class UserProfile(Base, BaseMixin):
 
     # Constraints
     __table_args__ = (
-        CheckConstraint("age >= 13 AND age <= 120", name="check_age_range"),
+        CheckConstraint("age >= 12 AND age <= 120", name="check_age_range"),
         CheckConstraint("height_cm > 0", name="check_height_positive"),
         CheckConstraint("weight_kg > 0", name="check_weight_positive"),
         CheckConstraint(

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -296,12 +296,12 @@ class TestUpdateUserMetricsCommandHandler:
         mock_uow = _make_mock_uow(profile)
 
         handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
-        command = UpdateUserMetricsCommand(user_id="test_user", age=12)
+        command = UpdateUserMetricsCommand(user_id="test_user", age=11)
 
         with pytest.raises(ValidationException) as exc_info:
             await handler.handle(command)
 
-        assert "Age must be between 13 and 120" in str(exc_info.value)
+        assert "Age must be between 12 and 120" in str(exc_info.value)
 
     async def test_invalid_height(self):
         """Test validation for invalid height."""


### PR DESCRIPTION
## Summary
- Lower minimum age from 13 to **12** across API validation, domain model, constants, and SQLAlchemy check constraint
- Add migration `20260807000001_lower_min_age_to_12`
- Update unit test invalid age case (now 11)

## Test plan
- [ ] `pytest tests/unit/domain/test_update_user_metrics.py -k invalid_age`
- [ ] Age 12 accepted on profile/TDEE update endpoints
- [ ] Run migration on staging before prod