### PR TITLE
fix: harden deterministic recommendation sentry handling

### DIFF
--- a/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
+++ b/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
@@ -61,7 +61,9 @@ class ThreeDayPlanOptimizer:
         ingredient_statistics: CatalogIngredientStatistics | None = None,
     ) -> MealRecommendationPlan | MealRecommendationInsufficiency:
         candidates = _filter_supported_catalog_meals(catalog_meals, cuisines)
-        if len({catalog_meal.id for catalog_meal in candidates}) < PLAN_DAYS * len(MEAL_TYPE_ORDER):
+        if len({catalog_meal.id for catalog_meal in candidates}) < PLAN_DAYS * len(
+            MEAL_TYPE_ORDER
+        ):
             return MealRecommendationInsufficiency(
                 reason=MealRecommendationInsufficiencyReason.NOT_ENOUGH_CURRENT_RECIPES,
                 message="not enough unique catalog_meals for 3-day plan",
@@ -70,7 +72,10 @@ class ThreeDayPlanOptimizer:
             )
 
         allocations = self._allocation.allocate(daily_calories)
-        statistics = ingredient_statistics or CatalogIngredientStatisticsService().build(candidates)
+        statistics = (
+            ingredient_statistics
+            or CatalogIngredientStatisticsService().build(candidates)
+        )
         ranked_pools = {
             meal_type: self._scoring.rank(
                 candidates,
@@ -149,7 +154,7 @@ class ThreeDayPlanOptimizer:
         target_calories: int,
         affinity: IngredientAffinityProfile,
         selected_ids: set[str],
-    ):
+    ) -> list[RecipeScore]:
         ranked = self._scoring.rank(
             catalog_meals,
             meal_type=meal_type,
@@ -157,22 +162,9 @@ class ThreeDayPlanOptimizer:
             affinity=affinity,
             excluded_catalog_meal_ids=selected_ids,
         )
-        for tolerance in (0.20, 0.30):
-            within_tolerance = [
-                item
-                for item in ranked
-                if abs(item.catalog_meal.calories - target_calories) / target_calories
-                <= tolerance
-            ]
-            if within_tolerance:
-                return within_tolerance
-        return sorted(
+        return self._select_ranked_candidates_with_fallback(
             ranked,
-            key=lambda item: (
-                abs(item.catalog_meal.calories - target_calories),
-                -item.score,
-                item.catalog_meal.id,
-            ),
+            target_calories=target_calories,
         )
 
     def _rank_pool_with_fallback(
@@ -181,12 +173,27 @@ class ThreeDayPlanOptimizer:
         *,
         target_calories: int,
         selected_ids: set[str],
+        minimum_count: int = 1,
     ) -> list[RecipeScore]:
         ranked = [
             item
             for item in ranked_pool
-            if item.catalog_meal.id not in selected_ids and item.catalog_meal.calories > 0
+            if item.catalog_meal.id not in selected_ids
+            and item.catalog_meal.calories > 0
         ]
+        return self._select_ranked_candidates_with_fallback(
+            ranked,
+            target_calories=target_calories,
+            minimum_count=minimum_count,
+        )
+
+    def _select_ranked_candidates_with_fallback(
+        self,
+        ranked: list[RecipeScore],
+        *,
+        target_calories: int,
+        minimum_count: int = 1,
+    ) -> list[RecipeScore]:
         for tolerance in (0.20, 0.30):
             within_tolerance = [
                 item
@@ -194,7 +201,7 @@ class ThreeDayPlanOptimizer:
                 if abs(item.catalog_meal.calories - target_calories) / target_calories
                 <= tolerance
             ]
-            if within_tolerance:
+            if len(within_tolerance) >= minimum_count:
                 return within_tolerance
         return sorted(
             ranked,
@@ -224,6 +231,7 @@ class ThreeDayPlanOptimizer:
             ranked_pool,
             target_calories=target_calories,
             selected_ids=excluded,
+            minimum_count=count,
         )
         ranked = self._diversity.rerank_shortlist(
             ranked,

--- a/tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py
+++ b/tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py
@@ -357,6 +357,61 @@ def test_alternatives_apply_calorie_gate_before_diversity_rerank():
     ]
 
 
+def test_alternatives_widen_past_tolerance_when_pool_can_fill_count():
+    optimizer = ThreeDayPlanOptimizer()
+    profile = IngredientAffinityService().build_profile([], now=datetime.now(UTC))
+    target_calories = 500
+    ranked_pool = RecipeScoringService().rank(
+        [
+            _catalog_meal("selected", "breakfast", 500),
+            _catalog_meal("near-1", "breakfast", 510),
+            _catalog_meal("near-2", "breakfast", 540),
+            _catalog_meal("far-1", "breakfast", 800),
+            _catalog_meal("far-2", "breakfast", 900),
+            _catalog_meal("far-3", "breakfast", 1000),
+        ],
+        meal_type="breakfast",
+        target_calories=target_calories,
+        affinity=profile,
+    )
+
+    shortlist = optimizer._rank_pool_with_fallback(
+        ranked_pool,
+        target_calories=target_calories,
+        selected_ids={"selected"},
+        minimum_count=1,
+    )
+
+    within_tolerance = [
+        item
+        for item in ranked_pool
+        if item.catalog_meal.id != "selected"
+        and abs(item.catalog_meal.calories - target_calories) / target_calories
+        <= 0.30
+    ]
+
+    assert len(within_tolerance) == 2
+    assert shortlist[0].catalog_meal.id == "near-1"
+
+    result = optimizer._select_alternatives_from_pool(
+        ranked_pool,
+        day_index=0,
+        meal_type="breakfast",
+        target_calories=target_calories,
+        selected_catalog_meal_id="selected",
+        selected_catalog_meal_ids={"selected"},
+    )
+
+    assert not isinstance(result, MealRecommendationInsufficiency)
+    assert [item.catalog_meal.id for item in result] == [
+        "near-1",
+        "near-2",
+        "far-1",
+        "far-2",
+        "far-3",
+    ]
+
+
 def _slot_golden(plan):
     return [
         (slot.day_index, slot.meal_type, slot.catalog_meal.id, round(slot.score, 6))


### PR DESCRIPTION
## Root cause\nThe deterministic meal recommendation path could surface unhandled production telemetry failures under specific fallback conditions.\n\n## Fix\n- tighten optimizer handling for the affected deterministic path\n- lock the regression with focused unit coverage\n\n## Validation\n- backend meal-recommendation suite: 45 passed\n- ruff: clean\n- staged diff check: git diff --cached --check\n\n## DeepL blocker\nDeepL production remediation was operationally blocked and was not part of this commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deterministic meal-plan and alternative selection logic in production recommendation paths; behavior shifts when catalogs are sparse on calorie-near options, though scoped to the optimizer with new regression coverage.
> 
> **Overview**
> Refactors the three-day plan optimizer’s calorie-tolerance fallback into **`_select_ranked_candidates_with_fallback`** and changes when the 20%/30% bands apply.
> 
> **Before:** the first tolerance band that had *any* match returned only those in-band recipes. **Alternative selection** could stop with a short list (e.g. two “near” meals) even when the catalog had enough other options, which could leave **`_select_alternatives_from_pool`** unable to fill five slots and surface failures on the deterministic path.
> 
> **Now:** tolerance bands only win when **`len(within_tolerance) >= minimum_count`**. Slot building still uses **`minimum_count=1`**; picking alternatives passes **`minimum_count=count`** (five), so the optimizer **falls through to distance-ranked candidates** when in-tolerance options are too few. A unit test locks the behavior: five alternatives can include higher-calorie “far” meals when only two are within 30% of target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da696f1d6498297ab9529cdcd1e8ac6d39378fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->