### PR TITLE
fix(meal-edit): allow high-calorie absolute overrides

### DIFF
--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -461,10 +461,10 @@ class CustomNutritionRequest(BaseModel):
 class NutritionOverrideRequest(BaseModel):
     """Absolute values that intentionally bypass nutrition recalculation."""
 
-    calories: float = Field(..., ge=0, le=900)
-    protein: float = Field(..., ge=0, le=1000)
-    carbs: float = Field(..., ge=0, le=1000)
-    fat: float = Field(..., ge=0, le=1000)
+    calories: float = Field(..., ge=0, allow_inf_nan=False)
+    protein: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
+    carbs: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
+    fat: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
 
 
 class EditMealIngredientsRequest(BaseModel):

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -246,6 +246,31 @@ def test_nutrition_override_rejects_negative_absolute_values():
         )
 
 
+def test_nutrition_override_accepts_absolute_calories_above_density_bound():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        override_intent="user_entered",
+        nutrition_override=NutritionOverrideRequest(
+            calories=1500,
+            protein=80,
+            carbs=120,
+            fat=70,
+        ),
+    )
+
+    assert request.nutrition_override.calories == 1500
+
+
+def test_nutrition_override_rejects_non_finite_calories():
+    with pytest.raises(ValidationError):
+        NutritionOverrideRequest(
+            calories=float("inf"),
+            protein=20,
+            carbs=30,
+            fat=15,
+        )
+
+
 def test_unknown_nutrition_contract_version_is_rejected():
     with pytest.raises(ValidationError):
         CreateManualMealFromFoodsRequest(


### PR DESCRIPTION
## Summary

- Remove the erroneous 900 kcal absolute ceiling from `NutritionOverrideRequest.calories`.
- Keep absolute overrides non-negative and finite, with existing macro bounds preserved.
- Keep the 900 kcal rule for per-100g nutrition density validation.
- Add regression coverage for a 1,500 kcal absolute override and non-finite calorie rejection.

## Context

Absolute meal and ingredient overrides represent the total nutrition for the edited item or meal. The 900 kcal value is a density integrity limit for 100g nutrition, not a valid total-calorie limit.

Companion mobile change: https://github.com/Nutree-AI-Vietnam/nutree_ai/pull/672

## Validation

- Focused backend tests: 52 passed
- Backend pre-push unit-test hook completed successfully
- git diff --check passed
- Staged secret scan passed
- Ruff reports existing UP045 baseline findings in the large request-schema module; no new formatting changes were introduced

## Docs impact

None.
