### PR TITLE
fix(meals): restore authoritative manual writes

### DIFF
--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -92,7 +92,7 @@ TRUSTED_QUANTITY_UNITS = {
 class _ParseTextRequestBudget:
     """Request-wide limits shared by AI and staged reference resolution."""
 
-    deadline: float
+    deadline: float | None = None
     ai_generations: int = 0
     provider_searches: int = 0
     provider_details: int = 0
@@ -148,9 +148,7 @@ class ParseMealTextHandler(
             language=command.language
         )
 
-        budget = _ParseTextRequestBudget(
-            deadline=time.monotonic() + _parse_text_fatsecret_timeout_seconds()
-        )
+        budget = _ParseTextRequestBudget()
         semantic_feedback: list[str] = []
         enhanced_items: list[dict[str, Any]] = []
         validated_payload: dict[str, Any] | None = None
@@ -170,6 +168,10 @@ class ParseMealTextHandler(
             parsed_items = self._to_flat_parse_text_items(
                 validated_payload, raw_payload
             )
+            if budget.deadline is None:
+                budget.deadline = (
+                    time.monotonic() + _parse_text_fatsecret_timeout_seconds()
+                )
             local_references = await self._find_local_references(parsed_items, budget)
             try:
                 enhanced_items = [
@@ -386,10 +388,11 @@ class ParseMealTextHandler(
             }
             - {""}
         )
-        if not names or time.monotonic() >= budget.deadline:
+        deadline = budget.deadline
+        if not names or deadline is None or time.monotonic() >= deadline:
             return {}
         try:
-            remaining = max(0.01, budget.deadline - time.monotonic())
+            remaining = max(0.01, deadline - time.monotonic())
             return await asyncio.wait_for(
                 self._food_reference_batch_lookup(names), timeout=remaining
             )
@@ -593,11 +596,17 @@ class ParseMealTextHandler(
         awaitable_factory: Callable[[], Awaitable[Any]],
         budget: _ParseTextRequestBudget,
     ) -> Any:
-        remaining = budget.deadline - time.monotonic()
+        deadline = budget.deadline
+        if deadline is None:
+            return None
+        remaining = deadline - time.monotonic()
         if remaining <= 0:
             return None
         async with budget.semaphore:
-            remaining = budget.deadline - time.monotonic()
+            deadline = budget.deadline
+            if deadline is None:
+                return None
+            remaining = deadline - time.monotonic()
             if remaining <= 0:
                 return None
             try:

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -480,7 +481,8 @@ class ParseMealTextHandler(
             return None
         budget.provider_searches += 1
         candidates = await self._provider_call(
-            provider.search_food_candidates(lookup_name, max_results=5), budget
+            lambda: provider.search_food_candidates(lookup_name, max_results=5),
+            budget,
         )
         if candidates is None:
             return None
@@ -491,7 +493,8 @@ class ParseMealTextHandler(
             return None
         budget.provider_details += 1
         details = await self._provider_call(
-            provider.get_food_details(str(selected["food_id"])), budget
+            lambda: provider.get_food_details(str(selected["food_id"])),
+            budget,
         )
         if not isinstance(details, dict):
             return None
@@ -517,7 +520,7 @@ class ParseMealTextHandler(
         budget.provider_searches += 1
         try:
             results = await self._provider_call(
-                provider.search_foods(lookup_name, max_results=5),
+                lambda: provider.search_foods(lookup_name, max_results=5),
                 budget,
             )
         except Exception as exc:
@@ -586,14 +589,19 @@ class ParseMealTextHandler(
         return item
 
     async def _provider_call(
-        self, awaitable: Any, budget: _ParseTextRequestBudget
+        self,
+        awaitable_factory: Callable[[], Awaitable[Any]],
+        budget: _ParseTextRequestBudget,
     ) -> Any:
         remaining = budget.deadline - time.monotonic()
         if remaining <= 0:
             return None
         async with budget.semaphore:
+            remaining = budget.deadline - time.monotonic()
+            if remaining <= 0:
+                return None
             try:
-                return await asyncio.wait_for(awaitable, timeout=remaining)
+                return await asyncio.wait_for(awaitable_factory(), timeout=remaining)
             except Exception as exc:
                 logger.debug("parse_text provider call failed: %s", type(exc).__name__)
                 return None

--- a/src/infra/repositories/meal_write_operation_repository_async.py
+++ b/src/infra/repositories/meal_write_operation_repository_async.py
@@ -67,11 +67,12 @@ class AsyncMealWriteOperationRepository:
         lease_seconds: int = 60,
     ) -> MealWriteReservation:
         now = utc_now()
+        operation_id = str(uuid.uuid4())
         lease_owner = str(uuid.uuid4())
         insert_stmt = (
             pg_insert(MealWriteOperationORM)
             .values(
-                id=str(uuid.uuid4()),
+                id=operation_id,
                 user_id=user_id,
                 operation=operation,
                 idempotency_key=idempotency_key,
@@ -86,8 +87,18 @@ class AsyncMealWriteOperationRepository:
             .on_conflict_do_nothing(
                 index_elements=["user_id", "operation", "idempotency_key"]
             )
+            .returning(MealWriteOperationORM.id)
         )
-        await self.session.execute(insert_stmt)
+        insert_result = await self.session.execute(insert_stmt)
+        inserted_id = insert_result.scalar_one_or_none()
+        if inserted_id is not None:
+            return MealWriteReservation(
+                operation_id=str(inserted_id),
+                lease_owner=lease_owner,
+                lease_generation=1,
+                state="acquired",
+            )
+
         result = await self.session.execute(
             select(MealWriteOperationORM)
             .where(

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -1,9 +1,14 @@
+import asyncio
+import gc
+import time
+
 import pytest
 
 from src.api.schemas.request.meal_requests import CreateManualMealFromFoodsRequest
 from src.app.commands.meal.parse_meal_text_command import ParseMealTextCommand
 from src.app.handlers.command_handlers.parse_meal_text_handler import (
     ParseMealTextHandler,
+    _ParseTextRequestBudget,
 )
 from src.domain.exceptions.ai_exceptions import (
     AIOutputValidationError,
@@ -166,6 +171,58 @@ class _CountingFatSecretService:
     async def search_foods(self, *args, **kwargs):
         self.search_calls += 1
         return []
+
+
+@pytest.mark.asyncio
+async def test_expired_provider_budget_does_not_leak_unawaited_coroutine(recwarn):
+    provider = _CountingFatSecretService()
+    handler = ParseMealTextHandler(
+        meal_generation_service=_FakeMealGenerationService(),
+        fat_secret_service=provider,
+        structured_reference_enabled=False,
+    )
+    budget = _ParseTextRequestBudget(deadline=time.monotonic() - 1)
+
+    result = await handler._resolve_legacy_provider(
+        _parse_item(), "food", 100, "g", budget
+    )
+    gc.collect()
+
+    assert result is None
+    assert provider.search_calls == 0
+    assert not [
+        warning
+        for warning in recwarn
+        if issubclass(warning.category, RuntimeWarning)
+        and "was never awaited" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_factory_is_not_called_when_budget_expires_waiting_for_slot():
+    handler = ParseMealTextHandler(meal_generation_service=_FakeMealGenerationService())
+    semaphore = asyncio.Semaphore(0)
+    budget = _ParseTextRequestBudget(
+        deadline=time.monotonic() + 60,
+        semaphore=semaphore,
+    )
+    factory_calls = 0
+
+    async def provider_call():
+        return []
+
+    def provider_factory():
+        nonlocal factory_calls
+        factory_calls += 1
+        return provider_call()
+
+    task = asyncio.create_task(handler._provider_call(provider_factory, budget))
+    await asyncio.sleep(0)
+    budget.deadline = time.monotonic() - 1
+    semaphore.release()
+
+    assert await task is None
+    assert factory_calls == 0
 
 
 def _parse_item(name="food", quantity=100, unit="g", macros=None):

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -225,6 +225,39 @@ async def test_provider_factory_is_not_called_when_budget_expires_waiting_for_sl
     assert factory_calls == 0
 
 
+@pytest.mark.asyncio
+async def test_ai_latency_does_not_consume_fatsecret_resolution_budget(monkeypatch):
+    meal_generation_service = _FakeMealGenerationService()
+    original_generate = meal_generation_service.generate_meal_plan_async
+
+    async def delayed_generate(**kwargs):
+        await asyncio.sleep(0.1)
+        return await original_generate(**kwargs)
+
+    monkeypatch.setattr(
+        meal_generation_service,
+        "generate_meal_plan_async",
+        delayed_generate,
+    )
+    monkeypatch.setattr(
+        "src.app.handlers.command_handlers.parse_meal_text_handler."
+        "_parse_text_fatsecret_timeout_seconds",
+        lambda: 0.05,
+    )
+    provider = _CountingFatSecretService()
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=provider,
+        structured_reference_enabled=False,
+    )
+
+    await handler.handle(
+        ParseMealTextCommand(text="100g rice", user_id="user-1", language="en")
+    )
+
+    assert provider.search_calls == 1
+
+
 def _parse_item(name="food", quantity=100, unit="g", macros=None):
     macros = macros or {"protein": 2, "carbs": 17, "fat": 0.1}
     return {

--- a/tests/unit/infra/test_meal_write_operation_repository.py
+++ b/tests/unit/infra/test_meal_write_operation_repository.py
@@ -17,6 +17,29 @@ def _result(row):
     return SimpleNamespace(scalars=lambda: scalars)
 
 
+def _insert_result(operation_id=None):
+    return SimpleNamespace(scalar_one_or_none=lambda: operation_id)
+
+
+@pytest.mark.asyncio
+async def test_new_reservation_is_acquired_by_the_inserting_caller():
+    session = SimpleNamespace(execute=AsyncMock(return_value=_insert_result("op-new")))
+    repo = AsyncMealWriteOperationRepository(session)
+
+    reservation = await repo.reserve(
+        user_id="user-1",
+        operation="create_manual_meal",
+        idempotency_key="brand-new-key",
+        request_fingerprint="fingerprint-a",
+    )
+
+    assert reservation.state == "acquired"
+    assert reservation.operation_id == "op-new"
+    assert reservation.lease_owner is not None
+    assert reservation.lease_generation == 1
+    assert session.execute.await_count == 1
+
+
 @pytest.mark.asyncio
 async def test_reservation_replays_completed_operation_and_rejects_fingerprint_reuse():
     row = SimpleNamespace(
@@ -29,7 +52,16 @@ async def test_reservation_replays_completed_operation_and_rejects_fingerprint_r
         target_meal_id="meal-1",
         response={"meal_id": "meal-1"},
     )
-    session = SimpleNamespace(execute=AsyncMock(return_value=_result(row)))
+    session = SimpleNamespace(
+        execute=AsyncMock(
+            side_effect=[
+                _insert_result(),
+                _result(row),
+                _insert_result(),
+                _result(row),
+            ]
+        )
+    )
     repo = AsyncMealWriteOperationRepository(session)
 
     replay = await repo.reserve(
@@ -51,6 +83,34 @@ async def test_reservation_replays_completed_operation_and_rejects_fingerprint_r
 
 
 @pytest.mark.asyncio
+async def test_active_existing_reservation_remains_in_progress_for_other_callers():
+    row = SimpleNamespace(
+        id="op-1",
+        request_fingerprint="fingerprint-a",
+        status="in_progress",
+        lease_owner="current-owner",
+        lease_generation=1,
+        lease_expires_at=utc_now() + timedelta(seconds=30),
+        target_meal_id=None,
+        response=None,
+    )
+    session = SimpleNamespace(
+        execute=AsyncMock(side_effect=[_insert_result(), _result(row)])
+    )
+    repo = AsyncMealWriteOperationRepository(session)
+
+    reservation = await repo.reserve(
+        user_id="user-1",
+        operation="create_manual_meal",
+        idempotency_key="key-1",
+        request_fingerprint="fingerprint-a",
+    )
+
+    assert reservation.state == "in_progress"
+    assert reservation.lease_owner == "current-owner"
+
+
+@pytest.mark.asyncio
 async def test_expired_lease_is_fenced_and_reacquired():
     row = SimpleNamespace(
         id="op-1",
@@ -63,7 +123,8 @@ async def test_expired_lease_is_fenced_and_reacquired():
         response=None,
     )
     session = SimpleNamespace(
-        execute=AsyncMock(return_value=_result(row)), flush=AsyncMock()
+        execute=AsyncMock(side_effect=[_insert_result(), _result(row)]),
+        flush=AsyncMock(),
     )
     repo = AsyncMealWriteOperationRepository(session)
 


### PR DESCRIPTION
## Summary
- acquire a newly inserted meal-write lease instead of returning a false 409 conflict
- defer FatSecret coroutine creation until parse-text budget and concurrency checks pass
- start the local-reference and FatSecret resolution window only after AI parsing completes, so AI latency cannot consume the provider budget
- add regression coverage for fresh/replayed/conflicting/expired leases, provider deadline expiry, and delayed AI parsing followed by a live FatSecret lookup

## Test plan
- [x] 23 focused repository and parse-text tests passed
- [x] 57 create/edit/parse blast-radius tests passed
- [x] Ruff, compileall, and git diff --check passed
- [x] Independent code review found no blocking issues
- [ ] Deploy to SIT and verify first create, same-key replay, no coroutine warning, FatSecret lookup after parse-text, and Neon completed operation

Note: full unit snapshot had 2,397 passed and one unrelated pre-existing cron failure caused by dirty claim-promotion work querying a missing `onboarding_completed_at` column; that cron code is not included in this PR.
