### PR TITLE
fix(manual-meal): preserve custom allowed_units on save

### DIFF
--- a/src/app/services/manual_meal_nutrition_resolver.py
+++ b/src/app/services/manual_meal_nutrition_resolver.py
@@ -192,6 +192,9 @@ class ManualMealNutritionResolver:
     def _resolve_custom(self, item: ManualMealItem) -> ManualMealItem:
         if item.custom_nutrition is None:
             raise ValueError("custom origin requires custom nutrition")
+        # Custom foods have no catalog servings — keep client units (Miếng, etc.)
+        # after normalization so reopen/edit can show the same chips as parse-text.
+        allowed_units = self._custom_allowed_units(item.allowed_units)
         result = self.policy.require_valid(
             {
                 "protein_100g": item.custom_nutrition.protein_per_100g,
@@ -199,6 +202,7 @@ class ManualMealNutritionResolver:
                 "fat_100g": item.custom_nutrition.fat_per_100g,
                 "fiber_100g": item.custom_nutrition.fiber_per_100g,
                 "sugar_100g": item.custom_nutrition.sugar_per_100g,
+                "allowed_units": allowed_units,
             },
             require_energy=False,
             require_metric_basis=False,
@@ -213,11 +217,30 @@ class ManualMealNutritionResolver:
                 fiber_per_100g=result.fiber_100g or 0.0,
                 sugar_per_100g=result.sugar_100g or 0.0,
             ),
-            allowed_units=[{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            allowed_units=allowed_units,
             source_kind="custom",
             nutrition_contract_version="2",
-            source_snapshot=self._snapshot(result, "custom", None, None),
+            source_snapshot=self._snapshot(
+                result, "custom", None, None, allowed_units
+            ),
         )
+
+    @staticmethod
+    def _custom_allowed_units(
+        raw_units: list[dict[str, Any]] | None,
+    ) -> list[dict[str, Any]]:
+        normalized = normalize_serving_options(raw_units or [])
+        if not normalized:
+            return [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
+        has_gram = any(
+            str(unit.get("unit", "")).strip().lower() == "g" for unit in normalized
+        )
+        if has_gram:
+            return normalized
+        return [
+            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            *normalized,
+        ]
 
     def _resolve_reference(self, item, reference, origin: str) -> ManualMealItem:
         if reference is None:

--- a/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
+++ b/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
@@ -40,6 +40,80 @@ class _References:
 
 
 @pytest.mark.asyncio
+async def test_custom_preserves_client_allowed_units_and_selected_unit():
+    resolved = await ManualMealNutritionResolver().resolve_items(
+        [
+            ManualMealItem(
+                name="Sườn Nướng",
+                quantity=1,
+                unit="Miếng",
+                origin="custom",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=630,
+                    protein_per_100g=60,
+                    carbs_per_100g=13.3,
+                    fat_per_100g=36.7,
+                ),
+                allowed_units=[
+                    {
+                        "unit": "Miếng",
+                        "gram_weight": 30.0,
+                        "description": "1 Miếng",
+                    },
+                    {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+                    {"unit": "kg", "gram_weight": 1000.0, "description": "1 kg"},
+                    {"unit": "oz", "gram_weight": 28.35, "description": "1 oz"},
+                ],
+            )
+        ],
+        _References(),
+        contract_version=2,
+    )
+
+    assert resolved[0].quantity == pytest.approx(1)
+    assert resolved[0].unit == "Miếng"
+    assert resolved[0].allowed_units[0] == {
+        "unit": "g",
+        "gram_weight": 1.0,
+        "description": "1 g",
+    }
+    assert any(unit["unit"] == "miếng" for unit in resolved[0].allowed_units)
+    assert {unit["unit"] for unit in resolved[0].allowed_units} >= {
+        "g",
+        "miếng",
+        "kg",
+        "oz",
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_without_allowed_units_defaults_to_grams():
+    resolved = await ManualMealNutritionResolver().resolve_items(
+        [
+            ManualMealItem(
+                name="Soup",
+                quantity=100,
+                unit="g",
+                origin="custom",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=50,
+                    protein_per_100g=2,
+                    carbs_per_100g=5,
+                    fat_per_100g=1,
+                ),
+                allowed_units=None,
+            )
+        ],
+        _References(),
+        contract_version=2,
+    )
+
+    assert resolved[0].allowed_units == [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_local_reference_ignores_client_nutrition_and_units():
     item = ManualMealItem(
         name="Rice",


### PR DESCRIPTION
## Summary
- Custom-origin manual meal resolution now keeps client `allowed_units` (normalized) instead of forcing `{g}`
- Ensures `g` remains present and invalid unit payloads still fall back safely
- Prevents selected servings like **Miếng** from being canonicalized to 30g on save

## Test plan
- [ ] Parse-text meal with Miếng → save → meal details → edit ingredient → **Miếng** chip still present and selected
- [ ] Quantity stays `1 Miếng` (not converted to `30g`)
- [ ] `pytest tests/unit/app/services/test_manual_meal_nutrition_resolver.py`


Made with [Cursor](https://cursor.com)