### PR TITLE
fix(parse-text): keep FatSecret per-100g macros for unknown units

### DIFF
--- a/src/api/routes/v1/meals_route_helpers.py
+++ b/src/api/routes/v1/meals_route_helpers.py
@@ -47,4 +47,9 @@ def parsed_food_item_to_response(item) -> ParsedFoodItem:
         nutrition_basis=getattr(item, "nutrition_basis", None),
         nutrition_contract_version=getattr(item, "nutrition_contract_version", None),
         calories_per_100g=getattr(item, "calories_per_100g", None),
+        protein_per_100g=getattr(item, "protein_per_100g", None),
+        carbs_per_100g=getattr(item, "carbs_per_100g", None),
+        fat_per_100g=getattr(item, "fat_per_100g", None),
+        fiber_per_100g=getattr(item, "fiber_per_100g", None),
+        sugar_per_100g=getattr(item, "sugar_per_100g", None),
     )

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -77,6 +77,21 @@ class ParsedFoodItem(BaseModel):
     calories_per_100g: float | None = Field(
         None, ge=0, description="Backend-derived calories per 100g"
     )
+    protein_per_100g: float | None = Field(
+        None, ge=0, description="Backend-derived protein per 100g"
+    )
+    carbs_per_100g: float | None = Field(
+        None, ge=0, description="Backend-derived carbs per 100g"
+    )
+    fat_per_100g: float | None = Field(
+        None, ge=0, description="Backend-derived fat per 100g"
+    )
+    fiber_per_100g: float | None = Field(
+        None, ge=0, description="Backend-derived fiber per 100g"
+    )
+    sugar_per_100g: float | None = Field(
+        None, ge=0, description="Backend-derived sugar per 100g"
+    )
 
 
 class ParseMealTextResponse(BaseModel):

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -254,6 +254,11 @@ class ParseMealTextHandler(
                 nutrition_basis=item.get("nutrition_basis"),
                 nutrition_contract_version=item.get("nutrition_contract_version"),
                 calories_per_100g=item.get("calories_per_100g"),
+                protein_per_100g=item.get("protein_per_100g"),
+                carbs_per_100g=item.get("carbs_per_100g"),
+                fat_per_100g=item.get("fat_per_100g"),
+                fiber_per_100g=item.get("fiber_per_100g"),
+                sugar_per_100g=item.get("sugar_per_100g"),
             )
             for item in enhanced_items
         ]
@@ -612,6 +617,13 @@ class ParseMealTextHandler(
                 "fiber_g": per_100g.get("fiber_100g", per_100g.get("fiber", 0)),
             }
         )
+        item["protein_per_100g"] = per_100g.get(
+            "protein_100g", per_100g.get("protein", 0)
+        )
+        item["carbs_per_100g"] = per_100g.get("carbs_100g", per_100g.get("carbs", 0))
+        item["fat_per_100g"] = per_100g.get("fat_100g", per_100g.get("fat", 0))
+        item["fiber_per_100g"] = per_100g.get("fiber_100g", per_100g.get("fiber", 0))
+        item["sugar_per_100g"] = per_100g.get("sugar_100g", per_100g.get("sugar", 0))
         return item
 
     async def _provider_call(
@@ -738,6 +750,11 @@ class ParseMealTextHandler(
                 "fiber_g": candidate.fiber_per_100g,
             }
         )
+        item["protein_per_100g"] = candidate.protein_per_100g
+        item["carbs_per_100g"] = candidate.carbs_per_100g
+        item["fat_per_100g"] = candidate.fat_per_100g
+        item["fiber_per_100g"] = candidate.fiber_per_100g
+        item["sugar_per_100g"] = candidate.sugar_per_100g
         item["allowed_units"] = allowed_units
         return item
 

--- a/src/app/schemas/meal_schemas.py
+++ b/src/app/schemas/meal_schemas.py
@@ -30,6 +30,11 @@ class ParsedFoodItemDto:
     nutrition_basis: str | None = None
     nutrition_contract_version: str | None = None
     calories_per_100g: float | None = None
+    protein_per_100g: float | None = None
+    carbs_per_100g: float | None = None
+    fat_per_100g: float | None = None
+    fiber_per_100g: float | None = None
+    sugar_per_100g: float | None = None
 
 
 @dataclass

--- a/tests/integration/api/test_parse_text_identity_contract.py
+++ b/tests/integration/api/test_parse_text_identity_contract.py
@@ -128,3 +128,4 @@ def test_parse_response_keeps_legacy_fields_and_adds_identity_metadata():
     assert response.source_namespace == "fatsecret"
     assert response.source_food_id == "fs-42"
     assert response.calories_per_100g == 124.7
+    assert response.protein_per_100g is None

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -16,6 +16,7 @@ from src.domain.model.nutrition import Macros, Nutrition
 from src.domain.services.meal_service import MealService
 from src.domain.services.nutrition_calculation_service import (
     NutritionCalculationService,
+    _convert_with_allowed_units,
     canonicalize_authoritative_quantity,
     clamp_nutrition_values,
     convert_quantity_to_grams,
@@ -274,6 +275,27 @@ def test_clamp_nutrition_uses_manual_save_unit_for_ai_free_text():
         "carbs": 80.0,
         "fat": 12.0,
     }
+
+
+def test_unknown_tuber_unit_uses_countable_provider_serving_not_one_gram():
+    allowed_units = [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+        {
+            "unit": "sweetpotato",
+            "gram_weight": 130.0,
+            "description": "1 sweetpotato",
+        },
+        {"unit": "oz", "gram_weight": 28.35, "description": "1 oz"},
+        {"unit": "cup", "gram_weight": 200.0, "description": "1 cup, mashed"},
+    ]
+
+    assert _convert_with_allowed_units(
+        1, "củ lớn", allowed_units, "Khoai lang"
+    ) == pytest.approx(130.0)
+    with pytest.raises(ValueError):
+        _convert_with_allowed_units(
+            1, "củ lớn", allowed_units, "Khoai lang", strict=True
+        )
 
 
 def _new_processing_meal() -> Meal:

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -213,6 +213,39 @@ class _LocalizedServingFatSecretService:
         }
 
 
+class _SweetPotatoFatSecretService:
+    async def search_food_candidates(self, *args, **kwargs):
+        return [
+            {
+                "food_id": "sweet-potato",
+                "food_name": "Sweetpotato, raw",
+                "food_type": "Generic",
+            }
+        ]
+
+    async def get_food_details(self, food_id, **kwargs):
+        return {
+            "food_id": food_id,
+            "food_name": "Sweetpotato, raw",
+            "protein_100g": 1.6,
+            "carbs_100g": 20.1,
+            "fat_100g": 0.1,
+            "fiber_100g": 3.0,
+            "calories_100g": 86.0,
+            "metric_serving_amount": 100.0,
+            "allowed_units": [
+                {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+                {
+                    "unit": "sweetpotato",
+                    "gram_weight": 130.0,
+                    "description": "1 sweetpotato",
+                },
+                {"unit": "oz", "gram_weight": 28.35, "description": "1 oz"},
+                {"unit": "cup", "gram_weight": 200.0, "description": "1 cup, mashed"},
+            ],
+        }
+
+
 class _CountingFatSecretService:
     def __init__(self):
         self.search_calls = 0
@@ -719,6 +752,9 @@ async def test_parse_text_uses_one_staged_detail_for_wrong_first_candidate():
     assert len(provider.detail_calls) == 1
     assert provider.detail_calls[0][0] == "generic-potato"
     assert response.items[0].data_source == "fatsecret"
+    assert response.items[0].protein_per_100g == pytest.approx(2.0)
+    assert response.items[0].carbs_per_100g == pytest.approx(17.0)
+    assert response.items[0].fat_per_100g == pytest.approx(0.1)
 
 
 @pytest.mark.asyncio
@@ -800,6 +836,46 @@ async def test_provider_parse_falls_back_to_grams_for_unsupported_serving_unit()
         item.name,
         strict=True,
     ) == pytest.approx(180)
+
+
+@pytest.mark.asyncio
+async def test_provider_parse_emits_catalog_density_for_unknown_tuber_unit():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[
+            {
+                "items": [
+                    {
+                        "name": "Khoai lang",
+                        "lookup_name": "sweetpotato",
+                        "quantity": 1,
+                        "unit": "củ lớn",
+                        "english_unit": "serving",
+                        "protein": 2.1,
+                        "carbs": 25.6,
+                        "fat": 0.1,
+                    }
+                ]
+            }
+        ]
+    )
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_SweetPotatoFatSecretService(),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(
+            text="1 củ lớn khoai lang", user_id="user-1", language="vi"
+        )
+    )
+    item = response.items[0]
+
+    assert item.data_source == "fatsecret"
+    assert item.protein_per_100g == pytest.approx(1.6)
+    assert item.carbs_per_100g == pytest.approx(20.1)
+    assert item.fat_per_100g == pytest.approx(0.1)
+    assert item.calories_per_100g == pytest.approx(81.7, abs=1.0)
+    assert item.unit == "g"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Unknown parse-text units like `củ lớn` were missing catalog density, so the client rebuilt per-100g macros from 1g and showed **890 kcal** for 100g.
- Send FatSecret `protein/carbs/fat_per_100g` on parse-text items so 100g stays **~89 kcal**.

## Test plan
- [ ] Parse `1 củ lớn khoai lang` and confirm response includes catalog `protein_per_100g` / `calories_per_100g`
- [ ] `uv run pytest tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py::test_provider_parse_emits_catalog_density_for_unknown_tuber_unit tests/unit/domain/services/test_nutrition_calculation_service.py tests/integration/api/test_parse_text_identity_contract.py`

Companion mobile (merged): https://github.com/Nutree-AI-Vietnam/nutree_ai/pull/657

Made with [Cursor](https://cursor.com)