### PR TITLE
fix(auth): widen users.provider so EMAIL_LINK sign-in can persist

### DIFF
--- a/migrations/versions/20260818000002_widen_users_provider_varchar.py
+++ b/migrations/versions/20260818000002_widen_users_provider_varchar.py
@@ -1,0 +1,44 @@
+"""Widen users.provider so EMAIL_LINK and ANONYMOUS persist.
+
+Production evidence (2026-08-18): POST /v1/users/sync failed with
+`StringDataRightTruncationError: value too long for type character varying(6)`
+while writing provider='EMAIL_LINK'. native_enum=False VARCHAR length defaulted
+to 6 for the original GOOGLE/APPLE names.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260818000002"
+down_revision = "20260818000001"
+branch_labels = None
+depends_on = None
+
+PROVIDER_LENGTH = 32
+
+
+def upgrade() -> None:
+    """Widen provider to VARCHAR(32), including native-enum leftovers."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("users"):
+        return
+    columns = {column["name"]: column for column in inspector.get_columns("users")}
+    provider = columns.get("provider")
+    if provider is None:
+        return
+    current_length = getattr(provider["type"], "length", None)
+    if current_length is not None and current_length >= PROVIDER_LENGTH:
+        return
+    op.execute(
+        sa.text(
+            "ALTER TABLE users ALTER COLUMN provider TYPE VARCHAR(32) "
+            "USING provider::text"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Keep the wider provider column; truncating would break EMAIL_LINK rows."""

--- a/src/infra/database/models/user/user.py
+++ b/src/infra/database/models/user/user.py
@@ -10,6 +10,10 @@ from src.domain.utils.timezone_utils import utc_now
 from src.infra.database.base import Base
 from src.infra.database.models.base import BaseMixin
 
+# native_enum=False stores enum *names* (GOOGLE, EMAIL_LINK). Fresh DBs used
+# VARCHAR(6) from GOOGLE/APPLE; EMAIL_LINK is 10 chars and must still fit.
+AUTH_PROVIDER_VARCHAR_LENGTH = 32
+
 
 class User(Base, BaseMixin):
     """Core user table for authentication and account management."""
@@ -32,10 +36,14 @@ class User(Base, BaseMixin):
     display_name = Column(String(100), nullable=True)
     photo_url = Column(Text, nullable=True)
     provider = Column(
-        Enum(AuthProviderEnum, native_enum=False),
+        Enum(
+            AuthProviderEnum,
+            native_enum=False,
+            length=AUTH_PROVIDER_VARCHAR_LENGTH,
+        ),
         nullable=False,
         default=AuthProviderEnum.GOOGLE,
-    )  # phone, google
+    )
 
     # Status & Activity
     is_active = Column(Boolean, default=True, nullable=False)

--- a/tests/migrations/test_merge_catalog_browse_and_translation_heads.py
+++ b/tests/migrations/test_merge_catalog_browse_and_translation_heads.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 
-from alembic.config import Config
-from alembic.script import ScriptDirectory
-
 MIGRATION = Path(
     "migrations/versions/20260818000001_merge_catalog_browse_and_translation_heads.py"
 )
@@ -14,10 +11,3 @@ def test_merge_revision_joins_catalog_and_translation_heads() -> None:
     assert 'revision: str = "20260818000001"' in text
     assert '"20260816000005"' in text
     assert '"20260817000001"' in text
-
-
-def test_alembic_heads_resolve_to_merge_revision() -> None:
-    script_dir = ScriptDirectory.from_config(Config("alembic.ini"))
-
-    assert script_dir.get_heads() == ["20260818000001"]
-    assert script_dir.get_current_head() == "20260818000001"

--- a/tests/migrations/test_widen_users_provider_varchar.py
+++ b/tests/migrations/test_widen_users_provider_varchar.py
@@ -1,0 +1,98 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+MIGRATION = Path("migrations/versions/20260818000002_widen_users_provider_varchar.py")
+
+
+class _Inspector:
+    def __init__(
+        self,
+        *,
+        has_users: bool = True,
+        provider_type: object | None = None,
+    ) -> None:
+        self._has_users = has_users
+        self._provider_type = provider_type
+
+    def has_table(self, table_name: str) -> bool:
+        return self._has_users and table_name == "users"
+
+    def get_columns(self, table_name: str) -> list[dict[str, object]]:
+        if table_name != "users" or self._provider_type is None:
+            return []
+        return [{"name": "provider", "type": self._provider_type}]
+
+
+class _Operations:
+    def __init__(self) -> None:
+        self.execute_sql: list[str] = []
+
+    def get_bind(self) -> object:
+        return object()
+
+    def execute(self, clause) -> None:
+        self.execute_sql.append(str(clause))
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("widen_users_provider", MIGRATION)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_widen_provider_migration_is_idempotent_and_cast_through_text() -> None:
+    text = MIGRATION.read_text()
+
+    assert 'revision = "20260818000002"' in text
+    assert 'down_revision = "20260818000001"' in text
+    assert "VARCHAR(32)" in text
+    assert "USING provider::text" in text
+    assert "EMAIL_LINK" in text
+
+
+def test_upgrade_widens_short_varchar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector(provider_type=module.sa.String(6)),
+    )
+
+    module.upgrade()
+
+    assert operations.execute_sql
+    assert "VARCHAR(32)" in operations.execute_sql[0]
+
+
+def test_upgrade_skips_when_already_wide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration()
+    operations = _Operations()
+    monkeypatch.setattr(module, "op", operations)
+    monkeypatch.setattr(
+        module.sa,
+        "inspect",
+        lambda _bind: _Inspector(provider_type=module.sa.String(32)),
+    )
+
+    module.upgrade()
+
+    assert operations.execute_sql == []
+
+
+def test_alembic_head_is_widen_provider_revision() -> None:
+    script_dir = ScriptDirectory.from_config(Config("alembic.ini"))
+
+    assert script_dir.get_heads() == ["20260818000002"]
+    assert script_dir.get_current_head() == "20260818000002"

--- a/tests/unit/handlers/command_handlers/test_sync_user_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_sync_user_command_handler.py
@@ -92,7 +92,43 @@ class TestSyncUserCommandHandler:
         assert fake_uow.committed is True
 
     @pytest.mark.asyncio
-    async def test_handle_rejects_email_collision_with_different_firebase_uid(self, handler):
+    async def test_handle_persists_email_link_provider_on_existing_google_user(
+        self, handler
+    ):
+        """Google-profile users can sync as EMAIL_LINK without dropping the update."""
+        fake_uow = FakeUnitOfWork()
+        from src.domain.model.auth.auth_provider import AuthProvider
+        from src.domain.model.user import UserDomainModel
+
+        existing_user = UserDomainModel(
+            firebase_uid="firebase_google_photo",
+            email="tung@example.com",
+            username="tung",
+            password_hash="",
+            provider=AuthProvider.GOOGLE,
+            display_name="Tung",
+        )
+        await fake_uow.users.save(existing_user)
+        handler.uow = fake_uow
+
+        command = SyncUserCommand(
+            firebase_uid="firebase_google_photo",
+            email="tung@example.com",
+            display_name="Tung",
+            photo_url="https://lh3.googleusercontent.com/a/example=s96-c",
+            provider="email_link",
+        )
+
+        result = await handler.handle(command)
+
+        assert result["updated"] is True
+        assert result["user"]["provider"] is AuthProvider.EMAIL_LINK
+        assert fake_uow.committed is True
+
+    @pytest.mark.asyncio
+    async def test_handle_rejects_email_collision_with_different_firebase_uid(
+        self, handler
+    ):
         """An email lookup must never move an existing account to a new UID."""
         fake_uow = FakeUnitOfWork()
         from src.domain.model.auth.auth_provider import AuthProvider
@@ -221,9 +257,9 @@ class TestSyncUserCommandHandler:
         # Debug: Check all subscriptions
         all_subs = list(fake_uow.subscriptions._subscriptions.values())
         matching = [s for s in all_subs if s.user_id == str(user_id)]
-        assert (
-            len(matching) > 0
-        ), f"Should have subscription for user {user_id}. All: {[(s.user_id, s.status) for s in all_subs]}"
+        assert len(matching) > 0, (
+            f"Should have subscription for user {user_id}. All: {[(s.user_id, s.status) for s in all_subs]}"
+        )
 
         # Verify subscription can be found before handler runs
         found_before = await fake_uow.subscriptions.find_active_by_user_id(str(user_id))
@@ -237,9 +273,9 @@ class TestSyncUserCommandHandler:
                     print(
                         f"Subscription expires_at={sub.expires_at}, now={dt.now()}, valid={is_valid}"
                     )
-        assert (
-            found_before is not None
-        ), f"Subscription should be findable for user {user_id} before handler runs"
+        assert found_before is not None, (
+            f"Subscription should be findable for user {user_id} before handler runs"
+        )
 
         handler.uow = fake_uow
 
@@ -253,25 +289,25 @@ class TestSyncUserCommandHandler:
 
         # Verify user ID matches - handler should find existing user
         result_user_id = result["user"]["id"]
-        assert str(result_user_id) == str(
-            user_id
-        ), f"User ID mismatch: {result_user_id} != {user_id}"
+        assert str(result_user_id) == str(user_id), (
+            f"User ID mismatch: {result_user_id} != {user_id}"
+        )
 
         # Verify subscription can still be found after handler runs
         found_after = await fake_uow.subscriptions.find_active_by_user_id(
             str(result_user_id)
         )
-        assert (
-            found_after is not None
-        ), f"Subscription should still be findable for user {result_user_id} after handler runs"
+        assert found_after is not None, (
+            f"Subscription should still be findable for user {result_user_id} after handler runs"
+        )
 
         # The handler should have found the subscription and set has_subscription
-        assert (
-            result["user"]["has_subscription"] is True
-        ), f"User should have subscription. Found subscription: {found_after is not None}"
-        assert (
-            result["user"]["subscription"] is not None
-        ), "Subscription info should be present"
+        assert result["user"]["has_subscription"] is True, (
+            f"User should have subscription. Found subscription: {found_after is not None}"
+        )
+        assert result["user"]["subscription"] is not None, (
+            "Subscription info should be present"
+        )
         assert result["user"]["subscription"]["product_id"] == "standard_monthly"
         assert result["user"]["subscription"]["is_monthly"] is True
 
@@ -426,9 +462,9 @@ class TestSyncUserReRegistration:
 
         # New user should have a different ID
         new_user_id = result["user"]["id"]
-        assert str(new_user_id) != str(
-            old_user_id
-        ), "New user should have different ID from deleted user"
+        assert str(new_user_id) != str(old_user_id), (
+            "New user should have different ID from deleted user"
+        )
 
         # New user should have onboarding_completed=False (fresh start)
         assert result["user"]["onboarding_completed"] is False
@@ -481,12 +517,12 @@ class TestSyncUserReRegistration:
         old_user = fake_uow.users.users.get(old_user_id)
         assert old_user is not None, "Deleted user record should still exist"
         assert old_user.is_active is False, "Deleted user should remain inactive"
-        assert (
-            old_user.email == "old_anonymized@deleted.local"
-        ), "Deleted user email should be preserved"
-        assert (
-            old_user.onboarding_completed is True
-        ), "Deleted user onboarding should be preserved"
+        assert old_user.email == "old_anonymized@deleted.local", (
+            "Deleted user email should be preserved"
+        )
+        assert old_user.onboarding_completed is True, (
+            "Deleted user onboarding should be preserved"
+        )
 
     @pytest.mark.asyncio
     async def test_new_user_triggers_onboarding(self, handler):
@@ -565,6 +601,6 @@ class TestSyncUserReRegistration:
         prefs = await fake_uow.notifications.find_notification_preferences_by_user(
             new_user_id
         )
-        assert (
-            prefs is not None
-        ), "Notification preferences should be created for new user"
+        assert prefs is not None, (
+            "Notification preferences should be created for new user"
+        )

--- a/tests/unit/infra/database/test_user_provider_column.py
+++ b/tests/unit/infra/database/test_user_provider_column.py
@@ -1,0 +1,13 @@
+from src.domain.model.auth.auth_provider import AuthProvider
+from src.infra.database.models.user.user import (
+    AUTH_PROVIDER_VARCHAR_LENGTH,
+    User,
+)
+
+
+def test_provider_varchar_fits_all_auth_provider_names() -> None:
+    longest_name = max(len(member.name) for member in AuthProvider)
+
+    assert User.provider.type.length == AUTH_PROVIDER_VARCHAR_LENGTH
+    assert AUTH_PROVIDER_VARCHAR_LENGTH >= longest_name
+    assert AUTH_PROVIDER_VARCHAR_LENGTH >= len(AuthProvider.EMAIL_LINK.name)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Delivery `POST /v1/users/sync` 500s on Google/email-link sign-in because `users.provider` is `varchar(6)` and SQLAlchemy persists the enum **name** `EMAIL_LINK` (10 chars).
- Widen the column to `VARCHAR(32)` (covers `EMAIL_LINK` and `ANONYMOUS`) and set `Enum(..., length=32)` so new databases match.
- The failing UPDATE bound `provider='EMAIL_LINK'` with a Google photo URL; the write itself is what breaks sign-in.

## Test plan
- [x] Alembic graph still has a single head (`20260818000002`)
- [x] CI unit + PostgreSQL Integration green
- [ ] Deploy to delivery and confirm pre-deploy `python migrations/run.py` applies this revision
- [ ] Retry Google sign-in / `POST /v1/users/sync` — should 200 instead of 500

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dabe03e-5311-43c8-9e0d-b028396f7e60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dabe03e-5311-43c8-9e0d-b028396f7e60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

