### PR TITLE
fix(progress): sync body-fat visuals after sex changes

### DIFF
--- a/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
+++ b/src/app/handlers/command_handlers/update_user_metrics_command_handler.py
@@ -9,6 +9,7 @@ from src.app.commands.user.update_user_metrics_command import UpdateUserMetricsC
 from src.app.events.base import EventHandler, handles
 from src.domain.cache.cache_keys import CacheKeys
 from src.domain.model.common.enums import FitnessGoal, JobType, TrainingLevel
+from src.domain.model.user.body_fat_visual import remap_visual_profile_selection
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.cache_port import CachePort
 from src.domain.services.training_policy import normalize_training_pair
@@ -82,6 +83,7 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 profile.fitness_goal,
                 profile.training_level,
             )
+            sex_changed = False
 
             # Update provided fields only
             if command.age is not None:
@@ -102,6 +104,7 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
             if command.biological_sex is not None:
                 if command.biological_sex not in _VALID_BIOLOGICAL_SEXES:
                     raise ValidationException("Biological sex must be male or female")
+                sex_changed = profile.gender != command.biological_sex
                 profile.gender = command.biological_sex
 
             if command.job_type is not None:
@@ -248,6 +251,17 @@ class UpdateUserMetricsCommandHandler(EventHandler[UpdateUserMetricsCommand, Non
                 profile.profile_target_revision = (
                     profile.profile_target_revision or 1
                 ) + 1
+
+            if sex_changed:
+                history = await uow.body_fat_visual_profiles.find_history_by_user(
+                    command.user_id
+                )
+                if history:
+                    await uow.body_fat_visual_profiles.append(
+                        remap_visual_profile_selection(
+                            history[-1], target_sex=profile.gender
+                        )
+                    )
 
             await uow.users.update_profile(profile)
 

--- a/src/domain/model/user/body_fat_visual.py
+++ b/src/domain/model/user/body_fat_visual.py
@@ -8,26 +8,22 @@ from uuid import UUID, uuid4
 BODY_FAT_VISUAL_SCHEMA_VERSION: Final = 1
 BODY_FAT_VISUAL_RANGE_CATALOG_VERSION: Final = 1
 
-BODY_FAT_VISUAL_RANGES_BY_SEX: Final[dict[str, frozenset[str]]] = {
-    "male": frozenset(
-        {
-            "male_8_12",
-            "male_13_16",
-            "male_17_20",
-            "male_21_24",
-            "male_25_29",
-            "male_30_plus",
-        }
+BODY_FAT_VISUAL_RANGES_BY_SEX: Final[dict[str, tuple[str, ...]]] = {
+    "male": (
+        "male_8_12",
+        "male_13_16",
+        "male_17_20",
+        "male_21_24",
+        "male_25_29",
+        "male_30_plus",
     ),
-    "female": frozenset(
-        {
-            "female_18_21",
-            "female_22_25",
-            "female_26_30",
-            "female_31_35",
-            "female_36_39",
-            "female_40_plus",
-        }
+    "female": (
+        "female_18_21",
+        "female_22_25",
+        "female_26_30",
+        "female_31_35",
+        "female_36_39",
+        "female_40_plus",
     ),
 }
 
@@ -53,4 +49,46 @@ class BodyFatVisualProfileSelection:
 
 def is_valid_visual_range_for_sex(sex: str, range_id: str) -> bool:
     """Return whether a catalog range belongs to the selected sex."""
-    return range_id in BODY_FAT_VISUAL_RANGES_BY_SEX.get(sex, frozenset())
+    return range_id in BODY_FAT_VISUAL_RANGES_BY_SEX.get(sex, ())
+
+
+def remap_visual_range_id(
+    range_id: str | None, *, source_sex: str, target_sex: str
+) -> str | None:
+    """Map a visual range to the same ordinal in another sex's catalog."""
+    if range_id is None:
+        return None
+
+    source_ranges = BODY_FAT_VISUAL_RANGES_BY_SEX[source_sex]
+    target_ranges = BODY_FAT_VISUAL_RANGES_BY_SEX[target_sex]
+    if len(source_ranges) != len(target_ranges):
+        raise ValueError("Visual body-fat catalogs must have matching range counts")
+
+    return target_ranges[source_ranges.index(range_id)]
+
+
+def remap_visual_profile_selection(
+    selection: BodyFatVisualProfileSelection, *, target_sex: str
+) -> BodyFatVisualProfileSelection:
+    """Create an append-only selection remapped to a new biological sex."""
+    return BodyFatVisualProfileSelection(
+        user_id=selection.user_id,
+        schema_version=selection.schema_version,
+        range_catalog_version=selection.range_catalog_version,
+        sex_at_selection=target_sex,
+        start_range_id=remap_visual_range_id(
+            selection.start_range_id,
+            source_sex=selection.sex_at_selection,
+            target_sex=target_sex,
+        ),
+        current_range_id=remap_visual_range_id(
+            selection.current_range_id,
+            source_sex=selection.sex_at_selection,
+            target_sex=target_sex,
+        ),
+        target_range_id=remap_visual_range_id(
+            selection.target_range_id,
+            source_sex=selection.sex_at_selection,
+            target_sex=target_sex,
+        ),
+    )

--- a/tests/unit/body_fat_visual/test_body_fat_visual_contract.py
+++ b/tests/unit/body_fat_visual/test_body_fat_visual_contract.py
@@ -24,7 +24,11 @@ from src.app.handlers.query_handlers.get_body_fat_visual_profile_query_handler i
 from src.app.queries.user.get_body_fat_visual_profile_query import (
     GetBodyFatVisualProfileQuery,
 )
-from src.domain.model.user.body_fat_visual import BodyFatVisualProfileSelection
+from src.domain.model.user.body_fat_visual import (
+    BODY_FAT_VISUAL_RANGES_BY_SEX,
+    BodyFatVisualProfileSelection,
+    remap_visual_profile_selection,
+)
 from src.infra.database.models.user.body_fat_visual_profile import BodyFatVisualProfile
 
 
@@ -45,6 +49,37 @@ def test_visual_body_fat_request_accepts_exact_catalog_values():
     request = BodyFatVisualProfileRequest(**valid_payload())
 
     assert request.current_range_id == "male_17_20"
+
+
+@pytest.mark.parametrize(
+    ("source_sex", "target_sex", "current_range_id", "expected_range_id"),
+    [
+        ("male", "female", "male_21_24", "female_31_35"),
+        ("female", "male", "female_36_39", "male_25_29"),
+    ],
+)
+def test_visual_profile_remaps_ranges_by_stable_catalog_ordinal(
+    source_sex, target_sex, current_range_id, expected_range_id
+):
+    selection = BodyFatVisualProfileSelection(
+        user_id="user-1",
+        schema_version=1,
+        range_catalog_version=1,
+        sex_at_selection=source_sex,
+        start_range_id=None,
+        current_range_id=current_range_id,
+        target_range_id=None,
+    )
+
+    remapped = remap_visual_profile_selection(selection, target_sex=target_sex)
+
+    assert len(BODY_FAT_VISUAL_RANGES_BY_SEX["male"]) == len(
+        BODY_FAT_VISUAL_RANGES_BY_SEX["female"]
+    )
+    assert remapped.sex_at_selection == target_sex
+    assert remapped.start_range_id is None
+    assert remapped.current_range_id == expected_range_id
+    assert remapped.target_range_id is None
 
 
 def test_visual_body_fat_request_allows_omitting_target_range():

--- a/tests/unit/domain/test_update_user_metrics.py
+++ b/tests/unit/domain/test_update_user_metrics.py
@@ -12,6 +12,7 @@ from src.app.commands.user.update_user_metrics_command import UpdateUserMetricsC
 from src.app.handlers.command_handlers.update_user_metrics_command_handler import (
     UpdateUserMetricsCommandHandler,
 )
+from src.domain.model.user.body_fat_visual import BodyFatVisualProfileSelection
 from src.domain.model.user.core_user import UserProfileDomainModel
 
 
@@ -40,6 +41,8 @@ def _make_mock_uow(profile=None):
     mock_uow = MagicMock()
     mock_uow.users.get_profile = AsyncMock(return_value=profile)
     mock_uow.users.update_profile = AsyncMock(side_effect=lambda p: p)
+    mock_uow.body_fat_visual_profiles.find_history_by_user = AsyncMock(return_value=[])
+    mock_uow.body_fat_visual_profiles.append = AsyncMock()
     mock_uow.__aenter__ = AsyncMock(return_value=mock_uow)
     mock_uow.__aexit__ = AsyncMock(return_value=False)
     return mock_uow
@@ -235,6 +238,53 @@ class TestUpdateUserMetricsCommandHandler:
         assert profile.body_fat_percentage == 15.0
         assert profile.fitness_goal == "cut"
         assert profile.is_current is True
+
+    async def test_sex_change_appends_latest_visual_profile_remapped_by_ordinal(self):
+        profile = _make_profile(gender="male")
+        visual_profile = BodyFatVisualProfileSelection(
+            user_id="test_user",
+            schema_version=1,
+            range_catalog_version=1,
+            sex_at_selection="male",
+            start_range_id="male_13_16",
+            current_range_id="male_17_20",
+            target_range_id=None,
+        )
+        mock_uow = _make_mock_uow(profile)
+        mock_uow.body_fat_visual_profiles.find_history_by_user = AsyncMock(
+            return_value=[visual_profile]
+        )
+
+        await UpdateUserMetricsCommandHandler(mock_uow).handle(
+            UpdateUserMetricsCommand(user_id="test_user", biological_sex="female")
+        )
+
+        remapped = mock_uow.body_fat_visual_profiles.append.await_args.args[0]
+        assert profile.gender == "female"
+        assert remapped.sex_at_selection == "female"
+        assert remapped.start_range_id == "female_22_25"
+        assert remapped.current_range_id == "female_26_30"
+        assert remapped.target_range_id is None
+        mock_uow.users.update_profile.assert_awaited_once_with(profile)
+
+    async def test_unchanged_sex_or_missing_visual_history_does_not_append(self):
+        profile = _make_profile(gender="male")
+        mock_uow = _make_mock_uow(profile)
+        handler = UpdateUserMetricsCommandHandler(mock_uow)
+
+        await handler.handle(
+            UpdateUserMetricsCommand(user_id="test_user", biological_sex="male")
+        )
+        mock_uow.body_fat_visual_profiles.find_history_by_user.assert_not_awaited()
+        mock_uow.body_fat_visual_profiles.append.assert_not_awaited()
+
+        await handler.handle(
+            UpdateUserMetricsCommand(user_id="test_user", biological_sex="female")
+        )
+        mock_uow.body_fat_visual_profiles.find_history_by_user.assert_awaited_once_with(
+            "test_user"
+        )
+        mock_uow.body_fat_visual_profiles.append.assert_not_awaited()
 
     async def test_clear_body_fat_when_explicitly_requested(self):
         """Test clearing body fat requires an explicit clear signal."""


### PR DESCRIPTION
Summary:\n- Sync body-fat visuals when sex changes in user metrics updates.\n- Align contract and unit coverage for body fat visual updates.\n\nTests:\n- uv run pytest tests/unit/body_fat_visual/test_body_fat_visual_contract.py tests/unit/domain/test_update_user_metrics.py -q\n- 41 passed\n\nSecurity:\n- Staged diff scanned for secrets before commit.