### PR TITLE
fix(web-funnel): finalize repeat purchases safely

### DIFF
--- a/migrations/versions/20260809000001_allow_repeat_web_funnel_purchases.py
+++ b/migrations/versions/20260809000001_allow_repeat_web_funnel_purchases.py
@@ -1,0 +1,36 @@
+"""Allow one authenticated account to finalize multiple paid web purchases."""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260809000001"
+down_revision: str | None = "20260807000002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Keep purchase-row identity unique without making Firebase UID global."""
+    op.drop_constraint(
+        "web_funnel_leads_claimed_uid_key",
+        "web_funnel_leads",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "web_funnel_redemptions_redeemer_uid_key",
+        "web_funnel_redemptions",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "web_funnel_redemptions_finalized_uid_key",
+        "web_funnel_redemptions",
+        type_="unique",
+    )
+
+
+def downgrade() -> None:
+    """Do not reintroduce data-loss-prone global UID uniqueness."""
+    raise NotImplementedError(
+        "This migration is forward-only to preserve repeat purchase history."
+    )

--- a/src/infra/database/models/web_funnel_claim.py
+++ b/src/infra/database/models/web_funnel_claim.py
@@ -39,7 +39,7 @@ class WebFunnelLead(Base, BaseMixin):
     payment_verified_at = Column(DateTime(timezone=True), nullable=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
     claimed_at = Column(DateTime(timezone=True), nullable=True)
-    claimed_uid = Column(String(128), nullable=True, unique=True)
+    claimed_uid = Column(String(128), nullable=True)
     access_sync_status = Column(String(16), nullable=False, default="pending")
 
     __table_args__ = (
@@ -119,9 +119,9 @@ class WebFunnelRedemption(Base, BaseMixin):
     entitlement_id = Column(String(128), nullable=False)
     product_id = Column(String(255), nullable=False)
     verified_at = Column(DateTime(timezone=True), nullable=False)
-    finalized_uid = Column(String(128), nullable=True, unique=True)
+    finalized_uid = Column(String(128), nullable=True)
     finalized_at = Column(DateTime(timezone=True), nullable=True)
-    redeemer_uid = Column(String(128), nullable=True, unique=True)
+    redeemer_uid = Column(String(128), nullable=True)
     redemption_confirmed_at = Column(DateTime(timezone=True), nullable=True)
     redemption_link_hash = Column(String(64), nullable=True, unique=True)
     preflight_token_hash = Column(String(64), nullable=True, unique=True)

--- a/src/infra/services/web_funnel_redemption_completion.py
+++ b/src/infra/services/web_funnel_redemption_completion.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import date
 
 from fastapi import HTTPException
-from sqlalchemy import and_, cast, func, or_, select
+from sqlalchemy import cast, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -97,24 +97,37 @@ async def finalize_redemption(
     auth_provider: str | None = None,
 ) -> dict:
     """Restore one paid lead once; the provider-derived original ID selects the lead."""
+    key_hash = hashlib.sha256(idempotency_key.encode()).hexdigest()
     binding = await db.scalar(
         select(WebFunnelRedemption)
         .where(
             WebFunnelRedemption.environment == environment,
-            or_(
-                WebFunnelRedemption.original_app_user_id == original_app_user_id,
-                and_(
-                    WebFunnelRedemption.redeemer_uid == uid,
-                    WebFunnelRedemption.redeemer_uid.is_not(None),
-                ),
-                cast(WebFunnelRedemption.provider_app_user_ids, JSONB).contains(
-                    [original_app_user_id]
-                ),
-            ),
+            WebFunnelRedemption.finalization_key_hash == key_hash,
         )
-        .order_by(WebFunnelRedemption.verified_at.desc())
         .with_for_update()
     )
+    if binding and not _provider_identity_matches(binding, original_app_user_id):
+        raise claim_not_found()
+    if binding is None:
+        binding = await _find_pending_binding(
+            db,
+            original_app_user_id=original_app_user_id,
+            environment=environment,
+        )
+    if binding is None:
+        # A concurrent finalizer may have committed while this request waited
+        # on the pending purchase row lock. Re-read the key after that lock so
+        # the losing request receives the committed idempotent result.
+        binding = await db.scalar(
+            select(WebFunnelRedemption)
+            .where(
+                WebFunnelRedemption.environment == environment,
+                WebFunnelRedemption.finalization_key_hash == key_hash,
+            )
+            .with_for_update()
+        )
+        if binding and not _provider_identity_matches(binding, original_app_user_id):
+            raise claim_not_found()
     if not binding:
         raise claim_not_found()
     # New redemption-link claims must be explicitly bound to this Firebase UID
@@ -127,7 +140,6 @@ async def finalize_redemption(
     if binding.redeemer_uid and binding.redeemer_uid != uid:
         raise claim_not_found()
     binding.redeemer_uid = uid
-    key_hash = hashlib.sha256(idempotency_key.encode()).hexdigest()
     if binding.finalized_uid:
         if binding.finalized_uid != uid:
             raise claim_conflict()
@@ -259,3 +271,52 @@ async def finalize_redemption(
     )
     await db.commit()
     return result
+
+
+async def _find_pending_binding(
+    db: AsyncSession,
+    *,
+    original_app_user_id: str,
+    environment: str,
+) -> WebFunnelRedemption | None:
+    """Prefer the current unfinalized purchase and fail closed on alias ambiguity."""
+    exact_pending = await db.scalar(
+        select(WebFunnelRedemption)
+        .where(
+            WebFunnelRedemption.environment == environment,
+            WebFunnelRedemption.original_app_user_id == original_app_user_id,
+            WebFunnelRedemption.finalized_uid.is_(None),
+        )
+        .with_for_update()
+    )
+    if exact_pending:
+        return exact_pending
+
+    alias_pending = list(
+        await db.scalars(
+            select(WebFunnelRedemption)
+            .where(
+                WebFunnelRedemption.environment == environment,
+                WebFunnelRedemption.finalized_uid.is_(None),
+                cast(WebFunnelRedemption.provider_app_user_ids, JSONB).contains(
+                    [original_app_user_id]
+                ),
+            )
+            .with_for_update()
+        )
+    )
+    if len(alias_pending) == 1:
+        return alias_pending[0]
+    if alias_pending:
+        return None
+
+    return None
+
+
+def _provider_identity_matches(
+    binding: WebFunnelRedemption,
+    original_app_user_id: str,
+) -> bool:
+    return binding.original_app_user_id == original_app_user_id or original_app_user_id in (
+        binding.provider_app_user_ids or []
+    )

--- a/src/infra/services/web_funnel_redemption_service.py
+++ b/src/infra/services/web_funnel_redemption_service.py
@@ -54,16 +54,19 @@ class WebFunnelRedemptionService:
         environment = event.get("environment")
         if not isinstance(environment, str):
             return False
-        binding = await db.scalar(
-            select(WebFunnelRedemption)
-            .where(
-                WebFunnelRedemption.original_app_user_id.in_(originals),
-                func.lower(WebFunnelRedemption.environment) == environment.lower(),
+        bindings = list(
+            await db.scalars(
+                select(WebFunnelRedemption)
+                .where(
+                    WebFunnelRedemption.original_app_user_id.in_(originals),
+                    func.lower(WebFunnelRedemption.environment) == environment.lower(),
+                )
+                .with_for_update()
             )
-            .with_for_update()
         )
-        if not binding:
+        if len(bindings) != 1:
             return False
+        binding = bindings[0]
         existing_aliases = set(binding.provider_app_user_ids or [])
         binding.provider_app_user_ids = sorted(existing_aliases | redeemers)
         binding.redemption_confirmed_at = utc_now()

--- a/tests/integration/postgres/test_web_funnel_repeat_purchase_constraints.py
+++ b/tests/integration/postgres/test_web_funnel_repeat_purchase_constraints.py
@@ -1,0 +1,164 @@
+import json
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+pytestmark = pytest.mark.integration
+
+
+def _lead_params(suffix: str) -> dict[str, object]:
+    lead_id = str(uuid.uuid4())
+    now = datetime.now(UTC)
+    return {
+        "id": lead_id,
+        "created_at": now,
+        "updated_at": now,
+        "email": f"repeat-{suffix}@example.com",
+        "access_key_hash": uuid.uuid4().hex,
+        "request_id": f"repeat-purchase-{suffix}-{uuid.uuid4().hex}",
+        "snapshot_version": "web_onboarding_snapshot_v1",
+        "snapshot": json.dumps({"target_calories": 2000}),
+        "snapshot_hash": uuid.uuid4().hex,
+        "status": "claimed",
+        "revision": 1,
+        "claimed_uid": "firebase-repeat-user",
+        "access_sync_status": "active",
+    }
+
+
+async def _insert_lead(session, params: dict[str, object]) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO web_funnel_leads (
+                id, created_at, updated_at, email, access_key_hash, request_id,
+                snapshot_version, snapshot, snapshot_hash, status, revision,
+                claimed_uid, access_sync_status
+            ) VALUES (
+                :id, :created_at, :updated_at, :email, :access_key_hash, :request_id,
+                :snapshot_version, CAST(:snapshot AS JSON), :snapshot_hash, :status,
+                :revision, :claimed_uid, :access_sync_status
+            )
+            """
+        ),
+        params,
+    )
+
+
+async def _insert_redemption(
+    session,
+    *,
+    lead_id: str,
+    suffix: str,
+    redemption_link_hash: str,
+    finalization_key_hash: str,
+) -> None:
+    now = datetime.now(UTC)
+    await session.execute(
+        text(
+            """
+            INSERT INTO web_funnel_redemptions (
+                id, created_at, updated_at, lead_id, provider, environment, project,
+                original_app_user_id, verified_app_user_id, entitlement_id, product_id,
+                verified_at, finalized_uid, redeemer_uid, redemption_link_hash,
+                finalization_key_hash, result
+            ) VALUES (
+                :id, :created_at, :updated_at, :lead_id, 'revenuecat', 'SANDBOX',
+                'default', :original_app_user_id, :verified_app_user_id, 'standard',
+                'web_monthly', :verified_at, 'firebase-repeat-user',
+                'firebase-repeat-user', :redemption_link_hash, :finalization_key_hash,
+                CAST(:result AS JSON)
+            )
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "created_at": now,
+            "updated_at": now,
+            "lead_id": lead_id,
+            "original_app_user_id": f"$RCAnonymousID:repeat-{suffix}",
+            "verified_app_user_id": f"$RCAnonymousID:repeat-{suffix}",
+            "verified_at": now,
+            "redemption_link_hash": redemption_link_hash,
+            "finalization_key_hash": finalization_key_hash,
+            "result": json.dumps({"access_status": "active"}),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_allows_repeat_uid_but_preserves_purchase_uniqueness(pg_session):
+    first_lead = _lead_params("first")
+    second_lead = _lead_params("second")
+    first_link_hash = uuid.uuid4().hex * 2
+    first_finalization_key_hash = uuid.uuid4().hex * 2
+    await _insert_lead(pg_session, first_lead)
+    await _insert_lead(pg_session, second_lead)
+    await _insert_redemption(
+        pg_session,
+        lead_id=first_lead["id"],
+        suffix="first",
+        redemption_link_hash=first_link_hash,
+        finalization_key_hash=first_finalization_key_hash,
+    )
+    await _insert_redemption(
+        pg_session,
+        lead_id=second_lead["id"],
+        suffix="second",
+        redemption_link_hash=uuid.uuid4().hex * 2,
+        finalization_key_hash=uuid.uuid4().hex * 2,
+    )
+
+    duplicate_link_lead = _lead_params("duplicate-link")
+    duplicate_customer_lead = _lead_params("duplicate-customer")
+    duplicate_key_lead = _lead_params("duplicate-key")
+    duplicate_lead_id_lead = _lead_params("duplicate-lead-id")
+    for lead in (
+        duplicate_link_lead,
+        duplicate_customer_lead,
+        duplicate_key_lead,
+        duplicate_lead_id_lead,
+    ):
+        await _insert_lead(pg_session, lead)
+    try:
+        with pytest.raises(IntegrityError):
+            async with pg_session.begin_nested():
+                await _insert_redemption(
+                    pg_session,
+                    lead_id=duplicate_link_lead["id"],
+                    suffix="duplicate-link",
+                    redemption_link_hash=first_link_hash,
+                    finalization_key_hash=uuid.uuid4().hex * 2,
+                )
+        with pytest.raises(IntegrityError):
+            async with pg_session.begin_nested():
+                await _insert_redemption(
+                    pg_session,
+                    lead_id=duplicate_customer_lead["id"],
+                    suffix="first",
+                    redemption_link_hash=uuid.uuid4().hex * 2,
+                    finalization_key_hash=uuid.uuid4().hex * 2,
+                )
+        with pytest.raises(IntegrityError):
+            async with pg_session.begin_nested():
+                await _insert_redemption(
+                    pg_session,
+                    lead_id=duplicate_key_lead["id"],
+                    suffix="duplicate-key",
+                    redemption_link_hash=uuid.uuid4().hex * 2,
+                    finalization_key_hash=first_finalization_key_hash,
+                )
+        with pytest.raises(IntegrityError):
+            async with pg_session.begin_nested():
+                await _insert_redemption(
+                    pg_session,
+                    lead_id=first_lead["id"],
+                    suffix="duplicate-lead-id",
+                    redemption_link_hash=uuid.uuid4().hex * 2,
+                    finalization_key_hash=uuid.uuid4().hex * 2,
+                )
+    finally:
+        await pg_session.rollback()

--- a/tests/migrations/test_web_funnel_repeat_purchase_constraints.py
+++ b/tests/migrations/test_web_funnel_repeat_purchase_constraints.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from src.infra.database.models.web_funnel_claim import (
+    WebFunnelLead,
+    WebFunnelRedemption,
+)
+
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "migrations"
+    / "versions"
+    / "20260809000001_allow_repeat_web_funnel_purchases.py"
+)
+
+
+def test_repeat_purchase_migration_drops_only_global_uid_constraints() -> None:
+    migration_text = MIGRATION_PATH.read_text()
+
+    assert migration_text.count("op.drop_constraint(") == 3
+    assert '"web_funnel_leads_claimed_uid_key"' in migration_text
+    assert '"web_funnel_redemptions_redeemer_uid_key"' in migration_text
+    assert '"web_funnel_redemptions_finalized_uid_key"' in migration_text
+    assert '"web_funnel_redemptions_finalization_key_hash_key"' not in migration_text
+    assert '"uq_web_funnel_redemptions_redemption_link_hash"' not in migration_text
+
+
+def test_repeat_purchase_models_allow_one_user_across_multiple_purchase_rows() -> None:
+    assert WebFunnelLead.__table__.c.claimed_uid.unique is not True
+    assert WebFunnelRedemption.__table__.c.redeemer_uid.unique is not True
+    assert WebFunnelRedemption.__table__.c.finalized_uid.unique is not True
+
+    assert WebFunnelRedemption.__table__.c.finalization_key_hash.unique is True
+    assert WebFunnelRedemption.__table__.c.redemption_link_hash.unique is True

--- a/tests/unit/infra/services/test_web_funnel_redemption_service.py
+++ b/tests/unit/infra/services/test_web_funnel_redemption_service.py
@@ -1,6 +1,7 @@
 """Focused safety tests for authenticated RevenueCat redemption."""
 
 import hashlib
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -31,6 +32,9 @@ class Session:
     async def scalar(self, _statement):
         return self.binding
 
+    async def scalars(self, _statement):
+        return [self.binding] if self.binding else []
+
     async def get(self, _model, _identifier, **_kwargs):
         return self.lead
 
@@ -39,11 +43,16 @@ class Session:
 
 
 class StatementCaptureSession:
-    statement = None
+    def __init__(self):
+        self.statements = []
 
     async def scalar(self, statement):
-        self.statement = statement
+        self.statements.append(statement)
         return None
+
+    async def scalars(self, statement):
+        self.statements.append(statement)
+        return []
 
 
 class FinalizationSession:
@@ -63,8 +72,9 @@ def _lead(email="buyer@example.com"):
     return WebFunnelLead(id="lead-1", email=email)
 
 
-def _binding(**values):
-    return WebFunnelRedemption(lead_id="lead-1", **values)
+def _binding(lead_id="lead-1", **values):
+    values.setdefault("original_app_user_id", "$RCAnonymousID:web")
+    return WebFunnelRedemption(lead_id=lead_id, **values)
 
 
 def _link_hash(link="rc-example://redeem?token=opaque"):
@@ -178,9 +188,137 @@ async def test_finalization_uses_jsonb_containment_for_provider_aliases():
         )
 
     assert error.value.status_code == 404
-    sql = str(session.statement.compile(dialect=postgresql.dialect()))
-    assert "CAST(web_funnel_redemptions.provider_app_user_ids AS JSONB) @>" in sql
-    assert "provider_app_user_ids LIKE" not in sql
+    sql_statements = [
+        str(statement.compile(dialect=postgresql.dialect()))
+        for statement in session.statements
+    ]
+    assert any(
+        "CAST(web_funnel_redemptions.provider_app_user_ids AS JSONB) @>" in sql
+        for sql in sql_statements
+    )
+    assert all("provider_app_user_ids LIKE" not in sql for sql in sql_statements)
+    assert all(
+        "web_funnel_redemptions.redeemer_uid =" not in sql
+        for sql in sql_statements
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalization_retry_returns_stored_result_for_same_purchase():
+    binding = _binding(
+        redeemer_uid="firebase-uid",
+        finalized_uid="firebase-uid",
+        finalization_key_hash=hashlib.sha256(
+            b"request-retry-same-purchase"
+        ).hexdigest(),
+        result={"version": "redemption_result_v1", "access_status": "active"},
+    )
+
+    result = await finalize_redemption(
+        FinalizationSession(binding, _lead(), None, None),
+        uid="firebase-uid",
+        email="buyer@example.com",
+        original_app_user_id="$RCAnonymousID:web",
+        idempotency_key="request-retry-same-purchase",
+        environment="SANDBOX",
+    )
+
+    assert result == binding.result
+
+
+@pytest.mark.asyncio
+async def test_finalization_retry_selects_by_idempotency_key_hash():
+    key = "request-keyed-retry"
+    binding = _binding(
+        redeemer_uid="firebase-uid",
+        finalized_uid="firebase-uid",
+        finalization_key_hash=hashlib.sha256(key.encode()).hexdigest(),
+        result={"version": "redemption_result_v1", "access_status": "active"},
+    )
+
+    class Session:
+        def __init__(self):
+            self.statements = []
+
+        async def scalar(self, statement):
+            self.statements.append(statement)
+            return binding
+
+    session = Session()
+    assert (
+        await finalize_redemption(
+            session,
+            uid="firebase-uid",
+            email="buyer@example.com",
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key=key,
+            environment="SANDBOX",
+        )
+        == binding.result
+    )
+    assert "finalization_key_hash" in str(
+        session.statements[0].compile(dialect=postgresql.dialect())
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalization_does_not_reuse_finalized_purchase_for_new_key():
+    class Session:
+        async def scalar(self, _statement):
+            return None
+
+        async def scalars(self, _statement):
+            return []
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            Session(),
+            uid="firebase-uid",
+            email="buyer@example.com",
+            original_app_user_id="$RCAnonymousID:web",
+            idempotency_key="request-different-key",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_finalization_rechecks_key_after_pending_lock_race():
+    key = "request-concurrent-retry"
+    binding = _binding(
+        redeemer_uid="firebase-uid",
+        finalized_uid="firebase-uid",
+        finalization_key_hash=hashlib.sha256(key.encode()).hexdigest(),
+        result={"version": "redemption_result_v1", "access_status": "active"},
+    )
+
+    class Session:
+        def __init__(self):
+            self.key_lookups = 0
+
+        async def scalar(self, statement):
+            sql = str(statement.compile(dialect=postgresql.dialect()))
+            if "finalization_key_hash" in sql:
+                self.key_lookups += 1
+                return binding if self.key_lookups == 2 else None
+            return None
+
+        async def scalars(self, _statement):
+            return []
+
+    session = Session()
+    result = await finalize_redemption(
+        session,
+        uid="firebase-uid",
+        email="buyer@example.com",
+        original_app_user_id="$RCAnonymousID:web",
+        idempotency_key=key,
+        environment="SANDBOX",
+    )
+
+    assert result == binding.result
+    assert session.key_lookups == 2
 
 
 @pytest.mark.asyncio
@@ -328,3 +466,188 @@ async def test_finalization_attaches_purchase_to_authenticated_user():
         "carbs": 200,
         "fat": 65,
     }
+
+
+@pytest.mark.asyncio
+async def test_finalization_allows_second_purchase_for_existing_authenticated_user():
+    binding = _binding(
+        original_app_user_id="$RCAnonymousID:second-purchase",
+        redemption_link_hash=_link_hash("rc-example://second-purchase"),
+        preflight_uid="existing-user",
+        product_id="web_monthly",
+        environment="SANDBOX",
+        verified_at=utcnow(),
+    )
+    lead = _lead()
+    lead.snapshot = {"target_calories": 2000}
+    existing_user = User(
+        id="user-1",
+        firebase_uid="existing-user",
+        email="buyer@example.com",
+        onboarding_completed=False,
+    )
+
+    class Session:
+        def __init__(self):
+            self.scalars = iter(
+                [
+                    binding,
+                    existing_user,
+                    None,
+                    object(),
+                    object(),
+                    SimpleNamespace(status="active"),
+                ]
+            )
+
+        async def scalar(self, _statement):
+            return next(self.scalars)
+
+        async def get(self, _model, _identifier, **_kwargs):
+            return lead
+
+        async def commit(self):
+            return None
+
+    result = await finalize_redemption(
+        Session(),
+        uid="existing-user",
+        email="buyer@example.com",
+        original_app_user_id="$RCAnonymousID:second-purchase",
+        idempotency_key="request-second-purchase",
+        environment="SANDBOX",
+    )
+
+    assert result["access_status"] == "active"
+    assert binding.redeemer_uid == "existing-user"
+    assert binding.finalized_uid == "existing-user"
+
+
+@pytest.mark.asyncio
+async def test_finalization_prefers_one_pending_alias_over_older_finalized_purchase():
+    old_binding = _binding(
+        original_app_user_id="$RCAnonymousID:root",
+        provider_app_user_ids=["$RCAnonymousID:root"],
+        finalized_uid="existing-user",
+        result={"version": "redemption_result_v1", "access_status": "active"},
+    )
+    new_binding = _binding(
+        original_app_user_id="$RCAnonymousID:new",
+        provider_app_user_ids=["$RCAnonymousID:root", "$RCAnonymousID:new"],
+        preflight_uid="existing-user",
+        product_id="web_monthly",
+        environment="SANDBOX",
+        verified_at=utcnow(),
+    )
+    lead = _lead()
+    lead.snapshot = {"target_calories": 2000}
+    existing_user = User(
+        id="user-1",
+        firebase_uid="existing-user",
+        email="buyer@example.com",
+        onboarding_completed=True,
+    )
+
+    class Session:
+        def __init__(self):
+            self.pending_lookup_count = 2
+            self.scalar_results = iter(
+                [existing_user, None, object(), object(), SimpleNamespace(status="active")]
+            )
+
+        async def scalar(self, _statement):
+            if self.pending_lookup_count:
+                self.pending_lookup_count -= 1
+                return None
+            return next(self.scalar_results)
+
+        async def scalars(self, _statement):
+            return [new_binding]
+
+        async def get(self, _model, _identifier, **_kwargs):
+            return lead
+
+        async def commit(self):
+            return None
+
+    result = await finalize_redemption(
+        Session(),
+        uid="existing-user",
+        email="buyer@example.com",
+        original_app_user_id="$RCAnonymousID:root",
+        idempotency_key="request-alias-purchase",
+        environment="SANDBOX",
+    )
+
+    assert result["access_status"] == "active"
+    assert old_binding.finalized_uid == "existing-user"
+    assert new_binding.finalized_uid == "existing-user"
+
+    new_binding.result = result
+
+    class RetrySession:
+        async def scalar(self, _statement):
+            return new_binding
+
+    assert (
+        await finalize_redemption(
+            RetrySession(),
+            uid="existing-user",
+            email="buyer@example.com",
+            original_app_user_id="$RCAnonymousID:root",
+            idempotency_key="request-alias-purchase",
+            environment="SANDBOX",
+        )
+        == new_binding.result
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalization_rejects_multiple_pending_alias_matches():
+    class Session:
+        async def scalar(self, _statement):
+            return None
+
+        async def scalars(self, _statement):
+            return [_binding(), _binding(lead_id="lead-2")]
+
+    with pytest.raises(HTTPException) as error:
+        await finalize_redemption(
+            Session(),
+            uid="existing-user",
+            email="buyer@example.com",
+            original_app_user_id="$RCAnonymousID:root",
+            idempotency_key="request-ambiguous-alias",
+            environment="SANDBOX",
+        )
+
+    assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_ambiguous_repeat_purchase_aliases():
+    first = _binding(original_app_user_id="$RCAnonymousID:first")
+    second = _binding(
+        lead_id="lead-2", original_app_user_id="$RCAnonymousID:second"
+    )
+
+    class Session:
+        async def scalars(self, _statement):
+            return [first, second]
+
+    recorded = await WebFunnelRedemptionService().record_webhook_redemption(
+        Session(),
+        {
+            "type": "PURCHASE_REDEEMED",
+            "environment": "SANDBOX",
+            "redeemed_from": [
+                "$RCAnonymousID:first",
+                "$RCAnonymousID:second",
+            ],
+            "redeemed_by": ["$RCAnonymousID:canonical"],
+        },
+    )
+
+    assert not recorded
+    assert first.redemption_confirmed_at is None
+    assert second.redemption_confirmed_at is None


### PR DESCRIPTION
## Summary

- allow multiple web purchases to finalize for the same authenticated Firebase user
- bind finalization to the idempotency key and the pending provider identity
- fail closed on ambiguous RevenueCat aliases
- preserve uniqueness for each purchase, redemption link, and finalization key
- add the forward migration and regression coverage

## Verification

- focused redemption and migration tests: 20 passed
- full unit suite: 2,260 passed
- targeted Ruff checks: passed
- `git diff --check`: passed

## Staging evidence

The latest preview-to-simulator run reached payment verification, preflight, and RevenueCat redemption, but the new redemption remained unfinalized (`finalized_at` was null). The current `origin/delivery` revision does not contain this fix; merging this PR is required before repeating the device flow.