### PR TITLE
fix(translation): invalidate legacy meal translations

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -76,7 +76,9 @@ Do not hand-maintain file, LOC, or endpoint counts in this document.
 - Translation: OpenAI-backed read-path localization via
   `src/app/services/food_name_localizer.py` and
   `src/infra/adapters/openai_translation_adapter.py`; Responses API payload
-  storage is disabled, and only complete translations are eligible for cache or
+  storage is disabled, persisted meal translation rows are versioned against
+  the active translation contract so older rows are invalidated and
+  retranslated, and only complete translations are eligible for cache or
   persistence.
 - Event bus: singleton PyMediator from `src/api/dependencies/event_bus.py`.
 - Migrations: `migrations/versions/` via Alembic / `migrations/run.py`.

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -91,6 +91,9 @@ internal IDs, status codes, and error class.
 - The OpenAI translation adapter uses the Responses API with
   `store_responses=False`; the translation path never opts back into payload
   storage.
+- Persisted meal translation rows written before the active translation version
+  are treated as stale and excluded from responses until the next translation
+  request rewrites them.
 - Translation requests are bounded indexed batches. The adapter sends the
   indexed item text only, treats it as data rather than instructions, and
   preserves placeholders, units, and brands.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -91,8 +91,10 @@ result calories are always derived from stored macros using the backend formula.
 
 Read-path localization is presentation-only. The application layer owns the
 translation service used by catalog and suggestion responses; the infrastructure
-adapter uses the OpenAI Responses API with payload storage disabled. The domain
-translation service returns explicit outcomes, and only
+adapter uses the OpenAI Responses API with payload storage disabled. Persisted
+meal translation rows are versioned against the active translation contract, so
+rows written before that version are invalidated and retranslated on demand.
+The domain translation service returns explicit outcomes, and only
 `TranslationOutcome.TRANSLATED` may be persisted or admitted to locale caches.
 `PARTIAL`, `PASSTHROUGH`, and `UNAVAILABLE` keep canonical text in the response
 path.

--- a/migrations/versions/20260817000001_add_meal_translation_version.py
+++ b/migrations/versions/20260817000001_add_meal_translation_version.py
@@ -1,0 +1,22 @@
+"""Track the translation contract used to create persisted meal translations."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260817000001"
+down_revision = "20260815000004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add a nullable version so pre-cutover rows are retranslated once."""
+    op.add_column(
+        "meal_translation",
+        sa.Column("translation_version", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove the translation contract marker."""
+    op.drop_column("meal_translation", "translation_version")

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -16,6 +16,9 @@ from src.api.schemas.response import (
 )
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
 from src.domain.model.meal import Meal
+from src.domain.model.meal.meal_translation_domain_models import (
+    CURRENT_MEAL_TRANSLATION_VERSION,
+)
 from src.domain.model.nutrition import FoodItem, Macros, Micros, Nutrition
 from src.domain.ports.food_reference_repository_port import (
     FoodReferenceNutritionProjection,
@@ -227,7 +230,7 @@ class MealMapper:
 
         if target_language and target_language != "en" and meal.translations:
             tr = meal.translations.get(target_language)
-            if tr:
+            if tr and tr.translation_version == CURRENT_MEAL_TRANSLATION_VERSION:
                 translation_language = target_language
                 # Apply each translated field independently if it exists
                 # (lenient check - scanned meals may not have instructions)

--- a/src/domain/model/meal/meal_translation_domain_models.py
+++ b/src/domain/model/meal/meal_translation_domain_models.py
@@ -117,9 +117,9 @@ class MealTranslation:
             dish_name=data["dish_name"],
             food_items=[FoodItemTranslation.from_dict(fi) for fi in data["food_items"]],
             translated_at=datetime.fromisoformat(data["translated_at"]),
-            translation_version=data.get(
-                "translation_version", CURRENT_MEAL_TRANSLATION_VERSION
-            ),
+            # Missing versions belong to the legacy contract and must not be
+            # admitted as current cache entries.
+            translation_version=data.get("translation_version"),
         )
 
     def get_food_item_translation(

--- a/src/domain/model/meal/meal_translation_domain_models.py
+++ b/src/domain/model/meal/meal_translation_domain_models.py
@@ -7,7 +7,8 @@ data integrity and support multiple languages.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional
+
+CURRENT_MEAL_TRANSLATION_VERSION = 2
 
 
 @dataclass
@@ -23,7 +24,7 @@ class FoodItemTranslation:
 
     food_item_id: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
@@ -56,32 +57,45 @@ class MealTranslation:
         translated_at: Timestamp of translation
         meal_instruction: Translated instructions as List[{instruction, duration_minutes}]
         meal_ingredients: Translated ingredient names as List[str] (same order as food items)
+        translation_version: Contract version used to create the persisted row.
     """
 
     meal_id: str
     language: str
     dish_name: str
-    food_items: List[FoodItemTranslation]
+    food_items: list[FoodItemTranslation]
     translated_at: datetime = field(default_factory=datetime.utcnow)
-    meal_instruction: Optional[list] = None
-    meal_ingredients: Optional[list] = None
+    meal_instruction: list | None = None
+    meal_ingredients: list | None = None
+    translation_version: int | None = CURRENT_MEAL_TRANSLATION_VERSION
 
     def is_fully_cached(
         self,
         *,
         expected_ingredient_count: int | None = None,
         expected_instruction_count: int | None = None,
+        expected_translation_version: int = CURRENT_MEAL_TRANSLATION_VERSION,
     ) -> bool:
         """Return whether the row covers the available source manifest."""
-        if self.dish_name is None or self.meal_ingredients is None:
+        if (
+            self.translation_version != expected_translation_version
+            or self.dish_name is None
+            or self.meal_ingredients is None
+        ):
             return False
-        if expected_ingredient_count is not None and len(self.meal_ingredients) != expected_ingredient_count:
+        if (
+            expected_ingredient_count is not None
+            and len(self.meal_ingredients) != expected_ingredient_count
+        ):
             return False
         if expected_instruction_count is None:
             return self.meal_instruction is not None
         if expected_instruction_count == 0:
             return self.meal_instruction in (None, [])
-        return self.meal_instruction is not None and len(self.meal_instruction) == expected_instruction_count
+        return (
+            self.meal_instruction is not None
+            and len(self.meal_instruction) == expected_instruction_count
+        )
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
@@ -91,6 +105,7 @@ class MealTranslation:
             "dish_name": self.dish_name,
             "food_items": [fi.to_dict() for fi in self.food_items],
             "translated_at": self.translated_at.isoformat(),
+            "translation_version": self.translation_version,
         }
 
     @classmethod
@@ -102,11 +117,14 @@ class MealTranslation:
             dish_name=data["dish_name"],
             food_items=[FoodItemTranslation.from_dict(fi) for fi in data["food_items"]],
             translated_at=datetime.fromisoformat(data["translated_at"]),
+            translation_version=data.get(
+                "translation_version", CURRENT_MEAL_TRANSLATION_VERSION
+            ),
         )
 
     def get_food_item_translation(
         self, food_item_id: str
-    ) -> Optional[FoodItemTranslation]:
+    ) -> FoodItemTranslation | None:
         """Get translation for a specific food item."""
         for fi in self.food_items:
             if fi.food_item_id == food_item_id:

--- a/src/domain/services/meal_analysis/meal_translation_service.py
+++ b/src/domain/services/meal_analysis/meal_translation_service.py
@@ -55,14 +55,14 @@ class MealTranslationService:
             return None
 
         try:
+            named_food_items = [item for item in food_items if item.name]
+
             # --- Cache check ---
             existing = await self._get_by_meal_and_language(
                 meal.meal_id, target_language
             )
             if existing and existing.is_fully_cached(
-                expected_ingredient_count=len(
-                    [item for item in food_items if item.name]
-                ),
+                expected_ingredient_count=len(named_food_items),
                 expected_instruction_count=len(instructions or []),
             ):
                 logger.debug(
@@ -83,7 +83,7 @@ class MealTranslationService:
                             {"instruction": step, "duration_minutes": None}
                         )
 
-            ingredient_names = [item.name for item in food_items if item.name]
+            ingredient_names = [item.name for item in named_food_items]
             instruction_texts = [s.get("instruction", "") for s in normalised_steps]
 
             # Build a single flat list so we use one provider call.
@@ -108,9 +108,8 @@ class MealTranslationService:
                     name=translated_name,
                 )
                 for item, translated_name in zip(
-                    food_items, translated_ingredients, strict=False
+                    named_food_items, translated_ingredients, strict=False
                 )
-                if item.name
             ]
 
             m = len(instruction_texts)

--- a/src/infra/database/models/meal/meal_translation_model.py
+++ b/src/infra/database/models/meal/meal_translation_model.py
@@ -4,7 +4,8 @@ Meal translation database models.
 Stores translated content separately from original English to support
 multiple languages.
 """
-from sqlalchemy import Column, String, DateTime, Integer, ForeignKey, Boolean, JSON
+
+from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from src.infra.database.base import Base
@@ -31,6 +32,8 @@ class MealTranslationORM(Base):
     created_at = Column(DateTime(timezone=True), nullable=False)
     meal_instruction = Column(JSON, nullable=True)
     meal_ingredients = Column(JSON, nullable=True)
+    # NULL marks rows created before the OpenAI translation contract.
+    translation_version = Column(Integer, nullable=True)
 
     # Soft delete
     is_deleted = Column(Boolean, default=False, nullable=False, server_default="false")

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -145,6 +145,7 @@ def meal_translation_orm_to_domain(orm: MealTranslationORM) -> DomainMealTransla
         translated_at=orm.translated_at,
         meal_instruction=orm.meal_instruction,
         meal_ingredients=orm.meal_ingredients,
+        translation_version=getattr(orm, "translation_version", None),
     )
 
 
@@ -299,6 +300,7 @@ def meal_translation_domain_to_orm(domain: DomainMealTranslation) -> MealTransla
         created_at=_to_naive_utc(now),
         meal_instruction=domain.meal_instruction,
         meal_ingredients=domain.meal_ingredients,
+        translation_version=domain.translation_version,
     )
     for fi in domain.food_items:
         translation.food_items.append(

--- a/src/infra/repositories/meal_translation_repository_async.py
+++ b/src/infra/repositories/meal_translation_repository_async.py
@@ -38,6 +38,7 @@ class AsyncMealTranslationRepository(MealTranslationRepositoryPort):
             existing.translated_at = translation.translated_at
             existing.meal_instruction = translation.meal_instruction
             existing.meal_ingredients = translation.meal_ingredients
+            existing.translation_version = translation.translation_version
             for food_item in list(existing.food_items):
                 await self._session.delete(food_item)
             await self._session.flush()

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -11,6 +11,9 @@ import pytest
 from src.api.mappers.meal_mapper import STATUS_MAPPING, MealMapper
 from src.domain.model import FoodItem, Macros, Meal, MealImage, MealStatus, Nutrition
 from src.domain.model.meal import FoodItemTranslation, MealTranslation
+from src.domain.model.meal.meal_translation_domain_models import (
+    CURRENT_MEAL_TRANSLATION_VERSION,
+)
 from src.domain.ports.food_reference_repository_port import (
     FoodReferenceNutritionProjection,
 )
@@ -457,6 +460,49 @@ class TestMealMapper:
         assert result.food_items[0].display_name == "Rice"
         assert result.food_items[0].canonical_name == "Rice"
         assert result.translation_language == "vi"
+
+    def test_to_detailed_response_does_not_apply_pre_cutover_translation(self):
+        food_item = FoodItem(
+            id="item-2",
+            name="Rice",
+            quantity=150,
+            unit="g",
+            macros=Macros(protein=4, carbs=43, fat=0.4),
+        )
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/detailed.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            dish_name="Rice",
+            ready_at=datetime(2025, 1, 15, 14, 0),
+            created_at=datetime(2025, 1, 15, 13, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=4, carbs=43, fat=0.4),
+                food_items=[food_item],
+            ),
+            translations={
+                "vi": MealTranslation(
+                    meal_id="meal-1",
+                    language="vi",
+                    dish_name="Cơm",
+                    meal_ingredients=["Cơm"],
+                    food_items=[],
+                    translation_version=CURRENT_MEAL_TRANSLATION_VERSION - 1,
+                )
+            },
+        )
+
+        result = MealMapper.to_detailed_response(meal, target_language="vi")
+
+        assert result.dish_name == "Rice"
+        assert result.food_items[0].name == "Rice"
+        assert result.translation_language is None
 
     def test_to_detailed_response_with_custom_food_item(self):
         """Test detailed response with custom food item."""

--- a/tests/unit/domain/model/test_meal_translation.py
+++ b/tests/unit/domain/model/test_meal_translation.py
@@ -122,6 +122,7 @@ class TestMealTranslation:
         assert translation.dish_name == "炒饭"
         assert len(translation.food_items) == 1
         assert translation.food_items[0].name == "米饭"
+        assert translation.translation_version is None
 
     def test_get_food_item_translation(self):
         """Test getting a specific food item translation."""

--- a/tests/unit/domain/model/test_meal_translation.py
+++ b/tests/unit/domain/model/test_meal_translation.py
@@ -2,12 +2,14 @@
 Unit tests for meal translation domain models.
 """
 
-import pytest
 from datetime import datetime
 
 from src.domain.model.meal import (
-    MealTranslation,
     FoodItemTranslation,
+    MealTranslation,
+)
+from src.domain.model.meal.meal_translation_domain_models import (
+    CURRENT_MEAL_TRANSLATION_VERSION,
 )
 
 
@@ -146,3 +148,32 @@ class TestMealTranslation:
         result = translation.get_food_item_translation("non-existent")
 
         assert result is None
+
+    def test_pre_cutover_translation_is_not_a_current_cache_hit(self):
+        translation = MealTranslation(
+            meal_id="meal-003",
+            language="vi",
+            dish_name="Banh mi",
+            food_items=[],
+            meal_ingredients=["Banh mi"],
+            translation_version=CURRENT_MEAL_TRANSLATION_VERSION - 1,
+        )
+
+        assert translation.is_fully_cached(expected_ingredient_count=1) is False
+
+    def test_current_translation_is_a_cache_hit_when_manifest_matches(self):
+        translation = MealTranslation(
+            meal_id="meal-004",
+            language="vi",
+            dish_name="Banh mi",
+            food_items=[],
+            meal_ingredients=["Banh mi"],
+            translation_version=CURRENT_MEAL_TRANSLATION_VERSION,
+        )
+
+        assert (
+            translation.is_fully_cached(
+                expected_ingredient_count=1, expected_instruction_count=0
+            )
+            is True
+        )

--- a/tests/unit/domain/services/test_meal_translation_service.py
+++ b/tests/unit/domain/services/test_meal_translation_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
@@ -6,7 +7,10 @@ import pytest
 
 from src.domain.model.meal.meal import Meal, MealStatus
 from src.domain.model.meal.meal_image import MealImage
-from src.domain.model.meal.meal_translation_domain_models import MealTranslation
+from src.domain.model.meal.meal_translation_domain_models import (
+    CURRENT_MEAL_TRANSLATION_VERSION,
+    MealTranslation,
+)
 from src.domain.model.nutrition.macros import Macros
 from src.domain.model.nutrition.nutrition import FoodItem
 from src.domain.model.translation_result import TranslationOutcome, TranslationResult
@@ -158,6 +162,33 @@ async def test_translate_meal_calls_provider_and_saves(
 
 
 @pytest.mark.asyncio
+async def test_translate_meal_keeps_named_items_aligned_after_filtering(
+    service, meal, food_items, text_translation_service
+):
+    unnamed_item = SimpleNamespace(id="unnamed", name=None)
+    text_translation_service.translate_texts.return_value = TranslationResult(
+        ("Bữa ăn", "Ức gà", "Cơm gạo lứt"),
+        TranslationOutcome.TRANSLATED,
+        "en",
+        "vi",
+    )
+
+    result = await service.translate_meal(
+        meal,
+        dish_name="Meal",
+        food_items=[unnamed_item, *food_items],
+        target_language="vi",
+    )
+
+    assert result is not None
+    assert [item.food_item_id for item in result.food_items] == [
+        str(food_items[0].id),
+        str(food_items[1].id),
+    ]
+    assert [item.name for item in result.food_items] == ["Ức gà", "Cơm gạo lứt"]
+
+
+@pytest.mark.asyncio
 async def test_translate_meal_awaits_async_translation_repo(
     async_repo_service, async_repo, meal, food_items, text_translation_service
 ):
@@ -178,6 +209,38 @@ async def test_translate_meal_awaits_async_translation_repo(
     assert result is not None
     async_repo.get_by_meal_and_language.assert_awaited_once_with(meal.meal_id, "vi")
     async_repo.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_translate_meal_retranslates_pre_cutover_cache(
+    service, meal, food_items, text_translation_service, repo
+):
+    repo.get_by_meal_and_language.return_value = MealTranslation(
+        meal_id=meal.meal_id,
+        language="vi",
+        dish_name="Bữa ăn cũ",
+        food_items=[],
+        meal_ingredients=["Bread", "Pork"],
+        translation_version=CURRENT_MEAL_TRANSLATION_VERSION - 1,
+    )
+    text_translation_service.translate_texts.return_value = TranslationResult(
+        ("Bữa ăn", "Ức gà", "Cơm gạo lứt"),
+        TranslationOutcome.TRANSLATED,
+        "en",
+        "vi",
+    )
+
+    result = await service.translate_meal(
+        meal,
+        dish_name="Meal",
+        food_items=food_items,
+        target_language="vi",
+    )
+
+    assert result is not None
+    text_translation_service.translate_texts.assert_awaited_once()
+    repo.save.assert_called_once()
+    assert result.translation_version == CURRENT_MEAL_TRANSLATION_VERSION
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infra/adapters/test_openai_translation_eval_fixture.py
+++ b/tests/unit/infra/adapters/test_openai_translation_eval_fixture.py
@@ -76,18 +76,18 @@ def test_active_repository_surfaces_contain_no_vendor_translation_residue() -> N
         root / "src/mealtrack_backend.egg-info",
     )
     excluded_names = {"repomix-output.xml"}
+    source_names = {".importlinter", ".env.example", "Dockerfile"}
     excluded_dir_names = {".venv", ".pytest_cache", "__pycache__"}
     source_suffixes = {".py", ".md", ".toml", ".txt", ".lock", ".example"}
     hits: list[str] = []
 
     for path in root.rglob("*"):
         relative_parts = path.relative_to(root).parts
-        if (
-            not path.is_file()
-            or path.name in excluded_names
-            or path.suffix not in source_suffixes
-            or any(part in excluded_dir_names for part in relative_parts)
-        ):
+        if not path.is_file() or path.name in excluded_names:
+            continue
+        if path.name not in source_names and path.suffix not in source_suffixes:
+            continue
+        if any(part in excluded_dir_names for part in relative_parts):
             continue
         if any(
             path == prefix or prefix in path.parents for prefix in excluded_prefixes

--- a/tests/unit/infra/repositories/test_meal_translation_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_translation_repository_async.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from src.domain.model.meal.meal_translation_domain_models import MealTranslation
+from src.domain.model.meal.meal_translation_domain_models import (
+    CURRENT_MEAL_TRANSLATION_VERSION,
+    MealTranslation,
+)
 from src.infra.repositories.meal_translation_repository_async import (
     AsyncMealTranslationRepository,
 )
@@ -66,6 +69,7 @@ def _translation_orm():
     row.translated_at = datetime(2026, 6, 9, tzinfo=UTC)
     row.meal_instruction = [{"instruction": "Cook", "duration_minutes": 5}]
     row.meal_ingredients = ["ga"]
+    row.translation_version = CURRENT_MEAL_TRANSLATION_VERSION
     return row
 
 
@@ -95,6 +99,7 @@ async def test_get_by_meal_and_language_maps_domain():
     assert result is not None
     assert result.meal_id == "meal-1"
     assert result.language == "vi"
+    assert result.translation_version == CURRENT_MEAL_TRANSLATION_VERSION
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Invalidate persisted meal translation rows created before the current OpenAI translation contract.
- Prevent stale rows from being displayed by meal detail responses until a new translation request rewrites them.
- Preserve ingredient-to-translation alignment when source items are filtered.
- Extend the active translation-residue guard to configuration surfaces and update translation docs.

PR #524 already removed the active DeepL provider path. This follow-up addresses the stale persisted rows and incomplete ingredient behavior that could make a deployed OpenAI path still appear untranslated.

## Validation

- `2497 passed` with `79.64%` coverage (`tests/unit --cov=src --cov-fail-under=65`)
- Focused translation/meal-insight/mapper tests: `72 passed`
- Compile, targeted Ruff, format, diff, and Alembic head checks passed
- Active source/config scan contains no DeepL residue

## Deployment notes

- Apply Alembic migration `20260817000001_add_meal_translation_version` before starting the application revision.
- Existing rows remain nullable and are intentionally treated as stale; they are not backfilled.
- Production/provider/device verification is still separate from local test evidence.
