### PR TITLE
Fix translation cache invalidation

### DIFF
--- a/src/api/routes/v1/meals_read.py
+++ b/src/api/routes/v1/meals_read.py
@@ -2,6 +2,7 @@
 
 import logging
 import uuid
+from dataclasses import replace
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -11,6 +12,7 @@ from src.api.base_dependencies import (
     get_async_food_reference_repository,
     get_cache_service,
     get_image_store,
+    get_meal_translation_service,
 )
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
@@ -42,6 +44,93 @@ from src.infra.event_bus import BackgroundTaskManager, EventBus
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _without_requested_meal_translation(meal, language: str):
+    """Keep incomplete locale data from leaking into a read response."""
+    translations = getattr(meal, "translations", None)
+    if not translations or language not in translations:
+        return meal
+    remaining = {
+        cached_language: translation
+        for cached_language, translation in translations.items()
+        if cached_language != language
+    }
+    return replace(meal, translations=remaining or None)
+
+
+async def _ensure_requested_meal_translation(
+    *,
+    meal,
+    language: str,
+    query: GetMealByIdQuery,
+    event_bus: EventBus,
+    meal_translation_service,
+):
+    """Materialize a missing locale without serving a partial translation."""
+    if language == "en":
+        return meal
+
+    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
+    instructions = getattr(meal, "instructions", None)
+    if not meal.dish_name and not food_items and not instructions:
+        return meal
+
+    expected_ingredient_count = sum(
+        1 for item in food_items if getattr(item, "name", None)
+    )
+    expected_instruction_count = sum(
+        1 for step in (instructions or []) if isinstance(step, (dict, str))
+    )
+    cached = (meal.translations or {}).get(language)
+    if cached and cached.is_fully_cached(
+        expected_ingredient_count=expected_ingredient_count,
+        expected_instruction_count=expected_instruction_count,
+    ):
+        return meal
+    if meal_translation_service is None:
+        return _without_requested_meal_translation(meal, language)
+
+    try:
+        translation = await meal_translation_service.translate_meal(
+            meal=meal,
+            dish_name=meal.dish_name or "",
+            food_items=food_items,
+            target_language=language,
+            instructions=instructions,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Meal translation on read failed meal=%s lang=%s error_type=%s",
+            meal.meal_id,
+            language,
+            type(exc).__name__,
+        )
+        return _without_requested_meal_translation(meal, language)
+
+    if translation is None or not translation.is_fully_cached(
+        expected_ingredient_count=expected_ingredient_count,
+        expected_instruction_count=expected_instruction_count,
+    ):
+        logger.warning(
+            "Meal translation remains incomplete meal=%s lang=%s",
+            meal.meal_id,
+            language,
+        )
+        return _without_requested_meal_translation(meal, language)
+
+    # The service returns a non-persisted object for partial provider results.
+    # Reload so the mapper can only use a complete, durable translation row.
+    try:
+        return await event_bus.send(query)
+    except Exception as exc:
+        logger.warning(
+            "Meal translation reload failed meal=%s lang=%s error_type=%s",
+            meal.meal_id,
+            language,
+            type(exc).__name__,
+        )
+        return _without_requested_meal_translation(meal, language)
 
 
 async def _source_nutrition_by_food_reference(meal, food_reference_repository):
@@ -138,6 +227,7 @@ async def get_meal(
     task_manager: BackgroundTaskManager | None = Depends(get_optional_task_manager),
     ai_manager: MealInsightAIPort = Depends(get_ai_model_manager),
     food_reference_repository=Depends(get_async_food_reference_repository),
+    meal_translation_service=Depends(get_meal_translation_service),
 ):
     """Get detailed information about a specific meal.
 
@@ -152,6 +242,13 @@ async def get_meal(
         image_url = meal.image.url or image_store.get_url(meal.image.image_id)
 
     language = get_request_language(request)
+    meal = await _ensure_requested_meal_translation(
+        meal=meal,
+        language=language,
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=meal_translation_service,
+    )
     user_context = await get_meal_insight_user_context(event_bus, user_id)
     insight_service = MealValueInsightService()
     value_insights = await insight_service.get_cached_ai(

--- a/src/domain/model/meal/meal_translation_domain_models.py
+++ b/src/domain/model/meal/meal_translation_domain_models.py
@@ -79,8 +79,14 @@ class MealTranslation:
         """Return whether the row covers the available source manifest."""
         if (
             self.translation_version != expected_translation_version
-            or self.dish_name is None
+            or not isinstance(self.dish_name, str)
+            or not self.dish_name.strip()
             or self.meal_ingredients is None
+            or not isinstance(self.meal_ingredients, list)
+            or any(
+                not isinstance(name, str) or not name.strip()
+                for name in self.meal_ingredients
+            )
         ):
             return False
         if (
@@ -93,8 +99,17 @@ class MealTranslation:
         if expected_instruction_count == 0:
             return self.meal_instruction in (None, [])
         return (
-            self.meal_instruction is not None
+            isinstance(self.meal_instruction, list)
             and len(self.meal_instruction) == expected_instruction_count
+            and all(
+                (
+                    isinstance(step.get("instruction"), str)
+                    and bool(step["instruction"].strip())
+                    if isinstance(step, dict)
+                    else bool(str(step).strip())
+                )
+                for step in self.meal_instruction
+            )
         )
 
     def to_dict(self) -> dict:

--- a/src/domain/services/meal_value_insight_service.py
+++ b/src/domain/services/meal_value_insight_service.py
@@ -18,6 +18,7 @@ from src.domain.services.meal_value_insight_contract import (
 from src.observability import log_event
 
 INSIGHT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7
+MEAL_VALUE_INSIGHT_CACHE_VERSION = "v11"
 logger = logging.getLogger(__name__)
 
 
@@ -348,7 +349,7 @@ class MealValueInsightService:
     def _cache_key(self, summary: dict[str, Any]) -> str:
         payload = json.dumps(summary, ensure_ascii=False, sort_keys=True)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
-        return f"meal-value-insights:v10:{digest}"
+        return f"meal-value-insights:{MEAL_VALUE_INSIGHT_CACHE_VERSION}:{digest}"
 
     def _target_language(self, language: str) -> str:
         normalized = (language or "en").split("-")[0].lower()

--- a/tests/unit/api/test_meals_read_translation.py
+++ b/tests/unit/api/test_meals_read_translation.py
@@ -1,0 +1,159 @@
+from dataclasses import replace
+from datetime import datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.api.routes.v1 import meals_read
+from src.app.queries.meal import GetMealByIdQuery
+from src.domain.model.meal import (
+    FoodItemTranslation,
+    Meal,
+    MealImage,
+    MealStatus,
+    MealTranslation,
+)
+from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+
+
+class _EventBus:
+    def __init__(self, *meals: Meal):
+        self._meals = list(meals)
+        self.queries = []
+
+    async def send(self, query):
+        self.queries.append(query)
+        return self._meals.pop(0)
+
+
+def _meal(*, translations=None) -> Meal:
+    now = datetime.utcnow()
+    return Meal(
+        meal_id=str(uuid4()),
+        user_id=str(uuid4()),
+        status=MealStatus.READY,
+        created_at=now,
+        ready_at=now,
+        image=MealImage(image_id=str(uuid4()), format="jpeg", size_bytes=1),
+        dish_name="Grilled chicken",
+        nutrition=Nutrition(
+            macros=Macros(protein=31, carbs=0, fat=3.6),
+            food_items=[
+                FoodItem(
+                    id=str(uuid4()),
+                    name="Chicken breast",
+                    quantity=150,
+                    unit="g",
+                    macros=Macros(protein=31, carbs=0, fat=3.6),
+                )
+            ],
+        ),
+        instructions=["Grill the chicken"],
+        translations=translations,
+    )
+
+
+def _translation(meal: Meal) -> MealTranslation:
+    return MealTranslation(
+        meal_id=meal.meal_id,
+        language="vi",
+        dish_name="Gà nướng",
+        food_items=[
+            FoodItemTranslation(
+                food_item_id=meal.nutrition.food_items[0].id,
+                name="Ức gà",
+            )
+        ],
+        meal_ingredients=["Ức gà"],
+        meal_instruction=[{"instruction": "Nướng gà", "duration_minutes": None}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_requested_translation_materializes_missing_locale():
+    english_meal = _meal()
+    vietnamese_translation = _translation(english_meal)
+    vietnamese_meal = replace(
+        english_meal,
+        translations={"vi": vietnamese_translation},
+    )
+    event_bus = _EventBus(vietnamese_meal)
+    translation_service = type("TranslationService", (), {})()
+    translation_service.translate_meal = AsyncMock(return_value=vietnamese_translation)
+    query = GetMealByIdQuery(meal_id=english_meal.meal_id, user_id=english_meal.user_id)
+
+    result = await meals_read._ensure_requested_meal_translation(
+        meal=english_meal,
+        language="vi",
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=translation_service,
+    )
+
+    assert result is vietnamese_meal
+    translation_service.translate_meal.assert_awaited_once_with(
+        meal=english_meal,
+        dish_name="Grilled chicken",
+        food_items=english_meal.nutrition.food_items,
+        target_language="vi",
+        instructions=["Grill the chicken"],
+    )
+    assert event_bus.queries == [query]
+
+
+@pytest.mark.asyncio
+async def test_ensure_requested_translation_does_not_call_provider_for_current_cache():
+    meal = _meal()
+    meal_translation = _translation(meal)
+    meal.translations = {"vi": meal_translation}
+    event_bus = _EventBus()
+    translation_service = type("TranslationService", (), {})()
+    translation_service.translate_meal = AsyncMock()
+    query = GetMealByIdQuery(meal_id=meal.meal_id, user_id=meal.user_id)
+
+    result = await meals_read._ensure_requested_meal_translation(
+        meal=meal,
+        language="vi",
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=translation_service,
+    )
+
+    assert result is meal
+    translation_service.translate_meal.assert_not_awaited()
+    assert event_bus.queries == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_requested_translation_does_not_serve_incomplete_cache():
+    meal = _meal(
+        translations={
+            "vi": MealTranslation(
+                meal_id="unused",
+                language="vi",
+                dish_name="Gà nướng",
+                food_items=[],
+                meal_ingredients=[""],
+                meal_instruction=[
+                    {"instruction": "Nướng gà", "duration_minutes": None}
+                ],
+            )
+        }
+    )
+    event_bus = _EventBus()
+    translation_service = type("TranslationService", (), {})()
+    translation_service.translate_meal = AsyncMock(return_value=None)
+    query = GetMealByIdQuery(meal_id=meal.meal_id, user_id=meal.user_id)
+
+    result = await meals_read._ensure_requested_meal_translation(
+        meal=meal,
+        language="vi",
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=translation_service,
+    )
+
+    assert result.translations is None
+    assert result.dish_name == meal.dish_name
+    translation_service.translate_meal.assert_awaited_once()

--- a/tests/unit/domain/services/test_meal_value_insight_service.py
+++ b/tests/unit/domain/services/test_meal_value_insight_service.py
@@ -13,7 +13,10 @@ from src.domain.services.meal_value_insight_contract import (
     ValueInsight,
     serialize_insights,
 )
-from src.domain.services.meal_value_insight_service import MealValueInsightService
+from src.domain.services.meal_value_insight_service import (
+    MEAL_VALUE_INSIGHT_CACHE_VERSION,
+    MealValueInsightService,
+)
 
 
 class FakeCache:
@@ -189,8 +192,49 @@ def test_versions_are_separate_per_language():
     )
 
     assert english != vietnamese
-    assert english.startswith("meal-value-insights:v10:")
-    assert vietnamese.startswith("meal-value-insights:v10:")
+    expected_prefix = f"meal-value-insights:{MEAL_VALUE_INSIGHT_CACHE_VERSION}:"
+    assert english.startswith(expected_prefix)
+    assert vietnamese.startswith(expected_prefix)
+
+
+@pytest.mark.asyncio
+async def test_previous_cache_namespace_is_not_reused():
+    service = MealValueInsightService()
+    summary = service._summary(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        ingredient_names_by_id={},
+        language="vi",
+        user_context={},
+    )
+    current_key = service._cache_key(summary)
+    legacy_key = current_key.replace(
+        f"meal-value-insights:{MEAL_VALUE_INSIGHT_CACHE_VERSION}:",
+        "meal-value-insights:v10:",
+    )
+    cache = FakeCache()
+    cache.values[legacy_key] = serialize_insights(
+        MealValueInsights(
+            meal_bullets=[
+                ValueInsight(
+                    text="Legacy mixed-language insight.",
+                    category="benefit",
+                    highlights=["mixed-language"],
+                )
+            ],
+            ingredient_insights=[],
+        )
+    )
+
+    result = await service.get_cached_ai(
+        dish_name="Egg bowl",
+        nutrition=_nutrition(),
+        language="vi",
+        cache_service=cache,
+    )
+
+    assert result is None
+    assert current_key not in cache.values
 
 
 def test_summary_groups_repeated_ingredients_for_overview():


### PR DESCRIPTION
## Summary\n- Materialize complete requested-language meal translations on the meal detail read path, while preventing incomplete translations from being served.\n- Invalidate stale v10 value-insight cache entries by moving the backend cache namespace to v11.\n\n## Test plan\n- [x] 35 targeted backend tests passed.\n- [x] Full unit suite passed: 2501 tests, 79.66% coverage.\n- [x] Focused Ruff, compile, and diff checks passed.\n- [x] GitHub CI, PostgreSQL integration, and Seer review passed.\n\n## Release boundary\n- This backend PR fixes missing locale materialization and stale server-side insight caches.\n- A mobile app release is still required to invalidate old Flutter SQLite insight entries; the backend cannot delete each device's local cache.