### PR TITLE
fix(observability): stop expected parse-text failures flooding Sentry

### DIFF
--- a/src/app/handlers/command_handlers/meal_text_parsing_utils.py
+++ b/src/app/handlers/command_handlers/meal_text_parsing_utils.py
@@ -67,7 +67,7 @@ def extract_json_from_response(content: str) -> list[dict[str, Any]]:
         except json.JSONDecodeError:
             pass
 
-    logger.error("Could not extract JSON from AI response: length=%s", len(content))
+    logger.warning("Could not extract JSON from AI response: length=%s", len(content))
     raise ValueError("Could not parse AI response. Please try again.")
 
 

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -409,7 +409,15 @@ class ParseMealTextHandler(
         elif isinstance(raw, list):
             payload = {"items": raw}
         else:
-            extracted = extract_json_from_response(str(raw))
+            try:
+                extracted = extract_json_from_response(str(raw))
+            except ValueError as exc:
+                raise AIOutputValidationError(
+                    "Invalid AI structured output",
+                    purpose=PARSE_TEXT_VALIDATION_PURPOSE,
+                    attempt_count=1,
+                    validation_details=["unparseable_ai_json"],
+                ) from exc
             payload = {"items": extracted} if isinstance(extracted, list) else extracted
 
         if not isinstance(payload, dict):

--- a/src/domain/services/nutrition_resolver.py
+++ b/src/domain/services/nutrition_resolver.py
@@ -236,7 +236,14 @@ def validate_ai_fallback(
     calories = Macros.raw_total_calories(
         protein_value, carbs_value, fat_value, fiber_value
     )
+    max_calories = quantity_g * (9.5 if _is_energy_dense_food(name) else 4.5)
+    return calories <= max_calories + 20.0
+
+
+def _is_energy_dense_food(name: str) -> bool:
+    """Match oily/nut foods even when the token is compound (walnuts, almonds)."""
     normalized = normalize_food_lookup_name(name)
+    tokens = set(normalized.split())
     dense_terms = {
         "oil",
         "butter",
@@ -252,9 +259,29 @@ def validate_ai_fallback(
         "powder",
         "flour",
     }
-    is_dense_exception = bool(dense_terms & set(normalized.split()))
-    max_calories = quantity_g * (9.5 if is_dense_exception else 4.5)
-    return calories <= max_calories + 20.0
+    if tokens & dense_terms:
+        return True
+    dense_names = (
+        "walnut",
+        "almond",
+        "pecan",
+        "cashew",
+        "pistachio",
+        "hazelnut",
+        "macadamia",
+        "peanut",
+        "coconut",
+        "avocado",
+        "chocolate",
+        "cocoa",
+        "sesame",
+        "sunflower",
+        "chia",
+        "flax",
+        "mayo",
+        "mayonnaise",
+    )
+    return any(term in normalized for term in dense_names)
 
 
 class NutritionResolver:

--- a/src/infra/ai/json_extract.py
+++ b/src/infra/ai/json_extract.py
@@ -84,7 +84,7 @@ def extract_json(content: str) -> dict[str, Any]:
         or content.rstrip().endswith(('":',  '": "', '"name": "', '",'))
     )
     if is_truncated:
-        logger.error(
+        logger.warning(
             "[JSON-TRUNCATED] content_len=%d open_braces=%d close_braces=%d",
             len(content),
             open_braces,
@@ -94,7 +94,7 @@ def extract_json(content: str) -> dict[str, Any]:
             "AI response was truncated. Please try again with a simpler image."
         )
 
-    logger.error(
+    logger.warning(
         "[JSON-EXTRACT-FAILED] all attempts failed content_len=%d", len(content)
     )
     from src.observability import increment_metric  # noqa: PLC0415

--- a/src/infra/event_bus/pymediator_event_bus.py
+++ b/src/infra/event_bus/pymediator_event_bus.py
@@ -13,7 +13,13 @@ from pymediator import SingletonRegistry
 
 from src.api.exceptions import MealTrackException
 from src.domain.events.base import DomainEvent, Event, EventHandler
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import (
+    AIOutputValidationError,
+    AIUnavailableError,
+)
+from src.domain.exceptions.meal_recommendation_exceptions import (
+    MealRecommendationCreationError,
+)
 
 from .background_task_manager import BackgroundTaskManager
 from .event_bus import EventBus
@@ -174,7 +180,12 @@ class PyMediatorEventBus(EventBus):
                         await self.publish(domain_event)
             return result
 
-        except (MealTrackException, AIUnavailableError) as e:
+        except (
+            MealTrackException,
+            AIUnavailableError,
+            AIOutputValidationError,
+            MealRecommendationCreationError,
+        ) as e:
             # Controlled application exceptions and degraded AI-provider failures
             # are converted to proper HTTP responses by the API layer. Keep this
             # at debug so routine control flow does not produce duplicate ERRORs.

--- a/src/infra/monitoring/sentry.py
+++ b/src/infra/monitoring/sentry.py
@@ -64,8 +64,12 @@ class SentryObservabilityConnector:
             "enable_logs": settings.SENTRY_ENABLE_LOGS,
             "enable_metrics": settings.SENTRY_ENABLE_METRICS,
             "integrations": [
-                StarletteIntegration(),
-                FastApiIntegration(),
+                StarletteIntegration(
+                    failed_request_status_codes={500, 501, 502, 504},
+                ),
+                FastApiIntegration(
+                    failed_request_status_codes={500, 501, 502, 504},
+                ),
                 SqlalchemyIntegration(),
                 LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
             ],

--- a/tests/unit/domain/services/test_nutrition_resolver.py
+++ b/tests/unit/domain/services/test_nutrition_resolver.py
@@ -178,3 +178,18 @@ def test_ai_fallback_rejects_potato_density_but_allows_oil_exception():
         fat=10,
         quantity_g=10,
     )
+    assert validate_ai_fallback(
+        name="Walnuts",
+        protein=4.3,
+        carbs=4.0,
+        fat=18.0,
+        fiber=2.0,
+        quantity_g=30,
+    )
+    assert not validate_ai_fallback(
+        name="apple",
+        protein=0,
+        carbs=0,
+        fat=20,
+        quantity_g=30,
+    )

--- a/tests/unit/infra/adapters/test_ai_json_logging.py
+++ b/tests/unit/infra/adapters/test_ai_json_logging.py
@@ -14,7 +14,7 @@ from src.observability_connectors import SAFE_CONTEXT_KEYS, SAFE_TAG_KEYS
 def test_shared_ai_json_extractor_does_not_log_raw_response(caplog):
     raw_response = "broken json with private meal notes and user@example.com"
 
-    with caplog.at_level("ERROR"), pytest.raises(ValueError):
+    with caplog.at_level("WARNING"), pytest.raises(ValueError):
         extract_json(raw_response)
 
     assert raw_response not in caplog.text
@@ -25,7 +25,7 @@ def test_shared_ai_json_extractor_does_not_log_raw_response(caplog):
 def test_meal_text_json_extractor_does_not_log_raw_response(caplog):
     raw_response = "not an array with private meal notes and user@example.com"
 
-    with caplog.at_level("ERROR"), pytest.raises(ValueError):
+    with caplog.at_level("WARNING"), pytest.raises(ValueError):
         extract_json_from_response(raw_response)
 
     assert raw_response not in caplog.text

--- a/tests/unit/infra/adapters/test_vision_ai_service.py
+++ b/tests/unit/infra/adapters/test_vision_ai_service.py
@@ -92,7 +92,7 @@ def test_extract_json_failure_does_not_log_raw_ai_response(caplog):
 
     raw_response = "not json with private meal notes and user@example.com"
 
-    with caplog.at_level("ERROR"), pytest.raises(ValueError):
+    with caplog.at_level("WARNING"), pytest.raises(ValueError):
         extract_json(raw_response)
 
     assert raw_response not in caplog.text

--- a/tests/unit/infra/monitoring/test_sentry_connector.py
+++ b/tests/unit/infra/monitoring/test_sentry_connector.py
@@ -119,6 +119,9 @@ def test_initialize_configures_integrations_and_release(monkeypatch):
     assert init_kwargs["profile_session_sample_rate"] == 0.02
     assert init_kwargs["profile_lifecycle"] == "trace"
     assert len(init_kwargs["integrations"]) == 4
+    starlette, fastapi, *_ = init_kwargs["integrations"]
+    assert starlette.failed_request_status_codes == {500, 501, 502, 504}
+    assert fastapi.failed_request_status_codes == {500, 501, 502, 504}
 
 
 def test_initialize_omits_optional_profile_session_settings_when_unset(monkeypatch):

--- a/tests/unit/infra/test_pymediator_event_bus.py
+++ b/tests/unit/infra/test_pymediator_event_bus.py
@@ -5,7 +5,7 @@ import pytest
 
 from src.api.exceptions import ResourceNotFoundException
 from src.domain.events.base import EventHandler, Query
-from src.domain.exceptions.ai_exceptions import AIUnavailableError
+from src.domain.exceptions.ai_exceptions import AIOutputValidationError, AIUnavailableError
 from src.infra.event_bus.pymediator_event_bus import PyMediatorEventBus
 
 
@@ -89,6 +89,35 @@ async def test_ai_unavailable_exception_is_not_logged_as_error(caplog):
         and "Application exception handling _AIUnavailableQuery" in record.message
         for record in caplog.records
     )
+
+
+class _AIOutputInvalidHandler(EventHandler[_AIUnavailableQuery, None]):
+    async def handle(self, event: _AIUnavailableQuery) -> None:
+        raise AIOutputValidationError(
+            "AI nutrition fallback failed physical validation",
+            purpose=event.purpose,
+            attempt_count=1,
+            validation_details=["unsafe_density_fallback"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_ai_output_validation_exception_is_not_logged_as_error(caplog):
+    bus = PyMediatorEventBus()
+    bus.register_handler(_AIUnavailableQuery, _AIOutputInvalidHandler())
+
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="src.infra.event_bus.pymediator_event_bus",
+    ):
+        with pytest.raises(AIOutputValidationError):
+            await bus.send(_AIUnavailableQuery(purpose="parse_text"))
+
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR and "Error handling" in record.message
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Allow energy-dense compound foods (walnuts, almonds, …) through AI fallback validation so parse-text no longer rejects plausible macros (`PYTHON-FX`).
- Log controlled `AIOutputValidationError` / meal-recommendation 409s at debug, and map unparseable AI JSON to a typed validation error instead of ERROR logs (`PYTHON-F2`, `PYTHON-FS`, `PYTHON-D6`).
- Stop Sentry FastAPI/Starlette integrations from capturing 503 `AI_UNAVAILABLE` as failed requests (`PYTHON-FN`, `PYTHON-ED`).

Fixes PYTHON-FX
Fixes PYTHON-F2
Fixes PYTHON-FS
Fixes PYTHON-FN
Fixes PYTHON-ED
Fixes PYTHON-D6

## Test plan
- [x] `pytest tests/unit/domain/services/test_nutrition_resolver.py tests/unit/infra/test_pymediator_event_bus.py tests/unit/infra/adapters/test_ai_json_logging.py tests/unit/infra/monitoring/test_sentry_connector.py tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py`
- [ ] Confirm walnuts/30g parse-text no longer appears as `unsafe_density_fallback` in production after deploy
- [ ] Confirm 503 AI outages and recommendation 409s stop creating new Sentry issues


Made with [Cursor](https://cursor.com)