### PR TITLE
fix: close production Sentry swap/precompute defects

### DIFF
--- a/src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/create_three_day_meal_recommendation_command_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -29,6 +30,8 @@ from src.domain.model.meal_recommendation import (
 from src.domain.services.meal_recommendation.three_day_plan_optimizer import (
     ThreeDayPlanOptimizer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @handles(CreateThreeDayMealRecommendationCommand)
@@ -95,6 +98,14 @@ class CreateThreeDayMealRecommendationCommandHandler(
                 ingredient_statistics=ingredient_statistics,
             )
             if isinstance(result, MealRecommendationInsufficiency):
+                logger.warning(
+                    "meal_recommendation_insufficient_catalog "
+                    "reason=%s required=%s available=%s message=%s",
+                    result.reason,
+                    result.required,
+                    result.available,
+                    result.message,
+                )
                 raise MealRecommendationInsufficientCatalogError(result.message)
 
             plan = _to_persisted_plan(command, fingerprint, result)

--- a/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
+++ b/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
     MealRecommendationAlternative,
@@ -32,6 +34,8 @@ from src.domain.services.meal_recommendation.slot_alternative_service import (
     SlotAlternativeService,
 )
 
+logger = logging.getLogger(__name__)
+
 PLAN_DAYS = 3
 
 
@@ -61,14 +65,21 @@ class ThreeDayPlanOptimizer:
         ingredient_statistics: CatalogIngredientStatistics | None = None,
     ) -> MealRecommendationPlan | MealRecommendationInsufficiency:
         candidates = _filter_supported_catalog_meals(catalog_meals, cuisines)
-        if len({catalog_meal.id for catalog_meal in candidates}) < PLAN_DAYS * len(
-            MEAL_TYPE_ORDER
-        ):
+        unique_count = len({catalog_meal.id for catalog_meal in candidates})
+        required_slots = PLAN_DAYS * len(MEAL_TYPE_ORDER)
+        if unique_count < required_slots:
+            logger.warning(
+                "meal_recommendation_insufficient_catalog "
+                "meal_type=plan required=%s available=%s pool_size=%s",
+                required_slots,
+                unique_count,
+                len(catalog_meals),
+            )
             return MealRecommendationInsufficiency(
                 reason=MealRecommendationInsufficiencyReason.NOT_ENOUGH_CURRENT_RECIPES,
                 message="not enough unique catalog_meals for 3-day plan",
-                required=PLAN_DAYS * len(MEAL_TYPE_ORDER),
-                available=len({catalog_meal.id for catalog_meal in candidates}),
+                required=required_slots,
+                available=unique_count,
             )
 
         allocations = self._allocation.allocate(daily_calories)
@@ -103,6 +114,14 @@ class ThreeDayPlanOptimizer:
                     ingredient_statistics=statistics,
                 )
                 if not ranked:
+                    logger.warning(
+                        "meal_recommendation_insufficient_catalog "
+                        "meal_type=%s required=%s available=%s pool_size=%s",
+                        meal_type,
+                        1,
+                        0,
+                        len(ranked_pools[meal_type]),
+                    )
                     return MealRecommendationInsufficiency(
                         reason=MealRecommendationInsufficiencyReason.NOT_ENOUGH_CURRENT_RECIPES,
                         message=f"not enough unique candidates for {meal_type}",
@@ -244,6 +263,14 @@ class ThreeDayPlanOptimizer:
             ),
         )
         if len(ranked) < count:
+            logger.warning(
+                "meal_recommendation_insufficient_alternatives "
+                "meal_type=%s required=%s available=%s pool_size=%s",
+                meal_type,
+                count,
+                len(ranked),
+                len(ranked_pool),
+            )
             return MealRecommendationInsufficiency(
                 reason=MealRecommendationInsufficiencyReason.NOT_ENOUGH_ALTERNATIVES,
                 message=f"not enough alternatives for {meal_type}",

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -247,7 +247,6 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
                     score=Decimal(str(alternative.score)),
                     selection_version=expected_version + 1,
                     seen_at=now if position == 0 else None,
-                    catalog_meal=alternative.catalog_meal,
                 )
                 self._session.add(row)
                 new_rows.append(row)

--- a/src/infra/services/daily_context_precompute_service.py
+++ b/src/infra/services/daily_context_precompute_service.py
@@ -736,6 +736,8 @@ class DailyContextPrecomputeService:
                 movement_by_user[row.user_id][local_date] = float(row.kcal)
 
             # ---- Compute calorie goals (batch preload + full effective-adjusted) ----
+            # Isolate per-user failures so one poisoned statement cannot abort
+            # the shared session for remaining users / bulk INSERT.
             calorie_goals: dict[str, int] = {}
             for user_id in user_ids:
                 profile = profiles_by_user.get(user_id)
@@ -757,20 +759,23 @@ class DailyContextPrecomputeService:
                         user_timezone=tz_name,
                     )
                 try:
-                    calorie_goals[user_id] = await self._get_user_calorie_goal(
-                        uow,
-                        user_id,
-                        today,
-                        profile,
-                        tz_name,
-                        weekly_budget=weekly_budget,
-                        cheat_dates=cheat_dates_by_user.get(user_id, []),
-                        weekly_preload=weekly_preload,
-                    )
+                    async with session.begin_nested():
+                        calorie_goals[user_id] = await self._get_user_calorie_goal(
+                            uow,
+                            user_id,
+                            today,
+                            profile,
+                            tz_name,
+                            weekly_budget=weekly_budget,
+                            cheat_dates=cheat_dates_by_user.get(user_id, []),
+                            weekly_preload=weekly_preload,
+                        )
                 except Exception as exc:
                     logger.warning(
-                        "TDEE calculation failed for user %s: %s; skipping target-bearing notification",
+                        "TDEE calculation failed for user %s in timezone %s: %s; "
+                        "skipping target-bearing notification",
                         user_id,
+                        tz_name,
                         exc,
                     )
 

--- a/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
@@ -449,6 +449,12 @@ async def test_swap_slot_replenishes_exhausted_pool_and_marks_outcome():
     assert len(result.slot.alternatives) == 4
     assert rows[0].retired_at is not None
     assert len(repo._session.added_rows) == 6
+    # Domain CatalogMeal must never be assigned onto ORM relationship state.
+    for row in repo._session.added_rows:
+        if getattr(row, "catalog_meal_id", None) in {
+            f"catalog-{index}" for index in range(3, 8)
+        }:
+            assert not isinstance(getattr(row, "catalog_meal", None), CatalogMeal)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infra/test_daily_context_precompute_service.py
+++ b/tests/unit/infra/test_daily_context_precompute_service.py
@@ -234,3 +234,57 @@ async def test_precompute_applies_keto_policy_before_returning_adjusted_goal():
     )
     assert policy_macros.calories == 1899.9
     assert result == round(policy_macros.calories)
+
+
+@pytest.mark.asyncio
+async def test_calorie_goal_loop_isolates_failures_with_savepoint():
+    """One poisoned calorie-goal lookup must not block remaining users."""
+    from contextlib import asynccontextmanager
+
+    from src.infra.services.daily_context_precompute_service import (
+        DailyContextPrecomputeService,
+    )
+
+    svc = DailyContextPrecomputeService()
+    nested_entries = []
+    processed: list[str] = []
+
+    class _Session:
+        @asynccontextmanager
+        async def begin_nested(self):
+            nested_entries.append("enter")
+            try:
+                yield
+            finally:
+                nested_entries.append("exit")
+
+    session = _Session()
+    user_ids = ["u-fail", "u-ok"]
+    profiles_by_user = {
+        "u-fail": SimpleNamespace(id="u-fail"),
+        "u-ok": SimpleNamespace(id="u-ok"),
+    }
+    calorie_goals: dict[str, int] = {}
+
+    async def fake_goal(uow, user_id, today, profile, tz_name):
+        if user_id == "u-fail":
+            raise RuntimeError("sql poisoned")
+        return 2100
+
+    with patch.object(svc, "_get_user_calorie_goal", side_effect=fake_goal):
+        for user_id in user_ids:
+            profile = profiles_by_user.get(user_id)
+            if profile is None:
+                continue
+            try:
+                async with session.begin_nested():
+                    calorie_goals[user_id] = await svc._get_user_calorie_goal(
+                        MagicMock(), user_id, date(2026, 4, 22), profile, "UTC"
+                    )
+                    processed.append(user_id)
+            except Exception:
+                processed.append(f"failed:{user_id}")
+
+    assert processed == ["failed:u-fail", "u-ok"]
+    assert calorie_goals == {"u-ok": 2100}
+    assert nested_entries == ["enter", "exit", "enter", "exit"]

--- a/tests/unit/infra/test_precompute_calorie_goals_characterization.py
+++ b/tests/unit/infra/test_precompute_calorie_goals_characterization.py
@@ -11,6 +11,7 @@ that SQLite (the default unit-test engine) cannot execute.
 """
 
 from datetime import date, timedelta
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -39,6 +40,7 @@ class _FakeSession:
     def __init__(self, query_results):
         self._results = list(query_results)
         self.executed_count = 0
+        self.nested_count = 0
 
     async def execute(self, _stmt, _params=None):
         self.executed_count += 1
@@ -48,6 +50,12 @@ class _FakeSession:
 
     async def flush(self):
         pass
+
+    @asynccontextmanager
+    async def begin_nested(self):
+        """Mirror SQLAlchemy savepoints used to isolate per-user calorie goals."""
+        self.nested_count += 1
+        yield
 
 
 class _FakeUow:
@@ -251,6 +259,9 @@ async def test_precompute_db_locks_calorie_goals_for_mixed_user_batch():
     }
     assert user_budget_stale not in captured_build_args["calorie_goals"]
     assert user_no_profile not in captured_build_args["calorie_goals"]
+    # Custom + matching-revision users enter savepoints; stale raises inside and
+    # still consumes a nested transaction.
+    assert session.nested_count == 3
 
     # CURRENT behavior: return value is len(pref_rows), regardless of per-user
     # skips (stale revision / missing profile). Not "count of users with a goal".


### PR DESCRIPTION
## Summary
- Stop attaching domain `CatalogMeal` to SQLAlchemy ORM during recommendation swap replenish (`PYTHON-F5`)
- Add structured catalog insufficiency diagnostics while keeping existing 422 mapping (`PYTHON-F3`/`FE`)
- Isolate per-user calorie-goal failures with `begin_nested` savepoints so one poisoned row cannot abort shared precompute (`PYTHON-FB`), preserving Wave 2 batch preload

## Test plan
- [x] `uv run pytest tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/infra/test_daily_context_precompute_service.py tests/unit/domain/services/meal_recommendation/ tests/unit/app/handlers/test_meal_recommendation_handlers.py` (79 passed)
- [ ] Deploy to delivery/staging and confirm `PYTHON-F5`/`FE`/`F3`/`FB` drop on new release SHA
- [ ] Confirm `PYTHON-D4` stays quiet (ops-resolved soak only)


Made with [Cursor](https://cursor.com)