### PR TITLE
fix(meal-edit): allow client IDs for ingredient adds

### DIFF
--- a/docs/archive/progress/project-changelog.md
+++ b/docs/archive/progress/project-changelog.md
@@ -3,6 +3,13 @@
 **Status:** Stateful release notes — archived; not evergreen product authority  
 **Evergreen route:** see `docs/codebase-summary.md` and root `README.md`
 
+## 2026-08-18
+
+### Fixed
+
+- Versioned meal ingredient adds now allow client-generated item IDs; ownership
+  validation remains restricted to updates and removals.
+
 ## 2026-08-07
 
 ### Changed

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -510,7 +510,9 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 prepared.append(change)
                 continue
 
-            if change.id and change.id not in current_by_id:
+            if change.action == "update" and (
+                not change.id or change.id not in current_by_id
+            ):
                 raise ValueError("v2 update requires an owned food item id")
 
             if change.nutrition_override is not None or change.clear_nutrition_override:

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -572,6 +572,9 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 )
                 continue
 
+            if change.action == "add":
+                raise ValueError("v2 add requires origin")
+
             existing = current_by_id[change.id]
             prepared.append(self._canonicalize_snapshot_unit(existing, change))
         if revalidate_local:

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -6,6 +6,7 @@ from src.app.commands.meal import FoodItemChange
 from src.app.handlers.command_handlers.edit_meal_command_handler import (
     EditMealCommandHandler,
 )
+from src.domain.model.meal.food_item_change import CustomNutritionData
 from src.domain.model.nutrition import FoodItem, Macros
 
 
@@ -23,6 +24,56 @@ class _References:
             sugar_100g=0.1,
             servings=[],
         )
+
+
+class _PassthroughResolver:
+    async def resolve_items(self, items, food_references, *, contract_version):
+        return items
+
+    async def revalidate_local_items(self, items, food_references):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_v2_add_allows_client_generated_id_not_owned_by_meal():
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="add",
+        id="client-generated-id",
+        name="Rau Xao",
+        quantity=100,
+        unit="g",
+        origin="custom",
+        custom_nutrition=CustomNutritionData(
+            calories_per_100g=51,
+            protein_per_100g=2,
+            carbs_per_100g=8,
+            fat_per_100g=1,
+            fiber_per_100g=2,
+            sugar_per_100g=1,
+        ),
+    )
+    handler = EditMealCommandHandler(
+        uow=None,
+        nutrition_resolver=_PassthroughResolver(),
+    )
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+
+    assert prepared[0].id == "client-generated-id"
+    assert len(updated) == 2
+    added = next(item for item in updated if item.name == "Rau Xao")
+    assert added.source_kind == "custom"
+    assert added.macros.protein == pytest.approx(2)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -1,3 +1,4 @@
+import uuid
 from types import SimpleNamespace
 
 import pytest
@@ -72,8 +73,37 @@ async def test_v2_add_allows_client_generated_id_not_owned_by_meal():
     assert prepared[0].id == "client-generated-id"
     assert len(updated) == 2
     added = next(item for item in updated if item.name == "Rau Xao")
+    assert added.id != change.id
+    uuid.UUID(added.id)
     assert added.source_kind == "custom"
     assert added.macros.protein == pytest.approx(2)
+
+
+@pytest.mark.asyncio
+async def test_v2_add_without_origin_is_rejected_before_id_lookup():
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="add",
+        id="client-generated-id",
+        name="Rau Xao",
+        quantity=100,
+        unit="g",
+    )
+    handler = EditMealCommandHandler(
+        uow=None,
+        nutrition_resolver=_PassthroughResolver(),
+    )
+
+    with pytest.raises(ValueError, match="v2 add requires origin"):
+        await handler._prepare_v2_changes(
+            [current], [change], SimpleNamespace(food_references=object())
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow v2 ingredient adds to carry a client-generated ID
- keep ownership validation for update and remove actions
- add regression coverage for a custom ingredient add

## Root cause
`_prepare_v2_changes` rejected any change with an ID not already in the meal. Mobile sends a generated ID for new ingredients, so the backend returned `400 v2 update requires an owned food item id`; the mobile optimistic row then disappeared after rollback.

## Fix
Apply the owned-ID check only to `action: "update"`. Add requests continue through the existing source-resolution and persistence flow, which assigns the server-side item identity.

## Validation
- `pytest tests/unit --cov=src --cov-fail-under=65`: 2,569 passed, 79.84% coverage
- focused meal-edit tests: 57 passed
- modified-file Ruff format and lint checks passed
- repository-wide Ruff/mypy remain outside this PR due to existing baseline violations

## Deployment note
After deploy, verify adding a new ingredient from the current mobile `origin/main` build and confirm the item remains after reopening the meal.