### PR TITLE
fix(api): classify nutrition write failures

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -152,6 +152,11 @@ handler/schema when implementing; the bullets below are the durable WHY.
   clearing restores source/macro-derived nutrition without rewriting source rows.
 - `custom_nutrition` on non-USDA ingredients is per-100g macros; calories stay
   macro-derived (fiber-aware), which is distinct from absolute overrides.
+- Manual meal v2 save failures now split between validation and provider trust
+  boundaries: `NUTRITION_UNIT_INVALID` returns 422 when the requested serving
+  unit is not allowed by the authoritative snapshot, `NUTRITION_PROVIDER_UNAVAILABLE`
+  returns 503 for temporary provider capacity loss, and other integrity rejects
+  return 422 `NUTRITION_INTEGRITY_REJECTED`.
 
 ### Meal recommendations (catalog)
 

--- a/src/api/exception_handlers.py
+++ b/src/api/exception_handlers.py
@@ -11,11 +11,19 @@ prevents duplicate Sentry issues per failure event.
 
 import logging
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from src.api.exceptions import MealTrackException, create_http_exception
+from src.api.exceptions import (
+    MealTrackException,
+    create_http_exception,
+    handle_exception,
+)
 from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.services.nutrition_calculation_service import (
+    AuthoritativeUnitMismatchError,
+)
+from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +64,19 @@ async def _ai_unavailable_handler(
                 "details": {"attempted_models": exc.attempted_models},
             }
         },
+    )
+
+
+async def _nutrition_exception_handler(
+    request: Request,
+    exc: NutritionIntegrityError | AuthoritativeUnitMismatchError,
+) -> JSONResponse:
+    """Convert nutrition trust-boundary failures at the global API boundary."""
+    http_exc = handle_exception(exc)
+    return JSONResponse(
+        status_code=http_exc.status_code,
+        content={"detail": http_exc.detail},
+        headers=http_exc.headers,
     )
 
 
@@ -109,6 +130,16 @@ def register_exception_handlers(app: FastAPI) -> None:
 
     # AIUnavailableError — degraded, WARNING only
     app.add_exception_handler(AIUnavailableError, _ai_unavailable_handler)  # type: ignore[arg-type]
+
+    # Nutrition trust-boundary failures are expected request/provider outcomes.
+    app.add_exception_handler(
+        NutritionIntegrityError,
+        _nutrition_exception_handler,  # type: ignore[arg-type]
+    )
+    app.add_exception_handler(
+        AuthoritativeUnitMismatchError,
+        _nutrition_exception_handler,  # type: ignore[arg-type]
+    )
 
     # Catch-all for truly unexpected exceptions — one ERROR (ServerErrorMiddleware)
     app.add_exception_handler(Exception, _unexpected_exception_handler)

--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -18,8 +18,20 @@ from src.domain.exceptions.ai_exceptions import (
     AIOutputValidationError,
     AIUnavailableError,
 )
+from src.domain.services.nutrition_calculation_service import (
+    AuthoritativeUnitMismatchError,
+)
+from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
 
 logger = logging.getLogger(__name__)
+
+_NUTRITION_PROVIDER_UNAVAILABLE_REASONS = frozenset(
+    {
+        "provider_budget_unavailable",
+        "provider_resolution_unavailable",
+        "provider_unavailable",
+    }
+)
 
 
 class MealTrackException(Exception):
@@ -156,6 +168,39 @@ def handle_exception(exc: Exception) -> HTTPException:
                     "purpose": exc.purpose,
                     "attempt_count": exc.attempt_count,
                 },
+            },
+        )
+
+    if isinstance(exc, AuthoritativeUnitMismatchError):
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error_code": "NUTRITION_UNIT_INVALID",
+                "message": "The selected serving unit is not available for this food.",
+                "details": {},
+            },
+        )
+
+    if isinstance(exc, NutritionIntegrityError):
+        result = exc.result
+        if result.reason_code in _NUTRITION_PROVIDER_UNAVAILABLE_REASONS:
+            return HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "error_code": "NUTRITION_PROVIDER_UNAVAILABLE",
+                    "message": (
+                        "Nutrition provider capacity is temporarily unavailable. "
+                        "Please try again later."
+                    ),
+                    "details": {},
+                },
+            )
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error_code": "NUTRITION_INTEGRITY_REJECTED",
+                "message": "The nutrition data could not be verified.",
+                "details": {},
             },
         )
 

--- a/tests/unit/api/test_exceptions_unexpected.py
+++ b/tests/unit/api/test_exceptions_unexpected.py
@@ -7,6 +7,13 @@ from src.domain.exceptions.ai_exceptions import (
     AIOutputValidationError,
     AIUnavailableError,
 )
+from src.domain.services.nutrition_calculation_service import (
+    AuthoritativeUnitMismatchError,
+)
+from src.domain.services.nutrition_integrity_policy import (
+    NutritionIntegrityError,
+    NutritionIntegrityResult,
+)
 
 
 def test_handle_exception_unexpected_returns_500():
@@ -58,3 +65,60 @@ def test_handle_exception_ai_output_validation_returns_422_without_field_details
         "attempt_count": 2,
     }
     assert "quantity_g" not in str(exc.detail)
+
+
+def test_handle_exception_authoritative_unit_mismatch_returns_422():
+    exc = handle_exception(
+        AuthoritativeUnitMismatchError(
+            "unit is not present in the authoritative source snapshot"
+        )
+    )
+
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc.detail == {
+        "error_code": "NUTRITION_UNIT_INVALID",
+        "message": "The selected serving unit is not available for this food.",
+        "details": {},
+    }
+
+
+def test_handle_exception_provider_failure_returns_503_without_internal_details():
+    exc = handle_exception(
+        NutritionIntegrityError(
+            NutritionIntegrityResult(
+                accepted=False,
+                reason_code="provider_unavailable",
+            )
+        )
+    )
+
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert exc.detail == {
+        "error_code": "NUTRITION_PROVIDER_UNAVAILABLE",
+        "message": (
+            "Nutrition provider capacity is temporarily unavailable. "
+            "Please try again later."
+        ),
+        "details": {},
+    }
+
+
+def test_handle_exception_integrity_rejection_hides_internal_reason_code():
+    exc = handle_exception(
+        NutritionIntegrityError(
+            NutritionIntegrityResult(
+                accepted=False,
+                reason_code="provider_identity_mismatch",
+            )
+        )
+    )
+
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc.detail == {
+        "error_code": "NUTRITION_INTEGRITY_REJECTED",
+        "message": "The nutrition data could not be verified.",
+        "details": {},
+    }

--- a/tests/unit/api/test_single_owner_exception_logging.py
+++ b/tests/unit/api/test_single_owner_exception_logging.py
@@ -19,14 +19,16 @@ from fastapi.testclient import TestClient
 from src.api.exception_handlers import register_exception_handlers
 from src.api.exceptions import (
     BusinessLogicException,
-    MealTrackException,
     ResourceNotFoundException,
     ValidationException,
     handle_exception,
 )
 from src.api.middleware.request_logger import RequestLoggerMiddleware
 from src.domain.exceptions.ai_exceptions import AIUnavailableError
-
+from src.domain.services.nutrition_integrity_policy import (
+    NutritionIntegrityError,
+    NutritionIntegrityResult,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -206,6 +208,28 @@ class TestExpectedExceptionOwnership:
             + "; ".join(r.message for r in errors)
         )
 
+    def test_nutrition_provider_failure_is_global_503_without_error(self, caplog):
+        app = _make_app()
+
+        @app.get("/nutrition-provider-failure")
+        def nutrition_provider_failure():
+            raise NutritionIntegrityError(
+                NutritionIntegrityResult(
+                    accepted=False,
+                    reason_code="provider_unavailable",
+                )
+            )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        with caplog.at_level(logging.ERROR):
+            response = client.get("/nutrition-provider-failure")
+
+        assert response.status_code == 503
+        assert response.json()["detail"]["error_code"] == (
+            "NUTRITION_PROVIDER_UNAVAILABLE"
+        )
+        assert _error_records(caplog) == []
+
 
 # ---------------------------------------------------------------------------
 # Middleware outcome log — must never duplicate root-cause ERROR
@@ -266,4 +290,7 @@ class TestBackgroundTaskLogging:
         assert len(errors) == 1, (
             f"Expected exactly 1 ERROR from background task failure, got {len(errors)}"
         )
-        assert "background failure" in errors[0].message or "test-task" in errors[0].message
+        assert (
+            "background failure" in errors[0].message
+            or "test-task" in errors[0].message
+        )


### PR DESCRIPTION
## Summary

- Return stable nutrition error codes for manual-meal v2 failures.
- Classify temporary provider-capacity failures as HTTP 503 and invalid/integrity nutrition data as HTTP 422.
- Register nutrition trust-boundary exceptions at the global FastAPI boundary without leaking internal reason codes or emitting duplicate error logs.
- Document the public error contract.

## Validation

- Focused manual-meal/API regression tests: 57 passed.
- Full backend unit suite: 2,412 passed.
- Ruff and `git diff --check` passed for the changed files.

## Notes

- The authoritative arbitrary-unit normalization fix is already present on `delivery` in PR #514; this PR adds the defensive API classification and boundary protection for remaining nutrition failures.
- This PR does not deploy the backend; runtime image/deployment verification remains a separate gate.
