### PR TITLE
Add SQL backfill for catalog popularity_rank

### DIFF
--- a/scripts/sql/backfill_meal_catalog_popularity_rank.sql
+++ b/scripts/sql/backfill_meal_catalog_popularity_rank.sql
@@ -1,0 +1,92 @@
+-- Backfill meal_catalog.popularity_rank on SIT/Neon without re-importing seeds.
+--
+-- Why: GET /v1/meal-catalog (feed=popular) returns 503 when any active meal
+-- has popularity_rank IS NULL. The 20260816000005 migration added the column
+-- as nullable and did not populate it.
+--
+-- Safe: only fills NULL ranks. Existing curated ranks are left unchanged.
+-- New ranks continue after MAX(popularity_rank) so they do not collide.
+-- Lower rank sorts first (1 is shown before 2).
+--
+-- After applying: wait up to 5 minutes for the in-process catalog snapshot
+-- TTL, or restart the SIT web service so ranks are loaded.
+--
+-- Run in the Neon SQL Editor against the SIT database (neondb).
+
+-- 1) Current coverage
+SELECT
+    count(*) AS total,
+    count(*) FILTER (WHERE is_active) AS active,
+    count(*) FILTER (WHERE is_active AND popularity_rank IS NOT NULL)
+        AS active_ranked,
+    count(*) FILTER (WHERE is_active AND popularity_rank IS NULL)
+        AS active_unranked,
+    count(*) FILTER (WHERE popularity_rank IS NULL) AS all_unranked
+FROM meal_catalog;
+
+-- 2) Preview assignment (no writes)
+WITH bounds AS (
+    SELECT coalesce(max(popularity_rank), 0) AS max_rank
+    FROM meal_catalog
+),
+ranked AS (
+    SELECT
+        mc.id,
+        mc.catalog_key,
+        mc.name,
+        mc.cuisine,
+        mc.is_active,
+        mc.popularity_rank AS current_rank,
+        bounds.max_rank
+        + row_number() OVER (
+            ORDER BY mc.cuisine ASC, mc.name ASC, mc.id ASC
+        ) AS proposed_rank
+    FROM meal_catalog AS mc
+    CROSS JOIN bounds
+    WHERE mc.popularity_rank IS NULL
+)
+SELECT *
+FROM ranked
+ORDER BY proposed_rank;
+
+-- 3) Apply
+BEGIN;
+
+WITH bounds AS (
+    SELECT coalesce(max(popularity_rank), 0) AS max_rank
+    FROM meal_catalog
+),
+ranked AS (
+    SELECT
+        mc.id,
+        bounds.max_rank
+        + row_number() OVER (
+            ORDER BY mc.cuisine ASC, mc.name ASC, mc.id ASC
+        ) AS new_rank
+    FROM meal_catalog AS mc
+    CROSS JOIN bounds
+    WHERE mc.popularity_rank IS NULL
+)
+UPDATE meal_catalog AS mc
+SET
+    popularity_rank = ranked.new_rank,
+    updated_at = now()
+FROM ranked
+WHERE mc.id = ranked.id;
+
+-- 4) Confirm popular feed can serve
+SELECT
+    count(*) AS total,
+    count(*) FILTER (WHERE is_active) AS active,
+    count(*) FILTER (WHERE is_active AND popularity_rank IS NOT NULL)
+        AS active_ranked,
+    count(*) FILTER (WHERE is_active AND popularity_rank IS NULL)
+        AS active_unranked
+FROM meal_catalog;
+
+-- Must be 0 for GET /v1/meal-catalog?feed=popular to stop 503-ing.
+SELECT count(*) AS active_unranked
+FROM meal_catalog
+WHERE is_active AND popularity_rank IS NULL;
+
+COMMIT;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SIT `GET /v1/meal-catalog` (default `feed=popular`) returns 503 because `meal_catalog.popularity_rank` is NULL. The 20260816000005 migration added the column without a data backfill, and there has been no seed re-import.

This adds `scripts/sql/backfill_meal_catalog_popularity_rank.sql` to run in the Neon SQL Editor against SIT:

- Inspect current ranked vs unranked counts
- Preview proposed ranks
- Fill **only NULL** ranks (does not overwrite curated values)
- Continue after `MAX(popularity_rank)` so new ranks do not collide
- Bump `updated_at` so the catalog snapshot revision changes

After applying, restart the SIT web service or wait up to 5 minutes for snapshot TTL.

This is a placeholder ordering (cuisine, name, id), not a curated popularity list. Re-import the seed later if product ranks should replace it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be029930-c7d4-4354-9b8f-0935d24ef19c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be029930-c7d4-4354-9b8f-0935d24ef19c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

