### PR TITLE
fix(nutrition): keep parse-text fallback for countable units

### DIFF
--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -538,6 +538,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                         if change.custom_nutrition
                         else None
                     ),
+                    allowed_units=change.allowed_units,
                     origin=change.origin,
                     food_reference_id=change.food_reference_id,
                     source_namespace=change.source_namespace,

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -31,9 +31,12 @@ from src.domain.services.ai_output_validation_service import (
 )
 from src.domain.services.emoji_validator import validate_emoji
 from src.domain.services.nutrition_calculation_service import (
+    UNIT_TO_GRAMS,
     _convert_with_allowed_units,
+    _normalize_unit,
     clamp_nutrition_values,
     convert_quantity_to_grams,
+    fallback_custom_serving_options,
     normalize_unit_for_manual_save,
     scale_per_100g_nutrition,
 )
@@ -71,21 +74,24 @@ TRUSTED_QUANTITY_UNITS = {
     "l",
     "liter",
     "litre",
-    "piece",
-    "pieces",
-    "slice",
-    "slices",
-    "cup",
-    "cups",
-    "tablespoon",
-    "tablespoons",
-    "tbsp",
-    "teaspoon",
-    "teaspoons",
-    "tsp",
-    "serving",
-    "portion",
+    "oz",
+    "ounce",
+    "ounces",
+    "lb",
+    "pound",
+    "pounds",
 }
+COUNTABLE_GRAM_UNITS = set(UNIT_TO_GRAMS) - {"kg", "lb", "oz"}
+
+
+def _preferred_parse_unit(item: dict[str, Any]) -> str:
+    """Prefer the local unit when it is a real mass, volume, or countable unit."""
+    local = str(item.get("unit") or "").strip()
+    english = str(item.get("english_unit") or "").strip()
+    local_norm = _normalize_unit(local) if local else ""
+    if local_norm in TRUSTED_QUANTITY_UNITS or local_norm in COUNTABLE_GRAM_UNITS:
+        return local
+    return english or local or "serving"
 
 
 @dataclass
@@ -235,7 +241,11 @@ class ParseMealTextHandler(
                 sugar=item.get("sugar", 0),
                 data_source=item.get("data_source"),
                 fdc_id=item.get("fdc_id"),
-                allowed_units=item.get("allowed_units") or [],
+                allowed_units=item.get("allowed_units")
+                or fallback_custom_serving_options(
+                    item.get("unit") or "serving",
+                    item.get("name") or "",
+                ),
                 food_id=item.get("food_id"),
                 food_reference_id=item.get("food_reference_id"),
                 origin=item.get("origin"),
@@ -632,7 +642,7 @@ class ParseMealTextHandler(
         if item.get("quantity_g") is not None:
             return float(item["quantity_g"])
         quantity = float(item.get("quantity") or 1)
-        unit = item.get("english_unit") or item.get("unit", "serving")
+        unit = _preferred_parse_unit(item)
         return convert_quantity_to_grams(
             quantity, normalize_unit_for_manual_save(unit), food_name
         )
@@ -640,13 +650,24 @@ class ParseMealTextHandler(
     def _trusted_quantity_in_grams(
         self, item: dict[str, Any], food_name: str
     ) -> float | None:
-        """Return grams only when the input supplies a reliable unit basis."""
-        if item.get("quantity_g") is not None:
-            return self._quantity_in_grams(item, food_name)
-        raw_unit = str(item.get("english_unit") or item.get("unit") or "")
-        unit = raw_unit.lower().strip().split(",", 1)[0].split(" ", 1)[0]
-        if unit not in TRUSTED_QUANTITY_UNITS:
+        """Return grams only for mass/volume units, where density is meaningful.
+
+        Countable units (miếng/piece/slice) use estimated gram weights. Treating
+        those estimates as exact grams 422s parse-text whenever FatSecret is down.
+        """
+        local_raw = str(item.get("unit") or "").strip()
+        english_raw = str(item.get("english_unit") or "").strip()
+        local_norm = _normalize_unit(local_raw) if local_raw else ""
+        english_norm = _normalize_unit(english_raw) if english_raw else ""
+        if local_norm and local_norm not in TRUSTED_QUANTITY_UNITS:
             return None
+        if (
+            local_norm not in TRUSTED_QUANTITY_UNITS
+            and english_norm not in TRUSTED_QUANTITY_UNITS
+        ):
+            return None
+        if item.get("quantity_g") is not None:
+            return float(item["quantity_g"])
         return self._quantity_in_grams(item, food_name)
 
     def _local_reference_is_usable(

--- a/src/app/services/manual_meal_nutrition_resolver.py
+++ b/src/app/services/manual_meal_nutrition_resolver.py
@@ -13,6 +13,7 @@ from src.app.commands.meal.create_manual_meal_command import (
 from src.domain.ports.provider_budget_port import ProviderBudgetPort
 from src.domain.services.nutrition_calculation_service import (
     canonicalize_authoritative_quantity,
+    fallback_custom_serving_options,
 )
 from src.domain.services.nutrition_integrity_policy import (
     NutritionIntegrityError,
@@ -203,6 +204,11 @@ class ManualMealNutritionResolver:
             require_energy=False,
             require_metric_basis=False,
         )
+        allowed_units = fallback_custom_serving_options(
+            item.unit,
+            item.name or "",
+            item.allowed_units,
+        )
         return replace(
             item,
             custom_nutrition=CustomNutrition(
@@ -213,10 +219,12 @@ class ManualMealNutritionResolver:
                 fiber_per_100g=result.fiber_100g or 0.0,
                 sugar_per_100g=result.sugar_100g or 0.0,
             ),
-            allowed_units=[{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            allowed_units=allowed_units,
             source_kind="custom",
             nutrition_contract_version="2",
-            source_snapshot=self._snapshot(result, "custom", None, None),
+            source_snapshot=self._snapshot(
+                result, "custom", None, None, allowed_units
+            ),
         )
 
     def _resolve_reference(self, item, reference, origin: str) -> ManualMealItem:

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -69,7 +69,7 @@ UNIT_TRANSLATION = {
     "quả": "piece",
     "trái": "piece",
     "cái": "piece",
-    "miếng": "slice",
+    "miếng": "piece",
     "lát": "slice",
     "khúc": "piece",
     "tô": "cup",
@@ -166,6 +166,36 @@ def normalize_unit_for_manual_save(unit: str | None) -> str:
         "returning 'serving' for manual-save compatibility"
     )
     return "serving"
+
+
+def fallback_custom_serving_options(
+    unit: str,
+    food_name: str = "",
+    existing: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Keep a custom/parse-text unit saveable instead of collapsing to grams."""
+    from src.domain.services.nutrition_integrity_policy import normalize_serving_options
+
+    selected = (unit or "g").strip()
+    selected_key = selected.lower()
+    raw = [option for option in (existing or []) if isinstance(option, dict)]
+    has_selected = any(
+        str(option.get("unit") or "").strip().lower() == selected_key for option in raw
+    )
+    if selected_key not in {"", "g"} and not has_selected:
+        grams = convert_quantity_to_grams(1.0, selected, food_name)
+        if grams <= 0 or (grams == 1.0 and selected_key not in {"g", "ml"}):
+            grams = 100.0
+        raw.append(
+            {
+                "unit": selected,
+                "gram_weight": grams,
+                "description": f"1 {selected}",
+            }
+        )
+    return normalize_serving_options(raw) or [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
+    ]
 
 
 def convert_quantity_to_grams(quantity: float, unit: str, food_name: str = "") -> float:

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -270,7 +270,12 @@ class FatSecretService:
         if not foods:
             error = result.get("error")
             if error:
-                logger.warning("fatsecret API error response received")
+                error_code = (
+                    error.get("code") if isinstance(error, dict) else type(error).__name__
+                )
+                logger.warning(
+                    "fatsecret API error response received: code=%s", error_code
+                )
             else:
                 logger.warning(
                     "fatsecret returned no foods: response_keys=%s",

--- a/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
+++ b/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
@@ -261,3 +261,33 @@ async def test_provider_unit_prefix_cannot_multiply_arbitrary_suffix(caplog):
     nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
     assert nutrition.calories == pytest.approx(76.9)
     assert raw_unit not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_custom_parse_text_unit_is_not_canonicalized_to_grams():
+    resolved = await ManualMealNutritionResolver().resolve_items(
+        [
+            ManualMealItem(
+                name="Sườn Nướng",
+                quantity=1,
+                unit="Miếng",
+                origin="custom",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=187.0,
+                    protein_per_100g=18.0,
+                    carbs_per_100g=4.0,
+                    fat_per_100g=11.0,
+                ),
+            )
+        ],
+        _References(),
+        contract_version=2,
+    )
+
+    assert resolved[0].quantity == pytest.approx(1.0)
+    assert resolved[0].unit == "Miếng"
+    units = {option["unit"]: option["gram_weight"] for option in resolved[0].allowed_units}
+    assert units["miếng"] == pytest.approx(100.0)
+    assert units["g"] == pytest.approx(1.0)
+    nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
+    assert nutrition.macros.protein == pytest.approx(18.0)

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -16,8 +16,10 @@ from src.domain.model.nutrition import Macros, Nutrition
 from src.domain.services.meal_service import MealService
 from src.domain.services.nutrition_calculation_service import (
     NutritionCalculationService,
+    canonicalize_authoritative_quantity,
     clamp_nutrition_values,
     convert_quantity_to_grams,
+    fallback_custom_serving_options,
     normalize_unit_for_manual_save,
     scale_per_100g_nutrition,
 )
@@ -291,3 +293,22 @@ def _new_processing_meal() -> Meal:
         ),
         created_at=datetime.now(UTC),
     )
+
+
+def test_mieng_maps_to_piece_grams_not_slice():
+    assert convert_quantity_to_grams(1, "miếng") == pytest.approx(100.0)
+    assert convert_quantity_to_grams(1, "lát") == pytest.approx(30.0)
+
+
+def test_fallback_custom_serving_options_keep_selected_countable_unit():
+    options = fallback_custom_serving_options("Miếng", "Sườn Nướng")
+    units = {option["unit"]: option["gram_weight"] for option in options}
+
+    assert units["g"] == pytest.approx(1.0)
+    assert units["miếng"] == pytest.approx(100.0)
+    quantity, unit, used_fallback = canonicalize_authoritative_quantity(
+        1, "Miếng", options, "Sườn Nướng"
+    )
+    assert quantity == pytest.approx(1.0)
+    assert unit == "Miếng"
+    assert used_fallback is False

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -362,6 +362,82 @@ async def test_parse_text_unit_stays_compatible_with_prompt_manual_save():
 
 
 @pytest.mark.asyncio
+async def test_parse_text_unmatched_countable_unit_is_saved_as_allowed_unit():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Sườn Nướng",
+                        "quantity": 1,
+                        "unit": "miếng",
+                        "english_unit": "piece",
+                        "calories": 298,
+                        "protein": 18,
+                        "carbs": 4,
+                        "fat": 11,
+                    }
+                ]
+            }
+        ]
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_FakeFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="1 miếng sườn nướng", user_id="user-1", language="vi")
+    )
+    item = response.items[0]
+    units = {option["unit"]: option["gram_weight"] for option in item.allowed_units}
+
+    assert item.unit == "miếng"
+    assert item.quantity == 1
+    assert "miếng" in units
+    assert units["miếng"] == pytest.approx(100.0)
+    assert units["g"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_parse_text_countable_unit_survives_provider_outage():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Sườn Nướng",
+                        "lookup_name": "grilled pork ribs",
+                        "quantity": 1,
+                        "unit": "miếng",
+                        "english_unit": "slice",
+                        "macros": {
+                            "protein_g": 18,
+                            "carbs_g": 4,
+                            "fat_g": 11,
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_FakeFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="1 miếng sườn nướng", user_id="user-1", language="vi")
+    )
+    item = response.items[0]
+
+    assert item.unit == "miếng"
+    assert item.quantity == 1
+    assert item.protein == pytest.approx(18)
+    assert item.data_source == "ai_estimate"
+
+
+@pytest.mark.asyncio
 async def test_parse_text_translates_only_structurally_identified_english_name():
     generation = _FakeMealGenerationService(
         responses=[

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -253,6 +253,21 @@ async def test_fatsecret_search_candidates_does_not_fetch_details():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_fatsecret_search_candidates_logs_error_code(caplog):
+    service = FatSecretService("client", "secret")
+    service._api_request = AsyncMock(
+        return_value={"error": {"code": 21, "message": "Invalid OAuth signature"}}
+    )
+
+    with caplog.at_level("WARNING"):
+        results = await service.search_food_candidates("grilled pork ribs")
+
+    assert results == []
+    assert any("code=21" in record.message for record in caplog.records)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_fatsecret_get_food_details_fetches_one_selected_candidate():
     service = FatSecretService("client", "secret")
     service._api_request = AsyncMock(


### PR DESCRIPTION
## Summary
- Skip the parse-text density 422 when FatSecret is down and the AI estimate uses a countable unit (`miếng`, piece, slice)
- Map Vietnamese `miếng` to `piece` (100g) instead of `slice` (30g)
- Persist selected custom servings on unmatched parse-text items and manual save
- Log FatSecret API error codes on empty search responses

## Test plan
- [ ] Parse `1 miếng sườn nướng` with FatSecret failing and confirm 200 + `ai_estimate` instead of 422
- [ ] Confirm `100g potato` with implausible fat still 422s
- [ ] `uv run pytest tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py tests/unit/infra/adapters/test_fat_secret_service.py tests/unit/domain/services/test_nutrition_calculation_service.py tests/unit/app/services/test_manual_meal_nutrition_resolver.py`

Made with [Cursor](https://cursor.com)