### PR TITLE
fix(food-label): preserve count-based serving sizes

### DIFF
--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -165,7 +165,9 @@ class MealMapper:
                         )
 
                     custom_nutrition_dto = (
-                        MealMapper._custom_nutrition_response_for_item(
+                        None
+                        if not MealMapper._food_label_has_gram_basis(meal)
+                        else MealMapper._custom_nutrition_response_for_item(
                             item,
                             item_calories,
                             canonical_name,
@@ -549,6 +551,24 @@ class MealMapper:
             fiber_per_100g=fiber,
             sugar_per_100g=sugar,
         )
+
+    @staticmethod
+    def _food_label_has_gram_basis(meal: Meal) -> bool:
+        """Return whether a food-label serving can be projected per 100g."""
+        if meal.source != "food_label":
+            return True
+
+        metadata = getattr(meal, "food_label_metadata", None)
+        serving_size = (
+            metadata.get("serving_size") if isinstance(metadata, dict) else None
+        )
+        if not isinstance(serving_size, dict) or "grams" not in serving_size:
+            return True
+
+        try:
+            return float(serving_size["grams"]) > 0
+        except (TypeError, ValueError):
+            return True
 
     @staticmethod
     def _custom_nutrition_response(calories, protein, carbs, fat, fiber, sugar):

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -179,7 +179,11 @@ class FoodLabelServingSizeResponse(BaseModel):
     """Serving-size metadata extracted from a Nutrition Facts label."""
 
     display_text: str = Field(..., description="Serving size text from label")
-    grams: float = Field(..., gt=0, description="Serving size in grams")
+    grams: float = Field(
+        ...,
+        ge=0,
+        description="Serving size in grams; 0 means the label did not provide it",
+    )
 
 
 class FoodLabelMetadataResponse(BaseModel):

--- a/src/domain/model/ai/nutrition_contracts.py
+++ b/src/domain/model/ai/nutrition_contracts.py
@@ -122,7 +122,12 @@ class FoodLabelServingSize(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     display_text: str = Field(..., min_length=1, max_length=80)
-    grams: float = Field(..., gt=0, le=MAX_FOOD_ITEM_QUANTITY)
+    grams: float = Field(
+        ...,
+        ge=0,
+        le=MAX_FOOD_ITEM_QUANTITY,
+        description="Serving mass in grams; 0 means the label does not provide it",
+    )
 
     @field_validator("display_text")
     @classmethod

--- a/src/domain/parsers/vision_response_parser.py
+++ b/src/domain/parsers/vision_response_parser.py
@@ -95,31 +95,40 @@ class VisionResponseParser:
                 fiber=float(canonical.macros_per_serving.fiber_g),
                 sugar=float(canonical.macros_per_serving.sugar_g),
             )
-            food_item = FoodItem(
-                id=str(uuid.uuid4()),
-                name=canonical.product_name,
-                quantity=float(canonical.serving_size.grams),
-                unit="g",
-                macros=macros,
-                micros=None,
-                confidence=min(max(0.0, float(canonical.confidence)), 1.0),
-                is_custom=True,
-                allowed_units=[
+            serving_grams = float(canonical.serving_size.grams)
+            if serving_grams > 0:
+                quantity = serving_grams
+                unit = "g"
+                allowed_units = [
                     {
                         "unit": "serving",
-                        "gram_weight": float(canonical.serving_size.grams),
+                        "gram_weight": serving_grams,
                         "description": (
                             f"1 serving ({canonical.serving_size.display_text})"
                         ),
                     },
                     {
                         "unit": "package",
-                        "gram_weight": float(canonical.serving_size.grams)
+                        "gram_weight": serving_grams
                         * float(canonical.servings_per_package),
                         "description": "1 package",
                     },
                     {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-                ],
+                ]
+            else:
+                quantity = 1.0
+                unit = "serving"
+                allowed_units = None
+            food_item = FoodItem(
+                id=str(uuid.uuid4()),
+                name=canonical.product_name,
+                quantity=quantity,
+                unit=unit,
+                macros=macros,
+                micros=None,
+                confidence=min(max(0.0, float(canonical.confidence)), 1.0),
+                is_custom=True,
+                allowed_units=allowed_units,
             )
             return Nutrition(
                 macros=macros,

--- a/src/domain/services/meal_calorie_service.py
+++ b/src/domain/services/meal_calorie_service.py
@@ -97,15 +97,35 @@ def _scaled_label_calories(
 
     quantity = getattr(item, "quantity", None)
     unit = str(getattr(item, "unit", "") or "").strip().lower()
-    if item is None or unit not in {"g", "gram", "grams"}:
+    if item is None:
         return round(label_calories, 1)
 
     try:
-        quantity_grams = float(quantity)
+        quantity_value = float(quantity)
     except (TypeError, ValueError):
         return round(label_calories, 1)
 
-    if not serving_grams or serving_grams <= 0 or quantity_grams <= 0:
+    if quantity_value <= 0:
         return round(label_calories, 1)
 
-    return round(label_calories * (quantity_grams / serving_grams), 1)
+    if unit in {"serving", "servings"}:
+        return round(label_calories * quantity_value, 1)
+
+    if unit in {"package", "packages"}:
+        servings_per_package = None
+        if isinstance(metadata, dict):
+            try:
+                servings_per_package = float(metadata.get("servings_per_package") or 0)
+            except (TypeError, ValueError):
+                servings_per_package = None
+        if servings_per_package and servings_per_package > 0:
+            return round(label_calories * quantity_value * servings_per_package, 1)
+        return round(label_calories, 1)
+
+    if unit not in {"g", "gram", "grams"}:
+        return round(label_calories, 1)
+
+    if not serving_grams or serving_grams <= 0:
+        return round(label_calories, 1)
+
+    return round(label_calories * (quantity_value / serving_grams), 1)

--- a/src/domain/strategies/meal_analysis_strategy.py
+++ b/src/domain/strategies/meal_analysis_strategy.py
@@ -213,12 +213,12 @@ FIELD RULES:
 - product_name: If visible, copy the product name as printed. If not visible, use "Scanned Food Label".
 - brand: Copy only when visible and clearly a brand. Otherwise null.
 - serving_size.display_text: Copy the serving-size text when visible, translated only if necessary for clarity.
-- serving_size.grams: Convert the serving size to grams. If serving size is missing or only per-100g values are shown, use 100.
+- serving_size.grams: Convert to grams only when the label explicitly gives a mass/weight serving. Use 0 when the serving is count- or volume-based (for example, "1 can") and no reliable gram weight is printed; never invent a gram weight. If serving size is missing or only per-100g values are shown, use 100.
 - servings_per_package: Use the label value when visible. If missing or unreadable, use 1.
 - label_calories_per_serving: Use kcal/calories per serving. If only kJ is visible, convert kcal = kJ / 4.184. If no energy value is readable, null is allowed.
 - macros_per_serving: Return protein_g, carbs_g, fat_g, fiber_g, and sugar_g per serving. Missing fiber or sugar should be 0.0. Protein, carbs, and fat must be present; use 0.0 only when the label explicitly says 0 or the row is clearly absent from a simplified zero-macro label.
 - confidence: 0.0 to 1.0 based on image clarity and table readability.
-- label_notes: Short factual notes only: source basis, per-100g fallback, kJ conversion, unreadable rows, or ignored micronutrients.
+- label_notes: Short factual notes only: source basis, per-100g fallback, kJ conversion, unreadable rows, missing gram weight, or ignored micronutrients. When grams is 0, preserve the visible display_text and note that the gram weight was not provided.
 
 NUTRIENT MAPPING:
 - protein_g: protein, proteine, proteina, proteinas, โปรตีน, たんぱく質, 蛋白质, 단백질.

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -859,6 +859,55 @@ class TestMealMapper:
         assert result.food_label_metadata.servings_per_package == 8
         assert result.food_label_metadata.label_notes == ["Stored metadata"]
 
+    def test_to_detailed_response_scales_count_based_food_label_servings(self):
+        """Scale printed calories without projecting an unknown gram basis."""
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/can.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            dish_name="Protein Drink",
+            ready_at=datetime(2025, 1, 15, 15, 0),
+            created_at=datetime(2025, 1, 15, 14, 30),
+            source="food_label",
+            food_label_metadata={
+                "product_name": "Protein Drink",
+                "brand": None,
+                "serving_size": {"display_text": "1 can", "grams": 0},
+                "servings_per_package": 1,
+                "label_calories_per_serving": 45,
+                "confidence": 0.91,
+                "label_notes": ["Serving weight not provided on label."],
+            },
+            nutrition=Nutrition(
+                macros=Macros(protein=20, carbs=4, fat=0),
+                food_items=[
+                    FoodItem(
+                        id="can-item",
+                        name="Protein Drink",
+                        quantity=2,
+                        unit="serving",
+                        macros=Macros(protein=20, carbs=4, fat=0),
+                        is_custom=True,
+                    )
+                ],
+            ),
+        )
+
+        result = MealMapper.to_detailed_response(meal)
+
+        assert result.total_calories == pytest.approx(90)
+        assert result.food_items[0].quantity == pytest.approx(2)
+        assert result.food_items[0].nutrition.calories == pytest.approx(90)
+        assert result.food_items[0].custom_nutrition is None
+        assert result.food_label_metadata is not None
+        assert result.food_label_metadata.serving_size.grams == pytest.approx(0)
+
     def test_to_detailed_response_custom_nutrition_uses_grams_for_large_units(self):
         """Custom nutrition is projected per 100g, not per serving count."""
         food_items = [
@@ -902,7 +951,9 @@ class TestMealMapper:
         assert custom.carbs_per_100g == pytest.approx(0.7)
         assert custom.fat_per_100g == pytest.approx(9.6)
 
-    def test_to_detailed_response_custom_nutrition_does_not_treat_nhanh_as_one_gram(self):
+    def test_to_detailed_response_custom_nutrition_does_not_treat_nhanh_as_one_gram(
+        self,
+    ):
         """Unknown culinary units must not explode per-100g calories 100x."""
         food_items = [
             FoodItem(

--- a/tests/unit/domain/model/ai/test_nutrition_contracts.py
+++ b/tests/unit/domain/model/ai/test_nutrition_contracts.py
@@ -321,6 +321,29 @@ class TestFoodLabelNutritionResponse:
         assert response.serving_size.grams == pytest.approx(100)
         assert response.servings_per_package == pytest.approx(1)
 
+    def test_accepts_zero_serving_grams_when_mass_is_not_printed(self):
+        response = FoodLabelNutritionResponse.model_validate(
+            {
+                "product_name": "Cereal",
+                "serving_size": {"display_text": "1 can", "grams": 0},
+                "servings_per_package": 1,
+                "macros_per_serving": _valid_macros(),
+            }
+        )
+
+        assert response.serving_size.grams == pytest.approx(0)
+
+    def test_rejects_negative_serving_grams(self):
+        with pytest.raises(ValidationError):
+            FoodLabelNutritionResponse.model_validate(
+                {
+                    "product_name": "Cereal",
+                    "serving_size": {"display_text": "Unknown", "grams": -1},
+                    "servings_per_package": 1,
+                    "macros_per_serving": _valid_macros(),
+                }
+            )
+
     def test_rejects_missing_macros(self):
         with pytest.raises(ValidationError):
             FoodLabelNutritionResponse.model_validate(

--- a/tests/unit/domain/parsers/test_gpt_response_parser.py
+++ b/tests/unit/domain/parsers/test_gpt_response_parser.py
@@ -390,6 +390,30 @@ def test_parse_food_label_to_nutrition_logs_one_serving(gpt_parser):
     assert nutrition.calories == pytest.approx(224)
 
 
+def test_parse_food_label_to_nutrition_preserves_count_based_serving(gpt_parser):
+    gpt_response = {
+        "structured_data": {
+            "product_name": "Protein Drink",
+            "serving_size": {"display_text": "1 can", "grams": 0},
+            "servings_per_package": 1,
+            "label_calories_per_serving": 45,
+            "macros_per_serving": {
+                "protein_g": 10,
+                "carbs_g": 2,
+                "fat_g": 0,
+            },
+            "confidence": 0.91,
+        }
+    }
+
+    nutrition = gpt_parser.parse_food_label_to_nutrition(gpt_response)
+
+    food_item = nutrition.food_items[0]
+    assert food_item.quantity == pytest.approx(1)
+    assert food_item.unit == "serving"
+    assert food_item.allowed_units is None
+
+
 def test_parse_food_label_metadata_returns_validated_label_data(gpt_parser):
     gpt_response = {
         "structured_data": {

--- a/tests/unit/domain/strategies/test_meal_analysis_strategy.py
+++ b/tests/unit/domain/strategies/test_meal_analysis_strategy.py
@@ -23,9 +23,9 @@ def test_all_5_strategies_return_vision_analysis_system_prompt():
     ]
     for s in strategies:
         result = s.get_analysis_prompt()
-        assert (
-            result == SystemPrompts.VISION_ANALYSIS
-        ), f"{s.__class__.__name__}.get_analysis_prompt() must return SystemPrompts.VISION_ANALYSIS"
+        assert result == SystemPrompts.VISION_ANALYSIS, (
+            f"{s.__class__.__name__}.get_analysis_prompt() must return SystemPrompts.VISION_ANALYSIS"
+        )
 
 
 def test_portion_aware_user_message_contains_portion_info():
@@ -62,6 +62,8 @@ def test_food_label_strategy_prompt_contains_multilingual_label_rules():
     assert "Return ONLY valid JSON" in prompt
     assert "Thai nutrition panel" in prompt
     assert "serving_size.display_text" in prompt
+    assert "no reliable gram weight is printed" in prompt
+    assert "preserve the visible display_text" in prompt
     assert "Scanned Food Label" in prompt
     assert "Do not use Daily Value percentages as gram values" in prompt
     assert "Do not require any pre-extracted text" in prompt

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -175,6 +175,37 @@ class TestUpdateFoodItemStrategy:
         assert updated_item.food_reference_id == 1001
 
     @pytest.mark.asyncio
+    async def test_update_count_based_serving_scales_nutrition(self):
+        strategy = UpdateFoodItemStrategy(Mock())
+        food_items_dict = {
+            "label-item": FoodItem(
+                id="label-item",
+                name="Protein Drink",
+                quantity=1.0,
+                unit="serving",
+                macros=Macros(protein=10.0, carbs=2.0, fat=0.0),
+                is_custom=True,
+            )
+        }
+
+        await strategy.apply(
+            food_items_dict,
+            FoodItemChange(
+                action="update",
+                id="label-item",
+                quantity=2.0,
+                unit="serving",
+            ),
+        )
+
+        updated_item = food_items_dict["label-item"]
+        assert updated_item.quantity == 2.0
+        assert updated_item.unit == "serving"
+        assert updated_item.macros.protein == 20.0
+        assert updated_item.macros.carbs == 4.0
+        assert updated_item.macros.fat == 0.0
+
+    @pytest.mark.asyncio
     async def test_update_keeps_manual_values_independent_from_source_macros(self):
         strategy = UpdateFoodItemStrategy(Mock())
         food_items_dict = {

--- a/tests/unit/infra/services/ai/test_langchain_openai_adapter.py
+++ b/tests/unit/infra/services/ai/test_langchain_openai_adapter.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from src.domain.model.ai.nutrition_contracts import VisionNutritionResponse
+from src.domain.model.ai.nutrition_contracts import (
+    FoodLabelNutritionResponse,
+    VisionNutritionResponse,
+)
 from src.infra.services.ai.langchain_openai_adapter import (
     LangChainOpenAIResult,
     OpenAILangChainAdapter,
@@ -34,7 +37,12 @@ def _parsed_vision_response() -> VisionNutritionResponse:
     )
 
 
-def _adapter(monkeypatch, *, store_responses: bool = False):
+def _adapter(
+    monkeypatch,
+    *,
+    store_responses: bool = False,
+    structured_parsed: dict | None = None,
+):
     created = []
 
     class FakeChatOpenAI:
@@ -69,7 +77,8 @@ def _adapter(monkeypatch, *, store_responses: bool = False):
             self.structured.ainvoke = AsyncMock(
                 return_value={
                     "raw": self.structured_raw_message,
-                    "parsed": _parsed_vision_response().model_dump(),
+                    "parsed": structured_parsed
+                    or _parsed_vision_response().model_dump(),
                     "parsing_error": None,
                 }
             )
@@ -254,8 +263,8 @@ async def test_vision_uses_multimodal_human_message_with_data_url(monkeypatch):
     assert isinstance(messages[1], HumanMessage)
     assert messages[1].content[0] == {"type": "text", "text": "Identify food."}
     assert messages[1].content[1]["type"] == "image_url"
-    assert messages[1].content[1]["image_url"]["url"].startswith(
-        "data:image/png;base64,"
+    assert (
+        messages[1].content[1]["image_url"]["url"].startswith("data:image/png;base64,")
     )
     assert messages[1].content[1]["image_url"]["url"].endswith("aW1hZ2UtYnl0ZXM=")
     assert messages[1].content[1]["image_url"]["detail"] == "high"
@@ -266,6 +275,41 @@ async def test_vision_uses_multimodal_human_message_with_data_url(monkeypatch):
     }
     assert created[0].structured_schema["name"] == "VisionNutritionResponse"
     assert created[0].structured_schema["strict"] is True
+
+
+@pytest.mark.asyncio
+async def test_vision_accepts_zero_food_label_serving_grams(monkeypatch):
+    adapter, _ = _adapter(
+        monkeypatch,
+        structured_parsed={
+            "is_food_label": True,
+            "product_name": "Cereal",
+            "brand": None,
+            "serving_size": {"display_text": "Unknown", "grams": 0},
+            "servings_per_package": 1,
+            "label_calories_per_serving": None,
+            "macros_per_serving": {
+                "protein_g": 3,
+                "carbs_g": 37,
+                "fat_g": 8,
+            },
+            "confidence": 0.5,
+            "label_notes": [],
+        },
+    )
+
+    result = await adapter.generate_vision_structured(
+        model="gpt-5.4-mini-2026-03-17",
+        prompt="Read label.",
+        image_data=b"image-bytes",
+        image_mime_type="image/jpeg",
+        system_message="Return canonical JSON.",
+        schema=FoodLabelNutritionResponse,
+        max_tokens=None,
+        request_kwargs=None,
+    )
+
+    assert result.parsed.serving_size.grams == pytest.approx(0)
 
 
 def test_usage_extractors_support_response_metadata_fallback(monkeypatch):


### PR DESCRIPTION
## Summary

- Accept count- or volume-based label servings when no reliable gram weight is printed.
- Preserve `1 serving` semantics and printed label calories without fabricating per-100g nutrition.
- Scale printed calories correctly when users change serving or package quantities.

## Linked Issues

No linked issues.

## Pre-Landing Review

No unresolved critical findings. The review identified and this PR fixes the multi-serving calorie-scaling edge case for count-based labels.

## Test Results

- [x] `2571 passed`, 0 failures
- [x] Coverage: `79.93%`
- [x] Scoped Ruff check and format check passed
- [x] Python compilation and `git diff --check` passed

## Changes

`11 files changed, 233 insertions(+), 31 deletions(-)`

## Ship Mode

- Mode: official
- Target: `main`