### PR TITLE
fix(nutrition): stop unknown units from exploding custom calories

### DIFF
--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -28,7 +28,10 @@ from src.domain.services.meal_calorie_service import (
     effective_meal_calories,
 )
 from src.domain.services.meal_value_insight_contract import MealValueInsights
-from src.domain.services.nutrition_calculation_service import convert_quantity_to_grams
+from src.domain.services.nutrition_calculation_service import (
+    quantity_to_grams,
+    reconcile_calories_per_100g,
+)
 
 # Status mapping from domain to API
 STATUS_MAPPING = {
@@ -88,7 +91,6 @@ class MealMapper:
             DetailedMealResponse DTO
         """
         from src.api.schemas.response.meal_responses import (
-            CustomNutritionResponse,
             MacrosResponse,
             MealTranslationResponse,
             NutritionOverrideResponse,
@@ -143,39 +145,12 @@ class MealMapper:
                             sugar_g=item.macros.sugar,
                         )
 
-                    # Calculate per-100g custom nutrition if custom ingredient
-                    custom_nutrition_dto = None
-                    if (
-                        hasattr(item, "is_custom")
-                        and item.is_custom
-                        and item.quantity > 0
-                    ):
-                        quantity_grams = convert_quantity_to_grams(
-                            item.quantity,
-                            item.unit,
-                            item.name,
+                    custom_nutrition_dto = (
+                        MealMapper._custom_nutrition_response_for_item(
+                            item,
+                            item_calories,
                         )
-                        scale_factor = 100.0 / quantity_grams
-                        custom_nutrition_dto = CustomNutritionResponse(
-                            calories_per_100g=item_calories * scale_factor,
-                            protein_per_100g=(
-                                item.macros.protein * scale_factor
-                                if item.macros
-                                else 0.0
-                            ),
-                            carbs_per_100g=(
-                                item.macros.carbs * scale_factor if item.macros else 0.0
-                            ),
-                            fat_per_100g=(
-                                item.macros.fat * scale_factor if item.macros else 0.0
-                            ),
-                            fiber_per_100g=(
-                                item.macros.fiber * scale_factor if item.macros else 0.0
-                            ),
-                            sugar_per_100g=(
-                                item.macros.sugar * scale_factor if item.macros else 0.0
-                            ),
-                        )
+                    )
 
                     source_nutrition_dto = MealMapper._source_nutrition_response(
                         source_nutrition_by_food_reference,
@@ -382,6 +357,45 @@ class MealMapper:
             macros.fat,
             macros.fiber,
             macros.sugar,
+        )
+
+    @staticmethod
+    def _custom_nutrition_response_for_item(item: FoodItem, item_calories: float):
+        from src.api.schemas.response.meal_responses import CustomNutritionResponse
+
+        if not getattr(item, "is_custom", False) or item.quantity <= 0:
+            return None
+
+        quantity_grams = quantity_to_grams(
+            item.quantity,
+            item.unit,
+            item.name,
+            getattr(item, "allowed_units", None) or [],
+        )
+        if quantity_grams <= 0:
+            return None
+        scale_factor = 100.0 / quantity_grams
+        protein = item.macros.protein * scale_factor if item.macros else 0.0
+        carbs = item.macros.carbs * scale_factor if item.macros else 0.0
+        fat = item.macros.fat * scale_factor if item.macros else 0.0
+        fiber = item.macros.fiber * scale_factor if item.macros else 0.0
+        sugar = item.macros.sugar * scale_factor if item.macros else 0.0
+        derived = Macros(
+            protein=protein,
+            carbs=carbs,
+            fat=fat,
+            fiber=fiber,
+        ).total_calories
+        return CustomNutritionResponse(
+            calories_per_100g=reconcile_calories_per_100g(
+                item_calories * scale_factor,
+                derived,
+            ),
+            protein_per_100g=protein,
+            carbs_per_100g=carbs,
+            fat_per_100g=fat,
+            fiber_per_100g=fiber,
+            sugar_per_100g=sugar,
         )
 
     @staticmethod

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -31,9 +31,11 @@ from src.domain.services.ai_output_validation_service import (
 )
 from src.domain.services.emoji_validator import validate_emoji
 from src.domain.services.nutrition_calculation_service import (
+    MASS_VOLUME_CANONICAL_UNITS,
     UNIT_TO_GRAMS,
     _convert_with_allowed_units,
     _normalize_unit,
+    canonicalize_mass_volume_unit,
     clamp_nutrition_values,
     convert_quantity_to_grams,
     fallback_custom_serving_options,
@@ -88,9 +90,13 @@ def _preferred_parse_unit(item: dict[str, Any]) -> str:
     """Prefer the local unit when it is a real mass, volume, or countable unit."""
     local = str(item.get("unit") or "").strip()
     english = str(item.get("english_unit") or "").strip()
-    local_norm = _normalize_unit(local) if local else ""
-    if local_norm in TRUSTED_QUANTITY_UNITS or local_norm in COUNTABLE_GRAM_UNITS:
-        return local
+    if local:
+        canonical = canonicalize_mass_volume_unit(local)
+        if canonical in MASS_VOLUME_CANONICAL_UNITS:
+            return canonical
+        local_norm = _normalize_unit(local)
+        if local_norm in TRUSTED_QUANTITY_UNITS or local_norm in COUNTABLE_GRAM_UNITS:
+            return local
     return english or local or "serving"
 
 
@@ -816,7 +822,9 @@ class ParseMealTextHandler(
     ) -> float:
         """Keep parsed portions saveable against the same source snapshot."""
         quantity = float(item.get("quantity") or 1.0)
-        source_unit = str(item.get("english_unit") or item.get("unit") or "g")
+        source_unit = canonicalize_mass_volume_unit(
+            str(item.get("english_unit") or item.get("unit") or "g")
+        )
         try:
             authoritative_grams = _convert_with_allowed_units(
                 quantity,

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -90,6 +90,23 @@ UNIT_TRANSLATION = {
     "sprigs": "serving",
     "cọng": "serving",
     "lá": "piece",
+    "ổ": "piece",
+    "loaf": "piece",
+    "ít": "serving",
+    "một ít": "serving",
+    "chút": "serving",
+    "chut": "serving",
+    "chút ít": "serving",
+    "chút xíu": "serving",
+    "vài": "serving",
+    "nắm": "serving",
+    "nhiều": "serving",
+    "pinch": "serving",
+    "pinches": "serving",
+    "dash": "serving",
+    "dashes": "serving",
+    "handful": "serving",
+    "a little": "serving",
     # Spanish
     "grande": "large",
     "mediano": "medium",
@@ -349,32 +366,35 @@ def _convert_with_allowed_units(
     if translated == "g":
         return quantity
 
-    # 1. Exact match against allowed_units
     for au in allowed_units:
-        if au.get("unit", "").lower() == unit_lower:
-            return quantity * au.get("gram_weight", 1.0)
-
-    # 2. Translate unit (e.g., "quả lớn" → "large") and re-match
-    if translated != unit_lower:
-        for au in allowed_units:
-            if au.get("unit", "").lower() == translated:
-                logger.info("Unit alias matched an allowed unit")
-                return quantity * au.get("gram_weight", 1.0)
+        au_unit = str(au.get("unit") or "")
+        gram_weight = float(au.get("gram_weight") or 0)
+        if not _units_refer_to_same_serving(au_unit, unit, strict=strict):
+            continue
+        if not _has_trusted_portion_weight(au_unit, gram_weight):
+            continue
+        if au_unit.lower().strip() != unit_lower:
+            logger.info("Unit alias matched an allowed unit")
+        return quantity * gram_weight
 
     if strict:
         raise AuthoritativeUnitMismatchError(
             "unit is not present in the authoritative source snapshot"
         )
 
-    # 3. Legacy keyword match: check if translated unit appears in description.
+    # Legacy keyword match: check if translated unit appears in description.
     # Authoritative writes never use free-form description tokens as unit identity.
     for au in allowed_units:
         desc = au.get("description", "").lower()
-        if translated in desc.split():
-            logger.info("Unit keyword matched an allowed-unit description")
-            return quantity * au.get("gram_weight", 1.0)
+        gram_weight = float(au.get("gram_weight") or 0)
+        if translated not in desc.split():
+            continue
+        if not _has_trusted_portion_weight(str(au.get("unit") or ""), gram_weight):
+            continue
+        logger.info("Unit keyword matched an allowed-unit description")
+        return quantity * gram_weight
 
-    # 4. Global UNIT_TO_GRAMS mapping for legacy, non-authoritative writes.
+    # Global UNIT_TO_GRAMS mapping for legacy, non-authoritative writes.
     grams = UNIT_TO_GRAMS.get(translated)
     if grams is not None:
         logger.warning(
@@ -382,16 +402,45 @@ def _convert_with_allowed_units(
         )
         return quantity * grams
 
-    # 5. Smart fallback: use first non-gram serving (common portion) instead of raw grams
+    # Smart fallback: use first non-gram serving (common portion) instead of raw grams
     for au in allowed_units:
         au_unit = au.get("unit", "").lower()
-        if _normalize_unit(au_unit) != "g" and au_unit not in ("100 g", "1 g"):
-            logger.warning("Unknown unit used the default allowed serving")
-            return quantity * au.get("gram_weight", 1.0)
+        gram_weight = float(au.get("gram_weight") or 0)
+        if _normalize_unit(au_unit) == "g" or au_unit in ("100 g", "1 g"):
+            continue
+        if not _has_trusted_portion_weight(au_unit, gram_weight):
+            continue
+        logger.warning("Unknown unit used the default allowed serving")
+        return quantity * gram_weight
 
     # Last resort: treat as grams (only if no allowed_units have useful servings)
     logger.warning(f"Unit '{unit}' unresolvable — treating quantity as grams")
     return quantity
+
+
+def _has_trusted_portion_weight(unit: str, gram_weight: float) -> bool:
+    normalized = _normalize_unit(unit)
+    if normalized in {"g", "ml"}:
+        return gram_weight > 0
+    return gram_weight > 1
+
+
+def _units_refer_to_same_serving(
+    left: str, right: str, *, strict: bool = False
+) -> bool:
+    a = (left or "").lower().strip()
+    b = (right or "").lower().strip()
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    left_alias = UNIT_TRANSLATION.get(a, a)
+    right_alias = UNIT_TRANSLATION.get(b, b)
+    if left_alias == right_alias:
+        return True
+    if strict:
+        return False
+    return _normalize_unit(a) == _normalize_unit(b)
 
 
 def canonicalize_authoritative_quantity(

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -58,6 +58,8 @@ UNIT_TRANSLATION = {
     "pounds": "lb",
     "ounce": "oz",
     "ounces": "oz",
+    "gramme": "g",
+    "grammes": "g",
     # Vietnamese count/size units
     "quả lớn": "large",
     "quả to": "large",
@@ -83,6 +85,11 @@ UNIT_TRANSLATION = {
     "phần": "serving",
     "suất": "serving",
     "khẩu phần": "serving",
+    "nhánh": "serving",
+    "sprig": "serving",
+    "sprigs": "serving",
+    "cọng": "serving",
+    "lá": "piece",
     # Spanish
     "grande": "large",
     "mediano": "medium",
@@ -121,6 +128,7 @@ UNIT_TRANSLATION = {
 }
 
 CONVERTIBLE_UNITS = set(UNIT_TO_GRAMS) | {"g", "ml", "l", "liter", "litre"}
+MASS_VOLUME_CANONICAL_UNITS = {"g", "kg", "ml", "l", "oz", "lb"}
 
 
 def _normalize_unit(unit: str) -> str:
@@ -153,6 +161,15 @@ def _normalize_authoritative_unit(unit: str) -> str:
         if singular in UNIT_TO_GRAMS:
             return singular
     return unit_lower
+
+
+def canonicalize_mass_volume_unit(unit: str | None) -> str:
+    """Collapse gram/ounce/liter aliases onto the canonical mass-volume token."""
+    raw = (unit or "g").strip() or "g"
+    normalized = _normalize_authoritative_unit(raw)
+    if normalized in MASS_VOLUME_CANONICAL_UNITS:
+        return normalized
+    return raw
 
 
 def normalize_unit_for_manual_save(unit: str | None) -> str:
@@ -222,6 +239,47 @@ def convert_quantity_to_grams(quantity: float, unit: str, food_name: str = "") -
     return quantity * grams_per_unit
 
 
+def quantity_to_grams(
+    quantity: float,
+    unit: str,
+    food_name: str = "",
+    allowed_units: list[dict[str, Any]] | None = None,
+    *,
+    strict: bool = False,
+) -> float:
+    """Convert using food servings first, then the shared unit table."""
+    if allowed_units:
+        try:
+            return _convert_with_allowed_units(
+                quantity,
+                unit,
+                allowed_units,
+                food_name,
+                strict=strict,
+            )
+        except AuthoritativeUnitMismatchError:
+            if strict:
+                raise
+    return convert_quantity_to_grams(quantity, unit, food_name)
+
+
+MAX_KCAL_PER_100G = 900.0
+_ENERGY_MISMATCH_RATIO = 5.0
+
+
+def reconcile_calories_per_100g(advertised: float, derived: float) -> float:
+    """Keep advertised energy only when it is physically plausible vs macros."""
+    if derived <= 0:
+        return max(advertised, 0.0)
+    if advertised < 0 or advertised > MAX_KCAL_PER_100G:
+        return derived
+    if advertised > derived * _ENERGY_MISMATCH_RATIO:
+        return derived
+    if derived > advertised * _ENERGY_MISMATCH_RATIO:
+        return derived
+    return advertised
+
+
 def scale_per_100g_nutrition(
     per_100g: dict,
     quantity: float,
@@ -285,7 +343,10 @@ def _convert_with_allowed_units(
     5. Smart fallback: first non-gram allowed_unit (common serving size)
     """
     unit_lower = unit.lower().strip()
-    if unit_lower == "g":
+    translated = (
+        _normalize_authoritative_unit(unit) if strict else _normalize_unit(unit)
+    )
+    if translated == "g":
         return quantity
 
     # 1. Exact match against allowed_units
@@ -294,9 +355,6 @@ def _convert_with_allowed_units(
             return quantity * au.get("gram_weight", 1.0)
 
     # 2. Translate unit (e.g., "quả lớn" → "large") and re-match
-    translated = (
-        _normalize_authoritative_unit(unit) if strict else _normalize_unit(unit)
-    )
     if translated != unit_lower:
         for au in allowed_units:
             if au.get("unit", "").lower() == translated:
@@ -327,7 +385,7 @@ def _convert_with_allowed_units(
     # 5. Smart fallback: use first non-gram serving (common portion) instead of raw grams
     for au in allowed_units:
         au_unit = au.get("unit", "").lower()
-        if au_unit not in ("g", "100 g", "1 g"):
+        if _normalize_unit(au_unit) != "g" and au_unit not in ("100 g", "1 g"):
             logger.warning("Unknown unit used the default allowed serving")
             return quantity * au.get("gram_weight", 1.0)
 
@@ -518,8 +576,7 @@ class NutritionCalculationService:
                     # established global unit mapping for those items; source
                     # backed v2 items remain strict against their snapshot.
                     strict=not (
-                        getattr(item, "origin", None) == "custom"
-                        and not allowed_units
+                        getattr(item, "origin", None) == "custom" and not allowed_units
                     ),
                 )
             factor = quantity_grams / 100.0

--- a/src/domain/services/nutrition_integrity_policy.py
+++ b/src/domain/services/nutrition_integrity_policy.py
@@ -12,7 +12,7 @@ from src.domain.model.nutrition import MAX_FOOD_ITEM_QUANTITY, Macros
 NUTRITION_INTEGRITY_POLICY_VERSION = "nutrition_integrity_v1"
 ACCEPTED_REASON = "accepted"
 DEFAULT_GRAM_SERVING = {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
-_GRAM_UNITS = {"g", "gram", "grams"}
+_GRAM_UNITS = {"g", "gram", "grams", "gramme", "grammes"}
 _PROVIDER_SOURCES = {"fatsecret", "openfoodfacts", "provider"}
 
 # The boundary cases are kept beside the policy so other enforcement layers can

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -12,8 +12,7 @@ from src.domain.model.nutrition import FoodItem, Macros, NutritionOverride
 from src.domain.services import NutritionCalculationService
 from src.domain.services.nutrition_calculation_service import (
     ScaledNutritionResult,
-    _convert_with_allowed_units,
-    convert_quantity_to_grams,
+    quantity_to_grams,
     scale_per_100g_nutrition,
 )
 
@@ -101,21 +100,16 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
         # Priority 1: Custom nutrition provided (user-edited macros)
         if change.custom_nutrition:
             allowed_units = change.allowed_units or existing_item.allowed_units
-            if (
-                change.origin is not None
-                or existing_item.nutrition_contract_version == "2"
-            ):
-                quantity_grams = _convert_with_allowed_units(
-                    new_quantity,
-                    new_unit,
-                    allowed_units or [],
-                    existing_item.name,
-                    strict=True,
-                )
-            else:
-                quantity_grams = convert_quantity_to_grams(
-                    new_quantity, new_unit, existing_item.name
-                )
+            quantity_grams = quantity_to_grams(
+                new_quantity,
+                new_unit,
+                existing_item.name,
+                allowed_units or [],
+                strict=(
+                    change.origin is not None
+                    or existing_item.nutrition_contract_version == "2"
+                ),
+            )
             _validate_quantity_grams(quantity_grams, new_quantity, new_unit)
             scale_factor = quantity_grams / 100.0
             food_items_dict[change.id] = FoodItem(
@@ -232,14 +226,19 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
     ) -> None:
         """Apply simple proportional scaling to nutrition with unit conversion."""
         # Convert new quantity to grams for proper scaling
-        new_quantity_grams = convert_quantity_to_grams(
-            new_quantity, new_unit, existing_item.name
+        new_quantity_grams = quantity_to_grams(
+            new_quantity,
+            new_unit,
+            existing_item.name,
+            existing_item.allowed_units or [],
         )
         _validate_quantity_grams(new_quantity_grams, new_quantity, new_unit)
 
-        # Convert existing quantity to grams (existing item's nutrition is already in grams)
-        existing_quantity_grams = convert_quantity_to_grams(
-            existing_item.quantity, existing_item.unit, existing_item.name
+        existing_quantity_grams = quantity_to_grams(
+            existing_item.quantity,
+            existing_item.unit,
+            existing_item.name,
+            existing_item.allowed_units or [],
         )
 
         # Scale factor based on gram conversion
@@ -483,16 +482,13 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
         change=None,
     ) -> FoodItem:
         """Create food item from custom nutrition data."""
-        if change is not None and change.origin is not None:
-            quantity_grams = _convert_with_allowed_units(
-                quantity,
-                unit,
-                allowed_units or [],
-                name,
-                strict=True,
-            )
-        else:
-            quantity_grams = convert_quantity_to_grams(quantity, unit, name)
+        quantity_grams = quantity_to_grams(
+            quantity,
+            unit,
+            name,
+            allowed_units or [],
+            strict=change is not None and change.origin is not None,
+        )
         _validate_quantity_grams(quantity_grams, quantity, unit)
         scale_factor = quantity_grams / 100.0  # Custom nutrition is per 100g
 

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -743,6 +743,52 @@ class TestMealMapper:
         assert custom.carbs_per_100g == pytest.approx(0.7)
         assert custom.fat_per_100g == pytest.approx(9.6)
 
+    def test_to_detailed_response_custom_nutrition_does_not_treat_nhanh_as_one_gram(self):
+        """Unknown culinary units must not explode per-100g calories 100x."""
+        food_items = [
+            FoodItem(
+                id="item-cilantro",
+                name="Cilantro",
+                quantity=1,
+                unit="nhánh",
+                macros=Macros(protein=5, carbs=5, fat=0),
+                confidence=0.8,
+                is_custom=True,
+                allowed_units=[
+                    {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+                    {"unit": "nhánh", "gram_weight": 100.0, "description": "1 nhánh"},
+                ],
+            )
+        ]
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/cilantro.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+                width=800,
+                height=600,
+            ),
+            dish_name="Herbs",
+            ready_at=datetime(2025, 1, 15, 15, 0),
+            created_at=datetime(2025, 1, 15, 14, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=5, carbs=5, fat=0),
+                food_items=food_items,
+            ),
+        )
+
+        result = MealMapper.to_detailed_response(meal)
+
+        custom = result.food_items[0].custom_nutrition
+        assert custom is not None
+        assert custom.protein_per_100g == pytest.approx(5.0)
+        assert custom.calories_per_100g == pytest.approx(40.0)
+        assert custom.calories_per_100g < 100
+
     def test_to_detailed_response_without_nutrition(self):
         """Test detailed response when nutrition is None."""
         image = MealImage(

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -269,6 +269,33 @@ def test_herb_sprig_units_use_countable_serving_grams():
     ) == 4
 
 
+def test_qualitative_garnish_units_use_countable_serving_grams():
+    assert convert_quantity_to_grams(1, "ít", "Hành Lá") == 100
+    assert convert_quantity_to_grams(1, "pinch", "Hành Lá") == 100
+    assert quantity_to_grams(
+        1,
+        "ít",
+        "Hành Lá",
+        [
+            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            {"unit": "ít", "gram_weight": 1.0, "description": "1 ít"},
+        ],
+    ) == pytest.approx(100.0)
+
+
+def test_bowl_alias_matches_cup_serving_not_one_gram():
+    assert quantity_to_grams(
+        1,
+        "bát",
+        "Bánh Phở",
+        [
+            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            {"unit": "cup", "gram_weight": 240.0, "description": "1 cup"},
+            {"unit": "bát", "gram_weight": 1.0, "description": "1 bát"},
+        ],
+    ) == pytest.approx(240.0)
+
+
 def test_reconcile_calories_drops_hundredfold_energy_mismatch():
     assert reconcile_calories_per_100g(4000, 40) == 40
     assert reconcile_calories_per_100g(123.4, 165) == 123.4

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -18,10 +18,13 @@ from src.domain.services.nutrition_calculation_service import (
     NutritionCalculationService,
     _convert_with_allowed_units,
     canonicalize_authoritative_quantity,
+    canonicalize_mass_volume_unit,
     clamp_nutrition_values,
     convert_quantity_to_grams,
     fallback_custom_serving_options,
     normalize_unit_for_manual_save,
+    quantity_to_grams,
+    reconcile_calories_per_100g,
     scale_per_100g_nutrition,
 )
 
@@ -255,6 +258,22 @@ def test_allowed_unit_logs_do_not_expose_unit_or_description(caplog):
     assert raw_unit not in caplog.text
 
 
+def test_herb_sprig_units_use_countable_serving_grams():
+    assert convert_quantity_to_grams(1, "nhánh", "Cilantro") == 100
+    assert convert_quantity_to_grams(1, "sprig", "Cilantro") == 100
+    assert quantity_to_grams(
+        1,
+        "nhánh",
+        "Cilantro",
+        [{"unit": "g", "gram_weight": 1.0}, {"unit": "nhánh", "gram_weight": 4.0}],
+    ) == 4
+
+
+def test_reconcile_calories_drops_hundredfold_energy_mismatch():
+    assert reconcile_calories_per_100g(4000, 40) == 40
+    assert reconcile_calories_per_100g(123.4, 165) == 123.4
+
+
 def test_clamp_nutrition_uses_manual_save_unit_for_ai_free_text():
     clamped = clamp_nutrition_values(
         {
@@ -296,6 +315,26 @@ def test_unknown_tuber_unit_uses_countable_provider_serving_not_one_gram():
         _convert_with_allowed_units(
             1, "củ lớn", allowed_units, "Khoai lang", strict=True
         )
+
+
+def test_gram_alias_is_one_gram_even_when_a_100g_row_exists():
+    allowed_units = [
+        {"unit": "gram", "gram_weight": 100.0, "description": "100 gram"},
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+        {"unit": "serving", "gram_weight": 100.0, "description": "1 serving"},
+        {"unit": "cup", "gram_weight": 120.0, "description": "1 cup"},
+    ]
+
+    assert _convert_with_allowed_units(100, "gram", allowed_units, "Beef") == 100
+    assert _convert_with_allowed_units(100, "grams", allowed_units, "Beef") == 100
+    assert convert_quantity_to_grams(100, "gram", "Beef") == 100
+
+
+def test_canonicalize_mass_volume_unit_maps_gram_aliases():
+    assert canonicalize_mass_volume_unit("gram") == "g"
+    assert canonicalize_mass_volume_unit("GRAMS") == "g"
+    assert canonicalize_mass_volume_unit("ounce") == "oz"
+    assert canonicalize_mass_volume_unit("miếng") == "miếng"
 
 
 def _new_processing_meal() -> Meal:

--- a/tests/unit/domain/services/test_nutrition_integrity_policy.py
+++ b/tests/unit/domain/services/test_nutrition_integrity_policy.py
@@ -103,6 +103,18 @@ def test_provider_100g_is_a_labelled_serving_and_g_is_one_gram():
     ]
 
 
+def test_provider_gram_alias_is_labelled_serving_and_g_is_one_gram():
+    normalized = normalize_serving_options(
+        [{"unit": "gram", "gram_weight": 100, "description": "100 gram"}],
+        provider_100g_label=True,
+    )
+
+    assert normalized == [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+        {"unit": "serving", "gram_weight": 100.0, "description": "100 gram"},
+    ]
+
+
 @pytest.mark.parametrize(
     "serving",
     [

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -1164,3 +1164,19 @@ async def test_parse_text_rejects_fatsecret_using_backend_derived_calories(
     assert item.protein == 10
     assert item.carbs == 10
     assert item.fat == 0
+
+
+def test_canonicalize_reference_quantity_maps_gram_alias_to_g():
+    item = {"quantity": 100, "unit": "gram", "english_unit": "gram"}
+    grams = ParseMealTextHandler._canonicalize_reference_quantity(
+        item,
+        quantity_g=100,
+        allowed_units=[
+            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            {"unit": "serving", "gram_weight": 100.0, "description": "1 serving"},
+        ],
+    )
+
+    assert grams == pytest.approx(100)
+    assert item["unit"] == "g"
+    assert item["english_unit"] == "g"


### PR DESCRIPTION
## Summary
- Custom nutrition treated unknown culinary units such as `nhánh` / sprig / `ít` as 1 g, so GET/custom-save rebuilt per-100g calories at 100x (4000 kcal next to 40-kcal macros).
- Map herb and qualitative units onto countable servings, prefer allowed-unit gram weights, skip untrusted 1 g countable servings, and drop advertised kcal/100g when it is physically implausible versus macros.
- Canonicalize gram aliases (`gram`/`grams`) onto `g` during parse-text reference quantity handling. Match aliases such as `bát` ↔ `cup` without treating unrelated suffixes as the same unit.

Independent of the parse-text display-name PR; both touch `parse_meal_text_handler.py` in different hunks.

## Test plan
- [ ] Open a custom cilantro item saved with unit `nhánh` and confirm calories/100g stay near ~40, not 4000.
- [ ] Switch hành lá between `ít` / `g` / `bát` and confirm calories stay aligned with macros.
- [ ] Change quantity to 1 kg and confirm scaling is 10x, not another explosion.
- [ ] Save/edit with `gram` and confirm it is treated as `g`.
- [ ] `pytest tests/unit/api/test_meal_mapper.py tests/unit/domain/services/test_nutrition_calculation_service.py tests/unit/domain/services/test_nutrition_integrity_policy.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py`
