### PR TITLE
feat: add authenticated meal catalog browsing

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -170,6 +170,30 @@ handler/schema when implementing; the bullets below are the durable WHY.
 - `Accept-Language` selects display language; translation failure returns
   successful canonical English rather than failing the request.
 
+### Public meal-catalog browser
+
+- `GET /v1/meal-catalog` and `GET /v1/meal-catalog/{catalog_id}` are
+  authenticated read-only catalog routes. The list accepts
+  `feed=popular|for_you` (default `popular`), `limit` 1–50, non-negative
+  `offset`, trimmed `q` up to 160 characters, normalized exact `cuisine`, and
+  the four catalog meal types.
+- List items use the recommendation nutrition contract, derive calories on the
+  backend from authoritative catalog macros, and intentionally return
+  `ingredients: []` plus `meal_types` and `ingredient_count`; detail returns the
+  full ingredient identity, quantity, and unit list.
+- `popular` is ordered only by the curated nullable `meal_catalog.popularity_rank`
+  with stable name/ID tie-breakers. The route returns 503 until the curated
+  source has been seeded rather than presenting UUID or timestamp order as
+  popularity.
+- `for_you` reuses the shared immutable catalog snapshot, adjusted daily target,
+  canonical linked 90-day ingredient affinity, and deterministic scoring. A
+  cold start falls back to the curated global order and sets `fallback=true`
+  with `ranking_source=curated`; a personalized warm path reports
+  `ranking_source=personalized`.
+- `allergy_evaluated` remains false until canonical allergen evaluation exists.
+- Browse requests do not create recommendation plans, candidate rows, or meal
+  logs; Home's three-day recommendation endpoints remain a separate flow.
+
 ### Food search and barcode
 
 - Search order: optional Redis cache → local `food_reference` → provider fill.

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -39,6 +39,7 @@ scripts, dependency manifests. Active execution plans live under repo-root
 |------|-------|
 | Live HTTP surface | OpenAPI: `/docs`, `/redoc`, `/openapi.json`; registration in `src/api/main.py` |
 | Offline OpenAPI dump + conventions | `api-endpoints.md` (Live OpenAPI contract; not a route table) |
+| Public catalog browser route | `src/api/routes/v1/meal_catalog.py` (`GET /v1/meal-catalog`, `GET /v1/meal-catalog/{catalog_id}`) |
 | Layer layout | `src/api/`, `src/app/`, `src/domain/`, `src/infra/` plus root/bootstrap/cron |
 | Tests | `pytest tests/unit --cov=src --cov-fail-under=65` (default CI path) |
 | Migrations | `migrations/versions/` via Alembic |
@@ -75,6 +76,10 @@ Do not hand-maintain file, LOC, or endpoint counts in this document.
 - AI: OpenAI default; optional Cloudflare Workers AI for configured text/vision.
 - Event bus: singleton PyMediator from `src/api/dependencies/event_bus.py`.
 - Migrations: `migrations/versions/` via Alembic / `migrations/run.py`.
+- Meal catalog browse: authenticated list/detail live in
+  `src/api/routes/v1/meal_catalog.py`; the browse contract is documented in
+  `api-endpoints.md` and the import manifest contract in
+  `meal-catalog-import-schema.md`.
 
 Non-derivable calorie and weekly-budget rules: `AGENTS.md` / `CLAUDE.md`
 MUST-Follow. Meal scan vs hydration and other system rules:

--- a/docs/journals/260816-2325-meal-catalog-browser-backend.md
+++ b/docs/journals/260816-2325-meal-catalog-browser-backend.md
@@ -1,0 +1,38 @@
+---
+title: "Meal catalog browser backend"
+date: "2026-08-16"
+status: complete
+---
+
+# Meal Catalog Browser Backend
+
+## Context
+
+Implemented the backend handoff for the authenticated Recipes catalog browser
+from `plans/260816-2251-meal-catalog-browser-backend-handoff/plan.md`.
+
+## What happened
+
+- Added authenticated list/detail routes using the shared immutable catalog
+  snapshot and the existing recommendation nutrition serializer.
+- Added deterministic curated `popularity_rank` ordering with a fail-closed
+  503 until ranks are seeded.
+- Added personalized ranking from the read-only weekly-budget target,
+  owner-scoped 90-day ingredient affinity, calorie allocation, and bounded
+  diversity; cold starts report curated fallback metadata.
+- Fixed snapshot last-good recovery for revision lookup failures and added
+  rank-only exact-key reimport updates.
+
+## Decisions
+
+- Browse requests do not create or update weekly budgets, recommendation plans,
+  candidate rows, or meal logs.
+- `allergy_evaluated` remains false until canonical allergen evaluation exists.
+- Home’s three-day recommendation flow remains separate.
+
+## Validation and next steps
+
+The venv unit suite passed 2,436 tests with 79.06% coverage; focused catalog,
+snapshot, importer, target, and migration tests passed 56 cases. Staging
+deployment/authenticated requests, warm/cold p95, image coverage, and curated
+rank population remain release gates.

--- a/docs/meal-catalog-import-schema.md
+++ b/docs/meal-catalog-import-schema.md
@@ -50,6 +50,7 @@ and derives nutrition from `food_reference`.
 | `name` | Yes | Display name shown in the app. |
 | `description` | No | Short display-only text. |
 | `image_url` | No | Public image URL. |
+| `popularity_rank` | No | Optional curated order signal for the public `popular` browse feed. Non-negative PostgreSQL `INTEGER` when present; null means the meal is unranked. |
 | `meal_types` | Yes | Any of `breakfast`, `lunch`, `dinner`, `snack`. |
 | `ingredients[].food_reference_id` | No | Prefer exact ID. If `null`, importer matches by normalized `name`. |
 | `ingredients[].name` | Yes | Used for display and lookup when ID is `null`. |
@@ -196,6 +197,8 @@ Production import requires exactly 180 reviewed meals:
 - Zero schema validation errors.
 - Zero unresolved ingredient `issues`.
 - Zero unreviewed near-duplicate `review_required` items.
+- If the public `popular` browse feed is expected to ship, seed explicit
+  `popularity_rank` values for the reviewed catalog rows before release.
 
 For every near duplicate, record one explicit disposition outside the importer:
 `approve_distinct` when the meals are intentionally separate catalog entries, or

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -27,6 +27,7 @@ recommendations, and reliable AI-assisted meal analysis.
 | AI meal analysis | Multiple analysis strategies; food-label scan is a separate validated path. Backend owns calorie presentation. |
 | Meal scan vs hydration | Meal image/scan endpoints treat edible/drinkable intake as **meals**. They must **not** create `hydration_entries`. Zero-cal drinks use `/v1/hydration/*` explicitly. |
 | Catalog recommendations | Deterministic ranking of curated catalog meals; **no LLM at recommendation time**. Separate from AI meal-suggestions. |
+| Public catalog browser | `popular` is curated by explicit `popularity_rank` and fails closed with 503 until seeded; `for_you` is a browse surface that can fall back to curated global order and surface fallback metadata. |
 | Meal suggestions | Session-based, additive AI discovery; not a fallback for catalog recommendations. |
 | Local-first food search | Cache (optional) → local `food_reference` → provider fill. Calories from macros on the backend. |
 | Weekly budget | Redistribution from prior consumption is the source of truth for adjusted daily targets. Movement credits balance without inflating baseline TDEE. See AGENTS MUST-Follow for `remaining_days`. |

--- a/docs/runbooks/meal-catalog-incident.md
+++ b/docs/runbooks/meal-catalog-incident.md
@@ -23,6 +23,9 @@ recommendation incidents.
    - `meal_recommendation.requests`
 4. Confirm whether the issue affects create, replay/read, slot detail, swap,
    log, skip, food search, or import only.
+5. For browse incidents, confirm whether `popular` is missing curated
+   `popularity_rank` values or `for_you` is legitimately reporting
+   `fallback=true` / `ranking_source=curated` on a cold start.
 
 ## Decision Tree
 
@@ -36,11 +39,15 @@ recommendation incidents.
    criteria, expected row count, rollback SQL, and reviewer sign-off.
 5. If migration state blocks startup, follow
    [Render CD Flow](../archive/guides/render-cd.md#emergency-recovery).
+6. If browse requests return 503, confirm whether the curated popularity source
+   has been seeded before treating it as an outage.
 
 ## SQL Safety
 
 Use read-only count queries first. For catalog deactivation, prefer a transaction
-with explicit `RETURNING` evidence:
+with explicit `RETURNING` evidence. For browse outages, inspect the current
+`popularity_rank` coverage first; a 503 from `popular` can be the expected
+fail-closed behavior when the curated signal has not been seeded.
 
 ```sql
 begin;

--- a/docs/runbooks/meal-catalog-release.md
+++ b/docs/runbooks/meal-catalog-release.md
@@ -13,6 +13,9 @@ payloads, search text, or user identifiers into release notes.
 - Confirm `scripts/data/meal-recommendation-recipes.json` and
   `scripts/data/meal-recommendation-resolver-map.json` are available from the
   approved storage location.
+- Confirm the public browse contract is ready to serve as documented:
+  `popular` requires seeded `popularity_rank` values, and `for_you` can report
+  `fallback=true` with `ranking_source=curated` on cold start.
 
 ## Release Checks
 
@@ -75,10 +78,19 @@ eligible request success >=99.95%.
 6. Smoke requests after deploy:
 
 - `GET /health`
+- `GET /v1/meal-catalog?feed=popular&limit=5`
+- `GET /v1/meal-catalog?feed=for_you&limit=5`
+- `GET /v1/meal-catalog/{catalog_id}`
 - `GET /v1/foods/search?query=rice&limit=5&language=en`
 - `POST /v1/meal-recommendations/three-day` with `Idempotency-Key`
 - `GET /v1/meal-recommendations/{plan_id}`
 - `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}`
+
+Verify `feed`, `ranking_source`, and `fallback` on the browse response instead
+of inferring readiness from a 200 alone.
+
+Local tests, OpenAPI shape, and import dry-runs are not deployment proof; check
+the deployed revision separately before calling the browse surface released.
 
 ## Rollback Order
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -81,6 +81,25 @@ Phase 0 persistence is four-table only: `meal_catalog`,
 separate additive system and is not a fallback or replacement for these
 catalog-backed recommendations.
 
+### Public Catalog Browser
+
+The authenticated browse route (`GET /v1/meal-catalog` and
+`GET /v1/meal-catalog/{catalog_id}`) reads the same immutable catalog snapshot
+as deterministic recommendation generation. Browse requests do not create plan
+rows, candidate rows, or meal logs.
+
+`popular` is a curated view ordered by the nullable `meal_catalog.popularity_rank`
+with stable name/ID tie-breakers. The route fails closed with 503 until that
+curated signal has been seeded instead of fabricating popularity from UUID or
+timestamp order.
+
+`for_you` reuses the shared snapshot, current daily target, linked 90-day
+ingredient affinity, and deterministic scoring. When the user has no usable
+history or the target cannot be resolved, the route falls back to the curated
+global order and reports `fallback=true` with `ranking_source=curated`; a warm
+personalized result reports `ranking_source=personalized`. `allergy_evaluated`
+remains false until canonical allergen evaluation is implemented.
+
 ### Local-First Food Search
 Manual food search reads Redis cache when available, then searches verified
 `food_reference` rows locally before provider fill. Cache, provider, and

--- a/migrations/versions/20260816000005_add_catalog_popularity_rank.py
+++ b/migrations/versions/20260816000005_add_catalog_popularity_rank.py
@@ -1,0 +1,38 @@
+"""Add the explicit curated ordering signal for public catalog discovery."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260816000005"
+down_revision: str | None = "20260815000004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "meal_catalog",
+        sa.Column("popularity_rank", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_meal_catalog_popularity_rank_non_negative",
+        "meal_catalog",
+        "popularity_rank IS NULL OR popularity_rank >= 0",
+    )
+    op.create_index(
+        "idx_meal_catalog_active_popularity",
+        "meal_catalog",
+        ["is_active", "popularity_rank", "name", "id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_meal_catalog_active_popularity", table_name="meal_catalog")
+    op.drop_constraint(
+        "ck_meal_catalog_popularity_rank_non_negative",
+        "meal_catalog",
+        type_="check",
+    )
+    op.drop_column("meal_catalog", "popularity_rank")

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -12,6 +12,7 @@ from src.app.services.catalog_food_reference_review_service import (
     CatalogFoodReferenceReviewService,
 )
 from src.app.services.catalog_meal_seed_import_service import CatalogMealSeedImporter
+from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshotService
 from src.app.services.meal_recommendation_analytics_service import (
     MealRecommendationAnalyticsService,
 )
@@ -36,6 +37,7 @@ from src.infra.cache.metrics import CacheMonitor
 from src.infra.cache.redis_client import RedisClient
 from src.infra.config.settings import settings
 from src.infra.database.config_async import get_async_db
+from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.repositories.admin_meal_catalog_repository_async import (
     AsyncAdminMealCatalogRepository,
 )
@@ -64,6 +66,8 @@ _cache_monitor = CacheMonitor()
 # Singleton service instances (initialized once, reused across requests)
 _image_store: ImageStorePort | None = None
 _vision_service: VisionAIServicePort | None = None
+_catalog_meal_snapshot_service: CatalogMealSnapshotService | None = None
+_catalog_meal_browse_service = None
 
 
 async def initialize_cache_layer() -> None:
@@ -202,6 +206,33 @@ def get_catalog_meal_seed_importer(
         food_reference_repository,
         candidate_enricher=enrich_missing_with_fatsecret,
     )
+
+
+def get_catalog_meal_snapshot_service() -> CatalogMealSnapshotService:
+    """Return the process-local snapshot shared by catalog readers."""
+    global _catalog_meal_snapshot_service
+    if _catalog_meal_snapshot_service is None:
+        _catalog_meal_snapshot_service = CatalogMealSnapshotService()
+    return _catalog_meal_snapshot_service
+
+
+def get_catalog_meal_browse_service():
+    """Return the read-only public catalog browser service."""
+    global _catalog_meal_browse_service
+    if _catalog_meal_browse_service is None:
+        from src.app.services.catalog_meal_browse_service import (
+            CatalogMealBrowseService,
+        )
+        from src.app.services.meal_recommendation_history_projector import (
+            MealRecommendationHistoryProjector,
+        )
+
+        _catalog_meal_browse_service = CatalogMealBrowseService(
+            uow_factory=AsyncUnitOfWork,
+            snapshot_service=get_catalog_meal_snapshot_service(),
+            history_projector=MealRecommendationHistoryProjector(),
+        )
+    return _catalog_meal_browse_service
 
 
 def get_catalog_food_reference_review_service(

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -205,7 +205,6 @@ from src.app.queries.user.get_user_onboarding_status_query import (
     GetUserOnboardingStatusQuery,
 )
 from src.app.queries.weight import GetWeightEntriesQuery
-from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshotService
 from src.app.services.meal_recommendation_history_projector import (
     MealRecommendationHistoryProjector,
 )
@@ -410,7 +409,9 @@ def get_configured_event_bus() -> EventBus:
     nutrition_integrity_policy = NutritionIntegrityPolicy()
 
     event_bus = PyMediatorEventBus()
-    recommendation_snapshot = CatalogMealSnapshotService()
+    from src.api.base_dependencies import get_catalog_meal_snapshot_service
+
+    recommendation_snapshot = get_catalog_meal_snapshot_service()
     recommendation_history = MealRecommendationHistoryProjector()
     graph_settings = get_meal_analyze_graph_settings()
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -61,6 +61,7 @@ from src.api.routes.v1.health import root_router as root_health_router
 from src.api.routes.v1.health import router as health_router
 from src.api.routes.v1.hydration import router as hydration_router
 from src.api.routes.v1.ingredients import router as ingredients_router
+from src.api.routes.v1.meal_catalog import router as meal_catalog_router
 from src.api.routes.v1.meal_recommendations import router as meal_recommendations_router
 from src.api.routes.v1.meal_scan_by_url import router as meal_scan_by_url_router
 from src.api.routes.v1.meal_suggestions import router as meal_suggestions_router
@@ -329,6 +330,7 @@ app.include_router(feature_flags_router)
 app.include_router(capabilities_router)
 app.include_router(meal_suggestions_router)
 app.include_router(meal_recommendations_router)
+app.include_router(meal_catalog_router)
 app.include_router(user_profiles_router)
 app.include_router(users_router)
 app.include_router(foods_router)

--- a/src/api/mappers/catalog_meal_mapper.py
+++ b/src/api/mappers/catalog_meal_mapper.py
@@ -1,0 +1,53 @@
+"""Map immutable catalog meals to shared recommendation and browse DTOs."""
+
+from src.api.schemas.response.meal_catalog_responses import MealCatalogItemResponse
+from src.api.schemas.response.meal_recommendation_responses import (
+    MealRecommendationCatalogMealResponse,
+    MealRecommendationIngredientResponse,
+    MealRecommendationMacrosResponse,
+)
+from src.domain.model.meal_recommendation import CatalogMeal
+
+
+def catalog_meal_response(
+    catalog_meal: CatalogMeal,
+) -> MealRecommendationCatalogMealResponse:
+    return MealRecommendationCatalogMealResponse(
+        id=catalog_meal.id,
+        name=catalog_meal.name,
+        cuisine=catalog_meal.cuisine,
+        description=catalog_meal.description,
+        image_url=catalog_meal.image_url,
+        calories=catalog_meal.calories,
+        macros=MealRecommendationMacrosResponse(
+            protein_g=float(catalog_meal.protein_g),
+            carbs_g=float(catalog_meal.carbs_g),
+            fat_g=float(catalog_meal.fat_g),
+            fiber_g=float(catalog_meal.fiber_g),
+            sugar_g=float(catalog_meal.sugar_g),
+        ),
+        ingredients=catalog_meal_ingredients(catalog_meal),
+    )
+
+
+def catalog_meal_browse_response(catalog_meal: CatalogMeal) -> MealCatalogItemResponse:
+    response = catalog_meal_response(catalog_meal)
+    return MealCatalogItemResponse(
+        **response.model_dump(),
+        meal_types=list(catalog_meal.meal_types),
+        ingredient_count=len(catalog_meal.ingredients),
+    )
+
+
+def catalog_meal_ingredients(
+    catalog_meal: CatalogMeal,
+) -> list[MealRecommendationIngredientResponse]:
+    return [
+        MealRecommendationIngredientResponse(
+            food_reference_id=ingredient.food_reference_id,
+            display_name=ingredient.display_name,
+            quantity=float(ingredient.quantity),
+            unit=ingredient.unit,
+        )
+        for ingredient in catalog_meal.ingredients
+    ]

--- a/src/api/routes/v1/admin_meal_catalog.py
+++ b/src/api/routes/v1/admin_meal_catalog.py
@@ -111,6 +111,7 @@ def _item_response(item: Any) -> AdminMealCatalogItemResponse:
         cuisine=meal.cuisine,
         description=meal.description,
         image_url=meal.image_url,
+        popularity_rank=meal.popularity_rank,
         meal_types=list(meal.meal_types),
         calories=meal.calories,
         protein_g=float(meal.protein_g),

--- a/src/api/routes/v1/admin_meal_catalog_import.py
+++ b/src/api/routes/v1/admin_meal_catalog_import.py
@@ -190,6 +190,7 @@ def _response(validation, summary, *, applied: bool) -> AdminMealCatalogImportRe
         recipe_count=validation.recipe_count,
         coverage=validation.coverage,
         inserted=summary.inserted,
+        updated=summary.updated,
         skipped_existing=summary.skipped_existing,
         dry_run=summary.dry_run,
         applied=applied,

--- a/src/api/routes/v1/meal_catalog.py
+++ b/src/api/routes/v1/meal_catalog.py
@@ -164,7 +164,7 @@ async def _personalization_context(request: Request, *, user_id: str, event_bus)
     except ResourceNotFoundException:
         return None, None, None
     except ExternalServiceException as exc:
-        if exc.error_code == "target_unavailable":
+        if exc.error_code in {"target_unavailable", "target_service_unavailable"}:
             return None, None, None
         raise
     except Exception as exc:

--- a/src/api/routes/v1/meal_catalog.py
+++ b/src/api/routes/v1/meal_catalog.py
@@ -1,0 +1,179 @@
+"""Authenticated read-only catalog browser endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from src.api.base_dependencies import get_catalog_meal_browse_service
+from src.api.dependencies.auth import get_current_user_id
+from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.exceptions import ExternalServiceException, ResourceNotFoundException
+from src.api.mappers.catalog_meal_mapper import catalog_meal_browse_response
+from src.api.schemas.response.meal_catalog_responses import (
+    MealCatalogItemResponse,
+    MealCatalogListResponse,
+)
+from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
+from src.app.queries.user import GetUserTimezoneQuery
+from src.app.services.catalog_meal_browse_ranking import (
+    CatalogPopularityUnavailableError,
+)
+from src.app.services.catalog_meal_browse_service import (
+    CatalogFeed,
+    CatalogMealBrowseService,
+)
+from src.domain.exceptions.meal_recommendation_exceptions import (
+    MealRecommendationCatalogUnavailableError,
+)
+from src.domain.utils.timezone_utils import get_zone_info
+
+router = APIRouter(prefix="/v1/meal-catalog", tags=["Meal Catalog"])
+MealType = Literal["breakfast", "lunch", "dinner", "snack"]
+
+
+@router.get(
+    "",
+    response_model=MealCatalogListResponse,
+    responses={503: {"description": "Catalog is unavailable or not curated"}},
+)
+async def list_meal_catalog(
+    request: Request,
+    feed: CatalogFeed = Query(CatalogFeed.POPULAR),
+    limit: int = Query(20, ge=1, le=50),
+    offset: int = Query(0, ge=0),
+    q: str | None = Query(None, max_length=160),
+    cuisine: str | None = Query(None, max_length=80),
+    meal_type: MealType | None = Query(None),
+    user_id: str = Depends(get_current_user_id),
+    service: CatalogMealBrowseService = Depends(get_catalog_meal_browse_service),
+) -> MealCatalogListResponse:
+    daily_calories = None
+    start_date = None
+    timezone = None
+    if feed is CatalogFeed.FOR_YOU:
+        try:
+            event_bus = get_configured_event_bus()
+            timezone, start_date, daily_calories = await _personalization_context(
+                request,
+                user_id=user_id,
+                event_bus=event_bus,
+            )
+        except ExternalServiceException as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=exc.message,
+            ) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Catalog personalization context is unavailable",
+            ) from exc
+
+    try:
+        page = await service.list_meals(
+            user_id=user_id,
+            feed=feed,
+            limit=limit,
+            offset=offset,
+            query=_clean(q),
+            cuisine=_clean(cuisine),
+            meal_type=meal_type,
+            daily_calories=daily_calories,
+            start_date=start_date,
+            timezone=timezone,
+        )
+    except CatalogPopularityUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Catalog popular feed is not configured",
+        ) from exc
+    except MealRecommendationCatalogUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.public_detail,
+        ) from exc
+
+    return MealCatalogListResponse(
+        items=[
+            catalog_meal_browse_response(item).model_copy(update={"ingredients": []})
+            for item in page.items
+        ],
+        total=page.total,
+        limit=limit,
+        offset=offset,
+        feed=page.feed.value,
+        ranking_source=page.ranking_source,
+        fallback=page.fallback,
+        allergy_evaluated=page.allergy_evaluated,
+    )
+
+
+@router.get(
+    "/{catalog_id}",
+    response_model=MealCatalogItemResponse,
+    responses={404: {"description": "Catalog meal not found"}, 503: {"description": "Catalog is unavailable"}},
+)
+async def get_meal_catalog_detail(
+    catalog_id: str,
+    user_id: str = Depends(get_current_user_id),
+    service: CatalogMealBrowseService = Depends(get_catalog_meal_browse_service),
+) -> MealCatalogItemResponse:
+    del user_id
+    try:
+        meal = await service.get_meal(catalog_id)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Catalog meal not found",
+        ) from exc
+    except MealRecommendationCatalogUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=exc.public_detail,
+        ) from exc
+    return catalog_meal_browse_response(meal)
+
+
+async def _personalization_context(request: Request, *, user_id: str, event_bus):
+    """Resolve the same timezone and adjusted target as three-day planning."""
+    try:
+        timezone = get_zone_info(
+            await event_bus.send(
+                GetUserTimezoneQuery(
+                    user_id=user_id,
+                    header_timezone=request.headers.get("X-Timezone"),
+                )
+            )
+        ).key
+        target_date = datetime.now(get_zone_info(timezone)).date()
+        weekly_budget = await event_bus.send(
+            GetWeeklyBudgetQuery(
+                user_id=user_id,
+                target_date=target_date,
+                header_timezone=timezone,
+                read_only=True,
+            )
+        )
+        daily_calories = int(round(weekly_budget.get("adjusted_daily_calories") or 0))
+        if daily_calories <= 0:
+            return timezone, target_date, None
+        return timezone, target_date, daily_calories
+    except ResourceNotFoundException:
+        return None, None, None
+    except ExternalServiceException as exc:
+        if exc.error_code == "target_unavailable":
+            return None, None, None
+        raise
+    except Exception as exc:
+        raise ExternalServiceException(
+            "Catalog personalization context is unavailable",
+            "catalog_personalization_unavailable",
+        ) from exc
+
+
+def _clean(value: str | None) -> str | None:
+    cleaned = (value or "").strip()
+    return cleaned or None

--- a/src/api/routes/v1/meal_recommendation_route_support.py
+++ b/src/api/routes/v1/meal_recommendation_route_support.py
@@ -7,6 +7,10 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from src.api.mappers.catalog_meal_mapper import (
+    catalog_meal_ingredients,
+    catalog_meal_response,
+)
 from src.api.schemas.response.meal_recommendation_responses import (
     MealRecommendationAlternativeResponse,
     MealRecommendationCatalogMealResponse,
@@ -254,27 +258,16 @@ def _selected_catalog_meal(slot) -> CatalogMeal:
 
 def _required_catalog_meal(catalog_meal: CatalogMeal | None) -> CatalogMeal:
     if catalog_meal is None:
-        raise ValueError("catalog meal details are missing for recommendation candidate")
+        raise ValueError(
+            "catalog meal details are missing for recommendation candidate"
+        )
     return catalog_meal
 
 
-def _catalog_meal_response(catalog_meal: CatalogMeal) -> MealRecommendationCatalogMealResponse:
-    return MealRecommendationCatalogMealResponse(
-        id=catalog_meal.id,
-        name=catalog_meal.name,
-        cuisine=catalog_meal.cuisine,
-        description=catalog_meal.description,
-        image_url=catalog_meal.image_url,
-        calories=catalog_meal.calories,
-        macros=MealRecommendationMacrosResponse(
-            protein_g=float(catalog_meal.protein_g),
-            carbs_g=float(catalog_meal.carbs_g),
-            fat_g=float(catalog_meal.fat_g),
-            fiber_g=float(catalog_meal.fiber_g),
-            sugar_g=float(catalog_meal.sugar_g),
-        ),
-        ingredients=_catalog_meal_ingredients(catalog_meal),
-    )
+def _catalog_meal_response(
+    catalog_meal: CatalogMeal,
+) -> MealRecommendationCatalogMealResponse:
+    return catalog_meal_response(catalog_meal)
 
 
 def _catalog_meal_summary_response(
@@ -300,12 +293,4 @@ def _catalog_meal_summary_response(
 def _catalog_meal_ingredients(
     catalog_meal: CatalogMeal,
 ) -> list[MealRecommendationIngredientResponse]:
-    return [
-        MealRecommendationIngredientResponse(
-            food_reference_id=ingredient.food_reference_id,
-            display_name=ingredient.display_name,
-            quantity=float(ingredient.quantity),
-            unit=ingredient.unit,
-        )
-        for ingredient in catalog_meal.ingredients
-    ]
+    return catalog_meal_ingredients(catalog_meal)

--- a/src/api/schemas/response/admin_meal_catalog_responses.py
+++ b/src/api/schemas/response/admin_meal_catalog_responses.py
@@ -35,6 +35,7 @@ class AdminMealCatalogItemResponse(BaseModel):
     cuisine: str
     description: str | None = None
     image_url: str | None = None
+    popularity_rank: int | None = None
     meal_types: list[str]
     calories: int
     protein_g: float
@@ -130,6 +131,7 @@ class AdminMealCatalogImportResponse(BaseModel):
     recipe_count: int
     coverage: dict[str, dict[str, int]]
     inserted: int
+    updated: int = 0
     skipped_existing: int
     dry_run: bool
     applied: bool

--- a/src/api/schemas/response/meal_catalog_responses.py
+++ b/src/api/schemas/response/meal_catalog_responses.py
@@ -1,0 +1,29 @@
+"""Public authenticated meal-catalog browse responses."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from src.api.schemas.response.meal_recommendation_responses import (
+    MealRecommendationCatalogMealResponse,
+)
+
+
+class MealCatalogItemResponse(MealRecommendationCatalogMealResponse):
+    """Catalog item using the recommendation detail nutrition contract."""
+
+    meal_types: list[str]
+    ingredient_count: int
+
+
+class MealCatalogListResponse(BaseModel):
+    items: list[MealCatalogItemResponse]
+    total: int
+    limit: int
+    offset: int
+    feed: Literal["popular", "for_you"]
+    ranking_source: Literal["curated", "personalized"]
+    fallback: bool = False
+    allergy_evaluated: bool = False

--- a/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
@@ -84,16 +84,26 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
                 if not weekly_budget:
                     # Lazy init: create weekly budget
                     weekly_budget, bmr = await self._create_weekly_budget(
-                        uow, query.user_id, week_start, target_date
+                        uow,
+                        query.user_id,
+                        week_start,
+                        target_date,
+                        persist=not query.read_only,
                     )
                 else:
                     # Check if targets are stale and sync if needed
                     weekly_budget, bmr = await self._sync_targets_if_stale(
-                        uow, weekly_budget, query.user_id
+                        uow,
+                        weekly_budget,
+                        query.user_id,
+                        persist=not query.read_only,
                     )
                 if weekly_budget.target_revision != profile_revision:
                     weekly_budget, bmr = await self._sync_targets_if_stale(
-                        uow, weekly_budget, query.user_id
+                        uow,
+                        weekly_budget,
+                        query.user_id,
+                        persist=not query.read_only,
                     )
 
                 # Load cheat days for this week (pre-loaded, passed to shared method)
@@ -144,7 +154,8 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
                 weekly_budget.consumed_protein = consumed["protein"]
                 weekly_budget.consumed_carbs = consumed["carbs"]
                 weekly_budget.consumed_fat = consumed["fat"]
-                await uow.weekly_budgets.update(weekly_budget)
+                if not query.read_only:
+                    await uow.weekly_budgets.update(weekly_budget)
 
                 # --- Tomorrow Preview ---
                 # Shows real impact of today's consumption on tomorrow's target.
@@ -328,7 +339,13 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
         )
 
     async def _create_weekly_budget(
-        self, uow: AsyncUnitOfWork, user_id: str, week_start: date, target_date: date
+        self,
+        uow: AsyncUnitOfWork,
+        user_id: str,
+        week_start: date,
+        target_date: date,
+        *,
+        persist: bool = True,
     ) -> tuple[WeeklyMacroBudget, float]:
         """Create a new weekly budget for the user. Returns (budget, bmr)."""
         import uuid
@@ -351,7 +368,8 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
             weekly_targets = self._weekly_targets_from_daily_macros(daily_macros)
         except Exception as exc:
             raise ExternalServiceException(
-                "Authoritative target calculation is unavailable", "target_unavailable"
+                "Authoritative target calculation is unavailable",
+                "target_unavailable" if persist else "target_service_unavailable",
             ) from exc
 
         # Create domain object
@@ -364,12 +382,18 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
         )
 
         # Save to DB
-        await uow.weekly_budgets.create(budget)
+        if persist:
+            await uow.weekly_budgets.create(budget)
 
         return budget, bmr
 
     async def _sync_targets_if_stale(
-        self, uow: AsyncUnitOfWork, weekly_budget: WeeklyMacroBudget, user_id: str
+        self,
+        uow: AsyncUnitOfWork,
+        weekly_budget: WeeklyMacroBudget,
+        user_id: str,
+        *,
+        persist: bool = True,
     ) -> tuple[WeeklyMacroBudget, float]:
         """Check if weekly targets match current TDEE; update if stale. Returns (budget, bmr)."""
         try:
@@ -411,13 +435,15 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
                 weekly_budget.target_carbs = expected_targets["target_carbs"]
                 weekly_budget.target_fat = expected_targets["target_fat"]
                 weekly_budget.target_revision = target_revision
-                await uow.weekly_budgets.update(weekly_budget)
+                if persist:
+                    await uow.weekly_budgets.update(weekly_budget)
                 logger.info("Updated stale weekly nutrition targets for user")
 
             return weekly_budget, bmr
         except Exception as exc:
             raise ExternalServiceException(
-                "Authoritative target calculation is unavailable", "target_unavailable"
+                "Authoritative target calculation is unavailable",
+                "target_unavailable" if persist else "target_service_unavailable",
             ) from exc
 
     @staticmethod

--- a/src/app/queries/get_weekly_budget_query.py
+++ b/src/app/queries/get_weekly_budget_query.py
@@ -4,11 +4,11 @@ Query to get weekly macro budget status.
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Optional
 
 
 @dataclass
 class GetWeeklyBudgetQuery:
     user_id: str
-    target_date: Optional[date] = None  # Defaults to today
-    header_timezone: Optional[str] = None  # X-Timezone header fallback
+    target_date: date | None = None  # Defaults to today
+    header_timezone: str | None = None  # X-Timezone header fallback
+    read_only: bool = False  # Browse callers must not initialize or update state

--- a/src/app/services/catalog_meal_browse_ranking.py
+++ b/src/app/services/catalog_meal_browse_ranking.py
@@ -1,0 +1,81 @@
+"""Deterministic ranking helpers for public catalog browsing."""
+
+from __future__ import annotations
+
+import unicodedata
+
+from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshot
+from src.domain.model.meal_recommendation import CatalogMeal
+from src.domain.services.meal_recommendation.plan_diversity_reranking_service import (
+    SHORTLIST_LIMIT,
+    PlanDiversityRerankingService,
+)
+from src.domain.services.meal_recommendation.recipe_scoring_service import RecipeScore
+
+
+class CatalogPopularityUnavailableError(Exception):
+    """Raised when no curated popularity rank has been seeded."""
+
+
+def filter_meals(
+    meals: tuple[CatalogMeal, ...],
+    query: str | None,
+    cuisine: str | None,
+    meal_type: str | None,
+) -> list[CatalogMeal]:
+    normalized_query = normalize(query)
+    normalized_cuisine = normalize(cuisine)
+    return [
+        meal
+        for meal in meals
+        if meal.calories > 0
+        and (meal_type is None or meal_type in meal.meal_types)
+        and (not normalized_cuisine or normalize(meal.cuisine) == normalized_cuisine)
+        and (
+            not normalized_query
+            or normalized_query in normalize(meal.name)
+            or normalized_query in normalize(meal.cuisine)
+        )
+    ]
+
+
+def rank_popular(
+    meals: list[CatalogMeal], *, popularity_configured: bool
+) -> list[CatalogMeal]:
+    if not popularity_configured or any(meal.popularity_rank is None for meal in meals):
+        raise CatalogPopularityUnavailableError
+    return sorted(
+        meals,
+        key=lambda meal: (
+            meal.popularity_rank,
+            normalize(meal.name),
+            meal.id,
+        ),
+    )
+
+
+def diversity_rank(
+    ranked_scores: list[RecipeScore],
+    diversity: PlanDiversityRerankingService,
+    snapshot: CatalogMealSnapshot,
+) -> list[CatalogMeal]:
+    selected: list[RecipeScore] = []
+    remaining = ranked_scores[:]
+    while remaining and len(selected) < SHORTLIST_LIMIT:
+        reranked = diversity.rerank_shortlist(
+            remaining,
+            comparison_meals=tuple(item.catalog_meal for item in selected),
+            ingredient_statistics=snapshot.ingredient_statistics,
+        )
+        winner = reranked[0]
+        selected.append(winner)
+        remaining = [
+            item for item in remaining if item.catalog_meal.id != winner.catalog_meal.id
+        ]
+    return [item.catalog_meal for item in selected] + [
+        item.catalog_meal for item in remaining
+    ]
+
+
+def normalize(value: str | None) -> str:
+    return " ".join(unicodedata.normalize("NFKC", value or "").split()).casefold()

--- a/src/app/services/catalog_meal_browse_service.py
+++ b/src/app/services/catalog_meal_browse_service.py
@@ -1,0 +1,196 @@
+"""Read-only catalog browsing and deterministic feed ranking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from typing import Any, Literal
+
+from src.app.services.catalog_meal_browse_ranking import (
+    diversity_rank,
+    filter_meals,
+    rank_popular,
+)
+from src.app.services.catalog_meal_snapshot_service import CatalogMealSnapshot
+from src.app.services.meal_recommendation_history_projector import (
+    MealRecommendationHistoryProjector,
+)
+from src.domain.exceptions.meal_recommendation_exceptions import (
+    MealRecommendationCatalogUnavailableError,
+)
+from src.domain.model.meal_recommendation import CatalogMeal
+from src.domain.services.meal_recommendation.calorie_allocation_policy import (
+    CalorieAllocationPolicy,
+)
+from src.domain.services.meal_recommendation.plan_diversity_reranking_service import (
+    PlanDiversityRerankingService,
+)
+from src.domain.services.meal_recommendation.recipe_scoring_service import (
+    RecipeScoringService,
+)
+
+
+class CatalogFeed(StrEnum):
+    POPULAR = "popular"
+    FOR_YOU = "for_you"
+
+
+@dataclass(frozen=True)
+class CatalogBrowsePage:
+    """Ranked, paginated catalog projection plus feed provenance."""
+
+    items: tuple[CatalogMeal, ...]
+    total: int
+    feed: CatalogFeed
+    ranking_source: Literal["curated", "personalized"]
+    fallback: bool = False
+    allergy_evaluated: bool = False
+
+
+class CatalogMealBrowseService:
+    """Compose snapshot reads and recommendation scoring without persistence."""
+
+    def __init__(
+        self,
+        *,
+        uow_factory,
+        snapshot_service,
+        history_projector: MealRecommendationHistoryProjector | None = None,
+        allocation: CalorieAllocationPolicy | None = None,
+        scoring: RecipeScoringService | None = None,
+        diversity: PlanDiversityRerankingService | None = None,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._snapshot_service = snapshot_service
+        self._history_projector = (
+            history_projector or MealRecommendationHistoryProjector()
+        )
+        self._allocation = allocation or CalorieAllocationPolicy()
+        self._scoring = scoring or RecipeScoringService()
+        self._diversity = diversity or PlanDiversityRerankingService()
+
+    async def list_meals(
+        self,
+        *,
+        user_id: str,
+        feed: CatalogFeed,
+        limit: int,
+        offset: int,
+        query: str | None,
+        cuisine: str | None,
+        meal_type: str | None,
+        daily_calories: int | None = None,
+        start_date: date | None = None,
+        timezone: str | None = None,
+    ) -> CatalogBrowsePage:
+        async with self._uow_factory() as uow:
+            snapshot = await self._get_snapshot(uow)
+            candidates = filter_meals(snapshot.meals, query, cuisine, meal_type)
+            popularity_configured = any(
+                meal.popularity_rank is not None for meal in snapshot.meals
+            )
+            fallback = False
+            if feed is CatalogFeed.POPULAR:
+                ranked = rank_popular(
+                    candidates, popularity_configured=popularity_configured
+                )
+            else:
+                ranked, fallback = await self._rank_for_you(
+                    uow,
+                    snapshot,
+                    candidates,
+                    user_id=user_id,
+                    meal_type=meal_type,
+                    daily_calories=daily_calories,
+                    start_date=start_date,
+                    timezone=timezone,
+                    popularity_configured=popularity_configured,
+                )
+            return CatalogBrowsePage(
+                items=tuple(ranked[offset : offset + limit]),
+                total=len(ranked),
+                feed=feed,
+                ranking_source="curated" if fallback or feed is CatalogFeed.POPULAR else "personalized",
+                fallback=fallback,
+            )
+
+    async def get_meal(self, catalog_id: str) -> CatalogMeal:
+        async with self._uow_factory() as uow:
+            snapshot = await self._get_snapshot(uow)
+            meal = next(
+                (item for item in snapshot.meals if item.id == catalog_id), None
+            )
+            if meal is None:
+                raise KeyError(catalog_id)
+            return meal
+
+    async def _get_snapshot(self, uow: Any) -> CatalogMealSnapshot:
+        try:
+            return await self._snapshot_service.get_snapshot(uow)
+        except MealRecommendationCatalogUnavailableError:
+            raise
+        except Exception as exc:
+            raise MealRecommendationCatalogUnavailableError from exc
+
+    async def _rank_for_you(
+        self,
+        uow: Any,
+        snapshot: CatalogMealSnapshot,
+        candidates: list[CatalogMeal],
+        *,
+        user_id: str,
+        meal_type: str | None,
+        daily_calories: int | None,
+        start_date: date | None,
+        timezone: str | None,
+        popularity_configured: bool,
+    ) -> tuple[list[CatalogMeal], bool]:
+        if (
+            not daily_calories
+            or daily_calories <= 0
+            or start_date is None
+            or not timezone
+        ):
+            return rank_popular(
+                candidates, popularity_configured=popularity_configured
+            ), True
+        affinity = await self._history_projector.build_affinity(
+            uow,
+            user_id=user_id,
+            start_date=start_date,
+            timezone=timezone,
+        )
+        if not affinity.weights:
+            return rank_popular(
+                candidates, popularity_configured=popularity_configured
+            ), True
+
+        scored = []
+        for meal in candidates:
+            eligible_types = (
+                [meal_type] if meal_type is not None else list(meal.meal_types)
+            )
+            meal_scores = [
+                self._scoring.score(
+                    meal,
+                    target_calories=self._allocation.target_for(
+                        daily_calories, candidate_type
+                    ),
+                    affinity=affinity,
+                    ingredient_statistics=snapshot.ingredient_statistics,
+                )
+                for candidate_type in eligible_types
+                if candidate_type in meal.meal_types
+            ]
+            if meal_scores:
+                scored.append(
+                    sorted(
+                        meal_scores,
+                        key=lambda item: (-item.score, item.catalog_meal.id),
+                    )[0]
+                )
+        ranked_scores = sorted(
+            scored, key=lambda item: (-item.score, item.catalog_meal.id)
+        )
+        return diversity_rank(ranked_scores, self._diversity, snapshot), False

--- a/src/app/services/catalog_meal_seed_import_service.py
+++ b/src/app/services/catalog_meal_seed_import_service.py
@@ -10,9 +10,10 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from difflib import SequenceMatcher
 from time import perf_counter
-from typing import Any
+from typing import Any, NoReturn
 
 from src.domain.ports.catalog_recipe_repository_port import (
+    MAX_CATALOG_POPULARITY_RANK,
     CatalogMealRepositoryPort,
     CatalogMealSeedExisting,
     CatalogMealSeedIngredientWrite,
@@ -157,6 +158,7 @@ class CatalogSeedImportSummary:
     """Import outcome for CLI reporting and tests."""
 
     inserted: int = 0
+    updated: int = 0
     skipped_existing: int = 0
     dry_run: bool = False
     errors: tuple[str, ...] = field(default_factory=tuple)
@@ -175,6 +177,7 @@ class CatalogSeedImportSummary:
     def resolution_report(self) -> dict[str, Any]:
         return {
             "inserted": self.inserted,
+            "updated": self.updated,
             "skipped_existing": self.skipped_existing,
             "dry_run": self.dry_run,
             "errors": list(self.errors),
@@ -267,6 +270,7 @@ class CatalogMealSeedImporter:
             allow_common_unit_fallbacks=resolve_all_best_effort,
         )
         self._candidate_rows: list[_FoodReferenceSearchRow] | None = None
+        self._pending_popularity_updates: list[tuple[str, int | None]] = []
 
     def with_options(
         self,
@@ -290,6 +294,7 @@ class CatalogMealSeedImporter:
 
     async def import_manifest(self, manifest: dict[str, Any]) -> CatalogSeedImportSummary:
         started = perf_counter()
+        self._pending_popularity_updates = []
         skipped = 0
         errors: list[str] = []
         resolution_issues: list[CatalogSeedResolutionIssue] = []
@@ -337,9 +342,13 @@ class CatalogMealSeedImporter:
             _record_seed_import_metrics(summary, started)
             return summary
 
-        to_insert, skipped_after_lock, lock_errors, lock_reviews = await self._recheck_under_lock(
-            prepared
-        )
+        if prepared:
+            to_insert, skipped_after_lock, lock_errors, lock_reviews = (
+                await self._recheck_under_lock(prepared)
+            )
+        else:
+            await self._catalog_repository.lock_seed_import()
+            to_insert, skipped_after_lock, lock_errors, lock_reviews = [], 0, [], []
         skipped += skipped_after_lock
         if lock_errors or lock_reviews:
             summary = CatalogSeedImportSummary(
@@ -354,8 +363,14 @@ class CatalogMealSeedImporter:
 
         for item in to_insert:
             await self._catalog_repository.add_seed_meal(item.seed)
+        for catalog_key, popularity_rank in self._pending_popularity_updates:
+            await self._catalog_repository.update_popularity_rank(
+                catalog_key=catalog_key,
+                popularity_rank=popularity_rank,
+            )
         summary = CatalogSeedImportSummary(
             inserted=len(to_insert),
+            updated=len(self._pending_popularity_updates),
             skipped_existing=skipped,
             dry_run=self._dry_run,
         )
@@ -372,12 +387,36 @@ class CatalogMealSeedImporter:
         content_hash = _content_hash(recipe, resolved_ingredients)
         existing = await self._find_existing(catalog_key, content_hash)
         if existing is not None:
-            if existing.catalog_key == catalog_key and existing.content_hash != content_hash:
-                raise CatalogSeedImportError(
-                    f"recipes[{index}] catalog_key already exists with different content: "
-                    f"{catalog_key}"
-                )
+            if existing.catalog_key == catalog_key:
+                if existing.content_hash != content_hash:
+                    raise CatalogSeedImportError(
+                        f"recipes[{index}] catalog_key already exists with different content: "
+                        f"{catalog_key}"
+                    )
+                if "popularity_rank" in recipe:
+                    popularity_rank = _optional_popularity_rank(
+                        recipe.get("popularity_rank")
+                    )
+                    if not self._dry_run:
+                        self._pending_popularity_updates.append(
+                            (catalog_key, popularity_rank)
+                        )
             return None
+
+        seed_ingredients = []
+        for item in resolved_ingredients:
+            if item.food_reference_id is None:
+                raise CatalogSeedImportError(
+                    f"recipes[{index}] resolved ingredient is missing food_reference_id"
+                )
+            seed_ingredients.append(
+                CatalogMealSeedIngredientWrite(
+                    food_reference_id=item.food_reference_id,
+                    display_name=item.display_name,
+                    quantity=item.quantity,
+                    unit=item.unit,
+                )
+            )
 
         seed = CatalogMealSeedWrite(
             catalog_key=catalog_key,
@@ -387,15 +426,8 @@ class CatalogMealSeedImporter:
             description=_optional_string(recipe.get("description")),
             image_url=_optional_string(recipe.get("image_url")),
             meal_types=tuple(str(item).strip() for item in recipe["meal_types"]),
-            ingredients=tuple(
-                CatalogMealSeedIngredientWrite(
-                    food_reference_id=item.food_reference_id,
-                    display_name=item.display_name,
-                    quantity=item.quantity,
-                    unit=item.unit,
-                )
-                for item in resolved_ingredients
-            ),
+            popularity_rank=_optional_popularity_rank(recipe.get("popularity_rank")),
+            ingredients=tuple(seed_ingredients),
         )
         return _PreparedCatalogSeed(
             recipe_index=index,
@@ -688,7 +720,7 @@ class CatalogMealSeedImporter:
         normalized_name: str,
         reason: str,
         candidates: tuple[CatalogSeedResolutionCandidate, ...],
-    ) -> None:
+    ) -> NoReturn:
         issue = CatalogSeedResolutionIssue(
             recipe_index=recipe_index,
             recipe_key=recipe_key,
@@ -825,6 +857,18 @@ def _content_hash(
 
 def _canonical_decimal(value: float) -> str:
     return format(Decimal(str(value)).quantize(Decimal("0.0001")), "f")
+
+
+def _optional_popularity_rank(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CatalogSeedImportError("popularity_rank must be an integer") from None
+    if value < 0 or value > MAX_CATALOG_POPULARITY_RANK:
+        raise CatalogSeedImportError(
+            "popularity_rank must fit a non-negative PostgreSQL INTEGER"
+        )
+    return value
 
 
 def _seed_signature(

--- a/src/app/services/catalog_meal_snapshot_service.py
+++ b/src/app/services/catalog_meal_snapshot_service.py
@@ -56,7 +56,25 @@ class CatalogMealSnapshotService:
             self._record_snapshot_metrics(snapshot, status="warm")
             return snapshot
 
-        revision = await uow.catalog_recipes.get_active_catalog_revision()
+        try:
+            revision = await uow.catalog_recipes.get_active_catalog_revision()
+        except Exception:
+            if snapshot is not None:
+                self._next_refresh_after = now + self._failure_retry_seconds
+                increment_metric(
+                    "meal_recommendation.catalog_snapshot.refresh",
+                    attributes={"status": "last_good"},
+                )
+                increment_metric(
+                    "meal_catalog.snapshot.refresh",
+                    attributes={"status": "last_good"},
+                )
+                increment_metric(
+                    "meal_catalog.snapshot.last_good",
+                    attributes={"status": "last_good"},
+                )
+                return snapshot
+            raise
         snapshot = self._snapshot
         if (
             snapshot is not None

--- a/src/domain/model/meal_recommendation/catalog_recipe.py
+++ b/src/domain/model/meal_recommendation/catalog_recipe.py
@@ -44,6 +44,7 @@ class CatalogMeal:
     meal_types: tuple[str, ...] = field(default_factory=tuple)
     ingredients: tuple[CatalogMealIngredient, ...] = field(default_factory=tuple)
     is_active: bool = True
+    popularity_rank: int | None = None
 
     @property
     def calories(self) -> int:

--- a/src/domain/ports/catalog_recipe_repository_port.py
+++ b/src/domain/ports/catalog_recipe_repository_port.py
@@ -8,6 +8,8 @@ from datetime import datetime
 
 from src.domain.model.meal_recommendation.catalog_recipe import CatalogMeal
 
+MAX_CATALOG_POPULARITY_RANK = 2_147_483_647
+
 
 @dataclass(frozen=True)
 class CatalogMealSeedIngredientWrite:
@@ -31,6 +33,7 @@ class CatalogMealSeedWrite:
     image_url: str | None
     meal_types: tuple[str, ...]
     ingredients: tuple[CatalogMealSeedIngredientWrite, ...]
+    popularity_rank: int | None = None
 
 
 @dataclass(frozen=True)
@@ -93,6 +96,12 @@ class CatalogMealRepositoryPort(ABC):
     @abstractmethod
     async def add_seed_meal(self, seed: CatalogMealSeedWrite) -> None:
         """Add one display-only catalog seed meal without owning commit."""
+
+    @abstractmethod
+    async def update_popularity_rank(
+        self, *, catalog_key: str, popularity_rank: int | None
+    ) -> None:
+        """Update the editorial rank for an existing catalog seed."""
 
     @abstractmethod
     async def lock_seed_import(self) -> None:

--- a/src/domain/services/meal_recommendation/calorie_allocation_policy.py
+++ b/src/domain/services/meal_recommendation/calorie_allocation_policy.py
@@ -25,3 +25,14 @@ class CalorieAllocationPolicy:
         allocations["dinner"] += drift
         return {meal_type: allocations[meal_type] for meal_type in MEAL_TYPE_ORDER}
 
+    def target_for(self, daily_calories: int, meal_type: str) -> int:
+        """Return the browse target for a supported meal type."""
+        if meal_type == "snack":
+            if daily_calories <= 0:
+                raise ValueError("daily_calories must be positive")
+            return max(1, round(daily_calories * 0.10))
+        allocations = self.allocate(daily_calories)
+        try:
+            return allocations[meal_type]
+        except KeyError:
+            raise ValueError(f"unsupported meal_type: {meal_type}") from None

--- a/src/domain/services/meal_recommendation/catalog_recipe_seed_validator.py
+++ b/src/domain/services/meal_recommendation/catalog_recipe_seed_validator.py
@@ -9,6 +9,8 @@ from collections.abc import Collection
 from dataclasses import dataclass, field
 from typing import Any
 
+from src.domain.ports.catalog_recipe_repository_port import MAX_CATALOG_POPULARITY_RANK
+
 REQUIRED_CUISINES = ("vietnamese", "japanese", "korean")
 ALLOWED_MEAL_TYPES = ("breakfast", "lunch", "dinner", "snack")
 REQUIRED_COVERAGE_MEAL_TYPES = ("breakfast", "lunch", "dinner")
@@ -171,6 +173,16 @@ def _validate_recipe(
 
     if _string(recipe.get("name")) is None:
         errors.append(f"recipes[{index}].name is required")
+
+    popularity_rank = recipe.get("popularity_rank")
+    if popularity_rank is not None and (
+        isinstance(popularity_rank, bool)
+        or not isinstance(popularity_rank, int)
+        or not 0 <= popularity_rank <= MAX_CATALOG_POPULARITY_RANK
+    ):
+        errors.append(
+            f"recipes[{index}].popularity_rank must fit a non-negative PostgreSQL INTEGER or null"
+        )
 
     _validate_absent_derived_recipe_fields(recipe, index, errors)
     _validate_ingredients(recipe.get("ingredients"), index, errors)

--- a/src/infra/database/models/meal_recommendation/catalog_recipe.py
+++ b/src/infra/database/models/meal_recommendation/catalog_recipe.py
@@ -38,6 +38,7 @@ class MealCatalogORM(Base):
     cuisine = Column(String(80), nullable=False)
     description = Column(Text, nullable=True)
     image_url = Column(Text, nullable=True)
+    popularity_rank = Column(Integer, nullable=True)
     breakfast_eligible = Column(Boolean, nullable=False, default=False)
     lunch_eligible = Column(Boolean, nullable=False, default=False)
     dinner_eligible = Column(Boolean, nullable=False, default=False)
@@ -62,10 +63,21 @@ class MealCatalogORM(Base):
         CheckConstraint("length(name) > 0", name="ck_meal_catalog_name"),
         CheckConstraint("length(cuisine) > 0", name="ck_meal_catalog_cuisine"),
         CheckConstraint(
+            "popularity_rank IS NULL OR popularity_rank >= 0",
+            name="ck_meal_catalog_popularity_rank_non_negative",
+        ),
+        CheckConstraint(
             "breakfast_eligible OR lunch_eligible OR dinner_eligible OR snack_eligible",
             name="ck_meal_catalog_has_eligible_meal_type",
         ),
         Index("idx_meal_catalog_active_cuisine", "is_active", "cuisine"),
+        Index(
+            "idx_meal_catalog_active_popularity",
+            "is_active",
+            "popularity_rank",
+            "name",
+            "id",
+        ),
     )
 
 

--- a/src/infra/repositories/catalog_recipe_repository_async.py
+++ b/src/infra/repositories/catalog_recipe_repository_async.py
@@ -6,7 +6,7 @@ import unicodedata
 from decimal import Decimal
 from typing import cast
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -133,6 +133,7 @@ class AsyncCatalogMealRepository(CatalogMealRepositoryPort):
             cuisine=seed.cuisine,
             description=seed.description,
             image_url=seed.image_url,
+            popularity_rank=seed.popularity_rank,
             breakfast_eligible="breakfast" in seed.meal_types,
             lunch_eligible="lunch" in seed.meal_types,
             dinner_eligible="dinner" in seed.meal_types,
@@ -149,6 +150,16 @@ class AsyncCatalogMealRepository(CatalogMealRepositoryPort):
             for item in seed.ingredients
         ]
         self._session.add(row)
+        await self._session.flush()
+
+    async def update_popularity_rank(
+        self, *, catalog_key: str, popularity_rank: int | None
+    ) -> None:
+        await self._session.execute(
+            update(MealCatalogORM)
+            .where(MealCatalogORM.catalog_key == catalog_key)
+            .values(popularity_rank=popularity_rank)
+        )
         await self._session.flush()
 
     async def lock_seed_import(self) -> None:
@@ -207,6 +218,7 @@ def _meal_to_domain(row: MealCatalogORM) -> CatalogMeal:
         cuisine=cast(str, row.cuisine),
         description=cast(str | None, row.description),
         image_url=cast(str | None, row.image_url),
+        popularity_rank=_optional_int(getattr(row, "popularity_rank", None)),
         protein_g=_decimal(nutrition.protein),
         carbs_g=_decimal(nutrition.carbs),
         fat_g=_decimal(nutrition.fat),
@@ -282,6 +294,10 @@ def _meal_types(row: MealCatalogORM) -> tuple[str, ...]:
     if row.snack_eligible:
         values.append("snack")
     return tuple(values)
+
+
+def _optional_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _decimal(value) -> Decimal:

--- a/tests/migrations/test_catalog_popularity_rank_migration.py
+++ b/tests/migrations/test_catalog_popularity_rank_migration.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+MIGRATION = Path("migrations/versions/20260816000005_add_catalog_popularity_rank.py")
+
+
+def test_catalog_popularity_rank_migration_is_forward_only_additive():
+    text = MIGRATION.read_text()
+
+    assert 'revision: str = "20260816000005"' in text
+    assert 'down_revision: str | None = "20260815000004"' in text
+    assert 'sa.Column("popularity_rank", sa.Integer(), nullable=True)' in text
+    assert '"idx_meal_catalog_active_popularity"' in text
+    assert "ck_meal_catalog_popularity_rank_non_negative" in text

--- a/tests/unit/api/test_meal_catalog_route.py
+++ b/tests/unit/api/test_meal_catalog_route.py
@@ -1,0 +1,152 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from src.api.dependencies.auth import get_current_user_id
+from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.routes.v1 import meal_catalog as meal_catalog_route
+from src.api.routes.v1.meal_catalog import router
+from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
+from src.app.queries.user import GetUserTimezoneQuery
+from src.app.services.catalog_meal_browse_service import CatalogFeed
+from src.domain.model.meal_recommendation import CatalogMeal, CatalogMealIngredient
+
+
+def _meal() -> CatalogMeal:
+    return CatalogMeal(
+        id="catalog-1",
+        catalog_key="catalog-1",
+        content_hash="a" * 64,
+        name="Japanese Egg Rice",
+        cuisine="Japanese",
+        description="A meal",
+        image_url="https://example.test/meal.jpg",
+        protein_g=Decimal("20"),
+        carbs_g=Decimal("40"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("2"),
+        sugar_g=Decimal("1"),
+        meal_types=("breakfast",),
+        ingredients=(
+            CatalogMealIngredient(
+                food_reference_id=7,
+                display_name="Egg",
+                quantity=Decimal("100"),
+                unit="g",
+            ),
+        ),
+        popularity_rank=1,
+    )
+
+
+class _Service:
+    async def list_meals(self, **kwargs):
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["limit"] == 20
+        assert kwargs["offset"] == 0
+        return SimpleNamespace(
+            items=(_meal(),),
+            total=1,
+            feed=CatalogFeed.POPULAR,
+            ranking_source="curated",
+            fallback=False,
+            allergy_evaluated=False,
+        )
+
+    async def get_meal(self, catalog_id):
+        assert catalog_id == "catalog-1"
+        return _meal()
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user_id] = lambda: "user-1"
+    app.dependency_overrides[get_configured_event_bus] = lambda: object()
+    from src.api.base_dependencies import get_catalog_meal_browse_service
+
+    app.dependency_overrides[get_catalog_meal_browse_service] = lambda: _Service()
+    return app
+
+
+def test_list_returns_mobile_catalog_projection_without_list_ingredients():
+    response = TestClient(_app()).get("/v1/meal-catalog")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["id"] == "catalog-1"
+    assert body["items"][0]["macros"]["protein_g"] == 20.0
+    assert body["items"][0]["calories"] == 326
+    assert body["items"][0]["meal_types"] == ["breakfast"]
+    assert body["items"][0]["ingredient_count"] == 1
+    assert body["items"][0]["ingredients"] == []
+    assert body["feed"] == "popular"
+    assert body["ranking_source"] == "curated"
+
+
+def test_popular_list_does_not_initialize_event_bus(monkeypatch):
+    def fail_event_bus():
+        raise AssertionError("popular feed must not initialize event bus")
+
+    monkeypatch.setattr(meal_catalog_route, "get_configured_event_bus", fail_event_bus)
+
+    response = TestClient(_app()).get("/v1/meal-catalog")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_for_you_context_marks_weekly_budget_read_only():
+    sent = []
+
+    class _Bus:
+        async def send(self, query):
+            sent.append(query)
+            if isinstance(query, GetUserTimezoneQuery):
+                return "UTC"
+            return {"adjusted_daily_calories": 2000}
+
+    request = Request(
+        {
+            "type": "http",
+            "headers": [(b"x-timezone", b"UTC")],
+        }
+    )
+    context = await meal_catalog_route._personalization_context(
+        request,
+        user_id="user-1",
+        event_bus=_Bus(),
+    )
+
+    assert context[2] == 2000
+    budget_query = next(query for query in sent if isinstance(query, GetWeeklyBudgetQuery))
+    assert budget_query.read_only is True
+
+
+def test_detail_returns_ingredient_identity_and_backend_calories():
+    response = TestClient(_app()).get("/v1/meal-catalog/catalog-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ingredients"] == [
+        {
+            "food_reference_id": 7,
+            "display_name": "Egg",
+            "quantity": 100.0,
+            "unit": "g",
+        }
+    ]
+    assert body["calories"] == 326
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["limit=0", "limit=51", "offset=-1", "feed=invalid", "meal_type=brunch"],
+)
+def test_list_validates_catalog_query_contract(query):
+    response = TestClient(_app()).get(f"/v1/meal-catalog?{query}")
+    assert response.status_code == 422

--- a/tests/unit/api/test_meal_catalog_route.py
+++ b/tests/unit/api/test_meal_catalog_route.py
@@ -8,6 +8,7 @@ from starlette.requests import Request
 
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
+from src.api.exceptions import ExternalServiceException
 from src.api.routes.v1 import meal_catalog as meal_catalog_route
 from src.api.routes.v1.meal_catalog import router
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
@@ -125,6 +126,100 @@ async def test_for_you_context_marks_weekly_budget_read_only():
     assert context[2] == 2000
     budget_query = next(query for query in sent if isinstance(query, GetWeeklyBudgetQuery))
     assert budget_query.read_only is True
+
+
+@pytest.mark.asyncio
+async def test_for_you_context_falls_back_when_read_only_target_is_unavailable():
+    class _Bus:
+        async def send(self, query):
+            if isinstance(query, GetUserTimezoneQuery):
+                return "UTC"
+            raise ExternalServiceException(
+                "Authoritative target calculation is unavailable",
+                "target_service_unavailable",
+            )
+
+    request = Request(
+        {
+            "type": "http",
+            "headers": [(b"x-timezone", b"UTC")],
+        }
+    )
+
+    context = await meal_catalog_route._personalization_context(
+        request,
+        user_id="user-1",
+        event_bus=_Bus(),
+    )
+
+    assert context == (None, None, None)
+
+
+def test_for_you_endpoint_falls_back_to_popular_when_target_is_unavailable(monkeypatch):
+    class _Bus:
+        async def send(self, query):
+            if isinstance(query, GetUserTimezoneQuery):
+                return "UTC"
+            raise ExternalServiceException(
+                "Authoritative target calculation is unavailable",
+                "target_service_unavailable",
+            )
+
+    class _FallbackService:
+        async def list_meals(self, **kwargs):
+            assert kwargs["daily_calories"] is None
+            assert kwargs["start_date"] is None
+            assert kwargs["timezone"] is None
+            return SimpleNamespace(
+                items=(_meal(),),
+                total=1,
+                feed=CatalogFeed.POPULAR,
+                ranking_source="curated",
+                fallback=True,
+                allergy_evaluated=False,
+            )
+
+    from src.api.base_dependencies import get_catalog_meal_browse_service
+
+    app = _app()
+    app.dependency_overrides[get_catalog_meal_browse_service] = (
+        lambda: _FallbackService()
+    )
+    monkeypatch.setattr(meal_catalog_route, "get_configured_event_bus", lambda: _Bus())
+
+    response = TestClient(app).get("/v1/meal-catalog?feed=for_you")
+
+    assert response.status_code == 200
+    assert response.json()["feed"] == "popular"
+    assert response.json()["fallback"] is True
+
+
+@pytest.mark.asyncio
+async def test_for_you_context_propagates_unrelated_external_service_errors():
+    class _Bus:
+        async def send(self, query):
+            if isinstance(query, GetUserTimezoneQuery):
+                return "UTC"
+            raise ExternalServiceException(
+                "Catalog personalization failed",
+                "catalog_personalization_unavailable",
+            )
+
+    request = Request(
+        {
+            "type": "http",
+            "headers": [(b"x-timezone", b"UTC")],
+        }
+    )
+
+    with pytest.raises(ExternalServiceException) as error:
+        await meal_catalog_route._personalization_context(
+            request,
+            user_id="user-1",
+            event_bus=_Bus(),
+        )
+
+    assert error.value.error_code == "catalog_personalization_unavailable"
 
 
 def test_detail_returns_ingredient_identity_and_backend_calories():

--- a/tests/unit/app/services/test_catalog_meal_browse_service.py
+++ b/tests/unit/app/services/test_catalog_meal_browse_service.py
@@ -1,0 +1,243 @@
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from src.app.services.catalog_meal_browse_ranking import (
+    CatalogPopularityUnavailableError,
+)
+from src.app.services.catalog_meal_browse_service import (
+    CatalogFeed,
+    CatalogMealBrowseService,
+)
+from src.domain.model.meal_recommendation import CatalogMeal, CatalogMealIngredient
+from src.domain.services.meal_recommendation.ingredient_affinity_service import (
+    IngredientAffinityProfile,
+)
+from src.domain.services.meal_recommendation.recipe_scoring_service import RecipeScore
+
+
+def _meal(meal_id: str, *, rank: int | None, food_reference_id: int) -> CatalogMeal:
+    return CatalogMeal(
+        id=meal_id,
+        catalog_key=meal_id,
+        content_hash="a" * 64,
+        name=meal_id.replace("-", " ").title(),
+        cuisine="Japanese",
+        description="description",
+        image_url="https://example.test/meal.jpg",
+        protein_g=Decimal("20"),
+        carbs_g=Decimal("40"),
+        fat_g=Decimal("10"),
+        fiber_g=Decimal("2"),
+        sugar_g=Decimal("1"),
+        meal_types=("breakfast", "snack"),
+        ingredients=(
+            CatalogMealIngredient(
+                food_reference_id=food_reference_id,
+                display_name="Ingredient",
+                quantity=Decimal("100"),
+                unit="g",
+            ),
+        ),
+        popularity_rank=rank,
+    )
+
+
+class _Uow:
+    def __init__(self, meals):
+        self.meals = SimpleNamespace(
+            aggregate_linked_ingredient_history=self._aggregate_history
+        )
+        self.meal_rows = meals
+        self.writes = []
+
+    async def _aggregate_history(self, **kwargs):
+        return []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class _UowFactory:
+    def __init__(self, uow):
+        self.uow = uow
+
+    def __call__(self):
+        return self.uow
+
+
+class _Snapshot:
+    def __init__(self, meals):
+        self.snapshot = SimpleNamespace(
+            meals=tuple(meals),
+            ingredient_statistics=SimpleNamespace(idf=lambda _food_id: 1.0),
+        )
+
+    async def get_snapshot(self, _uow):
+        return self.snapshot
+
+
+class _History:
+    def __init__(self):
+        self.users = []
+
+    async def build_affinity(self, _uow, *, user_id, start_date, timezone):
+        self.users.append(user_id)
+        food_reference_id = 1 if user_id == "user-a" else 2
+        return IngredientAffinityProfile(
+            weights={food_reference_id: 1.0},
+            confidence=1.0,
+        )
+
+
+class _Scoring:
+    def score(self, meal, *, affinity, **_kwargs):
+        matched = meal.ingredients[0].food_reference_id in affinity.weights
+        return RecipeScore(
+            catalog_meal=meal,
+            score=1.0 if matched else 0.0,
+            calorie_fit=1.0 if matched else 0.0,
+            ingredient_fit=1.0 if matched else 0.0,
+        )
+
+
+class _Diversity:
+    def rerank_shortlist(self, ranked_pool, **_kwargs):
+        return ranked_pool
+
+
+def _service(meals, history=None):
+    return CatalogMealBrowseService(
+        uow_factory=_UowFactory(_Uow(meals)),
+        snapshot_service=_Snapshot(meals),
+        history_projector=history or _History(),
+        scoring=_Scoring(),
+        diversity=_Diversity(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_popular_feed_uses_curated_rank_then_stable_ties_and_paginates_after_ranking():
+    meals = [
+        _meal("meal-b", rank=2, food_reference_id=2),
+        _meal("meal-a", rank=1, food_reference_id=1),
+        _meal("meal-c", rank=2, food_reference_id=3),
+    ]
+
+    page = await _service(meals).list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.POPULAR,
+        limit=1,
+        offset=1,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+    )
+
+    assert [meal.id for meal in page.items] == ["meal-b"]
+    assert page.total == 3
+    assert page.ranking_source == "curated"
+    assert page.fallback is False
+
+
+@pytest.mark.asyncio
+async def test_for_you_uses_owner_scoped_history_without_persisting():
+    meals = [
+        _meal("meal-a", rank=1, food_reference_id=1),
+        _meal("meal-b", rank=2, food_reference_id=2),
+    ]
+    history = _History()
+    service = _service(meals, history)
+
+    page_a = await service.list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.FOR_YOU,
+        limit=20,
+        offset=0,
+        query=None,
+        cuisine=None,
+        meal_type="breakfast",
+        daily_calories=2000,
+        start_date=date(2026, 8, 16),
+        timezone="UTC",
+    )
+    page_b = await service.list_meals(
+        user_id="user-b",
+        feed=CatalogFeed.FOR_YOU,
+        limit=20,
+        offset=0,
+        query=None,
+        cuisine=None,
+        meal_type="breakfast",
+        daily_calories=2000,
+        start_date=date(2026, 8, 16),
+        timezone="UTC",
+    )
+
+    assert [meal.id for meal in page_a.items] == ["meal-a", "meal-b"]
+    assert [meal.id for meal in page_b.items] == ["meal-b", "meal-a"]
+    assert history.users == ["user-a", "user-b"]
+
+
+@pytest.mark.asyncio
+async def test_missing_popularity_source_fails_closed():
+    with pytest.raises(CatalogPopularityUnavailableError):
+        await _service([_meal("meal-a", rank=None, food_reference_id=1)]).list_meals(
+            user_id="user-a",
+            feed=CatalogFeed.POPULAR,
+            limit=20,
+            offset=0,
+            query=None,
+            cuisine=None,
+            meal_type=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_popularity_source_fails_closed():
+    with pytest.raises(CatalogPopularityUnavailableError):
+        await _service(
+            [
+                _meal("meal-a", rank=1, food_reference_id=1),
+                _meal("meal-b", rank=None, food_reference_id=2),
+            ]
+        ).list_meals(
+            user_id="user-a",
+            feed=CatalogFeed.POPULAR,
+            limit=20,
+            offset=0,
+            query=None,
+            cuisine=None,
+            meal_type=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cold_start_for_you_falls_back_to_popular():
+    class _EmptyHistory(_History):
+        async def build_affinity(self, *_args, **_kwargs):
+            return IngredientAffinityProfile(weights={}, confidence=0.0)
+
+    page = await _service(
+        [_meal("meal-a", rank=1, food_reference_id=1)], _EmptyHistory()
+    ).list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.FOR_YOU,
+        limit=20,
+        offset=0,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+        daily_calories=2000,
+        start_date=date(2026, 8, 16),
+        timezone="UTC",
+    )
+
+    assert page.fallback is True
+    assert page.ranking_source == "curated"
+    assert [meal.id for meal in page.items] == ["meal-a"]

--- a/tests/unit/app/services/test_catalog_meal_seed_import_service.py
+++ b/tests/unit/app/services/test_catalog_meal_seed_import_service.py
@@ -60,6 +60,7 @@ def teardown_function():
 class _Session:
     def __init__(self):
         self.added = []
+        self.updated = []
         self.flushed = False
         self.locked = False
         self.signatures = []
@@ -67,6 +68,9 @@ class _Session:
     async def add_seed_meal(self, row):
         self.added.append(row)
         self.flushed = True
+
+    async def update_popularity_rank(self, *, catalog_key, popularity_rank):
+        self.updated.append((catalog_key, popularity_rank))
 
     async def find_seed_existing(self, *, catalog_key, content_hash):
         return None
@@ -144,6 +148,8 @@ class _Importer(CatalogMealSeedImporter):
             return SimpleNamespace(catalog_key=catalog_key, content_hash=content_hash)
         if self.existing == "changed":
             return SimpleNamespace(catalog_key=catalog_key, content_hash="different")
+        if self.existing == "same-content-different-key":
+            return SimpleNamespace(catalog_key="other-key", content_hash=content_hash)
         return None
 
     async def _ranked_candidates(self, normalized_name):
@@ -243,6 +249,34 @@ async def test_import_skips_exact_existing_catalog_meal():
     assert summary.inserted == 0
     assert summary.skipped_existing == 1
     assert importer.session.added == []
+
+
+@pytest.mark.asyncio
+async def test_import_updates_popularity_rank_for_exact_existing_catalog_meal():
+    importer = _Importer(refs_by_id={7: _reference()}, existing="exact")
+    manifest = _manifest()
+    manifest["recipes"][0]["popularity_rank"] = 4
+
+    summary = await importer.import_manifest(manifest)
+
+    assert summary.inserted == 0
+    assert summary.updated == 1
+    assert summary.skipped_existing == 1
+    assert importer.session.updated == [("vn-rice-breakfast", 4)]
+
+
+@pytest.mark.asyncio
+async def test_import_does_not_update_rank_for_same_content_under_another_key():
+    importer = _Importer(
+        refs_by_id={7: _reference()}, existing="same-content-different-key"
+    )
+    manifest = _manifest()
+    manifest["recipes"][0]["popularity_rank"] = 4
+
+    summary = await importer.import_manifest(manifest)
+
+    assert summary.updated == 0
+    assert importer.session.updated == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_catalog_meal_snapshot_service.py
+++ b/tests/unit/app/services/test_catalog_meal_snapshot_service.py
@@ -73,6 +73,8 @@ class _CatalogRepo:
 
     async def get_active_catalog_revision(self):
         self.revision_calls += 1
+        if isinstance(self.revision, Exception):
+            raise self.revision
         return self.revision
 
     async def list_active_meals(self):
@@ -194,6 +196,22 @@ async def test_snapshot_last_good_metric_records_no_payload_details():
     ) in metrics.calls
     assert "Meal meal-1" not in str(metrics.calls)
     assert "key-meal-1" not in str(metrics.calls)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_revision_failure_serves_last_good_snapshot():
+    clock = _Clock()
+    catalog = _CatalogRepo()
+    service = CatalogMealSnapshotService(ttl_seconds=10, clock=clock)
+
+    first = await service.get_snapshot(_Uow(catalog))
+    clock.value += 11
+    catalog.revision = RuntimeError("revision unavailable")
+
+    second = await service.get_snapshot(_Uow(catalog))
+
+    assert second is first
+    assert catalog.load_calls == 1
 
 
 def _revision(value: int) -> CatalogMealRevision:

--- a/tests/unit/domain/services/meal_recommendation/test_catalog_recipe_seed_validator.py
+++ b/tests/unit/domain/services/meal_recommendation/test_catalog_recipe_seed_validator.py
@@ -208,6 +208,25 @@ def test_manifest_rejects_derived_recipe_fields():
     assert any("protein_g is derived by backend" in error for error in result.errors)
 
 
+def test_manifest_rejects_invalid_popularity_rank():
+    manifest = {
+        "release_key": "test-release",
+        "expected_recipe_count": 1,
+        "recipes": [_recipe("vn-breakfast", "vietnamese", "breakfast")],
+    }
+    manifest["recipes"][0]["popularity_rank"] = 2_147_483_648
+
+    result = validate_catalog_seed_manifest(
+        manifest,
+        expected_recipe_count=1,
+        min_per_cuisine_meal_type=0,
+        expected_cuisine_counts=None,
+    )
+
+    assert result.is_valid is False
+    assert "popularity_rank must fit a non-negative PostgreSQL INTEGER or null" in result.errors[0]
+
+
 def test_manifest_rejects_derived_ingredient_fields():
     recipe = _recipe("vn-breakfast", "vietnamese", "breakfast")
     recipe["ingredients"][0]["resolved_grams"] = 100

--- a/tests/unit/handlers/query_handlers/test_weekly_budget_movement_credit.py
+++ b/tests/unit/handlers/query_handlers/test_weekly_budget_movement_credit.py
@@ -230,6 +230,49 @@ async def test_weekly_create_and_stale_sync_derive_calories_from_macros(
 
 
 @pytest.mark.asyncio
+async def test_read_only_budget_projection_does_not_create_or_update_budget():
+    handler = GetWeeklyBudgetQueryHandler()
+    uow = MagicMock()
+    uow.weekly_budgets.create = AsyncMock()
+    uow.weekly_budgets.update = AsyncMock()
+    target = {
+        "macros": {"protein": 100.0, "carbs": 200.0, "fat": 66.7},
+        "bmr": 1600.0,
+        "profile_target_revision": 2,
+        "macro_preset": "standard",
+        "is_custom": False,
+    }
+
+    with patch(
+        "src.app.handlers.query_handlers.get_user_tdee_query_handler."
+        "GetUserTdeeQueryHandler.handle",
+        new_callable=AsyncMock,
+        return_value=target,
+    ):
+        created, _ = await handler._create_weekly_budget(
+            uow,
+            "u1",
+            date(2026, 3, 9),
+            date(2026, 3, 9),
+            persist=False,
+        )
+        stale = WeeklyMacroBudget(
+            weekly_budget_id="stale",
+            user_id="u1",
+            week_start_date=date(2026, 3, 9),
+            target_calories=13300.0,
+            target_protein=created.target_protein,
+            target_carbs=created.target_carbs,
+            target_fat=created.target_fat,
+            target_revision=1,
+        )
+        await handler._sync_targets_if_stale(uow, stale, "u1", persist=False)
+
+    uow.weekly_budgets.create.assert_not_awaited()
+    uow.weekly_budgets.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_unavailable_authoritative_target_writes_no_weekly_budget():
     handler = GetWeeklyBudgetQueryHandler()
     uow = MagicMock()


### PR DESCRIPTION
## Summary
- Add authenticated `GET /v1/meal-catalog` and `/{catalog_id}` endpoints with popular, for-you, search, cuisine, meal-type, pagination, and typed error contracts.
- Add curated `popularity_rank` migration/import/admin support; popular browsing fails closed with 503 until ranks are seeded.
- Reuse shared snapshots and backend-authoritative nutrition, keep the existing three-day plan separate, and prevent browse requests from mutating weekly budgets.
- Fix `FOR_YOU` cold-start fallback when read-only target calculation emits `target_service_unavailable`; unrelated personalization errors still propagate.
- Add public fallback/error-path regression tests, last-good snapshot fallback, and API/release/runbook documentation.

## Validation
- `.venv/bin/pytest tests/unit --cov=src --cov-fail-under=65` — 2,439 passed; 79.10% coverage.
- Catalog route and affected catalog/snapshot/import/ranking/budget tests — passed.
- Changed-file Ruff, compileall, OpenAPI, Alembic-head, docs validation, and diff checks passed.

## Release gates
- Staging migration/deployment and authenticated requests for both feeds and detail are not yet verified.
- Warm/cold p95, image coverage, and active popularity-rank seed population remain required.
- `allergy_evaluated` remains false by design.
- Repository-wide Ruff has pre-existing baseline findings; changed-file checks are clean.

## Notes
- The active plan and report artifacts are intentionally preserved locally and are not included in the commits.