### PR TITLE
chore: sync main into delivery (260807)

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -118,7 +118,7 @@ The two health routes are declared with `api_route` and answer both GET and HEAD
 
 ### Meal Recommendation Contract
 
-- `create` and `get` return the compact summary contract: selected slots only, with no slot-level ingredients, alternatives, or scores in the plan payload.
+- `create` and `get` return the compact summary contract: selected slots only, with ingredients for each selected meal. Alternatives, scores, and full meal details remain available from slot detail responses.
 - Slot detail hydrates exactly one selected slot plus its alternatives. Mutation responses reuse the same changed-slot shape so clients can patch cached plans in place.
 - `swap`, `log`, and `skip` are owner-scoped, idempotent by request ID, and reject already terminal selected slots.
 - `shown_at`, `skipped_at`, and `logged_at` are backend-owned outcome fields. Clients must not infer terminal state by recalculating recommendation logic.

--- a/docs/meal-recommendation-mobile-handoff.md
+++ b/docs/meal-recommendation-mobile-handoff.md
@@ -86,7 +86,7 @@ Authorization: Bearer <firebase-jwt>
 Behavior:
 
 - Returns the compact plan summary for the owner-scoped plan.
-- The response includes selected slots only. Slot ingredients, alternatives, and scores are omitted from the summary payload.
+- The response includes selected slots only. Each selected meal includes its ingredients; alternatives, scores, and full meal details are omitted from the summary payload.
 
 ### Swap Slot
 
@@ -156,7 +156,8 @@ The plan summary is compact:
 
 - plan metadata: `id`, `status`, `timezone`, `start_date`, `daily_calories`, `allergy_evaluated`
 - slot summary: `id`, `slot_date`, `day_index`, `meal_type`, `catalog_meal_id`, compact `catalog_meal`, `target_calories`, `position`, `selection_version`, `logged_meal_id`, `shown_at`, `skipped_at`
-- omitted from plan summary: `score`, `alternatives`, and `catalog_meal.ingredients`
+- included in the compact `catalog_meal`: selected meal ingredients
+- omitted from plan summary: `score`, `alternatives`, and full meal-detail fields such as `description`
 
 Use `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` for the hydrated selected slot payload when the user needs details or alternatives.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -164,7 +164,7 @@ downloading Cloudinary bytes. Graph nodes must not import provider SDKs,
 ## Data Flow Example: Meal Recommendation Plan
 
 1. `POST /v1/meal-recommendations/three-day` resolves timezone and daily calories, then builds or replays a durable recommendation plan.
-2. The plan-level response is compact: it includes only the selected slots. Slot ingredients, alternatives, and scores stay out of the summary payload.
+2. The plan-level response is compact: it includes only the selected slots, with ingredients for each selected meal. Alternatives, scores, and full meal-detail fields stay out of the summary payload.
 3. `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` hydrates one selected slot and its alternatives when the client needs drill-down data.
 4. `swap`, `log`, and `skip` return the changed-slot detail shape so the mobile client can patch its cached plan without reloading everything.
 5. Recommendation analytics are scheduled through `BackgroundTaskManager` when available. Catalog meals are read from the process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback. Meal-history affinity is projected from aggregate linked ingredient buckets instead of loading the full meal graph, and logging a recommended meal reuses the already loaded selected catalog projection without fabricating image data.

--- a/migrations/versions/20260804000001_add_manual_nutrition_overrides.py
+++ b/migrations/versions/20260804000001_add_manual_nutrition_overrides.py
@@ -1,0 +1,36 @@
+"""Persist independent meal and ingredient nutrition overrides."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260804000001"
+down_revision: str | None = "20260730110500000000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table_name in ("nutrition", "food_item"):
+        if not inspector.has_table(table_name):
+            continue
+        columns = {column["name"] for column in inspector.get_columns(table_name)}
+        if "nutrition_override" not in columns:
+            op.add_column(
+                table_name,
+                sa.Column("nutrition_override", sa.JSON(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table_name in ("food_item", "nutrition"):
+        if not inspector.has_table(table_name):
+            continue
+        columns = {column["name"] for column in inspector.get_columns(table_name)}
+        if "nutrition_override" in columns:
+            op.drop_column(table_name, "nutrition_override")

--- a/migrations/versions/20260806000001_ensure_meal_image_id_nullable.py
+++ b/migrations/versions/20260806000001_ensure_meal_image_id_nullable.py
@@ -1,0 +1,43 @@
+"""Ensure meal.image_id is nullable for image-less materialization.
+
+Revision ID: 20260806000001
+Revises: 20260804000001
+
+Production evidence (2026-08-06): logging a meal recommendation failed with
+`NotNullViolationError` on meal.image_id. Code and migration 20260707000001
+already intend nullable image_id; this revision re-applies the alter
+idempotently for environments that still have NOT NULL.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260806000001"
+down_revision = "20260804000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {column["name"]: column for column in inspector.get_columns("meal")}
+    image_id = columns.get("image_id")
+    if image_id is None:
+        return
+    if image_id.get("nullable", False):
+        return
+    op.alter_column(
+        "meal",
+        "image_id",
+        existing_type=sa.String(length=36),
+        nullable=True,
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Do not re-tighten NOT NULL: historical rows may legitimately have no image.
+    pass

--- a/migrations/versions/20260807000001_lower_min_age_to_12.py
+++ b/migrations/versions/20260807000001_lower_min_age_to_12.py
@@ -1,0 +1,32 @@
+"""Lower user profile minimum age from 13 to 12 (App Store 12+).
+
+Revision ID: 20260807000001
+Revises: 20260806000001
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260807000001"
+down_revision = "20260806000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("check_age_range", "user_profiles", type_="check")
+    op.create_check_constraint(
+        "check_age_range",
+        "user_profiles",
+        "age >= 12 AND age <= 120",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("check_age_range", "user_profiles", type_="check")
+    op.create_check_constraint(
+        "check_age_range",
+        "user_profiles",
+        "age >= 13 AND age <= 120",
+    )

--- a/migrations/versions/20260807000002_merge_main_delivery_migration_heads.py
+++ b/migrations/versions/20260807000002_merge_main_delivery_migration_heads.py
@@ -1,0 +1,19 @@
+"""Merge main nutrition/age migrations with delivery web-funnel head."""
+
+from collections.abc import Sequence
+
+revision: str = "20260807000002"
+down_revision: tuple[str, str] = (
+    "20260803000004",
+    "20260807000001",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Record that both independent migration branches have been applied."""
+
+
+def downgrade() -> None:
+    """Keep forward-only production schema changes intact on rollback."""

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -619,7 +619,11 @@ def get_configured_event_bus() -> EventBus:
     )
     event_bus.register_handler(
         LogRecommendedMealCommand,
-        LogRecommendedMealCommandHandler(uow=AsyncUnitOfWork()),
+        LogRecommendedMealCommandHandler(
+            uow=AsyncUnitOfWork(),
+            meal_translation_service=meal_translation_service,
+            cache_invalidation=cache_invalidation_service,
+        ),
     )
     event_bus.register_handler(
         SkipMealRecommendationSlotCommand,

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -17,6 +17,9 @@ from src.api.schemas.response import (
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.domain.model.meal import Meal
 from src.domain.model.nutrition import FoodItem, Macros, Micros, Nutrition
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
 from src.domain.services.meal_calorie_service import (
     effective_food_item_calories,
     effective_meal_calories,
@@ -66,6 +69,9 @@ class MealMapper:
         image_url: str | None = None,
         target_language: str | None = None,
         value_insights: MealValueInsights | None = None,
+        source_nutrition_by_food_reference: dict[
+            int, FoodReferenceNutritionProjection
+        ] | None = None,
     ) -> DetailedMealResponse:
         """
         Convert Meal domain model to DetailedMealResponse DTO.
@@ -83,6 +89,7 @@ class MealMapper:
             CustomNutritionResponse,
             MacrosResponse,
             MealTranslationResponse,
+            NutritionOverrideResponse,
             TranslatedFoodItemResponse,
         )
 
@@ -96,12 +103,13 @@ class MealMapper:
 
             # Map total nutrition macros
             if hasattr(meal.nutrition, "macros") and meal.nutrition.macros:
+                effective_macros = meal.nutrition.effective_macros
                 total_nutrition = MacrosResponse(
-                    protein=meal.nutrition.macros.protein,
-                    carbs=meal.nutrition.macros.carbs,
-                    fat=meal.nutrition.macros.fat,
-                    fiber=meal.nutrition.macros.fiber,
-                    sugar=meal.nutrition.macros.sugar,
+                    protein=effective_macros.protein,
+                    carbs=effective_macros.carbs,
+                    fat=effective_macros.fat,
+                    fiber=effective_macros.fiber,
+                    sugar=effective_macros.sugar,
                 )
             # Handle legacy structure where nutrition has direct properties
             elif hasattr(meal.nutrition, "protein"):
@@ -123,6 +131,8 @@ class MealMapper:
                     if hasattr(item, "macros") and item.macros:
                         nutrition_dto = NutritionResponse(
                             nutrition_id=str(item.name),
+                            # Use effective item calories so label/overrides
+                            # are not replaced by macro-derived totals.
                             calories=item_calories,
                             protein_g=item.macros.protein,
                             carbs_g=item.macros.carbs,
@@ -165,6 +175,10 @@ class MealMapper:
                             ),
                         )
 
+                    source_nutrition_dto = MealMapper._source_nutrition_response(
+                        source_nutrition_by_food_reference,
+                        getattr(item, "food_reference_id", None),
+                    )
                     food_item_dto = FoodItemResponse(
                         id=str(item.id),
                         name=item.name,
@@ -176,6 +190,17 @@ class MealMapper:
                         description=None,
                         nutrition=nutrition_dto,
                         custom_nutrition=custom_nutrition_dto,
+                        source_nutrition=source_nutrition_dto,
+                        nutrition_override=(
+                            NutritionOverrideResponse(
+                                calories=item.nutrition_override.calories,
+                                protein=item.nutrition_override.protein,
+                                carbs=item.nutrition_override.carbs,
+                                fat=item.nutrition_override.fat,
+                            )
+                            if item.nutrition_override
+                            else None
+                        ),
                         fdc_id=getattr(item, "fdc_id", None),
                         food_reference_id=getattr(item, "food_reference_id", None),
                         is_custom=getattr(item, "is_custom", False),
@@ -269,6 +294,16 @@ class MealMapper:
                 meal.weight_grams if hasattr(meal, "weight_grams") else None
             ),
             total_nutrition=total_nutrition,
+            nutrition_override=(
+                NutritionOverrideResponse(
+                    calories=meal.nutrition.nutrition_override.calories,
+                    protein=meal.nutrition.nutrition_override.protein,
+                    carbs=meal.nutrition.nutrition_override.carbs,
+                    fat=meal.nutrition.nutrition_override.fat,
+                )
+                if meal.nutrition and meal.nutrition.nutrition_override
+                else None
+            ),
             translations=translations_response,
             food_label_metadata=MealMapper._food_label_metadata(meal),
             value_insights=value_insights_response,
@@ -279,6 +314,46 @@ class MealMapper:
             cook_time_min=getattr(meal, "cook_time_min", None),
             cuisine_type=getattr(meal, "cuisine_type", None),
             origin_country=getattr(meal, "origin_country", None),
+        )
+
+    @staticmethod
+    def _source_nutrition_response(
+        source_nutrition_by_food_reference: dict[
+            int, FoodReferenceNutritionProjection
+        ]
+        | None,
+        food_reference_id: int | None,
+    ):
+        if not source_nutrition_by_food_reference or food_reference_id is None:
+            return None
+
+        reference = source_nutrition_by_food_reference.get(food_reference_id)
+        if reference is None or any(
+            value is None
+            for value in (
+                reference.protein_100g,
+                reference.carbs_100g,
+                reference.fat_100g,
+            )
+        ):
+            return None
+
+        from src.api.schemas.response.meal_responses import CustomNutritionResponse
+
+        macros = Macros(
+            protein=reference.protein_100g,
+            carbs=reference.carbs_100g,
+            fat=reference.fat_100g,
+            fiber=reference.fiber_100g,
+            sugar=reference.sugar_100g,
+        )
+        return CustomNutritionResponse(
+            calories_per_100g=macros.total_calories,
+            protein_per_100g=macros.protein,
+            carbs_per_100g=macros.carbs,
+            fat_per_100g=macros.fat,
+            fiber_per_100g=macros.fiber,
+            sugar_per_100g=macros.sugar,
         )
 
     @staticmethod

--- a/src/api/routes/v1/meal_recommendation_route_support.py
+++ b/src/api/routes/v1/meal_recommendation_route_support.py
@@ -273,15 +273,7 @@ def _catalog_meal_response(catalog_meal: CatalogMeal) -> MealRecommendationCatal
             fiber_g=float(catalog_meal.fiber_g),
             sugar_g=float(catalog_meal.sugar_g),
         ),
-        ingredients=[
-            MealRecommendationIngredientResponse(
-                food_reference_id=ingredient.food_reference_id,
-                display_name=ingredient.display_name,
-                quantity=float(ingredient.quantity),
-                unit=ingredient.unit,
-            )
-            for ingredient in catalog_meal.ingredients
-        ],
+        ingredients=_catalog_meal_ingredients(catalog_meal),
     )
 
 
@@ -301,4 +293,19 @@ def _catalog_meal_summary_response(
             fiber_g=float(catalog_meal.fiber_g),
             sugar_g=float(catalog_meal.sugar_g),
         ),
+        ingredients=_catalog_meal_ingredients(catalog_meal),
     )
+
+
+def _catalog_meal_ingredients(
+    catalog_meal: CatalogMeal,
+) -> list[MealRecommendationIngredientResponse]:
+    return [
+        MealRecommendationIngredientResponse(
+            food_reference_id=ingredient.food_reference_id,
+            display_name=ingredient.display_name,
+            quantity=float(ingredient.quantity),
+            unit=ingredient.unit,
+        )
+        for ingredient in catalog_meal.ingredients
+    ]

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -223,13 +223,6 @@ async def log_recommended_meal(
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
-    logger.info(
-        "meal_recommendation.log.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-    )
     try:
         result = await event_bus.send(
             LogRecommendedMealCommand(
@@ -241,42 +234,7 @@ async def log_recommended_meal(
         )
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
-        logger.warning(
-            "meal_recommendation.log.failed user_id=%s plan_id=%s slot_id=%s "
-            "request_id=%s status=%s detail=%s error_type=%s",
-            user_id,
-            plan_id,
-            slot_id,
-            body.request_id,
-            exc.status_code,
-            exc.public_detail,
-            type(exc).__name__,
-        )
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
-    except Exception:
-        logger.exception(
-            "meal_recommendation.log.unhandled user_id=%s plan_id=%s slot_id=%s "
-            "request_id=%s",
-            user_id,
-            plan_id,
-            slot_id,
-            body.request_id,
-        )
-        raise
-    logged_meal_id = (
-        result.slot.logged_meal_id
-        if result.slot is not None
-        else None
-    )
-    logger.info(
-        "meal_recommendation.log.materialized user_id=%s plan_id=%s slot_id=%s "
-        "request_id=%s logged_meal_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-        logged_meal_id,
-    )
     response = to_slot_detail_response(
         result.plan_id,
         await localize_meal_recommendation_slot(
@@ -294,15 +252,6 @@ async def log_recommended_meal(
     )
     metric_status = "success"
     record_operation_latency("log", started, metric_status)
-    logger.info(
-        "meal_recommendation.log.success user_id=%s plan_id=%s slot_id=%s "
-        "request_id=%s logged_meal_id=%s",
-        user_id,
-        plan_id,
-        slot_id,
-        body.request_id,
-        logged_meal_id,
-    )
     return response
 
 

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -230,6 +230,7 @@ async def log_recommended_meal(
                 plan_id=plan_id,
                 slot_id=slot_id,
                 request_id=body.request_id,
+                language=get_request_language(request),
             )
         )
     except MealRecommendationCreationError as exc:

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -223,6 +223,13 @@ async def log_recommended_meal(
 ) -> MealRecommendationSlotDetailResponse:
     started = perf_counter()
     metric_status = "error"
+    logger.info(
+        "meal_recommendation.log.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
+        user_id,
+        plan_id,
+        slot_id,
+        body.request_id,
+    )
     try:
         result = await event_bus.send(
             LogRecommendedMealCommand(
@@ -234,7 +241,42 @@ async def log_recommended_meal(
         )
     except MealRecommendationCreationError as exc:
         metric_status = f"http_{exc.status_code}"
+        logger.warning(
+            "meal_recommendation.log.failed user_id=%s plan_id=%s slot_id=%s "
+            "request_id=%s status=%s detail=%s error_type=%s",
+            user_id,
+            plan_id,
+            slot_id,
+            body.request_id,
+            exc.status_code,
+            exc.public_detail,
+            type(exc).__name__,
+        )
         raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
+    except Exception:
+        logger.exception(
+            "meal_recommendation.log.unhandled user_id=%s plan_id=%s slot_id=%s "
+            "request_id=%s",
+            user_id,
+            plan_id,
+            slot_id,
+            body.request_id,
+        )
+        raise
+    logged_meal_id = (
+        result.slot.logged_meal_id
+        if result.slot is not None
+        else None
+    )
+    logger.info(
+        "meal_recommendation.log.materialized user_id=%s plan_id=%s slot_id=%s "
+        "request_id=%s logged_meal_id=%s",
+        user_id,
+        plan_id,
+        slot_id,
+        body.request_id,
+        logged_meal_id,
+    )
     response = to_slot_detail_response(
         result.plan_id,
         await localize_meal_recommendation_slot(
@@ -252,6 +294,15 @@ async def log_recommended_meal(
     )
     metric_status = "success"
     record_operation_latency("log", started, metric_status)
+    logger.info(
+        "meal_recommendation.log.success user_id=%s plan_id=%s slot_id=%s "
+        "request_id=%s logged_meal_id=%s",
+        user_id,
+        plan_id,
+        slot_id,
+        body.request_id,
+        logged_meal_id,
+    )
     return response
 
 

--- a/src/api/routes/v1/meals.py
+++ b/src/api/routes/v1/meals.py
@@ -23,6 +23,7 @@ from fastapi import (
 
 from src.api.base_dependencies import (
     get_ai_model_manager,
+    get_async_food_reference_repository,
     get_cache_service,
     get_image_store,
 )
@@ -59,7 +60,12 @@ from src.api.services.guest_parse_quota import (
     QuotaUnavailableError,
     validate_install_id,
 )
-from src.app.commands.meal import CustomNutritionData, EditMealCommand, FoodItemChange
+from src.app.commands.meal import (
+    CustomNutritionData,
+    EditMealCommand,
+    FoodItemChange,
+    NutritionOverride,
+)
 from src.app.commands.meal.attach_meal_photo_command import AttachMealPhotoCommand
 from src.app.commands.meal.create_manual_meal_command import (
     CreateManualMealCommand,
@@ -107,6 +113,27 @@ STATUS_MAPPING = {
     "FAILED": "failed",
     "INACTIVE": "inactive",
 }
+
+
+async def _source_nutrition_by_food_reference(meal, food_reference_repository):
+    """Load per-100g density for catalog-backed ingredients via the port."""
+    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
+    food_reference_ids = {
+        item.food_reference_id
+        for item in food_items
+        if getattr(item, "food_reference_id", None) is not None
+    }
+    if not food_reference_ids:
+        return {}
+
+    source_nutrition = {}
+    for food_reference_id in food_reference_ids:
+        reference = await food_reference_repository.get_nutrition_projection(
+            food_reference_id
+        )
+        if reference is not None:
+            source_nutrition[food_reference_id] = reference
+    return source_nutrition
 
 
 def _parse_target_date(target_date: str | None):
@@ -585,6 +612,7 @@ async def get_meal(
     cache_service: CachePort | None = Depends(get_cache_service),
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
+    food_reference_repository=Depends(get_async_food_reference_repository),
 ):
     """Get detailed information about a specific meal.
 
@@ -626,11 +654,15 @@ async def get_meal(
         )
 
     # Use mapper to convert to response with translation support
+    source_nutrition = await _source_nutrition_by_food_reference(
+        meal, food_reference_repository
+    )
     return MealMapper.to_detailed_response(
         meal,
         image_url,
         target_language=language,
         value_insights=value_insights,
+        source_nutrition_by_food_reference=source_nutrition,
     )
 
 
@@ -801,6 +833,17 @@ async def update_meal_ingredients(
                 quantity=change_request.quantity,
                 unit=change_request.unit,
                 custom_nutrition=custom_nutrition,
+                nutrition_override=(
+                    NutritionOverride(
+                        calories=change_request.nutrition_override.calories,
+                        protein=change_request.nutrition_override.protein,
+                        carbs=change_request.nutrition_override.carbs,
+                        fat=change_request.nutrition_override.fat,
+                    )
+                    if change_request.nutrition_override
+                    else None
+                ),
+                clear_nutrition_override=change_request.clear_nutrition_override,
                 allowed_units=[
                     unit.model_dump() for unit in change_request.allowed_units
                 ],
@@ -814,6 +857,16 @@ async def update_meal_ingredients(
         created_at=payload.created_at,
         meal_type=payload.meal_type,
         food_item_changes=food_item_changes,
+        nutrition_override=(
+            NutritionOverride(
+                calories=payload.nutrition_override.calories,
+                protein=payload.nutrition_override.protein,
+                carbs=payload.nutrition_override.carbs,
+                fat=payload.nutrition_override.fat,
+            )
+            if payload.nutrition_override
+            else None
+        ),
     )
 
     logger.info("Sending command to event bus: %s", command)

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -289,6 +289,12 @@ class FoodItemChangeRequest(BaseModel):
     custom_nutrition: Optional["CustomNutritionRequest"] = Field(
         None, description="Custom nutrition data for non-USDA ingredients"
     )
+    nutrition_override: Optional["NutritionOverrideRequest"] = Field(
+        None, description="Independent nutrition values entered by the user"
+    )
+    clear_nutrition_override: bool = Field(
+        False, description="Restore source nutrition for this ingredient"
+    )
 
     class Config:
         json_schema_extra = {
@@ -340,6 +346,15 @@ class CustomNutritionRequest(BaseModel):
         }
 
 
+class NutritionOverrideRequest(BaseModel):
+    """Absolute values that intentionally bypass nutrition recalculation."""
+
+    calories: float
+    protein: float
+    carbs: float
+    fat: float
+
+
 class EditMealIngredientsRequest(BaseModel):
     """Request DTO for editing meal ingredients."""
 
@@ -352,6 +367,9 @@ class EditMealIngredientsRequest(BaseModel):
     meal_type: Optional[str] = Field(
         None, description="Updated meal type derived from the user's local log time"
     )
+    nutrition_override: Optional[NutritionOverrideRequest] = Field(
+        None, description="Independent meal-level nutrition values"
+    )
     food_item_changes: list[FoodItemChangeRequest] = Field(
         default_factory=list, description="List of ingredient changes"
     )
@@ -362,6 +380,7 @@ class EditMealIngredientsRequest(BaseModel):
             self.dish_name is None
             and self.created_at is None
             and self.meal_type is None
+            and self.nutrition_override is None
             and not self.food_item_changes
         ):
             raise ValueError("At least one meal edit field is required")

--- a/src/api/schemas/request/tdee_requests.py
+++ b/src/api/schemas/request/tdee_requests.py
@@ -55,7 +55,7 @@ class UnitSystemEnum(StrEnum):
 class TdeeCalculationRequest(BaseModel):
     """Request DTO for TDEE calculation matching Flutter OnboardingData."""
 
-    age: int = Field(..., ge=13, le=120, description="User age")
+    age: int = Field(..., ge=12, le=120, description="User age")
     sex: SexEnum = Field(..., description="User biological sex")
     height: float = Field(..., gt=0, description="Height in user's preferred units")
     weight: float = Field(..., gt=0, description="Weight in user's preferred units")

--- a/src/api/schemas/request/user_profile_update_requests.py
+++ b/src/api/schemas/request/user_profile_update_requests.py
@@ -35,7 +35,7 @@ class UpdateMetricsRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    age: int | None = Field(None, ge=13, le=120, description="User age")
+    age: int | None = Field(None, ge=12, le=120, description="User age")
     height_cm: float | None = Field(None, ge=100, le=272, description="Height in cm")
     weight_kg: float | None = Field(None, description="Weight in kg", gt=0)
     biological_sex: str | None = Field(

--- a/src/api/schemas/response/meal_recommendation_responses.py
+++ b/src/api/schemas/response/meal_recommendation_responses.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MealRecommendationMacrosResponse(BaseModel):
@@ -40,6 +40,12 @@ class MealRecommendationCatalogMealSummaryResponse(BaseModel):
     image_url: str | None = None
     calories: int
     macros: MealRecommendationMacrosResponse
+    # Selected meals are rendered with their ingredients in the plan deck.
+    # Alternatives remain omitted from the summary and are returned by the
+    # hydrated slot-detail endpoint only.
+    ingredients: list[MealRecommendationIngredientResponse] = Field(
+        default_factory=list
+    )
 
 
 class MealRecommendationAlternativeResponse(BaseModel):

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -106,23 +106,30 @@ class MealTranslationResponse(BaseModel):
 class MacrosResponse(BaseModel):
     """Response DTO for macronutrient information."""
 
-    protein: float = Field(..., ge=0, description="Protein in grams")
-    carbs: float = Field(..., ge=0, description="Carbohydrates in grams")
-    fat: float = Field(..., ge=0, description="Fat in grams")
-    fiber: float = Field(0, ge=0, description="Fiber in grams")
-    sugar: float = Field(0, ge=0, description="Sugar in grams")
+    protein: float = Field(..., description="Protein in grams")
+    carbs: float = Field(..., description="Carbohydrates in grams")
+    fat: float = Field(..., description="Fat in grams")
+    fiber: float = Field(0, description="Fiber in grams")
+    sugar: float = Field(0, description="Sugar in grams")
 
 
 class NutritionResponse(BaseModel):
     """Response DTO for nutrition information."""
 
     nutrition_id: str = Field(..., description="Nutrition record ID")
-    calories: float = Field(..., ge=0, description="Calories")
-    protein_g: float = Field(..., ge=0, description="Protein in grams")
-    carbs_g: float = Field(..., ge=0, description="Carbohydrates in grams")
-    fat_g: float = Field(..., ge=0, description="Fat in grams")
-    fiber_g: float = Field(0, ge=0, description="Fiber in grams")
-    sugar_g: float = Field(0, ge=0, description="Sugar in grams")
+    calories: float = Field(..., description="Calories")
+    protein_g: float = Field(..., description="Protein in grams")
+    carbs_g: float = Field(..., description="Carbohydrates in grams")
+    fat_g: float = Field(..., description="Fat in grams")
+    fiber_g: float = Field(0, description="Fiber in grams")
+    sugar_g: float = Field(0, description="Sugar in grams")
+
+
+class NutritionOverrideResponse(BaseModel):
+    calories: float
+    protein: float
+    carbs: float
+    fat: float
 
 
 class CustomNutritionResponse(BaseModel):
@@ -225,6 +232,13 @@ class FoodItemResponse(BaseModel):
     custom_nutrition: CustomNutritionResponse | None = Field(
         None, description="Custom nutrition per 100g for custom ingredients"
     )
+    source_nutrition: CustomNutritionResponse | None = Field(
+        None,
+        description="Canonical source nutrition per 100g for source-backed ingredients",
+    )
+    nutrition_override: NutritionOverrideResponse | None = Field(
+        None, description="Independent nutrition values entered by the user"
+    )
     fdc_id: int | None = Field(None, description="USDA FDC ID if available")
     food_reference_id: int | None = Field(
         None, description="Canonical food reference ID if available"
@@ -262,9 +276,12 @@ class DetailedMealResponse(SimpleMealResponse):
         default_factory=list, description="Food items in the meal"
     )
     image_url: str | None = Field(None, description="Meal image URL")
-    total_calories: float | None = Field(None, ge=0, description="Total calories")
+    total_calories: float | None = Field(None, description="Total calories")
     total_weight_grams: float | None = Field(None, gt=0, description="Total weight")
     total_nutrition: MacrosResponse | None = Field(None, description="Total macros")
+    nutrition_override: NutritionOverrideResponse | None = Field(
+        None, description="Independent meal-level nutrition values"
+    )
     translations: dict[str, MealTranslationResponse] | None = Field(
         None, description="Translations keyed by language code"
     )

--- a/src/app/commands/meal/__init__.py
+++ b/src/app/commands/meal/__init__.py
@@ -10,6 +10,7 @@ from .edit_meal_command import (
     CustomNutritionData,
     EditMealCommand,
     FoodItemChange,
+    NutritionOverride,
 )
 from .scan_by_url_command import ScanByUrlCommand
 from .upload_meal_image_immediately_command import UploadMealImageImmediatelyCommand
@@ -21,6 +22,7 @@ __all__ = [
     "AddCustomIngredientCommand",
     "FoodItemChange",
     "CustomNutritionData",
+    "NutritionOverride",
     "DeleteMealCommand",
     "DeleteMealPhotoCommand",
     "AttachMealPhotoCommand",

--- a/src/app/commands/meal/edit_meal_command.py
+++ b/src/app/commands/meal/edit_meal_command.py
@@ -4,10 +4,14 @@ Command to edit meal ingredients and portions.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, List
+from typing import List, Optional
 
 from src.app.events.base import Command
-from src.domain.model.meal.food_item_change import FoodItemChange, CustomNutritionData
+from src.domain.model.meal.food_item_change import (
+    CustomNutritionData,
+    FoodItemChange,
+    NutritionOverride,
+)
 
 
 @dataclass
@@ -20,6 +24,7 @@ class EditMealCommand(Command):
     created_at: Optional[datetime] = None
     meal_type: Optional[str] = None
     food_item_changes: List[FoodItemChange] = field(default_factory=list)
+    nutrition_override: Optional[NutritionOverride] = None
 
 
 @dataclass

--- a/src/app/commands/meal_recommendation/log_recommended_meal_command.py
+++ b/src/app/commands/meal_recommendation/log_recommended_meal_command.py
@@ -11,3 +11,5 @@ class LogRecommendedMealCommand(Command):
     plan_id: str
     slot_id: str
     request_id: str
+    # ISO 639-1 request language; used to persist meal_translation after materialize.
+    language: str = "en"

--- a/src/app/handlers/command_handlers/delete_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/delete_meal_command_handler.py
@@ -41,6 +41,12 @@ class DeleteMealCommandHandler(EventHandler[DeleteMealCommand, dict[str, Any]]):
                     raise AuthorizationException(
                         "You do not have permission to delete this meal"
                     )
+                # Recommended-meal logs set meal_recommendations.logged_meal_id
+                # with ON DELETE SET NULL. Clearing only the FK leaves logged_at
+                # set and violates ck_meal_recommendations_logged_coherent.
+                plans = getattr(uow, "meal_recommendation_plans", None)
+                if plans is not None:
+                    await plans.clear_links_for_deleted_meal(meal_id=command.meal_id)
                 await uow.meals.delete(command.meal_id)
                 log_date = (meal.created_at or utc_now()).date()
             else:

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -16,6 +16,7 @@ from src.app.events.meal import MealEditedEvent
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.domain.model.meal import FoodItemTranslation, MealStatus
 from src.domain.model.meal_projection import MealProjection
+from src.domain.model.nutrition import Macros, NutritionOverride
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.services.meal_type_determination_service import (
     determine_meal_type_from_timestamp,
@@ -61,13 +62,52 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 updated_food_items = await self._apply_food_item_changes(
                     meal.nutrition.food_items if meal.nutrition else [],
                     command.food_item_changes,
+                    food_reference_repository=getattr(uow, "food_references", None),
                 )
                 self._realign_translations_after_food_item_changes(
                     meal, updated_food_items
                 )
 
-                # 3. Recalculate nutrition
+                # 3. Recalculate nutrition from current ingredients.
                 updated_nutrition = self._calculate_total_nutrition(updated_food_items)
+                existing_override = (
+                    meal.nutrition.nutrition_override if meal.nutrition else None
+                )
+                # Meal-level override is only for intentional whole-meal edits.
+                # Ingredient composition changes must clear it so totals follow
+                # the ingredient sum (unless this request sets a new override).
+                if command.nutrition_override is not None:
+                    nutrition_override = NutritionOverride(
+                        calories=command.nutrition_override.calories,
+                        protein=command.nutrition_override.protein,
+                        carbs=command.nutrition_override.carbs,
+                        fat=command.nutrition_override.fat,
+                    )
+                    updated_nutrition.nutrition_override = nutrition_override
+                    updated_nutrition.macros = Macros(
+                        protein=nutrition_override.protein,
+                        carbs=nutrition_override.carbs,
+                        fat=nutrition_override.fat,
+                        fiber=updated_nutrition.macros.fiber,
+                        sugar=updated_nutrition.macros.sugar,
+                    )
+                elif command.food_item_changes:
+                    updated_nutrition.nutrition_override = None
+                elif existing_override is not None:
+                    nutrition_override = NutritionOverride(
+                        calories=existing_override.calories,
+                        protein=existing_override.protein,
+                        carbs=existing_override.carbs,
+                        fat=existing_override.fat,
+                    )
+                    updated_nutrition.nutrition_override = nutrition_override
+                    updated_nutrition.macros = Macros(
+                        protein=nutrition_override.protein,
+                        carbs=nutrition_override.carbs,
+                        fat=nutrition_override.fat,
+                        fiber=updated_nutrition.macros.fiber,
+                        sugar=updated_nutrition.macros.sugar,
+                    )
 
                 updated_created_at = command.created_at or meal.created_at
                 if command.meal_type is not None:
@@ -156,7 +196,12 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 await uow.rollback()
                 raise
 
-    async def _apply_food_item_changes(self, current_food_items, changes):
+    async def _apply_food_item_changes(
+        self,
+        current_food_items,
+        changes,
+        food_reference_repository=None,
+    ):
         """Apply food item changes to current list using strategy pattern."""
         from src.domain.services import NutritionCalculationService
         from src.domain.strategies.meal_edit_strategies import (
@@ -173,6 +218,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         nutrition_service = NutritionCalculationService()
         strategies = FoodItemChangeStrategyFactory.create_strategies(
             nutrition_service,
+            food_reference_repository=food_reference_repository,
         )
 
         # Apply each change using the appropriate strategy

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -1,5 +1,7 @@
 """Handler for logging recommended meals through normal meal persistence."""
 
+import logging
+
 from src.app.commands.meal_recommendation import LogRecommendedMealCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.recommended_meal_materialization_service import (
@@ -8,6 +10,8 @@ from src.app.services.recommended_meal_materialization_service import (
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationSlotMutationResult,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @handles(LogRecommendedMealCommand)
@@ -28,6 +32,13 @@ class LogRecommendedMealCommandHandler(
     async def handle(
         self, command: LogRecommendedMealCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
+        logger.info(
+            "log_handler.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
+            command.user_id,
+            command.plan_id,
+            command.slot_id,
+            command.request_id,
+        )
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -35,17 +46,64 @@ class LogRecommendedMealCommandHandler(
                 slot_id=command.slot_id,
                 request_id=command.request_id,
             )
+            selected = slot.selected
+            logger.info(
+                "log_handler.claimed user_id=%s plan_id=%s slot_id=%s "
+                "request_id=%s replayed=%s slot_date=%s meal_type=%s "
+                "catalog_meal_id=%s has_catalog_meal=%s logged_meal_id=%s "
+                "skipped_at=%s",
+                command.user_id,
+                command.plan_id,
+                command.slot_id,
+                command.request_id,
+                replayed,
+                slot.slot_date,
+                slot.meal_type,
+                selected.catalog_meal_id if selected is not None else None,
+                bool(selected is not None and selected.catalog_meal is not None),
+                slot.logged_meal_id,
+                slot.skipped_at,
+            )
             if replayed:
+                logger.info(
+                    "log_handler.replay user_id=%s plan_id=%s slot_id=%s "
+                    "request_id=%s logged_meal_id=%s",
+                    command.user_id,
+                    command.plan_id,
+                    command.slot_id,
+                    command.request_id,
+                    slot.logged_meal_id,
+                )
                 return PersistedMealRecommendationSlotMutationResult(
                     plan_id=plan.id,
                     user_id=plan.user_id,
                     slot=slot,
                 )
             meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
-            return await uow.meal_recommendation_plans.finalize_slot_logged(
+            logger.info(
+                "log_handler.materialized user_id=%s plan_id=%s slot_id=%s "
+                "request_id=%s meal_id=%s",
+                command.user_id,
+                command.plan_id,
+                command.slot_id,
+                command.request_id,
+                meal.meal_id,
+            )
+            result = await uow.meal_recommendation_plans.finalize_slot_logged(
                 user_id=command.user_id,
                 plan_id=command.plan_id,
                 slot_id=command.slot_id,
                 request_id=command.request_id,
                 meal_id=meal.meal_id,
             )
+            logger.info(
+                "log_handler.finalized user_id=%s plan_id=%s slot_id=%s "
+                "request_id=%s meal_id=%s result_logged_meal_id=%s",
+                command.user_id,
+                command.plan_id,
+                command.slot_id,
+                command.request_id,
+                meal.meal_id,
+                result.slot.logged_meal_id,
+            )
+            return result

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -1,13 +1,24 @@
 """Handler for logging recommended meals through normal meal persistence."""
 
+from __future__ import annotations
+
+import logging
+
 from src.app.commands.meal_recommendation import LogRecommendedMealCommand
 from src.app.events.base import EventHandler, handles
+from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.recommended_meal_materialization_service import (
     RecommendedMealMaterializationService,
 )
+from src.domain.model.meal import Meal
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationSlotMutationResult,
 )
+from src.domain.services.meal_analysis.deepl_meal_translation_service import (
+    DeepLMealTranslationService,
+)
+
+logger = logging.getLogger(__name__)
 
 
 @handles(LogRecommendedMealCommand)
@@ -21,13 +32,20 @@ class LogRecommendedMealCommandHandler(
         self,
         uow,
         materializer: RecommendedMealMaterializationService | None = None,
+        meal_translation_service: DeepLMealTranslationService | None = None,
+        cache_invalidation: CacheInvalidationService | None = None,
     ):
         self.uow = uow
         self.materializer = materializer or RecommendedMealMaterializationService()
+        self.meal_translation_service = meal_translation_service
+        self.cache_invalidation = cache_invalidation
 
     async def handle(
         self, command: LogRecommendedMealCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
+        saved_meal: Meal | None = None
+        meal_date = None
+
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -36,16 +54,67 @@ class LogRecommendedMealCommandHandler(
                 request_id=command.request_id,
             )
             if replayed:
-                return PersistedMealRecommendationSlotMutationResult(
+                result = PersistedMealRecommendationSlotMutationResult(
                     plan_id=plan.id,
                     user_id=plan.user_id,
                     slot=slot,
                 )
-            meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
-            return await uow.meal_recommendation_plans.finalize_slot_logged(
-                user_id=command.user_id,
-                plan_id=command.plan_id,
-                slot_id=command.slot_id,
-                request_id=command.request_id,
-                meal_id=meal.meal_id,
+            else:
+                meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
+                result = await uow.meal_recommendation_plans.finalize_slot_logged(
+                    user_id=command.user_id,
+                    plan_id=command.plan_id,
+                    slot_id=command.slot_id,
+                    request_id=command.request_id,
+                    meal_id=meal.meal_id,
+                )
+                saved_meal = meal
+                meal_date = slot.slot_date
+
+        # meal_translation uses its own DB session; parent meal must be committed first.
+        if saved_meal is not None:
+            await self._persist_request_language_translation(command, saved_meal)
+            if self.cache_invalidation is not None and meal_date is not None:
+                await self.cache_invalidation.after_meal_write(
+                    command.user_id, meal_date
+                )
+
+        return result
+
+    async def _persist_request_language_translation(
+        self,
+        command: LogRecommendedMealCommand,
+        meal: Meal,
+    ) -> None:
+        """Persist DeepL meal_translation so Today's Meals can show localized titles."""
+
+        language = (command.language or "en").strip().lower()
+        if language == "en" or self.meal_translation_service is None:
+            return
+
+        nutrition = getattr(meal, "nutrition", None)
+        food_items = list(getattr(nutrition, "food_items", None) or [])
+        dish_name = getattr(meal, "dish_name", None) or ""
+        if not dish_name and not food_items:
+            return
+
+        try:
+            await self.meal_translation_service.translate_meal(
+                meal=meal,
+                dish_name=dish_name,
+                food_items=food_items,
+                target_language=language,
+            )
+            logger.info(
+                "recommended meal translated meal=%s language=%s",
+                meal.meal_id,
+                language,
+            )
+        except Exception as exc:
+            # Logging must succeed even when translation is unavailable.
+            logger.warning(
+                "recommended meal translation failed meal=%s language=%s error=%s",
+                meal.meal_id,
+                language,
+                exc,
             )

--- a/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/log_recommended_meal_command_handler.py
@@ -1,7 +1,5 @@
 """Handler for logging recommended meals through normal meal persistence."""
 
-import logging
-
 from src.app.commands.meal_recommendation import LogRecommendedMealCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.recommended_meal_materialization_service import (
@@ -10,8 +8,6 @@ from src.app.services.recommended_meal_materialization_service import (
 from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationSlotMutationResult,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @handles(LogRecommendedMealCommand)
@@ -32,13 +28,6 @@ class LogRecommendedMealCommandHandler(
     async def handle(
         self, command: LogRecommendedMealCommand
     ) -> PersistedMealRecommendationSlotMutationResult:
-        logger.info(
-            "log_handler.start user_id=%s plan_id=%s slot_id=%s request_id=%s",
-            command.user_id,
-            command.plan_id,
-            command.slot_id,
-            command.request_id,
-        )
         async with self.uow as uow:
             plan, slot, replayed = await uow.meal_recommendation_plans.claim_slot_log(
                 user_id=command.user_id,
@@ -46,64 +35,17 @@ class LogRecommendedMealCommandHandler(
                 slot_id=command.slot_id,
                 request_id=command.request_id,
             )
-            selected = slot.selected
-            logger.info(
-                "log_handler.claimed user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s replayed=%s slot_date=%s meal_type=%s "
-                "catalog_meal_id=%s has_catalog_meal=%s logged_meal_id=%s "
-                "skipped_at=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                replayed,
-                slot.slot_date,
-                slot.meal_type,
-                selected.catalog_meal_id if selected is not None else None,
-                bool(selected is not None and selected.catalog_meal is not None),
-                slot.logged_meal_id,
-                slot.skipped_at,
-            )
             if replayed:
-                logger.info(
-                    "log_handler.replay user_id=%s plan_id=%s slot_id=%s "
-                    "request_id=%s logged_meal_id=%s",
-                    command.user_id,
-                    command.plan_id,
-                    command.slot_id,
-                    command.request_id,
-                    slot.logged_meal_id,
-                )
                 return PersistedMealRecommendationSlotMutationResult(
                     plan_id=plan.id,
                     user_id=plan.user_id,
                     slot=slot,
                 )
             meal = await self.materializer.materialize(uow, plan=plan, slot=slot)
-            logger.info(
-                "log_handler.materialized user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s meal_id=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                meal.meal_id,
-            )
-            result = await uow.meal_recommendation_plans.finalize_slot_logged(
+            return await uow.meal_recommendation_plans.finalize_slot_logged(
                 user_id=command.user_id,
                 plan_id=command.plan_id,
                 slot_id=command.slot_id,
                 request_id=command.request_id,
                 meal_id=meal.meal_id,
             )
-            logger.info(
-                "log_handler.finalized user_id=%s plan_id=%s slot_id=%s "
-                "request_id=%s meal_id=%s result_logged_meal_id=%s",
-                command.user_id,
-                command.plan_id,
-                command.slot_id,
-                command.request_id,
-                meal.meal_id,
-                result.slot.logged_meal_id,
-            )
-            return result

--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -85,8 +85,8 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
 
             # Update provided fields only
             if command.age is not None:
-                if command.age < 13 or command.age > 120:
-                    raise ValidationException("Age must be between 13 and 120")
+                if command.age < 12 or command.age > 120:
+                    raise ValidationException("Age must be between 12 and 120")
                 profile.age = command.age
 
             if command.height_cm is not None:

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -2,21 +2,22 @@
 
 from __future__ import annotations
 
-import logging
 from uuid import uuid4
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
     MealRecommendationNotFoundError,
 )
-from src.domain.model.meal import Meal, MealStatus
+from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_recommendation import (
+    CatalogMeal,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
 from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
-logger = logging.getLogger(__name__)
+# mealimage.url is VARCHAR(255); keep inserts valid when catalog URLs are longer.
+_MEAL_IMAGE_URL_MAX_LEN = 255
 
 
 class RecommendedMealMaterializationService:
@@ -30,31 +31,8 @@ class RecommendedMealMaterializationService:
         slot: PersistedMealRecommendationSlot,
     ) -> Meal:
         if slot.selected is None or slot.selected.catalog_meal is None:
-            logger.warning(
-                "materialize.missing_catalog_meal user_id=%s plan_id=%s "
-                "slot_id=%s selected_null=%s catalog_meal_id=%s",
-                plan.user_id,
-                plan.id,
-                slot.id,
-                slot.selected is None,
-                slot.selected.catalog_meal_id if slot.selected is not None else None,
-            )
             raise MealRecommendationNotFoundError
         catalog_meal = slot.selected.catalog_meal
-        ingredient_count = len(catalog_meal.ingredients)
-        logger.info(
-            "materialize.start user_id=%s plan_id=%s slot_id=%s "
-            "catalog_meal_id=%s ingredients=%s meal_type=%s "
-            "slot_date=%s timezone=%s",
-            plan.user_id,
-            plan.id,
-            slot.id,
-            catalog_meal.id,
-            ingredient_count,
-            slot.meal_type,
-            slot.slot_date,
-            plan.timezone,
-        )
 
         food_items = [
             FoodItem(
@@ -68,13 +46,16 @@ class RecommendedMealMaterializationService:
             for ingredient in catalog_meal.ingredients
         ]
         meal_time = noon_utc_for_date(slot.slot_date, plan.timezone)
+        # Always attach a MealImage row. Production still enforces NOT NULL on
+        # meal.image_id in some environments; image-less inserts 500 there.
+        # Matches manual / AI-suggestion materialization (placeholder image).
         meal = Meal(
             meal_id=str(uuid4()),
             user_id=plan.user_id,
             status=MealStatus.READY,
             created_at=meal_time,
             ready_at=meal_time,
-            image=None,
+            image=_meal_image_for_catalog(catalog_meal),
             dish_name=catalog_meal.name,
             nutrition=Nutrition(
                 macros=Macros(
@@ -88,14 +69,17 @@ class RecommendedMealMaterializationService:
             meal_type=slot.meal_type,
             source="meal_recommendation",
         )
-        saved = await uow.meals.save(meal)
-        logger.info(
-            "materialize.saved user_id=%s plan_id=%s slot_id=%s meal_id=%s "
-            "food_item_count=%s",
-            plan.user_id,
-            plan.id,
-            slot.id,
-            saved.meal_id,
-            len(food_items),
-        )
-        return saved
+        return await uow.meals.save(meal)
+
+
+def _meal_image_for_catalog(catalog_meal: CatalogMeal) -> MealImage:
+    """Build a mealimage row from catalog URL, or a placeholder when absent."""
+
+    raw_url = (catalog_meal.image_url or "").strip() or None
+    url = raw_url if raw_url and len(raw_url) <= _MEAL_IMAGE_URL_MAX_LEN else None
+    return MealImage(
+        image_id=str(uuid4()),
+        format="jpeg",
+        size_bytes=1,
+        url=url,
+    )

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import uuid4
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
@@ -15,6 +16,8 @@ from src.domain.model.meal_recommendation import (
 from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
+logger = logging.getLogger(__name__)
+
 
 class RecommendedMealMaterializationService:
     """Build and persist normal meals from immutable catalog recipe snapshots."""
@@ -27,8 +30,31 @@ class RecommendedMealMaterializationService:
         slot: PersistedMealRecommendationSlot,
     ) -> Meal:
         if slot.selected is None or slot.selected.catalog_meal is None:
+            logger.warning(
+                "materialize.missing_catalog_meal user_id=%s plan_id=%s "
+                "slot_id=%s selected_null=%s catalog_meal_id=%s",
+                plan.user_id,
+                plan.id,
+                slot.id,
+                slot.selected is None,
+                slot.selected.catalog_meal_id if slot.selected is not None else None,
+            )
             raise MealRecommendationNotFoundError
         catalog_meal = slot.selected.catalog_meal
+        ingredient_count = len(catalog_meal.ingredients)
+        logger.info(
+            "materialize.start user_id=%s plan_id=%s slot_id=%s "
+            "catalog_meal_id=%s ingredients=%s meal_type=%s "
+            "slot_date=%s timezone=%s",
+            plan.user_id,
+            plan.id,
+            slot.id,
+            catalog_meal.id,
+            ingredient_count,
+            slot.meal_type,
+            slot.slot_date,
+            plan.timezone,
+        )
 
         food_items = [
             FoodItem(
@@ -62,4 +88,14 @@ class RecommendedMealMaterializationService:
             meal_type=slot.meal_type,
             source="meal_recommendation",
         )
-        return await uow.meals.save(meal)
+        saved = await uow.meals.save(meal)
+        logger.info(
+            "materialize.saved user_id=%s plan_id=%s slot_id=%s meal_id=%s "
+            "food_item_count=%s",
+            plan.user_id,
+            plan.id,
+            slot.id,
+            saved.meal_id,
+            len(food_items),
+        )
+        return saved

--- a/src/domain/constants/meal_constants.py
+++ b/src/domain/constants/meal_constants.py
@@ -174,7 +174,7 @@ class TDEEConstants:
     MIN_CALORIES_MALE = 1500
 
     # Validation ranges
-    MIN_AGE = 13
+    MIN_AGE = 12
     MAX_AGE = 120
     MIN_WEIGHT_KG = 30
     MAX_WEIGHT_KG = 300

--- a/src/domain/model/meal/food_item_change.py
+++ b/src/domain/model/meal/food_item_change.py
@@ -18,6 +18,8 @@ class FoodItemChange:
     quantity: Optional[float] = None
     unit: Optional[str] = None
     custom_nutrition: Optional["CustomNutritionData"] = None
+    nutrition_override: Optional["NutritionOverride"] = None
+    clear_nutrition_override: bool = False
     allowed_units: Optional[list[dict[str, Any]]] = None
 
 
@@ -31,3 +33,11 @@ class CustomNutritionData:
     fat_per_100g: float
     fiber_per_100g: float = 0.0
     sugar_per_100g: float = 0.0
+
+
+@dataclass
+class NutritionOverride:
+    calories: float
+    protein: float
+    carbs: float
+    fat: float

--- a/src/domain/model/nutrition/__init__.py
+++ b/src/domain/model/nutrition/__init__.py
@@ -5,13 +5,14 @@ Nutrition bounded context - Domain models for nutritional information.
 from .food import Food
 from .macros import Macros
 from .micros import Micros
-from .nutrition import MAX_FOOD_ITEM_QUANTITY, FoodItem, Nutrition
+from .nutrition import MAX_FOOD_ITEM_QUANTITY, FoodItem, Nutrition, NutritionOverride
 
 __all__ = [
     "Nutrition",
     "FoodItem",
     "MAX_FOOD_ITEM_QUANTITY",
     "Macros",
+    "NutritionOverride",
     "Micros",
     "Food",
 ]

--- a/src/domain/model/nutrition/macros.py
+++ b/src/domain/model/nutrition/macros.py
@@ -6,7 +6,8 @@ class Macros:
     """
     Value object representing macronutrient breakdown of a meal.
     All values are in grams.
-    Invariant: Values cannot be negative.
+    Values may be manually overridden by the user, so they are intentionally
+    not constrained here.
     """
 
     protein: float
@@ -14,17 +15,6 @@ class Macros:
     fat: float
     fiber: float = 0.0
     sugar: float = 0.0
-
-    def __post_init__(self):
-        # Validate invariants
-        for field_name in ["protein", "carbs", "fat", "fiber", "sugar"]:
-            value = getattr(self, field_name)
-            if value < 0:
-                raise ValueError(f"{field_name} cannot be negative: {value}")
-            if value > 5000:  # Sanity check
-                raise ValueError(
-                    f"{field_name} exceeds realistic limit (5000g): {value}"
-                )
 
     @property
     def total_calories(self) -> float:

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -8,6 +8,24 @@ MAX_FOOD_ITEM_QUANTITY = 10000.0
 
 
 @dataclass
+class NutritionOverride:
+    """Absolute nutrition values entered directly by a user."""
+
+    calories: float
+    protein: float
+    carbs: float
+    fat: float
+
+    def to_dict(self) -> dict:
+        return {
+            "calories": self.calories,
+            "protein": self.protein,
+            "carbs": self.carbs,
+            "fat": self.fat,
+        }
+
+
+@dataclass
 class FoodItem:
     """Represents a single food item in a meal with nutritional information."""
 
@@ -22,6 +40,7 @@ class FoodItem:
     food_reference_id: int | None = None
     is_custom: bool = False  # Whether this is a custom ingredient
     allowed_units: list[dict[str, Any]] | None = None
+    nutrition_override: NutritionOverride | None = None
 
     def __post_init__(self):
         """Validate invariants."""
@@ -42,8 +61,24 @@ class FoodItem:
 
     @property
     def calories(self) -> float:
-        """Derive calories from macros: P*4 + C*4 + F*9."""
-        return self.macros.total_calories
+        """Use a user-entered value when one exists."""
+        return (
+            self.nutrition_override.calories
+            if self.nutrition_override
+            else self.macros.total_calories
+        )
+
+    @property
+    def effective_macros(self) -> Macros:
+        if self.nutrition_override is None:
+            return self.macros
+        return Macros(
+            protein=self.nutrition_override.protein,
+            carbs=self.nutrition_override.carbs,
+            fat=self.nutrition_override.fat,
+            fiber=self.macros.fiber,
+            sugar=self.macros.sugar,
+        )
 
     def to_dict(self) -> dict:
         """Convert to dictionary format."""
@@ -53,7 +88,7 @@ class FoodItem:
             "quantity": self.quantity,
             "unit": self.unit,
             "calories": self.calories,
-            "macros": self.macros.to_dict(),
+            "macros": self.effective_macros.to_dict(),
             "confidence": self.confidence,
             "is_custom": self.is_custom,
         }
@@ -65,6 +100,8 @@ class FoodItem:
             result["food_reference_id"] = self.food_reference_id
         if self.allowed_units:
             result["allowed_units"] = self.allowed_units
+        if self.nutrition_override:
+            result["nutrition_override"] = self.nutrition_override.to_dict()
         return result
 
 
@@ -76,6 +113,7 @@ class Nutrition:
     micros: Micros | None = None
     food_items: list[FoodItem] | None = None
     confidence_score: float = 1.0  # 0.0-1.0 overall confidence score
+    nutrition_override: NutritionOverride | None = None
 
     def __post_init__(self):
         """Validate invariants."""
@@ -93,14 +131,35 @@ class Nutrition:
 
     @property
     def calories(self) -> float:
-        """Derive calories from macros: P*4 + C*4 + F*9."""
-        return self.macros.total_calories
+        """Meal calories prefer meal override; else sum of item effective
+        calories when any ingredient has a calorie override; else macros.
+        """
+        if self.nutrition_override is not None:
+            return float(self.nutrition_override.calories)
+        if self.food_items and any(
+            getattr(item, "nutrition_override", None) is not None
+            for item in self.food_items
+        ):
+            return float(sum(item.calories for item in self.food_items))
+        return float(self.macros.total_calories)
+
+    @property
+    def effective_macros(self) -> Macros:
+        if self.nutrition_override is None:
+            return self.macros
+        return Macros(
+            protein=self.nutrition_override.protein,
+            carbs=self.nutrition_override.carbs,
+            fat=self.nutrition_override.fat,
+            fiber=self.macros.fiber,
+            sugar=self.macros.sugar,
+        )
 
     def to_dict(self) -> dict:
         """Convert to dictionary format."""
         result = {
             "calories": self.calories,
-            "macros": self.macros.to_dict(),
+            "macros": self.effective_macros.to_dict(),
             "confidence_score": self.confidence_score,
         }
 
@@ -109,5 +168,8 @@ class Nutrition:
 
         if self.food_items:
             result["food_items"] = [item.to_dict() for item in self.food_items]
+
+        if self.nutrition_override:
+            result["nutrition_override"] = self.nutrition_override.to_dict()
 
         return result

--- a/src/domain/model/user/tdee.py
+++ b/src/domain/model/user/tdee.py
@@ -64,8 +64,8 @@ class TdeeRequest:
 
     def __post_init__(self):
         """Validate invariants."""
-        if not (13 <= self.age <= 120):
-            raise ValueError(f"Age must be between 13 and 120: {self.age}")
+        if not (12 <= self.age <= 120):
+            raise ValueError(f"Age must be between 12 and 120: {self.age}")
 
         if self.unit_system == UnitSystem.METRIC:
             if not (100 <= self.height <= 272):

--- a/src/domain/ports/meal_recommendation_plan_repository_port.py
+++ b/src/domain/ports/meal_recommendation_plan_repository_port.py
@@ -137,3 +137,10 @@ class MealRecommendationPlanRepositoryPort(ABC):
         meal_id: str,
     ) -> PersistedMealRecommendationSlotMutationResult:
         """Attach a materialized meal to a claimed slot log and return the slot."""
+
+    async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
+        """Clear recommendation links before a normal meal is hard-deleted.
+
+        Default no-op for lightweight fakes; production repos must implement.
+        """
+        return None

--- a/src/domain/services/meal_calorie_service.py
+++ b/src/domain/services/meal_calorie_service.py
@@ -7,11 +7,18 @@ def effective_meal_calories(meal: Any) -> float:
     """Return calories users expect for a meal.
 
     Food-label scans should match the printed label calories. Other meal
-    sources keep the canonical macro-derived value.
+    sources keep the canonical macro-derived value, unless a meal-level
+    override is set or ingredient calorie overrides require summing items.
     """
+    from src.domain.model.nutrition.nutrition import Nutrition, NutritionOverride
+
     nutrition = getattr(meal, "nutrition", None)
     if nutrition is None:
         return 0.0
+
+    override = getattr(nutrition, "nutrition_override", None)
+    if isinstance(override, NutritionOverride):
+        return float(override.calories)
 
     if getattr(meal, "source", None) == "food_label":
         metadata = getattr(meal, "food_label_metadata", None)
@@ -19,6 +26,10 @@ def effective_meal_calories(meal: Any) -> float:
         if label_calories is not None:
             item = (getattr(nutrition, "food_items", None) or [None])[0]
             return _scaled_label_calories(label_calories, item, metadata)
+
+    # Real Nutrition VOs may include per-item calorie overrides in .calories.
+    if isinstance(nutrition, Nutrition):
+        return float(nutrition.calories)
 
     return _macro_calories(getattr(nutrition, "macros", None))
 

--- a/src/domain/services/notification_messages.py
+++ b/src/domain/services/notification_messages.py
@@ -63,6 +63,10 @@ NOTIFICATION_MESSAGES = {
                     "body_template": "Almost there, bro! {consumed_ml}ml logged today\nJust {remaining_ml}ml left to hit your goal 💧",
                 },
             },
+            "subscription_hook": {
+                "title": "Your Nutree plan is ready",
+                "body": "Your personalized nutrition plan is ready, bro\nSubscribe to unlock your next step ✨",
+            },
         },
         "female": {
             "meal_reminder": {
@@ -110,6 +114,10 @@ NOTIFICATION_MESSAGES = {
                 "evening": {
                     "body_template": "Almost there, mate! {consumed_ml}ml logged today\nJust {remaining_ml}ml left to hit your goal 💧",
                 },
+            },
+            "subscription_hook": {
+                "title": "Your Nutree plan is ready",
+                "body": "Your personalized nutrition plan is ready, mate\nSubscribe to unlock your next step ✨",
             },
         },
     },
@@ -161,6 +169,10 @@ NOTIFICATION_MESSAGES = {
                     "body_template": "Chiều tà rồi bro! Uống được {consumed_ml}ml rồi, còn {remaining_ml}ml nữa là đủ nước\nCố lên nha 💧",
                 },
             },
+            "subscription_hook": {
+                "title": "Kế hoạch Nutree đã sẵn sàng",
+                "body": "Kế hoạch dinh dưỡng của bro đã sẵn sàng\nĐăng ký để mở khóa bước tiếp theo ✨",
+            },
         },
         "female": {
             "meal_reminder": {
@@ -208,6 +220,10 @@ NOTIFICATION_MESSAGES = {
                 "evening": {
                     "body_template": "Chiều tà rồi bạn ơi! Uống được {consumed_ml}ml rồi, còn {remaining_ml}ml nữa là đủ nước\nCố lên nha 💧",
                 },
+            },
+            "subscription_hook": {
+                "title": "Kế hoạch Nutree đã sẵn sàng",
+                "body": "Kế hoạch dinh dưỡng của bạn đã sẵn sàng\nĐăng ký để mở khóa bước tiếp theo ✨",
             },
         },
     },

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -373,11 +373,11 @@ class NutritionCalculationService:
                 confidence_score=1.0,
             )
 
-        total_protein = sum(item.macros.protein for item in food_items)
-        total_carbs = sum(item.macros.carbs for item in food_items)
-        total_fat = sum(item.macros.fat for item in food_items)
-        total_fiber = sum(item.macros.fiber for item in food_items)
-        total_sugar = sum(item.macros.sugar for item in food_items)
+        total_protein = sum(item.effective_macros.protein for item in food_items)
+        total_carbs = sum(item.effective_macros.carbs for item in food_items)
+        total_fat = sum(item.effective_macros.fat for item in food_items)
+        total_fiber = sum(item.effective_macros.fiber for item in food_items)
+        total_sugar = sum(item.effective_macros.sugar for item in food_items)
 
         # Calculate average confidence
         avg_confidence = sum(item.confidence for item in food_items) / len(food_items)

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -8,13 +8,30 @@ import uuid
 from abc import ABC, abstractmethod
 
 from src.domain.model.meal.food_item_change import FoodItemChange
-from src.domain.model.nutrition import FoodItem, Macros
+from src.domain.model.nutrition import FoodItem, Macros, NutritionOverride
 from src.domain.services import NutritionCalculationService
-from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
+from src.domain.services.nutrition_calculation_service import (
+    ScaledNutritionResult,
+    convert_quantity_to_grams,
+    scale_per_100g_nutrition,
+)
 
 logger = logging.getLogger(__name__)
 
 MAX_QUANTITY_GRAMS = 10000.0  # 10kg max per food item
+
+
+def _resolved_nutrition_override(change, existing: FoodItem | None = None):
+    if change.clear_nutrition_override:
+        return None
+    if change.nutrition_override is not None:
+        return NutritionOverride(
+            calories=change.nutrition_override.calories,
+            protein=change.nutrition_override.protein,
+            carbs=change.nutrition_override.carbs,
+            fat=change.nutrition_override.fat,
+        )
+    return existing.nutrition_override if existing else None
 
 
 def _validate_quantity_grams(quantity_grams: float, quantity: float, unit: str) -> None:
@@ -64,6 +81,10 @@ class RemoveFoodItemStrategy(FoodItemChangeStrategy):
 class UpdateFoodItemStrategy(FoodItemChangeStrategy):
     """Strategy for updating an existing food item."""
 
+    def __init__(self, nutrition_service, food_reference_repository=None):
+        super().__init__(nutrition_service)
+        self.food_reference_repository = food_reference_repository
+
     async def apply(
         self, food_items_dict: dict[str, FoodItem], change: FoodItemChange
     ) -> None:
@@ -101,22 +122,24 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 food_reference_id=existing_item.food_reference_id,
                 is_custom=True,
                 allowed_units=change.allowed_units or existing_item.allowed_units,
+                nutrition_override=_resolved_nutrition_override(
+                    change, existing_item
+                ),
             )
             logger.info(
                 f"Updated food item with custom nutrition: {existing_item.name}"
             )
             return
 
-        # Priority 2: Check if unit changed - if so, fetch fresh nutrition data
+        # Priority 2: A unit switch must use the selected unit's canonical
+        # source nutrition, rather than rescaling the previously selected unit.
         unit_changed = change.unit and change.unit != existing_item.unit
 
         if unit_changed:
-            # Unit changed - fetch fresh nutrition data
-            scaled_nutrition = self.nutrition_service.get_nutrition_for_ingredient(
-                name=existing_item.name,
-                quantity=new_quantity,
-                unit=new_unit,
-                fdc_id=existing_item.fdc_id,
+            scaled_nutrition = await self._get_selected_unit_nutrition(
+                existing_item,
+                new_quantity,
+                new_unit,
             )
 
             if scaled_nutrition:
@@ -136,14 +159,17 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     food_reference_id=existing_item.food_reference_id,
                     is_custom=existing_item.is_custom,
                     allowed_units=change.allowed_units or existing_item.allowed_units,
+                    nutrition_override=_resolved_nutrition_override(
+                        change, existing_item
+                    ),
                 )
                 logger.info(f"Updated food item with unit change: {existing_item.name}")
             else:
-                # Fallback to simple scaling
                 logger.warning(
-                    "Could not fetch nutrition for unit change, using scaling"
+                    "Could not load canonical nutrition for unit change; "
+                    "preserving the existing source nutrition"
                 )
-                self._apply_simple_scaling(
+                self._preserve_source_nutrition(
                     food_items_dict, change, existing_item, new_quantity, new_unit
                 )
         else:
@@ -196,8 +222,90 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             food_reference_id=existing_item.food_reference_id,
             is_custom=existing_item.is_custom,
             allowed_units=change.allowed_units or existing_item.allowed_units,
+            nutrition_override=_resolved_nutrition_override(change, existing_item),
         )
         logger.info(f"Updated food item with scaling: {existing_item.name}")
+
+    async def _get_selected_unit_nutrition(
+        self,
+        existing_item: FoodItem,
+        quantity: float,
+        unit: str,
+    ) -> ScaledNutritionResult | None:
+        if existing_item.food_reference_id and self.food_reference_repository:
+            reference = await self.food_reference_repository.get_nutrition_projection(
+                existing_item.food_reference_id
+            )
+            if reference is not None and all(
+                value is not None
+                for value in (
+                    reference.protein_100g,
+                    reference.carbs_100g,
+                    reference.fat_100g,
+                )
+            ):
+                allowed_units = [
+                    {
+                        "unit": serving.name,
+                        "gram_weight": serving.grams,
+                        "description": serving.name,
+                    }
+                    for serving in reference.servings
+                    if serving.grams is not None and serving.grams > 0
+                ]
+                nutrition = scale_per_100g_nutrition(
+                    {
+                        "protein": reference.protein_100g,
+                        "carbs": reference.carbs_100g,
+                        "fat": reference.fat_100g,
+                        "fiber": reference.fiber_100g,
+                        "sugar": reference.sugar_100g,
+                    },
+                    quantity,
+                    unit,
+                    allowed_units=allowed_units,
+                    food_name=reference.name,
+                )
+                return ScaledNutritionResult(
+                    calories=nutrition["calories"],
+                    protein=nutrition["protein"],
+                    carbs=nutrition["carbs"],
+                    fat=nutrition["fat"],
+                )
+
+            # A canonical source was expected but is unavailable. Do not make
+            # a new value out of the prior unit's nutrition.
+            return None
+
+        return self.nutrition_service.get_nutrition_for_ingredient(
+            name=existing_item.name,
+            quantity=quantity,
+            unit=unit,
+            fdc_id=existing_item.fdc_id,
+        )
+
+    def _preserve_source_nutrition(
+        self,
+        food_items_dict: dict[str, FoodItem],
+        change: FoodItemChange,
+        existing_item: FoodItem,
+        quantity: float,
+        unit: str,
+    ) -> None:
+        food_items_dict[change.id] = FoodItem(
+            id=existing_item.id,
+            name=existing_item.name,
+            quantity=quantity,
+            unit=unit,
+            macros=existing_item.macros,
+            micros=existing_item.micros,
+            confidence=existing_item.confidence,
+            fdc_id=existing_item.fdc_id,
+            food_reference_id=existing_item.food_reference_id,
+            is_custom=existing_item.is_custom,
+            allowed_units=change.allowed_units or existing_item.allowed_units,
+            nutrition_override=_resolved_nutrition_override(change, existing_item),
+        )
 
 
 class AddFoodItemStrategy(FoodItemChangeStrategy):
@@ -228,6 +336,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                 unit,
                 change.custom_nutrition,
                 change.allowed_units,
+                change.nutrition_override,
             )
             food_items_dict[new_item_id] = food_item
             logger.info(f"Added custom food item: {change.name}")
@@ -254,6 +363,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                     fdc_id=change.fdc_id,
                     is_custom=False,
                     allowed_units=change.allowed_units,
+                    nutrition_override=_resolved_nutrition_override(change),
                 )
                 logger.info(f"Added food item from nutrition service: {change.name}")
                 return
@@ -272,6 +382,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=change.fdc_id,
             is_custom=True,
             allowed_units=change.allowed_units,
+            nutrition_override=_resolved_nutrition_override(change),
         )
 
     def _create_from_custom_nutrition(
@@ -282,6 +393,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
         unit: str,
         custom_nutrition,
         allowed_units=None,
+        nutrition_override=None,
     ) -> FoodItem:
         """Create food item from custom nutrition data."""
         quantity_grams = convert_quantity_to_grams(quantity, unit, name)
@@ -304,6 +416,16 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=None,
             is_custom=True,
             allowed_units=allowed_units,
+            nutrition_override=(
+                NutritionOverride(
+                    calories=nutrition_override.calories,
+                    protein=nutrition_override.protein,
+                    carbs=nutrition_override.carbs,
+                    fat=nutrition_override.fat,
+                )
+                if nutrition_override
+                else None
+            ),
         )
 
 
@@ -312,11 +434,16 @@ class FoodItemChangeStrategyFactory:
 
     @staticmethod
     def create_strategies(
-        nutrition_service: NutritionCalculationService, food_service=None
+        nutrition_service: NutritionCalculationService,
+        food_service=None,
+        food_reference_repository=None,
     ) -> dict[str, FoodItemChangeStrategy]:
         """Create all available strategies."""
         return {
             "add": AddFoodItemStrategy(nutrition_service, food_service),
-            "update": UpdateFoodItemStrategy(nutrition_service),
+            "update": UpdateFoodItemStrategy(
+                nutrition_service,
+                food_reference_repository,
+            ),
             "remove": RemoveFoodItemStrategy(nutrition_service),
         }

--- a/src/infra/database/models/nutrition/food_item.py
+++ b/src/infra/database/models/nutrition/food_item.py
@@ -2,7 +2,7 @@
 Food item model for individual food components within a meal.
 """
 
-from sqlalchemy import Column, String, Float, Integer, ForeignKey, Boolean, JSON
+from sqlalchemy import JSON, Boolean, Column, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from src.infra.database.base import Base
@@ -19,6 +19,7 @@ class FoodItemORM(Base, PrimaryEntityMixin):
     unit = Column(String(120), nullable=False)
     confidence = Column(Float, nullable=True)
     allowed_units = Column(JSON, nullable=True)
+    nutrition_override = Column(JSON, nullable=True)
 
     # Edit support fields
     fdc_id = Column(

--- a/src/infra/database/models/nutrition/nutrition.py
+++ b/src/infra/database/models/nutrition/nutrition.py
@@ -2,7 +2,7 @@
 Nutrition model for overall nutritional information of a meal.
 """
 
-from sqlalchemy import Column, Float, Text, String, ForeignKey
+from sqlalchemy import JSON, Column, Float, ForeignKey, String, Text
 from sqlalchemy.orm import relationship
 
 from src.infra.database.base import Base
@@ -16,6 +16,7 @@ class NutritionORM(Base, SecondaryEntityMixin):
 
     confidence_score = Column(Float, nullable=True)
     raw_ai_response = Column(Text, nullable=True)
+    nutrition_override = Column(JSON, nullable=True)
 
     # Macro fields -- calories are always derived: P*4 + (C-fiber)*4 + fiber*2 + F*9
     protein = Column(Float, default=0, nullable=False)

--- a/src/infra/database/models/user/profile.py
+++ b/src/infra/database/models/user/profile.py
@@ -97,7 +97,7 @@ class UserProfile(Base, BaseMixin):
 
     # Constraints
     __table_args__ = (
-        CheckConstraint("age >= 13 AND age <= 120", name="check_age_range"),
+        CheckConstraint("age >= 12 AND age <= 120", name="check_age_range"),
         CheckConstraint("height_cm > 0", name="check_height_positive"),
         CheckConstraint("weight_kg > 0", name="check_weight_positive"),
         CheckConstraint(

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -17,6 +17,7 @@ from src.domain.model.nutrition import (
 )
 from src.domain.model.nutrition import (
     Macros,
+    NutritionOverride,
 )
 from src.domain.model.nutrition import (
     Nutrition as DomainNutrition,
@@ -39,6 +40,17 @@ _UNHYDRATABLE_READY_MEAL_ERRORS = {
     "Meal with READY status must have nutrition data",
     "Meal with READY status must have ready_at timestamp",
 }
+
+
+def _nutrition_override_from_orm(value: dict | None) -> NutritionOverride | None:
+    if not value:
+        return None
+    return NutritionOverride(
+        calories=float(value["calories"]),
+        protein=float(value["protein"]),
+        carbs=float(value["carbs"]),
+        fat=float(value["fat"]),
+    )
 
 
 def _to_naive_utc(dt: datetime | None) -> datetime | None:
@@ -74,6 +86,7 @@ def food_item_orm_to_domain(orm: FoodItemORM) -> DomainFoodItem:
         food_reference_id=orm.food_reference_id,
         is_custom=orm.is_custom,
         allowed_units=orm.allowed_units,
+        nutrition_override=_nutrition_override_from_orm(orm.nutrition_override),
     )
 
 
@@ -94,6 +107,7 @@ def nutrition_orm_to_domain(orm: NutritionORM) -> DomainNutrition:
         micros=None,
         food_items=food_items,
         confidence_score=orm.confidence_score,
+        nutrition_override=_nutrition_override_from_orm(orm.nutrition_override),
     )
 
 
@@ -211,6 +225,11 @@ def food_item_domain_to_orm(domain: DomainFoodItem, nutrition_id=None) -> FoodIt
         food_reference_id=getattr(domain, "food_reference_id", None),
         is_custom=getattr(domain, "is_custom", False),
         allowed_units=getattr(domain, "allowed_units", None),
+        nutrition_override=(
+            domain.nutrition_override.to_dict()
+            if domain.nutrition_override
+            else None
+        ),
     )
     if hasattr(domain, "id") and domain.id:
         item.id = str(domain.id)
@@ -226,6 +245,9 @@ def food_item_domain_to_orm(domain: DomainFoodItem, nutrition_id=None) -> FoodIt
 def nutrition_domain_to_orm(domain: DomainNutrition, meal_id: str) -> NutritionORM:
     meal_id_str = str(meal_id) if meal_id else None
     orm = NutritionORM(confidence_score=domain.confidence_score, meal_id=meal_id_str)
+    orm.nutrition_override = (
+        domain.nutrition_override.to_dict() if domain.nutrition_override else None
+    )
     if domain.macros:
         orm.protein = domain.macros.protein
         orm.carbs = domain.macros.carbs

--- a/src/infra/repositories/food_reference_uow_adapter.py
+++ b/src/infra/repositories/food_reference_uow_adapter.py
@@ -75,3 +75,9 @@ class AsyncFoodReferenceUowAdapter:
     async def upsert(self, data: dict[str, Any]) -> None:
         async with self._uow_factory() as uow:
             await uow.food_references.upsert(data)
+
+    async def get_nutrition_projection(self, food_reference_id: int) -> Any | None:
+        async with self._uow_factory() as uow:
+            return await uow.food_references.get_nutrition_projection(
+                food_reference_id
+            )

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -8,7 +8,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import cast
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -505,6 +505,29 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             user_id=user_id,
             slot=_rows_to_slot_detail(anchor, rows),
         )
+
+    async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
+        """Detach recommendation state from a meal about to be hard-deleted.
+
+        ``logged_meal_id`` FKs use ON DELETE SET NULL. That leaves ``logged_at``
+        set and breaks ``ck_meal_recommendations_logged_coherent``. Log operation
+        rows also require ``result_logged_meal_id`` non-null, so SET NULL there
+        violates ``ck_meal_recommendation_operations_payload``. Clear both sides
+        before the meal row is removed.
+        """
+        await self._session.execute(
+            update(MealRecommendationORM)
+            .where(MealRecommendationORM.logged_meal_id == meal_id)
+            .values(logged_meal_id=None, logged_at=None)
+        )
+        await self._session.execute(
+            delete(MealRecommendationOperationORM).where(
+                MealRecommendationOperationORM.result_logged_meal_id == meal_id
+            )
+        )
+        # Plain flush — do not use _flush_operations(), which remaps IntegrityError
+        # into meal-recommendation swap/idempotency domain errors (wrong for delete).
+        await self._session.flush()
 
     async def _load_batch(
         self, *, user_id: str, batch_id: str

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -600,7 +600,14 @@ class AsyncMealRepository(MealRepositoryPort):
         db_nutrition.protein = domain_nutrition.macros.protein
         db_nutrition.carbs = domain_nutrition.macros.carbs
         db_nutrition.fat = domain_nutrition.macros.fat
+        db_nutrition.fiber = domain_nutrition.macros.fiber
+        db_nutrition.sugar = domain_nutrition.macros.sugar
         db_nutrition.confidence_score = domain_nutrition.confidence_score
+        db_nutrition.nutrition_override = (
+            domain_nutrition.nutrition_override.to_dict()
+            if domain_nutrition.nutrition_override
+            else None
+        )
 
         # food_items pre-loaded via selectinload in save() — safe to iterate
         for item in db_nutrition.food_items:

--- a/src/infra/services/cron_notification_dispatch_service.py
+++ b/src/infra/services/cron_notification_dispatch_service.py
@@ -29,6 +29,14 @@ DEACTIVATABLE_FCM_ERRORS = {
 }
 
 PROCESSING_RECLAIM_AFTER = timedelta(minutes=10)
+_NORMAL_NOTIFICATION_TYPES = {
+    "meal_reminder_breakfast",
+    "meal_reminder_lunch",
+    "meal_reminder_dinner",
+    "daily_summary",
+    "hydration_reminder_afternoon",
+    "hydration_reminder_evening",
+}
 
 
 class CronNotificationDispatchService:
@@ -53,12 +61,19 @@ class CronNotificationDispatchService:
         if not due:
             return
 
+        regular_notification_user_ids = await _fetch_regular_notification_user_ids(
+            {notification.user_id for notification in due}, now
+        )
+
         logger.info("Sending %d claimed due notifications", len(due))
 
         # Batch-fetch real-time calories_consumed from DB for meal reminders.
         # daily_summary uses the JSONB snapshot; trial_expiry ignores calories.
         meal_reminder_ids = [
-            n.user_id for n in due if n.notification_type.startswith("meal_reminder")
+            n.user_id
+            for n in due
+            if n.notification_type.startswith("meal_reminder")
+            and n.user_id in regular_notification_user_ids
         ]
         consumed_map: dict[str, int] = {}
         if meal_reminder_ids:
@@ -68,6 +83,7 @@ class CronNotificationDispatchService:
             n.user_id
             for n in due
             if n.notification_type.startswith("hydration_reminder")
+            and n.user_id in regular_notification_user_ids
         ]
         hydration_map: dict[str, tuple[int, int]] = {}
         if hydration_user_ids:
@@ -91,6 +107,26 @@ class CronNotificationDispatchService:
             tokens = ctx.get("fcm_tokens", [])
             if not tokens:
                 failed_ids.append(notif.id)
+                continue
+
+            has_regular_notification_access = (
+                notif.user_id in regular_notification_user_ids
+            )
+            if (
+                notif.notification_type in _NORMAL_NOTIFICATION_TYPES
+                and not has_regular_notification_access
+            ):
+                title, body = _render_message(
+                    notif.notification_type,
+                    0,
+                    ctx.get("gender", "male"),
+                    ctx.get("language_code", "en"),
+                    subscription_hook=True,
+                )
+                group = groups[(notif.notification_type, title, body)]
+                group["tokens"].extend(tokens)
+                group["ids"].append(str(notif.id))
+                group["row_ids"].append(notif.id)
                 continue
 
             calorie_goal = int(ctx.get("calorie_goal", 2000))
@@ -316,9 +352,13 @@ def _render_message(
     consumed_ml: int = 0,
     goal_ml: int = 2000,
     remaining_ml: int = 0,
+    subscription_hook: bool = False,
 ) -> tuple[str, str]:
     """Render non-empty title + body for a notification type."""
     messages = get_messages(lang, gender)
+    if subscription_hook:
+        hook = messages["subscription_hook"]
+        return hook["title"], hook["body"]
     if notification_type == "meal_reminder_breakfast":
         cfg = messages["meal_reminder"]["breakfast"]
         return "Nutree", cfg.get("body", "Time to log your meal 🍽️")
@@ -371,6 +411,39 @@ def _render_message(
 def _chunked(lst: list, size: int):
     for i in range(0, len(lst), size):
         yield lst[i : i + size]
+
+
+async def _fetch_regular_notification_user_ids(
+    user_ids: set[str], now: datetime
+) -> set[str]:
+    """Load users eligible for regular reminders once per dispatch tick."""
+    if not user_ids:
+        return set()
+
+    try:
+        async with AsyncUnitOfWork() as uow:
+            result = await uow.session.execute(
+                text("""
+                    SELECT u.id AS user_id
+                    FROM users u
+                    WHERE u.id = ANY(:ids)
+                      AND u.onboarding_completed = true
+                      AND EXISTS (
+                          SELECT 1
+                          FROM subscriptions s
+                          WHERE s.user_id = u.id
+                            AND s.status IN ('active', 'cancelled')
+                            AND (s.expires_at IS NULL OR s.expires_at > :now)
+                      )
+                """),
+                {"ids": list(user_ids), "now": now},
+            )
+            return {row.user_id for row in result.fetchall()}
+    except Exception:
+        logger.exception(
+            "Failed to resolve regular notification eligibility; using hook copy"
+        )
+        return set()
 
 
 async def _fetch_calories_consumed_batch(

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -2,8 +2,9 @@
 Unit tests for meal edit request validation.
 """
 
-import pytest
 from datetime import datetime
+
+import pytest
 from pydantic import ValidationError
 
 from src.api.schemas.request.meal_requests import (
@@ -12,6 +13,7 @@ from src.api.schemas.request.meal_requests import (
     CustomNutritionRequest,
     EditMealIngredientsRequest,
     FoodItemChangeRequest,
+    NutritionOverrideRequest,
 )
 
 
@@ -95,6 +97,21 @@ class TestFoodItemChangeRequest:
         # Assert
         assert request.action == "remove"
         assert request.id == "test-food-item-id"
+
+    def test_manual_nutrition_override_allows_independent_values(self):
+        request = FoodItemChangeRequest(
+            action="update",
+            id="test-food-item-id",
+            nutrition_override=NutritionOverrideRequest(
+                calories=123.4,
+                protein=-5.0,
+                carbs=999.0,
+                fat=1.0,
+            ),
+        )
+
+        assert request.nutrition_override.calories == 123.4
+        assert request.nutrition_override.protein == -5.0
 
     def test_invalid_action(self):
         """Test invalid action value."""
@@ -381,6 +398,18 @@ class TestEditMealIngredientsRequest:
         assert request.dish_name == "Updated Meal Name"
         assert len(request.food_item_changes) == 1
         assert request.food_item_changes[0].action == "add"
+
+    def test_accepts_meal_nutrition_override_without_food_changes(self):
+        request = EditMealIngredientsRequest(
+            nutrition_override=NutritionOverrideRequest(
+                calories=777.0,
+                protein=1.0,
+                carbs=2.0,
+                fat=3.0,
+            )
+        )
+
+        assert request.nutrition_override.calories == 777.0
 
     def test_valid_edit_request_without_dish_name(self):
         """Test valid edit request without dish name."""

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -11,6 +11,9 @@ import pytest
 from src.api.mappers.meal_mapper import STATUS_MAPPING, MealMapper
 from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
 from src.domain.model.meal import FoodItemTranslation, MealTranslation
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
 from src.domain.services.meal_value_insight_contract import (
     IngredientValueInsight,
     MealValueInsights,
@@ -168,6 +171,53 @@ class TestMealMapper:
         assert result.image_url == "https://example.com/image.jpg"
         # total_weight_grams is calculated from food items
         assert result.total_weight_grams == 350 or result.total_weight_grams is None
+
+    def test_to_detailed_response_includes_canonical_source_nutrition(self):
+        item = FoodItem(
+            id="item-1",
+            name="Pâté",
+            quantity=1,
+            unit="g",
+            macros=Macros(protein=0.2, carbs=0.1, fat=0.3),
+            food_reference_id=321,
+        )
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/pate.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            created_at=datetime(2025, 1, 15),
+            ready_at=datetime(2025, 1, 15),
+            nutrition=Nutrition(macros=item.macros, food_items=[item]),
+        )
+        source = FoodReferenceNutritionProjection(
+            id=321,
+            name="Pâté",
+            source="fatsecret",
+            is_verified=True,
+            protein_100g=20,
+            carbs_100g=10,
+            fat_100g=30,
+            fiber_100g=2,
+            sugar_100g=1,
+        )
+
+        result = MealMapper.to_detailed_response(
+            meal,
+            source_nutrition_by_food_reference={321: source},
+        )
+
+        nutrition = result.food_items[0].source_nutrition
+        assert nutrition is not None
+        assert nutrition.protein_per_100g == 20
+        assert nutrition.carbs_per_100g == 10
+        assert nutrition.fat_per_100g == 30
+        assert nutrition.calories_per_100g == pytest.approx(386)
 
     def test_to_detailed_response_uses_item_id_translations_when_list_is_stale(self):
         """Translated food item IDs preserve locale after ingredient add/remove."""

--- a/tests/unit/api/test_meal_recommendation_http_contract.py
+++ b/tests/unit/api/test_meal_recommendation_http_contract.py
@@ -79,7 +79,7 @@ def test_current_openapi_schema_exposes_full_plan_fields():
     assert "macros" in meal_fields
 
 
-def test_summary_openapi_schema_omits_full_plan_fields():
+def test_summary_openapi_schema_keeps_selected_ingredients_compact():
     schema = MealRecommendationPlanSummaryResponse.model_json_schema()
     definitions = schema["$defs"]
 
@@ -88,7 +88,7 @@ def test_summary_openapi_schema_omits_full_plan_fields():
 
     assert "alternatives" not in slot_fields
     assert "score" not in slot_fields
-    assert "ingredients" not in meal_fields
+    assert "ingredients" in meal_fields
     assert "description" not in meal_fields
     assert "macros" in meal_fields
 

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -317,8 +317,29 @@ async def test_log_route_sends_recommended_meal_command():
         item for item in event_bus.commands if isinstance(item, LogRecommendedMealCommand)
     )
     assert command.request_id == "log-1"
+    assert command.language == "en"
     assert response.plan_id == "plan-1"
     assert response.slot.id == "slot-1"
+
+
+@pytest.mark.asyncio
+async def test_log_route_forwards_request_language_to_command():
+    event_bus = _EventBus()
+
+    await log_recommended_meal(
+        request=_request(language="vi"),
+        plan_id="plan-1",
+        slot_id="slot-1",
+        body=LogRecommendedMealRequest(request_id="log-1"),
+        user_id="user-1",
+        event_bus=event_bus,
+        analytics_service=_Analytics(),
+    )
+
+    command = next(
+        item for item in event_bus.commands if isinstance(item, LogRecommendedMealCommand)
+    )
+    assert command.language == "vi"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -175,7 +175,7 @@ async def test_create_three_day_recommendations_snapshots_target_and_timezone():
     )
     assert response.id == "plan-1"
     assert not hasattr(response.slots[0], "alternatives")
-    assert not hasattr(response.slots[0].catalog_meal, "ingredients")
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "Rice"
     assert command.idempotency_key == "key-1"
     assert command.timezone == "Asia/Ho_Chi_Minh"
     assert command.daily_calories == 2150
@@ -219,7 +219,7 @@ async def test_get_plan_returns_owner_scoped_compact_summary():
     assert response.slots[0].catalog_meal.name == "Breakfast Rice"
     assert response.slots[0].catalog_meal.calories == 380
     assert not hasattr(response.slots[0], "alternatives")
-    assert not hasattr(response.slots[0].catalog_meal, "ingredients")
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "Rice"
 
 
 @pytest.mark.asyncio
@@ -255,6 +255,7 @@ async def test_get_plan_translates_catalog_text_from_request_language():
     assert response.slots[0].catalog_meal.name == "vi:Breakfast Rice"
     assert response.slots[0].catalog_meal.cuisine == "vi:vietnamese"
     assert response.slots[0].catalog_meal.calories == 380
+    assert response.slots[0].catalog_meal.ingredients[0].display_name == "vi:Rice"
     assert translator.calls == [
         (
             [

--- a/tests/unit/app/handlers/test_handler_with_fake_uow.py
+++ b/tests/unit/app/handlers/test_handler_with_fake_uow.py
@@ -47,6 +47,9 @@ class TestDeleteMealWithFakeUoW:
         mock_uow = MagicMock()
         mock_uow.meals.find_by_id = AsyncMock(return_value=meal)
         mock_uow.meals.delete = AsyncMock(return_value=None)
+        mock_uow.meal_recommendation_plans.clear_links_for_deleted_meal = AsyncMock(
+            return_value=None
+        )
         mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
         mock_uow.__aexit__ = AsyncMock(return_value=False)
 
@@ -59,7 +62,58 @@ class TestDeleteMealWithFakeUoW:
         # Assert
         assert result["meal_id"] == meal.meal_id
         assert "deleted" in result["message"].lower()
+        mock_uow.meal_recommendation_plans.clear_links_for_deleted_meal.assert_awaited_once_with(
+            meal_id=meal.meal_id
+        )
         mock_uow.meals.delete.assert_called_once_with(meal.meal_id)
+
+
+    @pytest.mark.asyncio
+    async def test_delete_meal_clears_recommendation_links_before_delete(self):
+        """Recommended-meal FK clear must run before hard-deleting the meal."""
+        user_id = str(uuid4())
+        meal = Meal.create_new_processing(
+            user_id=user_id,
+            image=MealImage(
+                image_id=str(uuid4()),
+                format="jpeg",
+                size_bytes=100000,
+                url="https://example.com/image.jpg",
+            ),
+        )
+        from src.domain.model.nutrition import Nutrition, Macros
+
+        meal = meal.mark_ready(
+            nutrition=Nutrition(
+                macros=Macros(protein=30, carbs=50, fat=20), food_items=[]
+            ),
+            dish_name="Recommended meal",
+        )
+        meal = meal.__class__(
+            **{**meal.__dict__, "source": "meal_recommendation"}
+        )
+
+        call_order: list[str] = []
+
+        async def clear_links(*, meal_id: str) -> None:
+            call_order.append(f"clear:{meal_id}")
+
+        async def delete_meal(meal_id: str) -> None:
+            call_order.append(f"delete:{meal_id}")
+
+        mock_uow = MagicMock()
+        mock_uow.meals.find_by_id = AsyncMock(return_value=meal)
+        mock_uow.meals.delete = AsyncMock(side_effect=delete_meal)
+        mock_uow.meal_recommendation_plans.clear_links_for_deleted_meal = AsyncMock(
+            side_effect=clear_links
+        )
+        mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
+        mock_uow.__aexit__ = AsyncMock(return_value=False)
+
+        handler = DeleteMealCommandHandler(uow=mock_uow)
+        await handler.handle(DeleteMealCommand(meal_id=meal.meal_id, user_id=user_id))
+
+        assert call_order == [f"clear:{meal.meal_id}", f"delete:{meal.meal_id}"]
 
 
 # Removed TestSyncUserWithFakeUoW - SyncUserCommand not in scope for this demo

--- a/tests/unit/app/handlers/test_meal_recommendation_handlers.py
+++ b/tests/unit/app/handlers/test_meal_recommendation_handlers.py
@@ -104,10 +104,23 @@ class _SkipPlanRepo(_PlanRepo):
 
 
 class _Materializer:
-    def __init__(self):
-        self.materialize = AsyncMock(
-            return_value=type("Meal", (), {"meal_id": "meal-1"})()
-        )
+    def __init__(self, meal=None):
+        food_item = type(
+            "FoodItem",
+            (),
+            {"id": "food-1", "name": "Rice"},
+        )()
+        nutrition = type("Nutrition", (), {"food_items": [food_item]})()
+        self.meal = meal or type(
+            "Meal",
+            (),
+            {
+                "meal_id": "meal-1",
+                "dish_name": "Rice Bowl",
+                "nutrition": nutrition,
+            },
+        )()
+        self.materialize = AsyncMock(return_value=self.meal)
 
 
 class _Uow:
@@ -183,12 +196,13 @@ def _catalog_meal(meal_id: str) -> CatalogMeal:
     )
 
 
-def _log_command() -> LogRecommendedMealCommand:
+def _log_command(*, language: str = "en") -> LogRecommendedMealCommand:
     return LogRecommendedMealCommand(
         user_id="user-1",
         plan_id="plan-1",
         slot_id="slot-1",
         request_id="log-1",
+        language=language,
     )
 
 
@@ -314,6 +328,80 @@ async def test_log_handler_claims_materializes_then_finalizes():
         request_id="log-1",
         meal_id="meal-1",
     )
+
+
+@pytest.mark.asyncio
+async def test_log_handler_translates_and_invalidates_cache_for_non_english():
+    plans = _LogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    translation_service = type(
+        "TranslationService",
+        (),
+        {"translate_meal": AsyncMock(return_value=None)},
+    )()
+    cache_invalidation = type(
+        "CacheInvalidation",
+        (),
+        {"after_meal_write": AsyncMock()},
+    )()
+    handler = LogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_translation_service=translation_service,
+        cache_invalidation=cache_invalidation,
+    )
+
+    await handler.handle(_log_command(language="vi"))
+
+    translation_service.translate_meal.assert_awaited_once()
+    kwargs = translation_service.translate_meal.await_args.kwargs
+    assert kwargs["target_language"] == "vi"
+    assert kwargs["dish_name"] == "Rice Bowl"
+    assert kwargs["food_items"][0].name == "Rice"
+    cache_invalidation.after_meal_write.assert_awaited_once_with(
+        "user-1", _plan().slots[0].slot_date
+    )
+
+
+@pytest.mark.asyncio
+async def test_log_handler_skips_translation_for_english():
+    plans = _LogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    translation_service = type(
+        "TranslationService",
+        (),
+        {"translate_meal": AsyncMock(return_value=None)},
+    )()
+    handler = LogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_translation_service=translation_service,
+    )
+
+    await handler.handle(_log_command(language="en"))
+
+    translation_service.translate_meal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_log_handler_does_not_fail_when_translation_raises():
+    plans = _LogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    translation_service = type(
+        "TranslationService",
+        (),
+        {"translate_meal": AsyncMock(side_effect=RuntimeError("deepl down"))},
+    )()
+    handler = LogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_translation_service=translation_service,
+    )
+
+    result = await handler.handle(_log_command(language="vi"))
+
+    assert result.plan_id == "plan-1"
+    translation_service.translate_meal.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -137,7 +137,42 @@ async def test_materializer_preserves_food_reference_ids_and_macro_snapshot():
     assert meal.nutrition is not None
     assert meal.nutrition.macros.protein == 30
     assert meal.nutrition.food_items[0].food_reference_id == 123
-    assert meal.image is None
+    # Placeholder image keeps inserts valid when meal.image_id is NOT NULL.
+    assert meal.image is not None
+    assert meal.image.url is None
+    assert meal.image.size_bytes == 1
+
+
+@pytest.mark.asyncio
+async def test_materializer_attaches_catalog_image_url_when_present():
+    plan, slot = _plan_and_slot()
+    catalog_meal = slot.selected.catalog_meal
+    assert catalog_meal is not None
+    slot = PersistedMealRecommendationSlot(
+        **{
+            **slot.__dict__,
+            "selected": PersistedMealRecommendationCandidate(
+                **{
+                    **slot.selected.__dict__,
+                    "catalog_meal": CatalogMeal(
+                        **{
+                            **catalog_meal.__dict__,
+                            "image_url": "https://cdn.example.com/meals/tuna.jpg",
+                        }
+                    ),
+                }
+            ),
+        }
+    )
+
+    meal = await RecommendedMealMaterializationService().materialize(
+        _Uow(),
+        plan=plan,
+        slot=slot,
+    )
+
+    assert meal.image is not None
+    assert meal.image.url == "https://cdn.example.com/meals/tuna.jpg"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/services/test_weekly_budget_async.py
+++ b/tests/unit/domain/services/test_weekly_budget_async.py
@@ -16,10 +16,15 @@ def _ready_meal(*, protein: float, carbs: float, fat: float, created_at: datetim
     meal = Mock()
     meal.status = MealStatus.READY
     meal.created_at = created_at
+    meal.source = "scan"
+    meal.food_label_metadata = None
+    meal.nutrition.nutrition_override = None
+    meal.nutrition.food_items = []
     meal.nutrition.macros.protein = protein
     meal.nutrition.macros.carbs = carbs
     meal.nutrition.macros.fat = fat
     meal.nutrition.macros.fiber = 0.0
+    meal.nutrition.calories = protein * 4 + carbs * 4 + fat * 9
     return meal
 
 
@@ -61,7 +66,11 @@ class TestCalculateWeeklyConsumedAsync:
 
         ready_meal = Mock()
         ready_meal.status = MealStatus.READY
-        ready_meal.nutrition.calories = 9999
+        ready_meal.source = "scan"
+        ready_meal.food_label_metadata = None
+        ready_meal.nutrition.nutrition_override = None
+        ready_meal.nutrition.food_items = []
+        ready_meal.nutrition.calories = 495
         ready_meal.nutrition.macros.protein = 30
         ready_meal.nutrition.macros.carbs = 60
         ready_meal.nutrition.macros.fat = 15
@@ -69,6 +78,10 @@ class TestCalculateWeeklyConsumedAsync:
 
         processing_meal = Mock()
         processing_meal.status = MealStatus.PROCESSING
+        processing_meal.source = "scan"
+        processing_meal.food_label_metadata = None
+        processing_meal.nutrition.nutrition_override = None
+        processing_meal.nutrition.food_items = []
         processing_meal.nutrition.calories = 300
         processing_meal.nutrition.macros.protein = 20
         processing_meal.nutrition.macros.carbs = 40

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -6,12 +6,20 @@ on food items during meal editing.
 """
 
 import uuid
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from src.app.commands.meal.edit_meal_command import CustomNutritionData, FoodItemChange
+from src.app.commands.meal.edit_meal_command import (
+    CustomNutritionData,
+    FoodItemChange,
+    NutritionOverride,
+)
 from src.domain.model import FoodItem, Macros
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+    FoodReferenceServingProjection,
+)
 from src.domain.strategies.meal_edit_strategies import (
     AddFoodItemStrategy,
     FoodItemChangeStrategyFactory,
@@ -167,6 +175,39 @@ class TestUpdateFoodItemStrategy:
         assert updated_item.food_reference_id == 1001
 
     @pytest.mark.asyncio
+    async def test_update_keeps_manual_values_independent_from_source_macros(self):
+        strategy = UpdateFoodItemStrategy(Mock())
+        food_items_dict = {
+            "item1": FoodItem(
+                id="item1",
+                name="Chicken",
+                quantity=100.0,
+                unit="g",
+                macros=Macros(protein=30.0, carbs=0.0, fat=8.0),
+            )
+        }
+
+        await strategy.apply(
+            food_items_dict,
+            FoodItemChange(
+                action="update",
+                id="item1",
+                nutrition_override=NutritionOverride(
+                    calories=123.4,
+                    protein=-5.0,
+                    carbs=999.0,
+                    fat=1.0,
+                ),
+            ),
+        )
+
+        updated_item = food_items_dict["item1"]
+        assert updated_item.macros.protein == 30.0
+        assert updated_item.calories == 123.4
+        assert updated_item.effective_macros.protein == -5.0
+        assert updated_item.effective_macros.carbs == 999.0
+
+    @pytest.mark.asyncio
     async def test_update_unit_with_nutrition_service_success(self):
         """Test updating unit fetches new nutrition from service."""
         # Arrange
@@ -217,6 +258,58 @@ class TestUpdateFoodItemStrategy:
         )
 
     @pytest.mark.asyncio
+    async def test_update_unit_uses_canonical_fatsecret_reference(self):
+        mock_nutrition_service = Mock()
+        mock_food_references = Mock()
+        mock_food_references.get_nutrition_projection = AsyncMock(
+            return_value=FoodReferenceNutritionProjection(
+                id=1002,
+                name="Pâté",
+                source="fatsecret",
+                is_verified=True,
+                protein_100g=3.0,
+                carbs_100g=1.0,
+                fat_100g=5.0,
+                servings=[
+                    FoodReferenceServingProjection(
+                        name="Muỗng Canh",
+                        grams=15.0,
+                        milliliters=None,
+                    ),
+                ],
+            )
+        )
+        strategy = UpdateFoodItemStrategy(
+            mock_nutrition_service,
+            mock_food_references,
+        )
+        food_items_dict = {
+            "item1": FoodItem(
+                id="item1",
+                name="Pâté",
+                quantity=1.0,
+                unit="Muỗng Canh",
+                macros=Macros(protein=3.0, carbs=1.0, fat=5.0),
+                food_reference_id=1002,
+                is_custom=True,
+            )
+        }
+
+        await strategy.apply(
+            food_items_dict,
+            FoodItemChange(action="update", id="item1", quantity=1.0, unit="kg"),
+        )
+
+        updated_item = food_items_dict["item1"]
+        assert updated_item.quantity == 1.0
+        assert updated_item.unit == "kg"
+        assert updated_item.macros.protein == pytest.approx(30.0)
+        assert updated_item.macros.carbs == pytest.approx(10.0)
+        assert updated_item.macros.fat == pytest.approx(50.0)
+        mock_food_references.get_nutrition_projection.assert_awaited_once_with(1002)
+        mock_nutrition_service.get_nutrition_for_ingredient.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_update_custom_nutrition_preserves_food_reference_id(self):
         """Custom nutrition updates preserve canonical food reference identity."""
         mock_nutrition_service = Mock()
@@ -254,8 +347,8 @@ class TestUpdateFoodItemStrategy:
         assert updated_item.is_custom is True
 
     @pytest.mark.asyncio
-    async def test_update_unit_nutrition_service_fails_uses_scaling(self):
-        """Test falling back to scaling when nutrition service fails."""
+    async def test_update_unit_nutrition_service_fails_preserves_source(self):
+        """Keep source nutrition unchanged when canonical data is unavailable."""
         # Arrange
         mock_nutrition_service = Mock()
         mock_nutrition_service.get_nutrition_for_ingredient.return_value = (
@@ -283,16 +376,12 @@ class TestUpdateFoodItemStrategy:
         # Act
         await strategy.apply(food_items_dict, change)
 
-        # Assert - Should use scaling fallback with unit conversion
+        # Assert - Never synthesize a new unit's nutrition from the old unit.
         updated_item = food_items_dict["item1"]
         assert updated_item.quantity == 150.0
         assert updated_item.unit == "oz"
-        # scale = 150oz * 28.35g/oz / 100g = 42.525x
-        scale = 150.0 * 28.35 / 100.0
-        # calories derived from scaled macros: (30*scale)*4 + (0*scale)*4 + (8*scale)*9
-        expected_cal = round(30.0 * scale * 4 + 0 + 8.0 * scale * 9, 1)
-        assert updated_item.calories == pytest.approx(expected_cal, rel=0.01)
-        assert updated_item.macros.protein == pytest.approx(30.0 * scale, rel=0.01)
+        assert updated_item.calories == pytest.approx(192.0)
+        assert updated_item.macros.protein == pytest.approx(30.0)
 
     @pytest.mark.asyncio
     async def test_update_quantity_only(self):

--- a/tests/unit/domain/test_nutrition_validation.py
+++ b/tests/unit/domain/test_nutrition_validation.py
@@ -11,13 +11,15 @@ class TestMacrosValidation:
         assert macros.protein == 20
         assert macros.total_calories == 20 * 4 + 30 * 4 + 10 * 9
 
-    def test_negative_protein_raises_error(self):
-        with pytest.raises(ValueError, match="protein cannot be negative"):
-            Macros(protein=-1, carbs=10, fat=10)
+    def test_negative_protein_allowed_for_manual_overrides(self):
+        # Manual nutrition overrides can carry user-entered extremes; validation
+        # is enforced at API/request boundaries, not on the domain value object.
+        macros = Macros(protein=-1, carbs=10, fat=10)
+        assert macros.protein == -1
 
-    def test_excessive_value_raises_error(self):
-        with pytest.raises(ValueError, match="protein exceeds realistic limit"):
-            Macros(protein=6000, carbs=10, fat=10)
+    def test_excessive_value_allowed_for_manual_overrides(self):
+        macros = Macros(protein=6000, carbs=10, fat=10)
+        assert macros.protein == 6000
 
 
 class TestFoodItemValidation:

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -296,12 +296,12 @@ class TestUpdateUserMetricsCommandHandler:
         mock_uow = _make_mock_uow(profile)
 
         handler = UpdateUserMetricsCommandHandler(uow=mock_uow)
-        command = UpdateUserMetricsCommand(user_id="test_user", age=12)
+        command = UpdateUserMetricsCommand(user_id="test_user", age=11)
 
         with pytest.raises(ValidationException) as exc_info:
             await handler.handle(command)
 
-        assert "Age must be between 13 and 120" in str(exc_info.value)
+        assert "Age must be between 12 and 120" in str(exc_info.value)
 
     async def test_invalid_height(self):
         """Test validation for invalid height."""

--- a/tests/unit/infra/test_cron_notification_dispatch_service.py
+++ b/tests/unit/infra/test_cron_notification_dispatch_service.py
@@ -29,6 +29,7 @@ async def test_send_loop_marks_notifications_sent():
     svc = CronNotificationDispatchService.__new__(CronNotificationDispatchService)
     svc._firebase = mock_firebase
     svc._recover_stale_processing = AsyncMock()
+
     async def _claim_due(_now):
         mock_notif.status = "processing"
         return [mock_notif]
@@ -36,9 +37,15 @@ async def test_send_loop_marks_notifications_sent():
     svc._claim_due_notifications = AsyncMock(side_effect=_claim_due)
     svc._mark_notifications = AsyncMock()
 
-    with patch(
-        "src.infra.services.cron_notification_dispatch_service._fetch_calories_consumed_batch",
-        AsyncMock(return_value={"user-1": 400}),
+    with (
+        patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_calories_consumed_batch",
+            AsyncMock(return_value={"user-1": 400}),
+        ),
+        patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+            AsyncMock(return_value={"user-1"}),
+        ),
     ):
         now = datetime(2026, 4, 22, 5, 0, 0, tzinfo=UTC)
         await svc._send_due_notifications(now)
@@ -53,6 +60,58 @@ async def test_send_loop_marks_notifications_sent():
     assert "1400" in call_kwargs.get("body", ""), (
         f"Expected remaining=1400 in body, got: {call_kwargs.get('body')}"
     )
+
+
+@pytest.mark.asyncio
+async def test_unpaid_user_receives_subscription_hook_copy_for_existing_reminder():
+    from src.infra.services.cron_notification_dispatch_service import (
+        CronNotificationDispatchService,
+    )
+
+    mock_notif = MagicMock()
+    mock_notif.notification_type = "daily_summary"
+    mock_notif.context = {
+        "fcm_tokens": ["tok1"],
+        "calorie_goal": 1800,
+        "calories_consumed": 0,
+        "gender": "male",
+        "language_code": "en",
+    }
+    mock_notif.id = "unpaid-notif-1"
+    mock_notif.user_id = "unpaid-user"
+
+    mock_firebase = MagicMock()
+    mock_firebase.send_multicast = MagicMock(
+        return_value={"success": True, "failed_tokens": []}
+    )
+
+    svc = CronNotificationDispatchService.__new__(CronNotificationDispatchService)
+    svc._firebase = mock_firebase
+    svc._recover_stale_processing = AsyncMock()
+    svc._claim_due_notifications = AsyncMock(return_value=[mock_notif])
+    svc._mark_notifications = AsyncMock()
+
+    with patch(
+        "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+        AsyncMock(return_value=set()),
+    ):
+        await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
+
+    call_kwargs = mock_firebase.send_multicast.call_args.kwargs
+    assert call_kwargs["notification_type"] == "daily_summary"
+    assert "Subscribe" in call_kwargs["body"]
+    assert "calorie" not in call_kwargs["body"].lower()
+
+
+def test_render_subscription_hook_copy_has_display_text():
+    from src.infra.services.cron_notification_dispatch_service import _render_message
+
+    title, body = _render_message(
+        "meal_reminder_breakfast", 0, "female", "en", subscription_hook=True
+    )
+
+    assert title == "Your Nutree plan is ready"
+    assert "Subscribe" in body
 
 
 @pytest.mark.asyncio
@@ -88,7 +147,11 @@ async def test_wholesale_fcm_failure_requeues_instead_of_marking_sent():
     svc._claim_due_notifications = AsyncMock(return_value=[mock_notif])
     svc._mark_notifications = AsyncMock()
 
-    await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
+    with patch(
+        "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+        AsyncMock(return_value={"user-1"}),
+    ):
+        await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
 
     mock_firebase.send_multicast.assert_called_once()
     sent_ids, failed_ids, retry_ids = svc._mark_notifications.call_args.args
@@ -248,7 +311,11 @@ async def test_send_due_normalizes_trial_fcm_type():
     )
     svc._mark_notifications = AsyncMock()
 
-    await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
+    with patch(
+        "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+        AsyncMock(return_value=set()),
+    ):
+        await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
 
     call_kwargs = svc._firebase.send_multicast.call_args.kwargs
     assert call_kwargs["notification_type"] == "trial_expiry"
@@ -273,7 +340,11 @@ async def test_send_due_trial_skips_redis_lookup(caplog):
     svc._mark_notifications = AsyncMock()
 
     with caplog.at_level("WARNING"):
-        await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
+        with patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+            AsyncMock(return_value=set()),
+        ):
+            await svc._send_due_notifications(datetime(2026, 5, 17, tzinfo=UTC))
 
     assert "Redis cache miss" not in caplog.text
 
@@ -344,9 +415,15 @@ async def test_hydration_reminder_skipped_when_above_threshold():
     svc._mark_notifications = AsyncMock()
 
     # consumed_ml=1500, goal_ml=2000 → 75% → above 50% afternoon threshold → skip FCM
-    with patch(
-        "src.infra.services.cron_notification_dispatch_service._fetch_hydration_data_batch",
-        AsyncMock(return_value={"user-h1": (1500, 2000)}),
+    with (
+        patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_hydration_data_batch",
+            AsyncMock(return_value={"user-h1": (1500, 2000)}),
+        ),
+        patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+            AsyncMock(return_value={"user-h1"}),
+        ),
     ):
         now = datetime(2026, 5, 23, 6, 0, 0, tzinfo=UTC)
         await svc._send_due_notifications(now)
@@ -387,9 +464,15 @@ async def test_hydration_reminder_sent_when_below_threshold():
     svc._mark_notifications = AsyncMock()
 
     # consumed_ml=1200, goal_ml=2000 → 60% → below 80% evening threshold → send
-    with patch(
-        "src.infra.services.cron_notification_dispatch_service._fetch_hydration_data_batch",
-        AsyncMock(return_value={"user-h2": (1200, 2000)}),
+    with (
+        patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_hydration_data_batch",
+            AsyncMock(return_value={"user-h2": (1200, 2000)}),
+        ),
+        patch(
+            "src.infra.services.cron_notification_dispatch_service._fetch_regular_notification_user_ids",
+            AsyncMock(return_value={"user-h2"}),
+        ),
     ):
         now = datetime(2026, 5, 23, 11, 0, 0, tzinfo=UTC)
         await svc._send_due_notifications(now)


### PR DESCRIPTION
## Summary
- Merge `main` into `delivery` on feature branch `sync/main-to-delivery-260807`
- No content conflicts; added Alembic merge migration for forked migration heads

### Migration note
Main's nutrition-override / meal-image-nullable / min-age migrations branched from `20260730110500000000`, while delivery had already advanced through the web-funnel chain to `20260803000004`.

Added empty merge revision:
- `migrations/versions/20260807000002_merge_main_delivery_migration_heads.py`
- merges `20260803000004` + `20260807000001` → single head `20260807000002`

### Main changes included
- Min age 12 (App Store alignment)
- Meal nutrition overrides
- Recommended-meal log locale + image + delete-link fixes
- Subscription hook notification messages

## Test plan
- [ ] CI unit tests green
- [ ] `alembic heads` shows single modern head `20260807000002`
- [ ] Staging upgrade path from delivery tip applies merge + new main migrations cleanly

Supersedes https://github.com/phuoctung28/mealtrack_backend/pull/489 (head was `main`; this branch adds the migration merge fix).