### PR TITLE
fix(api): map expected hydration/scan rejects away from Sentry 500s

### DIFF
--- a/src/app/graphs/meal_analyze/nodes.py
+++ b/src/app/graphs/meal_analyze/nodes.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from src.api.exceptions import ValidationException
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.commands.meal.upload_meal_image_immediately_command import (
     UploadMealImageImmediatelyCommand,
@@ -266,16 +267,22 @@ async def parse_nutrition(
             runtime.vision_result
         )
         if not runtime.label_metadata.get("is_food_label", True):
-            raise ValueError(
-                "Nutrition Facts label could not be read. "
-                "Please retake the label photo and try again."
+            raise ValidationException(
+                message=(
+                    "Nutrition Facts label could not be read. "
+                    "Please retake the label photo and try again."
+                ),
+                error_code="NOT_FOOD_LABEL_IMAGE",
             )
         return {"nutrition_parsed": True}
 
     if not runtime.gpt_parser.parse_is_food(runtime.vision_result):
-        raise ValueError(
-            "Image does not appear to contain food. "
-            "Please take a photo of food and try again."
+        raise ValidationException(
+            message=(
+                "Image does not appear to contain food. "
+                "Please take a photo of food and try again."
+            ),
+            error_code="NOT_FOOD_IMAGE",
         )
 
     nutrition = runtime.gpt_parser.parse_to_nutrition(runtime.vision_result)
@@ -286,9 +293,12 @@ async def parse_nutrition(
         and nutrition.calories > 0
     )
     if not has_food:
-        raise ValueError(
-            "No edible food detected in the image. "
-            "Please take a photo of food and try again."
+        raise ValidationException(
+            message=(
+                "No edible food detected in the image. "
+                "Please take a photo of food and try again."
+            ),
+            error_code="NOT_FOOD_IMAGE",
         )
     runtime.nutrition = nutrition
     return {"nutrition_parsed": True}

--- a/src/app/handlers/command_handlers/delete_hydration_entry_command_handler.py
+++ b/src/app/handlers/command_handlers/delete_hydration_entry_command_handler.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from src.api.exceptions import ResourceNotFoundException
 from src.app.commands.hydration.delete_hydration_entry_command import (
     DeleteHydrationEntryCommand,
 )
@@ -54,9 +55,9 @@ class DeleteHydrationEntryCommandHandler(
             else:
                 meal = await uow.meals.find_by_id(cmd.entry_id)
                 if meal is None or meal.user_id != cmd.user_id:
-                    raise ValueError("Hydration entry not found")
+                    raise ResourceNotFoundException("Hydration entry not found")
                 if meal.meal_type != "hydration":
-                    raise ValueError("Hydration entry not found")
+                    raise ResourceNotFoundException("Hydration entry not found")
 
                 if meal.status != MealStatus.INACTIVE:
                     await uow.meals.save(meal.mark_inactive())

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import httpx
 
+from src.api.exceptions import ValidationException
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
@@ -134,9 +135,15 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
             )
             structured_data = vision_result.get("structured_data")
             if not isinstance(structured_data, dict):
-                raise ValueError("Nutrition Facts label could not be read.")
+                raise ValidationException(
+                    message="Nutrition Facts label could not be read.",
+                    error_code="NOT_FOOD_LABEL_IMAGE",
+                )
             if not structured_data.get("is_food_label", True):
-                raise ValueError("Nutrition Facts label could not be read.")
+                raise ValidationException(
+                    message="Nutrition Facts label could not be read.",
+                    error_code="NOT_FOOD_LABEL_IMAGE",
+                )
             self._record_food_label_metric("food_label.image_ai_success")
             return {"structured_data": structured_data}
         except Exception as exc:
@@ -228,9 +235,12 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                     vision_result
                 )
                 if not label_metadata.get("is_food_label", True):
-                    raise ValueError(
-                        "Nutrition Facts label could not be read. "
-                        "Please retake the label photo and try again."
+                    raise ValidationException(
+                        message=(
+                            "Nutrition Facts label could not be read. "
+                            "Please retake the label photo and try again."
+                        ),
+                        error_code="NOT_FOOD_LABEL_IMAGE",
                     )
 
                 meal = Meal(
@@ -277,9 +287,12 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                     image_url=command.image_url,
                     reason="parser_not_food",
                 )
-                raise ValueError(
-                    "Image does not appear to contain food. "
-                    "Please take a photo of food and try again."
+                raise ValidationException(
+                    message=(
+                        "Image does not appear to contain food. "
+                        "Please take a photo of food and try again."
+                    ),
+                    error_code="NOT_FOOD_IMAGE",
                 )
 
             nutrition = self.gpt_parser.parse_to_nutrition(vision_result)
@@ -297,9 +310,12 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                     image_url=command.image_url,
                     reason="nutrition_empty_or_zero_calorie",
                 )
-                raise ValueError(
-                    "No edible food detected in the image. "
-                    "Please take a photo of food and try again."
+                raise ValidationException(
+                    message=(
+                        "No edible food detected in the image. "
+                        "Please take a photo of food and try again."
+                    ),
+                    error_code="NOT_FOOD_IMAGE",
                 )
 
             meal = Meal(

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -7,6 +7,7 @@ import time
 from typing import Any
 from uuid import uuid4
 
+from src.api.exceptions import ValidationException
 from src.app.commands.meal import UploadMealImageImmediatelyCommand
 from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
@@ -240,9 +241,12 @@ class UploadMealImageImmediatelyHandler(
                 image_url=image_url,
                 reason="parser_not_food",
             )
-            raise ValueError(
-                "Image does not appear to contain food. "
-                "Please take a photo of food and try again."
+            raise ValidationException(
+                message=(
+                    "Image does not appear to contain food. "
+                    "Please take a photo of food and try again."
+                ),
+                error_code="NOT_FOOD_IMAGE",
             )
 
         nutrition = self.gpt_parser.parse_to_nutrition(analysis_result)
@@ -260,9 +264,12 @@ class UploadMealImageImmediatelyHandler(
                 image_url=image_url,
                 reason="nutrition_empty_or_zero_calorie",
             )
-            raise ValueError(
-                "No edible food detected in the image. "
-                "Please take a photo of food and try again."
+            raise ValidationException(
+                message=(
+                    "No edible food detected in the image. "
+                    "Please take a photo of food and try again."
+                ),
+                error_code="NOT_FOOD_IMAGE",
             )
 
         # Step 6: NOW create meal record with verified image URL
@@ -349,9 +356,13 @@ class UploadMealImageImmediatelyHandler(
     async def handle(self, command: UploadMealImageImmediatelyCommand) -> Meal:
         """Handle immediate meal image upload and analysis."""
         if command.scan_mode == "food_label":
-            raise ValueError(
-                "Food-label scans require the scan-by-url image flow. "
-                "Use /v1/meals/food-label/scan-by-url."
+            raise ValidationException(
+                message=(
+                    "Food-label scans require the scan-by-url image flow. "
+                    "Use /v1/meals/food-label/scan-by-url."
+                ),
+                error_code="INVALID_SCAN_MODE",
+                details={"scan_mode": command.scan_mode},
             )
 
         if not all([self.image_store, self.vision_service, self.gpt_parser]):

--- a/tests/unit/app/graphs/test_meal_analyze_graph_scaffold.py
+++ b/tests/unit/app/graphs/test_meal_analyze_graph_scaffold.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from src.api.exceptions import ValidationException
 
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.commands.meal.upload_meal_image_immediately_command import (
@@ -441,7 +442,7 @@ async def test_async_graph_runner_no_food_does_not_persist():
         image_id_factory=lambda: image_id,
     )
 
-    with pytest.raises(ValueError, match="Image does not appear to contain food"):
+    with pytest.raises(ValidationException, match="Image does not appear to contain food"):
         await run_meal_analyze_graph_async(
             {
                 "scan_mode": "meal_scan",

--- a/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
+++ b/tests/unit/app/handlers/command_handlers/test_upload_meal_image_immediately_command_handler.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from src.api.exceptions import ValidationException
 
 from src.infra.services.ai.ai_vision_errors import AIVisionError, AIVisionFailureKind
 
@@ -152,7 +153,7 @@ class TestVisionRetryRouting:
         command = _make_command()
         command.scan_mode = "food_label"
 
-        with pytest.raises(ValueError, match="require the scan-by-url image flow"):
+        with pytest.raises(ValidationException, match="require the scan-by-url image flow"):
             await handler.handle(command)
 
         analyze_mock.assert_not_called()

--- a/tests/unit/handlers/command_handlers/test_beverage_scan_routing.py
+++ b/tests/unit/handlers/command_handlers/test_beverage_scan_routing.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from src.api.exceptions import ValidationException
 
 from src.app.commands.meal.upload_meal_image_immediately_command import (
     UploadMealImageImmediatelyCommand,
@@ -266,7 +267,7 @@ async def test_zero_calorie_drink_does_not_create_hydration_entry_from_meal_scan
     handler.gpt_parser.parse_to_nutrition.return_value = nutrition
     handler.gpt_parser.parse_dish_name.return_value = "Water bottle"
 
-    with pytest.raises(ValueError, match="No edible food detected"):
+    with pytest.raises(ValidationException, match="No edible food detected"):
         await handler.handle(_make_command())
 
     mock_uow.hydration_entries.add.assert_not_called()
@@ -299,7 +300,7 @@ async def test_upload_scan_captures_rejected_image_for_review(monkeypatch):
     handler.gpt_parser = MagicMock()
     handler.gpt_parser.parse_is_food.return_value = False
 
-    with pytest.raises(ValueError, match="Image does not appear to contain food"):
+    with pytest.raises(ValidationException, match="Image does not appear to contain food"):
         await handler.handle(_make_command())
 
     capture_message.assert_called_once()

--- a/tests/unit/handlers/command_handlers/test_delete_hydration_entry_not_found.py
+++ b/tests/unit/handlers/command_handlers/test_delete_hydration_entry_not_found.py
@@ -1,0 +1,32 @@
+"""Missing hydration deletes must be expected 404s, not ValueError 500s."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.api.exceptions import ResourceNotFoundException
+from src.app.commands.hydration.delete_hydration_entry_command import (
+    DeleteHydrationEntryCommand,
+)
+from src.app.handlers.command_handlers.delete_hydration_entry_command_handler import (
+    DeleteHydrationEntryCommandHandler,
+)
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_hydration_entry_raises_resource_not_found():
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=None)
+    uow.hydration_entries.find_by_id_or_legacy_meal_id = AsyncMock(return_value=None)
+    uow.meals.find_by_id = AsyncMock(return_value=None)
+
+    handler = DeleteHydrationEntryCommandHandler(uow=uow)
+
+    with pytest.raises(ResourceNotFoundException, match="Hydration entry not found"):
+        await handler.handle(
+            DeleteHydrationEntryCommand(
+                user_id="user-1",
+                entry_id="hydr_missing",
+            )
+        )

--- a/tests/unit/handlers/command_handlers/test_food_guard_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_food_guard_command_handlers.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.api.exceptions import ValidationException
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.handlers.command_handlers.scan_by_url_command_handler import (
     ScanByUrlCommandHandler,
@@ -62,7 +63,7 @@ async def test_scan_by_url_rejects_non_food_before_meal_creation(monkeypatch):
         public_id="mealtrack/abc",
     )
 
-    with pytest.raises(ValueError, match="Image does not appear to contain food"):
+    with pytest.raises(ValidationException, match="Image does not appear to contain food"):
         await handler.handle(command)
 
     handler.gpt_parser.parse_to_nutrition.assert_not_called()
@@ -111,7 +112,7 @@ async def test_scan_by_url_captures_rejected_image_for_review(monkeypatch):
         public_id="mealtrack/abc",
     )
 
-    with pytest.raises(ValueError, match="Image does not appear to contain food"):
+    with pytest.raises(ValidationException, match="Image does not appear to contain food"):
         await handler.handle(command)
 
     capture_message.assert_called_once_with(

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from src.api.exceptions import ValidationException
 
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.handlers.command_handlers.scan_by_url_command_handler import (
@@ -265,7 +266,7 @@ async def test_scan_by_url_food_label_image_ai_failure_does_not_save(monkeypatch
         gpt_parser=MagicMock(),
     )
 
-    with pytest.raises(ValueError, match="could not be read"):
+    with pytest.raises(ValidationException, match="could not be read"):
         await handler.handle(
             ScanByUrlCommand(
                 user_id=_USER_ID,

--- a/tests/unit/handlers/command_handlers/test_upload_image_consistency.py
+++ b/tests/unit/handlers/command_handlers/test_upload_image_consistency.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from src.api.exceptions import ValidationException
 
 from src.app.commands.meal.upload_meal_image_immediately_command import (
     UploadMealImageImmediatelyCommand,
@@ -136,7 +137,7 @@ async def test_non_food_upload_rejects_before_db_record():
         content_type="image/jpeg",
     )
 
-    with pytest.raises(ValueError, match="Image does not appear to contain food"):
+    with pytest.raises(ValidationException, match="Image does not appear to contain food"):
         await handler.handle(command)
 
     handler.gpt_parser.parse_to_nutrition.assert_not_called()

--- a/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
@@ -329,7 +329,12 @@ class _ReplenishmentReloadRepo(_SlotMutationRepo):
                         "skipped_at": None,
                         "retired_at": None,
                         "seen_at": None,
-                        **row.__dict__,
+                        **{
+                            key: value
+                            for key, value in row.__dict__.items()
+                            # Simulate a DB reload: in-memory domain cache is gone.
+                            if key != "_domain_catalog_meal"
+                        },
                         "catalog_meal": catalog_meals[row.catalog_meal_id],
                     }
                 )


### PR DESCRIPTION
## Summary
- Missing hydration deletes now raise `ResourceNotFoundException` (404) instead of `ValueError` (500 / Sentry ERROR via event-bus logging) — **Fixes PYTHON-EC** and stops the correlated mobile Dio 500 spike (**NUTREE-DJ**).
- Non-food / unreadable-label scan rejects now raise `ValidationException` in scan-by-url, upload, and meal-analyze graph nodes so the event bus does not ERROR-log expected rejects — **Fixes PYTHON-EW**.
- Adds/updates unit coverage for the new exception types.

## Context
Production recommended issues (last 24h, flutter project `4510928734650368` + python backend) showed hydration delete `ValueError` and scan-by-url food rejects being captured as unexpected backend errors even when routes later mapped some cases to 400.

## Test plan
- [x] `pytest tests/unit/handlers/command_handlers/test_delete_hydration_entry_not_found.py` (+ related scan/upload/graph tests) — 40 passed
- [ ] Deploy backend; confirm PYTHON-EC / PYTHON-EW stop for new release
- [ ] Delete already-removed hydration entry → 404, not 500
- [ ] Scan non-food image → 400 `NOT_FOOD_IMAGE`, no backend ERROR event


Made with [Cursor](https://cursor.com)