### PR TITLE
fix(nutrition): accept arbitrary manual meal units

### DIFF
--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -3,8 +3,8 @@ Handler for editing meal ingredients.
 """
 
 import logging
-from datetime import timedelta
 from dataclasses import replace
+from datetime import timedelta
 from typing import Any
 
 from src.api.exceptions import (
@@ -28,6 +28,9 @@ from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.provider_budget_port import ProviderBudgetPort
 from src.domain.services.meal_type_determination_service import (
     determine_meal_type_from_timestamp,
+)
+from src.domain.services.nutrition_calculation_service import (
+    canonicalize_authoritative_quantity,
 )
 from src.domain.utils.timezone_utils import utc_now
 
@@ -552,6 +555,8 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                         change,
                         fdc_id=authoritative.fdc_id,
                         name=authoritative.name,
+                        quantity=authoritative.quantity,
+                        unit=authoritative.unit,
                         custom_nutrition=self._to_domain_custom_nutrition(
                             authoritative.custom_nutrition
                         ),
@@ -565,8 +570,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 continue
 
             existing = current_by_id[change.id]
-            self._validate_snapshot_unit(existing, change.unit)
-            prepared.append(change)
+            prepared.append(self._canonicalize_snapshot_unit(existing, change))
         if revalidate_local:
             await self.nutrition_resolver.revalidate_local_items(
                 resolved_items, uow.food_references
@@ -602,19 +606,32 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         return locked_meal
 
     @staticmethod
-    def _validate_snapshot_unit(existing_item, unit: str | None) -> None:
+    def _canonicalize_snapshot_unit(existing_item, change):
+        unit = change.unit
         if unit is None or unit.lower().strip() == existing_item.unit.lower().strip():
-            return
+            return change
         snapshot = existing_item.source_snapshot
         if not snapshot:
             raise ValueError("v2 quantity updates require an immutable source snapshot")
         allowed_units = snapshot.get("allowed_units") or []
-        normalized = unit.lower().strip()
-        if normalized != "g" and not any(
-            normalized == str(option.get("unit", "")).lower().strip()
-            for option in allowed_units
-        ):
-            raise ValueError("quantity unit is not allowed by the source snapshot")
+        quantity = (
+            change.quantity if change.quantity is not None else existing_item.quantity
+        )
+        canonical_quantity, canonical_unit, used_fallback = (
+            canonicalize_authoritative_quantity(
+                quantity,
+                unit,
+                allowed_units,
+                existing_item.name,
+            )
+        )
+        if used_fallback:
+            return replace(
+                change,
+                quantity=canonical_quantity,
+                unit=canonical_unit,
+            )
+        return change
 
     @staticmethod
     def _to_manual_custom_nutrition(value):

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -29,6 +29,7 @@ from src.domain.services.ai_output_validation_service import (
 )
 from src.domain.services.emoji_validator import validate_emoji
 from src.domain.services.nutrition_calculation_service import (
+    _convert_with_allowed_units,
     clamp_nutrition_values,
     convert_quantity_to_grams,
     normalize_unit_for_manual_save,
@@ -551,6 +552,12 @@ class ParseMealTextHandler(
         )
         if not per_100g:
             return None
+        allowed_units = self._safe_allowed_units(selected.get("allowed_units"))
+        quantity_g = self._canonicalize_reference_quantity(
+            item,
+            quantity_g=self._quantity_in_grams(item, lookup_name),
+            allowed_units=allowed_units,
+        )
         scaled = scale_per_100g_nutrition(
             {
                 "calories": per_100g.get("calories_100g", per_100g.get("calories", 0)),
@@ -560,10 +567,11 @@ class ParseMealTextHandler(
                 "fiber": per_100g.get("fiber_100g", per_100g.get("fiber", 0)),
                 "sugar": per_100g.get("sugar_100g", per_100g.get("sugar", 0)),
             },
-            quantity,
-            unit,
-            allowed_units=selected.get("allowed_units"),
+            item["quantity"],
+            item["unit"],
+            allowed_units=allowed_units,
             food_name=lookup_name,
+            strict_allowed_units=True,
         )
         if not validate_ai_fallback(
             name=lookup_name,
@@ -571,12 +579,12 @@ class ParseMealTextHandler(
             carbs=scaled.get("carbs"),
             fat=scaled.get("fat"),
             fiber=scaled.get("fiber"),
-            quantity_g=self._quantity_in_grams(item, lookup_name),
+            quantity_g=quantity_g,
         ):
             return None
         item.update(scaled)
         item["calories"] = self._derive_calories_from_macros(item)
-        item["allowed_units"] = self._safe_allowed_units(selected.get("allowed_units"))
+        item["allowed_units"] = allowed_units
         item["data_source"] = "fatsecret"
         item.update(self._reference_identity(selected, "fatsecret"))
         item["nutrition_basis"] = "100g"
@@ -665,6 +673,16 @@ class ParseMealTextHandler(
         source: str,
         raw: dict[str, Any],
     ) -> dict[str, Any]:
+        allowed_units = self._safe_allowed_units(
+            raw.get("allowed_units") or raw.get("serving_sizes")
+        )
+        if not allowed_units:
+            allowed_units = list(candidate.allowed_units or [])
+        quantity_g = self._canonicalize_reference_quantity(
+            item,
+            quantity_g=quantity_g,
+            allowed_units=allowed_units,
+        )
         factor = quantity_g / 100.0
         item.update(
             {
@@ -694,10 +712,38 @@ class ParseMealTextHandler(
                 "fiber_g": candidate.fiber_per_100g,
             }
         )
-        item["allowed_units"] = self._safe_allowed_units(
-            raw.get("allowed_units") or raw.get("serving_sizes")
-        )
+        item["allowed_units"] = allowed_units
         return item
+
+    @staticmethod
+    def _canonicalize_reference_quantity(
+        item: dict[str, Any],
+        *,
+        quantity_g: float,
+        allowed_units: list[dict[str, Any]],
+    ) -> float:
+        """Keep parsed portions saveable against the same source snapshot."""
+        quantity = float(item.get("quantity") or 1.0)
+        source_unit = str(item.get("english_unit") or item.get("unit") or "g")
+        try:
+            authoritative_grams = _convert_with_allowed_units(
+                quantity,
+                source_unit,
+                allowed_units,
+                str(item.get("lookup_name") or item.get("name") or ""),
+                strict=True,
+            )
+        except ValueError:
+            item["quantity"] = quantity_g
+            item["unit"] = "g"
+            item["english_unit"] = "g"
+            item["quantity_g"] = quantity_g
+            return quantity_g
+
+        item["unit"] = source_unit
+        item["english_unit"] = source_unit
+        item["quantity_g"] = authoritative_grams
+        return authoritative_grams
 
     @staticmethod
     def _reference_identity(raw: dict[str, Any], source: str) -> dict[str, Any]:

--- a/src/app/services/manual_meal_nutrition_resolver.py
+++ b/src/app/services/manual_meal_nutrition_resolver.py
@@ -10,14 +10,14 @@ from src.app.commands.meal.create_manual_meal_command import (
     CustomNutrition,
     ManualMealItem,
 )
+from src.domain.ports.provider_budget_port import ProviderBudgetPort
+from src.domain.services.nutrition_calculation_service import (
+    canonicalize_authoritative_quantity,
+)
 from src.domain.services.nutrition_integrity_policy import (
     NutritionIntegrityError,
     NutritionIntegrityPolicy,
     normalize_serving_options,
-)
-from src.domain.ports.provider_budget_port import ProviderBudgetPort
-from src.domain.services.nutrition_calculation_service import (
-    _convert_with_allowed_units,
 )
 from src.observability import increment_metric
 
@@ -95,13 +95,7 @@ class ManualMealNutritionResolver:
                     )
                 else:
                     raise ValueError("v2 item origin is required")
-                _convert_with_allowed_units(
-                    resolved_item.quantity,
-                    resolved_item.unit,
-                    resolved_item.allowed_units or [],
-                    resolved_item.name or "Food Item",
-                    strict=True,
-                )
+                resolved_item = self._canonicalize_unmatched_unit(resolved_item)
                 resolved.append(resolved_item)
             except Exception as exc:
                 result = getattr(exc, "result", None)
@@ -118,6 +112,23 @@ class ManualMealNutritionResolver:
                 attributes={"origin": item.origin or "unknown"},
             )
         return resolved
+
+    @staticmethod
+    def _canonicalize_unmatched_unit(item: ManualMealItem) -> ManualMealItem:
+        """Keep valid source units; convert any other request unit to grams."""
+        quantity, unit, used_fallback = canonicalize_authoritative_quantity(
+            item.quantity,
+            item.unit,
+            item.allowed_units or [],
+            item.name or "Food Item",
+        )
+        if used_fallback:
+            increment_metric(
+                "manual_nutrition_resolution.unit_fallback",
+                attributes={"origin": item.origin or "unknown"},
+            )
+            return replace(item, quantity=quantity, unit=unit)
+        return item
 
     async def revalidate_local_items(self, items, food_references) -> None:
         """Lock local references and reject a snapshot changed mid-write."""

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -12,6 +12,11 @@ from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 
 logger = logging.getLogger(__name__)
 
+
+class AuthoritativeUnitMismatchError(ValueError):
+    """The requested unit is absent from a source-controlled serving snapshot."""
+
+
 # Shared unit-to-grams conversion table for common serving units.
 # Used by both parse-text and manual-meal handlers to ensure consistent nutrition.
 UNIT_TO_GRAMS = {
@@ -137,6 +142,19 @@ def _normalize_unit(unit: str) -> str:
     return base
 
 
+def _normalize_authoritative_unit(unit: str) -> str:
+    """Normalize only exact aliases; never discard arbitrary suffix text."""
+    unit_lower = (unit or "g").lower().strip()
+    translated = UNIT_TRANSLATION.get(unit_lower)
+    if translated is not None:
+        return translated
+    if " " not in unit_lower and unit_lower.endswith("s"):
+        singular = unit_lower[:-1]
+        if singular in UNIT_TO_GRAMS:
+            return singular
+    return unit_lower
+
+
 def normalize_unit_for_manual_save(unit: str | None) -> str:
     """Return a client-safe unit accepted by manual meal creation."""
     normalized = _normalize_unit(unit or "")
@@ -169,9 +187,7 @@ def convert_quantity_to_grams(quantity: float, unit: str, food_name: str = "") -
 
     grams_per_unit = UNIT_TO_GRAMS.get(normalized)
     if grams_per_unit is None:
-        logger.warning(
-            f"Unknown unit '{unit}' (normalized: '{normalized}') — treating quantity as grams"
-        )
+        logger.warning("Unknown unit used quantity as grams")
         return quantity
     return quantity * grams_per_unit
 
@@ -248,25 +264,27 @@ def _convert_with_allowed_units(
             return quantity * au.get("gram_weight", 1.0)
 
     # 2. Translate unit (e.g., "quả lớn" → "large") and re-match
-    translated = _normalize_unit(unit)
+    translated = (
+        _normalize_authoritative_unit(unit) if strict else _normalize_unit(unit)
+    )
     if translated != unit_lower:
         for au in allowed_units:
             if au.get("unit", "").lower() == translated:
-                logger.info(
-                    f"Unit '{unit}' translated to '{translated}', matched allowed_unit"
-                )
+                logger.info("Unit alias matched an allowed unit")
                 return quantity * au.get("gram_weight", 1.0)
 
-    # 3. Keyword match: check if translated unit appears in description
-    #    e.g., translated="large" matches description="1 large egg"
+    if strict:
+        raise AuthoritativeUnitMismatchError(
+            "unit is not present in the authoritative source snapshot"
+        )
+
+    # 3. Legacy keyword match: check if translated unit appears in description.
+    # Authoritative writes never use free-form description tokens as unit identity.
     for au in allowed_units:
         desc = au.get("description", "").lower()
         if translated in desc.split():
             logger.info("Unit keyword matched an allowed-unit description")
             return quantity * au.get("gram_weight", 1.0)
-
-    if strict:
-        raise ValueError("unit is not present in the authoritative source snapshot")
 
     # 4. Global UNIT_TO_GRAMS mapping for legacy, non-authoritative writes.
     grams = UNIT_TO_GRAMS.get(translated)
@@ -286,6 +304,40 @@ def _convert_with_allowed_units(
     # Last resort: treat as grams (only if no allowed_units have useful servings)
     logger.warning(f"Unit '{unit}' unresolvable — treating quantity as grams")
     return quantity
+
+
+def canonicalize_authoritative_quantity(
+    quantity: float,
+    unit: str,
+    allowed_units: list[dict[str, Any]],
+    food_name: str = "",
+) -> tuple[float, str, bool]:
+    """Return an authoritative unit unchanged or a bounded gram fallback."""
+    try:
+        _convert_with_allowed_units(
+            quantity,
+            unit,
+            allowed_units,
+            food_name,
+            strict=True,
+        )
+        return quantity, unit, False
+    except AuthoritativeUnitMismatchError:
+        normalized = _normalize_authoritative_unit(unit)
+        if normalized == "g":
+            quantity_g = quantity
+        elif normalized in ("ml", "l", "liter", "litre"):
+            base_ml = quantity if normalized == "ml" else quantity * 1000
+            density = get_density(food_name) if food_name else DEFAULT_DENSITY
+            quantity_g = base_ml * density
+        else:
+            grams_per_unit = UNIT_TO_GRAMS.get(normalized)
+            if grams_per_unit is None:
+                logger.warning("Unknown authoritative unit used quantity as grams")
+                quantity_g = quantity
+            else:
+                quantity_g = quantity * grams_per_unit
+        return quantity_g, "g", True
 
 
 def clamp_nutrition_values(item: dict) -> dict:

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -29,6 +29,16 @@ def test_v2_reference_item_requires_one_matching_source_identity():
     assert payload.items[0].origin == "local"
 
 
+def test_v2_create_accepts_arbitrary_unit_for_backend_normalization():
+    payload = CreateManualMealFromFoodsRequest(
+        dish_name="Rice",
+        nutrition_contract_version=2,
+        items=[_v2_create_item(quantity=100, unit="my family bowl")],
+    )
+
+    assert payload.items[0].unit == "my family bowl"
+
+
 def test_v2_custom_item_is_source_less_and_keeps_custom_nutrition():
     payload = CreateManualMealFromFoodsRequest(
         dish_name="Homemade rice",

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -51,3 +51,76 @@ async def test_v2_source_replacement_is_resolved_before_edit_strategy():
     assert prepared[0].name == "Canonical rice"
     assert prepared[0].custom_nutrition.protein_per_100g == pytest.approx(2.7)
     assert prepared[0].source_snapshot["basis"] == "100g"
+
+
+@pytest.mark.asyncio
+async def test_v2_source_replacement_canonicalizes_arbitrary_unit_before_strategy():
+    current = FoodItem(
+        id="item-1",
+        name="Old rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=1, carbs=1, fat=1),
+    )
+    change = FoodItemChange(
+        action="update",
+        id="item-1",
+        origin="local",
+        food_reference_id=42,
+        quantity=100,
+        unit="g private-text",
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=_References())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+
+    assert prepared[0].quantity == pytest.approx(100)
+    assert prepared[0].unit == "g"
+    assert updated[0].quantity == pytest.approx(100)
+    assert updated[0].unit == "g"
+    assert updated[0].macros.protein == pytest.approx(2.7)
+
+
+@pytest.mark.asyncio
+async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy():
+    current = FoodItem(
+        id="item-1",
+        name="Canonical rice",
+        quantity=1,
+        unit="cup",
+        macros=Macros(protein=4.266, carbs=44.24, fat=0.474),
+        nutrition_contract_version="2",
+        source_snapshot={
+            "basis": "100g",
+            "protein_per_100g": 2.7,
+            "carbs_per_100g": 28.0,
+            "fat_per_100g": 0.3,
+            "fiber_per_100g": 0.4,
+            "sugar_per_100g": 0.1,
+            "allowed_units": [
+                {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+                {"unit": "cup", "gram_weight": 158.0, "description": "cup"},
+            ],
+        },
+    )
+    change = FoodItemChange(
+        action="update",
+        id="item-1",
+        quantity=100,
+        unit="cup private-text",
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=_References())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+
+    assert prepared[0].quantity == pytest.approx(100)
+    assert prepared[0].unit == "g"
+    assert updated[0].quantity == pytest.approx(100)
+    assert updated[0].unit == "g"
+    assert updated[0].macros.protein == pytest.approx(2.7)

--- a/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
+++ b/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
@@ -10,6 +10,9 @@ from src.app.commands.meal.create_manual_meal_command import (
 from src.app.services.manual_meal_nutrition_resolver import (
     ManualMealNutritionResolver,
 )
+from src.domain.services.nutrition_calculation_service import (
+    NutritionCalculationService,
+)
 from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
 
 
@@ -67,21 +70,45 @@ async def test_local_reference_ignores_client_nutrition_and_units():
 
 
 @pytest.mark.asyncio
-async def test_local_reference_rejects_unit_not_in_source_snapshot():
-    with pytest.raises(ValueError, match="authoritative source snapshot"):
-        await ManualMealNutritionResolver().resolve_items(
-            [
-                ManualMealItem(
-                    name="Rice",
-                    quantity=1,
-                    unit="bowl",
-                    origin="local",
-                    food_reference_id=42,
-                )
-            ],
-            _References(),
-            contract_version=2,
-        )
+async def test_local_reference_canonicalizes_unknown_unit_to_grams():
+    resolved = await ManualMealNutritionResolver().resolve_items(
+        [
+            ManualMealItem(
+                name="Rice",
+                quantity=100,
+                unit="bowl",
+                origin="local",
+                food_reference_id=42,
+            )
+        ],
+        _References(),
+        contract_version=2,
+    )
+
+    assert resolved[0].quantity == pytest.approx(100.0)
+    assert resolved[0].unit == "g"
+    nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
+    assert nutrition.macros.protein == pytest.approx(2.7)
+
+
+@pytest.mark.asyncio
+async def test_local_reference_canonicalizes_known_global_unit_to_grams():
+    resolved = await ManualMealNutritionResolver().resolve_items(
+        [
+            ManualMealItem(
+                name="Rice",
+                quantity=2,
+                unit="oz",
+                origin="local",
+                food_reference_id=42,
+            )
+        ],
+        _References(),
+        contract_version=2,
+    )
+
+    assert resolved[0].quantity == pytest.approx(56.7)
+    assert resolved[0].unit == "g"
 
 
 @pytest.mark.asyncio
@@ -181,3 +208,56 @@ async def test_provider_resolution_uses_shared_budget_and_deadline():
 
     assert resolved[0].source_snapshot["source_food_id"] == "provider-1"
     provider.get_food_details.assert_awaited_once_with("provider-1")
+
+
+@pytest.mark.asyncio
+async def test_provider_unit_prefix_cannot_multiply_arbitrary_suffix(caplog):
+    raw_unit = "medium private-text"
+    provider = SimpleNamespace(
+        get_food_details=AsyncMock(
+            return_value={
+                "food_id": "provider-1",
+                "food_name": "Potato",
+                "protein_100g": 2.0,
+                "carbs_100g": 17.0,
+                "fat_100g": 0.1,
+                "calories_100g": 77.0,
+                "allowed_units": [
+                    {
+                        "unit": "medium",
+                        "gram_weight": 173.0,
+                        "description": "1 medium potato",
+                    }
+                ],
+            }
+        )
+    )
+
+    class _Budget:
+        async def acquire(self, namespace, limit):
+            return True
+
+    resolved = await ManualMealNutritionResolver(
+        provider=provider,
+        provider_budget=_Budget(),
+        provider_rpm=10,
+    ).resolve_items(
+        [
+            ManualMealItem(
+                name="Potato",
+                quantity=100,
+                unit=raw_unit,
+                origin="provider",
+                source_namespace="fatsecret",
+                source_food_id="provider-1",
+            )
+        ],
+        _References(),
+        contract_version=2,
+    )
+
+    assert resolved[0].quantity == pytest.approx(100)
+    assert resolved[0].unit == "g"
+    nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
+    assert nutrition.calories == pytest.approx(76.9)
+    assert raw_unit not in caplog.text

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -17,6 +17,7 @@ from src.domain.services.meal_service import MealService
 from src.domain.services.nutrition_calculation_service import (
     NutritionCalculationService,
     clamp_nutrition_values,
+    convert_quantity_to_grams,
     normalize_unit_for_manual_save,
     scale_per_100g_nutrition,
 )
@@ -125,6 +126,45 @@ def test_authoritative_snapshot_rejects_unknown_serving_unit():
         )
 
 
+def test_authoritative_snapshot_does_not_match_free_text_description_tokens():
+    with pytest.raises(ValueError, match="authoritative source snapshot"):
+        scale_per_100g_nutrition(
+            {"calories": 77.0},
+            quantity=100,
+            unit="potato",
+            allowed_units=[
+                {
+                    "unit": "medium",
+                    "gram_weight": 173.0,
+                    "description": "1 medium potato",
+                }
+            ],
+            food_name="Potato",
+            strict_allowed_units=True,
+        )
+
+
+def test_authoritative_snapshot_does_not_strip_arbitrary_unit_suffixes(caplog):
+    raw_unit = "medium private-text"
+    with pytest.raises(ValueError, match="authoritative source snapshot"):
+        scale_per_100g_nutrition(
+            {"calories": 77.0},
+            quantity=100,
+            unit=raw_unit,
+            allowed_units=[
+                {
+                    "unit": "medium",
+                    "gram_weight": 173.0,
+                    "description": "1 medium potato",
+                }
+            ],
+            food_name="Potato",
+            strict_allowed_units=True,
+        )
+
+    assert raw_unit not in caplog.text
+
+
 def test_meal_service_add_custom_nutrition_uses_unit_grams():
     meal = _new_processing_meal()
 
@@ -204,6 +244,12 @@ def test_allowed_unit_logs_do_not_expose_unit_or_description(caplog):
     assert "Unknown unit used the default allowed serving" in caplog.text
     assert fallback_unit not in caplog.text
     assert fallback_description not in caplog.text
+
+    caplog.clear()
+    raw_unit = "private family serving"
+    assert convert_quantity_to_grams(100, raw_unit, "Rice") == 100
+    assert "Unknown unit used quantity as grams" in caplog.text
+    assert raw_unit not in caplog.text
 
 
 def test_clamp_nutrition_uses_manual_save_unit_for_ai_free_text():

--- a/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
@@ -22,7 +22,6 @@ from src.app.handlers.command_handlers.create_manual_meal_command_handler import
 )
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 
-
 # ---------------------------------------------------------------------------
 # Minimal fakes (no mocking framework dependency for simple objects)
 # ---------------------------------------------------------------------------
@@ -130,8 +129,12 @@ async def test_handler_timing_logs_show_cache_delay(caplog):
         "Cache invalidation may not be awaited."
     )
 
-    timing_logs = [r.message for r in caplog.records if "manual_save handler timing" in r.message]
-    assert timing_logs, "No 'manual_save handler timing' log found — instrumentation missing."
+    timing_logs = [
+        r.message for r in caplog.records if "manual_save handler timing" in r.message
+    ]
+    assert timing_logs, (
+        "No 'manual_save handler timing' log found — instrumentation missing."
+    )
 
     # Result is the saved meal
     assert result is fake_meal
@@ -161,8 +164,12 @@ async def test_handler_timing_logs_fast_cache(caplog):
     with caplog.at_level(logging.INFO):
         result = await handler.handle(cmd)
 
-    timing_logs = [r.message for r in caplog.records if "manual_save handler timing" in r.message]
-    assert timing_logs, "No 'manual_save handler timing' log found — instrumentation missing."
+    timing_logs = [
+        r.message for r in caplog.records if "manual_save handler timing" in r.message
+    ]
+    assert timing_logs, (
+        "No 'manual_save handler timing' log found — instrumentation missing."
+    )
 
     assert result is fake_meal
 
@@ -181,10 +188,16 @@ async def test_cache_invalidation_service_emits_timing_log(caplog):
     svc = CacheInvalidationService(cache=fast_cache)
 
     with caplog.at_level(logging.INFO):
-        await svc.after_meal_write("550e8400-e29b-41d4-a716-446655440003", date(2026, 6, 10))
+        await svc.after_meal_write(
+            "550e8400-e29b-41d4-a716-446655440003", date(2026, 6, 10)
+        )
 
-    timing_logs = [r.message for r in caplog.records if "cache_invalidation timing" in r.message]
-    assert timing_logs, "No 'cache_invalidation timing' log found in CacheInvalidationService."
+    timing_logs = [
+        r.message for r in caplog.records if "cache_invalidation timing" in r.message
+    ]
+    assert timing_logs, (
+        "No 'cache_invalidation timing' log found in CacheInvalidationService."
+    )
     assert "critical_ms" in timing_logs[0]
     assert "secondary_ms" in timing_logs[0]
     assert "total_ms" in timing_logs[0]

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -16,7 +16,10 @@ from src.domain.exceptions.ai_exceptions import (
 )
 from src.domain.model.ai.nutrition_contracts import MealTextNutritionResponse
 from src.domain.model.nutrition.macros import Macros
-from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
+from src.domain.services.nutrition_calculation_service import (
+    _convert_with_allowed_units,
+    convert_quantity_to_grams,
+)
 
 
 class _FakeMealGenerationService:
@@ -161,6 +164,36 @@ class _StagedFatSecretService:
             "calories_100g": 77.0,
             "metric_serving_amount": 100.0,
             "allowed_units": [{"unit": "g", "gram_weight": 100.0}],
+        }
+
+
+class _LocalizedServingFatSecretService:
+    async def search_food_candidates(self, *args, **kwargs):
+        return [
+            {
+                "food_id": "potato-medium",
+                "food_name": "Potato, raw",
+                "food_type": "Generic",
+            }
+        ]
+
+    async def get_food_details(self, food_id, **kwargs):
+        return {
+            "food_id": food_id,
+            "food_name": "Potato, raw",
+            "protein_100g": 2.0,
+            "carbs_100g": 17.0,
+            "fat_100g": 0.1,
+            "calories_100g": 77.0,
+            "metric_serving_amount": 100.0,
+            "allowed_units": [
+                {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
+                {
+                    "unit": "medium",
+                    "gram_weight": 173.0,
+                    "description": "1 medium potato",
+                },
+            ],
         }
 
 
@@ -527,6 +560,87 @@ async def test_parse_text_uses_one_staged_detail_for_wrong_first_candidate():
     assert len(provider.detail_calls) == 1
     assert provider.detail_calls[0][0] == "generic-potato"
     assert response.items[0].data_source == "fatsecret"
+
+
+@pytest.mark.asyncio
+async def test_provider_parse_returns_authoritative_unit_instead_of_localized_alias():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Khoai tay",
+                        "lookup_name": "potato",
+                        "quantity": 1,
+                        "quantity_g": 173,
+                        "unit": "cu vua",
+                        "english_unit": "medium",
+                        "macros": {"protein_g": 2, "carbs_g": 17, "fat_g": 0.1},
+                    }
+                ]
+            }
+        ]
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_LocalizedServingFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="1 cu khoai tay vua", user_id="user-1", language="vi")
+    )
+    item = response.items[0]
+
+    assert item.unit == "medium"
+    assert item.quantity == 1
+    assert item.protein == pytest.approx(3.46)
+    assert _convert_with_allowed_units(
+        item.quantity,
+        item.unit,
+        item.allowed_units,
+        item.name,
+        strict=True,
+    ) == pytest.approx(173)
+
+
+@pytest.mark.asyncio
+async def test_provider_parse_falls_back_to_grams_for_unsupported_serving_unit():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Potato bowl",
+                        "lookup_name": "potato",
+                        "quantity": 1,
+                        "quantity_g": 180,
+                        "unit": "to",
+                        "english_unit": "bowl",
+                        "macros": {"protein_g": 2, "carbs_g": 17, "fat_g": 0.1},
+                    }
+                ]
+            }
+        ]
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_StagedFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="1 to khoai tay", user_id="user-1", language="vi")
+    )
+    item = response.items[0]
+
+    assert item.unit == "g"
+    assert item.quantity == pytest.approx(180)
+    assert _convert_with_allowed_units(
+        item.quantity,
+        item.unit,
+        item.allowed_units,
+        item.name,
+        strict=True,
+    ) == pytest.approx(180)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- accept arbitrary manual-meal units by canonicalizing unsupported or free-text units to grams instead of rejecting the write
- preserve exact authoritative serving-unit and alias conversions from the source snapshot
- prevent strict writes from matching arbitrary description words or stripping arbitrary suffixes, avoiding inflated macro and calorie scaling
- keep create, edit, and parse-text behavior aligned while the backend remains the only calorie authority

## Test plan

- [x] 56 focused create/edit/parse/nutrition tests passed on latest `delivery`
- [x] targeted Ruff checks passed
- [x] targeted Python compile checks passed
- [x] `git diff --check` passed
- [x] staged secret scan passed
- [x] verified PR #512 lease acquisition and deferred FatSecret coroutine guards remain intact
- [ ] deploy to SIT and verify parse-text -> manual create plus edit using an unsupported unit

Additional pre-PR evidence from the implementation checkout: 146 focused tests passed; CI-aligned unit suite passed 2,408 tests with one unrelated dirty cron test deselected and 78.88% coverage; offline nutrition evaluation passed 10/10 cases with zero catastrophic outliers.

## Contract

Mobile sends the quantity and unit selected or entered by the user. The backend resolves authoritative serving conversions or applies the bounded gram fallback, derives calories from authoritative macros, and returns the canonical persisted result. Mobile must not recalculate calories.
