### PR TITLE
fix: complete web redemption targets and sync main

### DIFF
--- a/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
+++ b/src/domain/services/meal_recommendation/three_day_plan_optimizer.py
@@ -181,6 +181,7 @@ class ThreeDayPlanOptimizer:
         *,
         target_calories: int,
         selected_ids: set[str],
+        min_count: int = 1,
     ) -> list[RecipeScore]:
         ranked = [
             item
@@ -194,7 +195,7 @@ class ThreeDayPlanOptimizer:
                 if abs(item.catalog_meal.calories - target_calories) / target_calories
                 <= tolerance
             ]
-            if within_tolerance:
+            if len(within_tolerance) >= min_count:
                 return within_tolerance
         return sorted(
             ranked,
@@ -224,6 +225,7 @@ class ThreeDayPlanOptimizer:
             ranked_pool,
             target_calories=target_calories,
             selected_ids=excluded,
+            min_count=count,
         )
         ranked = self._diversity.rerank_shortlist(
             ranked,


### PR DESCRIPTION
## Summary
- merge `main` into `delivery`, retaining the extracted optimizer fallback helper and its count-aware selection behavior
- derive redemption age from date of birth and map Firebase password authentication to email-link accounts
- calculate default redemption targets through `TdeeCalculationService`, while preserving complete custom macro overrides and deriving calories from macros

## Validation
- `uv run pytest tests/unit/infra/services/test_web_funnel_redemption_service.py tests/unit/domain/services/meal_recommendation/test_deterministic_recommendation_domain.py -q`
- `uv run pytest tests/unit --cov=src --cov-fail-under=65` (2267 passed, 79.38%)
- touched-file Ruff check passed

## Known baseline checks
- repository-wide `ruff check src/ tests/` currently reports 1265 pre-existing violations
- scoped mypy reports 15 pre-existing SQLAlchemy model annotation errors in the redemption completion service

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding nutrition targets and user provider assignment at account creation; incorrect TDEE or macro logic would affect new web redeemers’ weekly budgets and stored results.
> 
> **Overview**
> Web funnel redemption completion no longer uses fixed macro defaults or a snapshot `age` field. **Age** is computed from birth date, and **default calories/macros** come from `TdeeCalculationService` using the lead snapshot (goal, training, body stats). The API result now includes **`age`** and **`tdee`** alongside macros.
> 
> When all three custom macro grams are present in the snapshot, those values are kept and **calories are derived** from the 4/4/9 formula instead of TDEE defaults.
> 
> Firebase **`password`** sign-in is mapped to **`AuthProvider.EMAIL_LINK`** (previously fell through to Google).
> 
> Unit tests cover TDEE-based defaults, full custom macro overrides, password provider mapping, and updated finalize expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2eaa0d43362a32e34db03aef40d125fe60d80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->