### PR TITLE
fix(meal-edit): tolerate legacy v2 quantity updates

### DIFF
--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -574,13 +574,29 @@ class EditMealIngredientsRequest(BaseModel):
             elif change.origin is not None:
                 _validate_change_origin(change)
             elif change.origin is None:
+                if any(value is not None for value in identity_fields):
+                    raise ValueError("v2 quantity update cannot replace source")
+                is_portion_update = change.action == "update" and (
+                    change.quantity is not None or change.unit is not None
+                )
+                has_legacy_source_echo = any(
+                    value is not None
+                    for value in (change.name, change.custom_nutrition)
+                ) or bool(change.allowed_units)
+                if is_portion_update and has_legacy_source_echo:
+                    # Older clients echo source fields on portion updates. They
+                    # cannot replace authoritative nutrition without an origin,
+                    # so discard the echoes before the domain strategy runs.
+                    change.name = None
+                    change.custom_nutrition = None
+                    change.allowed_units = []
+                    continue
                 if any(
                     value is not None
                     for value in (
                         change.name,
                         change.custom_nutrition,
                         change.allowed_units or None,
-                        *identity_fields,
                     )
                 ):
                     raise ValueError("v2 quantity update cannot replace source")

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -145,15 +145,76 @@ def test_v2_remove_rejects_nutrition_and_source_fields():
         )
 
 
-def test_v2_quantity_update_can_inherit_source_without_client_units():
+def test_v2_quantity_update_strips_legacy_source_echoes():
     payload = EditMealIngredientsRequest(
         nutrition_contract_version=2,
         food_item_changes=[
-            {"action": "update", "id": "item-1", "quantity": 200, "unit": "g"}
+            {
+                "action": "update",
+                "id": "item-1",
+                "name": "Echoed source name",
+                "quantity": 200,
+                "unit": "g",
+                "custom_nutrition": {
+                    "protein_per_100g": 10,
+                    "carbs_per_100g": 20,
+                    "fat_per_100g": 8,
+                },
+                "allowed_units": [
+                    {"unit": "g", "gram_weight": 1, "description": "1 g"}
+                ],
+            }
         ],
     )
 
-    assert payload.food_item_changes[0].id == "item-1"
+    change = payload.food_item_changes[0]
+    assert change.id == "item-1"
+    assert change.quantity == 200
+    assert change.unit == "g"
+    assert change.name is None
+    assert change.custom_nutrition is None
+    assert change.allowed_units == []
+
+
+def test_v2_quantity_update_rejects_identity_with_legacy_source_echoes():
+    with pytest.raises(ValidationError, match="cannot replace source"):
+        EditMealIngredientsRequest(
+            nutrition_contract_version=2,
+            food_item_changes=[
+                {
+                    "action": "update",
+                    "id": "item-1",
+                    "fdc_id": 999999,
+                    "name": "Echoed source name",
+                    "quantity": 200,
+                    "unit": "g",
+                    "custom_nutrition": {
+                        "protein_per_100g": 10,
+                        "carbs_per_100g": 20,
+                        "fat_per_100g": 8,
+                    },
+                }
+            ],
+        )
+
+
+def test_v2_source_replacement_without_portion_fields_is_still_rejected():
+    with pytest.raises(ValidationError, match="cannot replace source"):
+        EditMealIngredientsRequest(
+            nutrition_contract_version=2,
+            food_item_changes=[
+                {
+                    "action": "update",
+                    "id": "item-1",
+                    "name": "Replacement source",
+                    "custom_nutrition": {
+                        "protein_per_100g": 10,
+                        "carbs_per_100g": 20,
+                        "fat_per_100g": 8,
+                    },
+                }
+            ],
+        )
 
 
 def test_v2_override_requires_explicit_user_intent():


### PR DESCRIPTION
## Summary
- Strip legacy `name`, `custom_nutrition`, and `allowed_units` echoes from v2 quantity/unit updates.
- Reject all source identity fields when `origin` is absent, before compatibility normalization.
- Preserve backend-authoritative nutrition and add regression coverage for both behaviors.

This is a temporary backend mitigation for existing mobile clients. The follow-up mobile fix should make `toUpdateRequest()` omit source-identity fields for v2 quantity edits.

## Test plan
- [x] `uv run pytest` full unit suite — 2568 passed
- [x] Focused meal-edit/API tests — 53 passed
- [x] Secret scan and diff check
- [x] Schema compilation