### PR TITLE
fix(api): raise ingredient edit rate limit and return v2 meal_detail

### DIFF
--- a/src/api/routes/v1/meals_edit.py
+++ b/src/api/routes/v1/meals_edit.py
@@ -39,6 +39,9 @@ from src.infra.event_bus import BackgroundTaskManager, EventBus
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
+# Ingredient PUTs are cheap writes. 60/minute is a backstop, not an AI cap.
+MEAL_INGREDIENTS_EDIT_LIMIT = "60/minute"
+
 
 def _validate_uploaded_meal_photo_url(image_url: str, image_id: str) -> None:
     parsed = urlparse(image_url)
@@ -61,7 +64,7 @@ async def delete_meal(
 
 
 @router.put("/{meal_id}/ingredients", response_model=None)
-@limiter.limit("10/minute")
+@limiter.limit(MEAL_INGREDIENTS_EDIT_LIMIT)
 async def update_meal_ingredients(
     meal_id: str,
     payload: EditMealIngredientsRequest,

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -448,6 +448,71 @@ def test_meals_edit_ingredients_edit_group(client: TestClient):
     assert edit_command.dish_name == "Updated Dish"
 
 
+def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
+    """v2 PUT returns meal_detail so clients can skip a follow-up GET."""
+    from datetime import datetime
+    from uuid import uuid4
+
+    from src.api.dependencies.event_bus import get_configured_event_bus
+    from src.app.commands.meal import EditMealCommand
+    from src.domain.model.meal import Meal, MealStatus
+    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+
+    meal_id = str(uuid4())
+    meal = Meal(
+        meal_id=meal_id,
+        user_id=str(uuid4()),
+        status=MealStatus.READY,
+        created_at=datetime(2026, 7, 2, 12, 0),
+        ready_at=datetime(2026, 7, 2, 12, 0),
+        image=None,
+        dish_name="Updated Dish",
+        source="scanner",
+        nutrition=Nutrition(
+            macros=Macros(protein=35, carbs=5, fat=20),
+            food_items=[
+                FoodItem(
+                    id="item-1",
+                    name="Salmon",
+                    quantity=200,
+                    unit="g",
+                    macros=Macros(protein=35, carbs=5, fat=20),
+                )
+            ],
+        ),
+    )
+
+    class _EditBus:
+        async def send(self, msg):
+            if isinstance(msg, EditMealCommand):
+                return {"success": True}
+            return meal
+
+    client.app.dependency_overrides[get_configured_event_bus] = lambda: _EditBus()
+
+    r = client.put(
+        f"/v1/meals/{meal_id}/ingredients",
+        json={
+            "dish_name": "Updated Dish",
+            "food_item_changes": [],
+            "nutrition_contract_version": 2,
+        },
+        headers={
+            "X-Nutrition-Contract-Version": "2",
+            "X-App-Version": "1.0.0",
+            "X-Platform": "ios",
+            "Idempotency-Key": "smoke-edit-v2",
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["meal_detail"]["meal_id"] == meal_id
+    assert body["meal_detail"]["dish_name"] == "Updated Dish"
+    assert body["meal_detail"]["food_items"][0]["name"] == "Salmon"
+
+
 def test_meals_streak_smoke(client: TestClient):
     """Smoke coverage for GET /v1/meals/streak."""
     from src.api.dependencies.event_bus import get_configured_event_bus

--- a/tests/unit/api/test_meals_edit_rate_limit.py
+++ b/tests/unit/api/test_meals_edit_rate_limit.py
@@ -1,0 +1,6 @@
+from src.api.routes.v1 import meals_edit
+
+
+def test_meal_ingredient_writes_use_a_backstop_limit():
+    assert meals_edit.MEAL_INGREDIENTS_EDIT_LIMIT == "60/minute"
+    assert getattr(meals_edit.update_meal_ingredients, "__wrapped__", None) is not None


### PR DESCRIPTION
## Summary
- Raise `PUT /v1/meals/{id}/ingredients` from `10/minute` to `60/minute` so unit-chip saves are not treated like expensive AI routes.
- Return `meal_detail` on nutrition-contract v2 writes so the client can skip a follow-up GET after each persist.
- Companion mobile PR: https://github.com/Nutree-AI-Vietnam/nutree_ai/pull/659

## Test plan
- [ ] Confirm `MEAL_INGREDIENTS_EDIT_LIMIT == "60/minute"` and the route stays limiter-wrapped
- [ ] Confirm v2 PUT with contract headers returns `meal_detail` for the edited meal
- [ ] Confirm legacy (non-v2) PUT still returns the previous payload without requiring `meal_detail`