### PR TITLE
fix(web-funnel): block checkout for registered emails

### DIFF
--- a/src/api/routes/v1/web_funnel.py
+++ b/src/api/routes/v1/web_funnel.py
@@ -5,7 +5,7 @@ import json
 from hmac import compare_digest
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,6 +39,7 @@ from src.app.services.web_funnel_redemption_verification import (
 )
 from src.infra.config.settings import settings
 from src.infra.database.config_async import get_async_db
+from src.infra.database.models.user.user import User
 from src.infra.database.models.web_funnel_claim import (
     WebFunnelClaim,
     WebFunnelLead,
@@ -56,6 +57,13 @@ def _hash(value: str) -> str:
 def _masked_email(email: str) -> str:
     local, domain = email.split("@", maxsplit=1)
     return f"{local[:1]}***@{domain}"
+
+
+def _registered_user_conflict() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="This email is already registered. Please sign in to continue.",
+    )
 
 
 def _projection(lead: WebFunnelLead) -> dict[str, str | int | None]:
@@ -153,6 +161,12 @@ async def create_lead(
         if compare_digest(existing.access_key_hash, access_key_hash):
             return _projection(existing)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    registered_user_id = await db.scalar(
+        select(User.id).where(func.lower(User.email) == str(payload.email).lower())
+    )
+    if registered_user_id is not None:
+        raise _registered_user_conflict()
 
     snapshot = payload.payload.model_dump(mode="json")
     lead = WebFunnelLead(

--- a/tests/unit/api/routes/test_web_funnel_lead_routes.py
+++ b/tests/unit/api/routes/test_web_funnel_lead_routes.py
@@ -26,15 +26,26 @@ class FakeSession:
 
 
 class CreateSession(FakeSession):
-    def __init__(self, existing: WebFunnelLead | None, *, conflict: bool = False):
+    def __init__(
+        self,
+        existing: WebFunnelLead | None,
+        *,
+        conflict: bool = False,
+        registered_user_id: str | None = None,
+    ):
         super().__init__(existing)
         self.conflict = conflict
+        self.registered_user_id = registered_user_id
         self.added: list[object] = []
         self.scalar_calls = 0
 
     async def scalar(self, _statement):
         self.scalar_calls += 1
-        return self.lead
+        if self.scalar_calls == 1:
+            return self.lead
+        if self.scalar_calls == 2:
+            return self.registered_user_id
+        return None
 
     def add(self, item):
         self.added.append(item)
@@ -43,7 +54,7 @@ class CreateSession(FakeSession):
         return None
 
     async def commit(self):
-        if self.conflict and self.scalar_calls == 1:
+        if self.conflict and self.scalar_calls <= 2:
             raise IntegrityError("insert", {}, Exception("duplicate"))
         self.committed = True
 
@@ -58,7 +69,7 @@ class ConcurrentCreateSession(CreateSession):
 
     async def scalar(self, _statement):
         self.scalar_calls += 1
-        return self.winner if self.scalar_calls > 1 else None
+        return self.winner if self.scalar_calls > 2 else None
 
 
 class CorrelationSession(FakeSession):
@@ -195,6 +206,35 @@ async def test_create_hides_replayed_request_from_another_capability(monkeypatch
             CreateSession(_lead()),
         )
     assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_registered_email_before_checkout(monkeypatch):
+    monkeypatch.setattr(
+        web_funnel.settings, "WEB_FUNNEL_BFF_ORIGIN", "https://web.example"
+    )
+    monkeypatch.setattr(
+        web_funnel.settings, "WEB_FUNNEL_BFF_SHARED_SECRET", "bff-secret"
+    )
+    session = CreateSession(None, registered_user_id="user-1")
+
+    with pytest.raises(HTTPException) as error:
+        await web_funnel.create_lead(
+            _request(),
+            _payload(),
+            "a" * 32,
+            "request-1",
+            "https://web.example",
+            "bff-secret",
+            session,
+        )
+
+    assert error.value.status_code == 409
+    assert error.value.detail == (
+        "This email is already registered. Please sign in to continue."
+    )
+    assert session.added == []
+    assert not session.committed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reject checkout lead creation when the email already belongs to a Nutree user
- return HTTP 409 with `This email is already registered. Please sign in to continue.`
- prevent payment and RevenueCat redemption from starting for repeat purchases
- add regression coverage proving no lead is created or committed

## Verification

- focused web-funnel route tests: 15 passed
- full unit suite: 2,253 passed
- Ruff: passed
- `git diff --check`: passed

This replaces the previously closed repeat-purchase PR; it does not change repeat-finalization behavior.