### PR TITLE
Add catalog recommendation slot relog endpoint

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -163,8 +163,10 @@ handler/schema when implementing; the bullets below are the durable WHY.
 - Catalog recommendations are separate from `/v1/meal-suggestions` (AI session
   flow). Do not treat suggestions as a recommendation fallback.
 - Create/get return compact selected-slot summaries; slot detail hydrates one
-  selected slot plus alternatives; swap/log/skip return the changed-slot shape
-  and are owner-scoped and request-id idempotent.
+  selected slot plus alternatives; swap/log/relog/skip return the changed-slot
+  shape and are owner-scoped and request-id idempotent. Relog requires the slot
+  to already be logged, returns `meal_id` for the new meal, and leaves the
+  original `logged_meal_id` in place.
 - Outcome timestamps (`shown_at`, `skipped_at`, `logged_at`) are backend-owned;
   clients must not recompute terminal state.
 - `Accept-Language` selects display language; translation failure returns

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -249,7 +249,7 @@ downloading Cloudinary bytes. Graph nodes must not import provider SDKs,
 1. `POST /v1/meal-recommendations/three-day` resolves timezone and daily calories, then builds or replays a durable recommendation plan.
 2. The plan-level response is compact: it includes only the selected slots, with ingredients for each selected meal. Alternatives, scores, and full meal-detail fields stay out of the summary payload.
 3. `GET /v1/meal-recommendations/{plan_id}/slots/{slot_id}` hydrates one selected slot and its alternatives when the client needs drill-down data.
-4. `swap`, `log`, and `skip` return the changed-slot detail shape so the mobile client can patch its cached plan without reloading everything.
+4. `swap`, `log`, `relog`, and `skip` return the changed-slot detail shape so the mobile client can patch its cached plan without reloading everything. Relog creates a new meal from the currently selected catalog recipe without replacing `logged_meal_id`.
 5. Recommendation analytics are scheduled through `BackgroundTaskManager` when available. Catalog meals are read from the process-local snapshot service with revision-aware TTL, single-flight refresh, and last-good fallback. Meal-history affinity is projected from aggregate linked ingredient buckets instead of loading the full meal graph, and logging a recommended meal reuses the already loaded selected catalog projection without fabricating image data.
 6. Candidate rows retain `seen_at` and `retired_at`. Swap locks only the requested slot, consumes unseen active candidates, and when exhausted retires that slot's inactive pool before inserting five deterministic fresh alternatives. Replenishment never mutates another slot or changes the response contract; daily jobs remain out of scope.
 

--- a/migrations/versions/20260818000002_add_meal_recommendation_relog_operation.py
+++ b/migrations/versions/20260818000002_add_meal_recommendation_relog_operation.py
@@ -1,0 +1,74 @@
+"""Allow additional catalog meals from an already logged recommendation slot."""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260818000002"
+down_revision: str | None = "20260818000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TYPE_CONSTRAINT = "ck_meal_recommendation_operations_type"
+_PAYLOAD_CONSTRAINT = "ck_meal_recommendation_operations_payload"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        _TYPE_CONSTRAINT, "meal_recommendation_operations", type_="check"
+    )
+    op.create_check_constraint(
+        _TYPE_CONSTRAINT,
+        "meal_recommendation_operations",
+        "operation_type IN ('swap', 'log', 'skip', 'relog')",
+    )
+
+    op.drop_constraint(
+        _PAYLOAD_CONSTRAINT, "meal_recommendation_operations", type_="check"
+    )
+    op.create_check_constraint(
+        _PAYLOAD_CONSTRAINT,
+        "meal_recommendation_operations",
+        "("
+        "operation_type = 'swap' AND result_selection_version IS NOT NULL "
+        "AND result_catalog_meal_id IS NOT NULL AND result_logged_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'log' AND result_logged_meal_id IS NOT NULL "
+        "AND result_catalog_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'relog' AND result_logged_meal_id IS NOT NULL "
+        "AND result_catalog_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'skip' AND result_selection_version IS NULL "
+        "AND result_catalog_meal_id IS NULL AND result_logged_meal_id IS NULL"
+        ")",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        _PAYLOAD_CONSTRAINT, "meal_recommendation_operations", type_="check"
+    )
+    op.create_check_constraint(
+        _PAYLOAD_CONSTRAINT,
+        "meal_recommendation_operations",
+        "("
+        "operation_type = 'swap' AND result_selection_version IS NOT NULL "
+        "AND result_catalog_meal_id IS NOT NULL AND result_logged_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'log' AND result_logged_meal_id IS NOT NULL "
+        "AND result_catalog_meal_id IS NULL"
+        ") OR ("
+        "operation_type = 'skip' AND result_selection_version IS NULL "
+        "AND result_catalog_meal_id IS NULL AND result_logged_meal_id IS NULL"
+        ")",
+    )
+
+    op.drop_constraint(
+        _TYPE_CONSTRAINT, "meal_recommendation_operations", type_="check"
+    )
+    op.create_check_constraint(
+        _TYPE_CONSTRAINT,
+        "meal_recommendation_operations",
+        "operation_type IN ('swap', 'log', 'skip')",
+    )

--- a/plans/260818-2216-catalog-meal-log-insight-relog/phase-02-catalog-meal-relog.md
+++ b/plans/260818-2216-catalog-meal-log-insight-relog/phase-02-catalog-meal-relog.md
@@ -1,0 +1,16 @@
+---
+phase: 2
+title: "Catalog meal relog"
+status: in-progress
+priority: P1
+---
+
+# Phase 2: Catalog meal relog
+
+Add `POST /v1/meal-recommendations/{plan_id}/slots/{slot_id}/relog`.
+
+- Requires the slot to already be logged.
+- Materializes a new meal dated to the user's today.
+- Leaves `logged_meal_id` pointing at the original log.
+- Request-id idempotent via `operation_type='relog'`.
+- Warms meal value insights for the new meal.

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -22,6 +22,7 @@ from src.app.commands.meal.parse_meal_text_command import ParseMealTextCommand
 from src.app.commands.meal_recommendation import (
     CreateThreeDayMealRecommendationCommand,
     LogRecommendedMealCommand,
+    RelogRecommendedMealCommand,
     SkipMealRecommendationSlotCommand,
     SwapMealRecommendationSlotCommand,
 )
@@ -112,6 +113,7 @@ from src.app.handlers.command_handlers.mark_cheat_day_command_handler import (
 from src.app.handlers.command_handlers.meal_recommendation import (
     CreateThreeDayMealRecommendationCommandHandler,
     LogRecommendedMealCommandHandler,
+    RelogRecommendedMealCommandHandler,
     SkipMealRecommendationSlotCommandHandler,
     SwapMealRecommendationSlotCommandHandler,
 )
@@ -665,6 +667,18 @@ def get_configured_event_bus() -> EventBus:
             uow=AsyncUnitOfWork(),
             meal_translation_service=meal_translation_service,
             cache_invalidation=cache_invalidation_service,
+        ),
+    )
+    event_bus.register_handler(
+        RelogRecommendedMealCommand,
+        RelogRecommendedMealCommandHandler(
+            uow=AsyncUnitOfWork(),
+            meal_translation_service=meal_translation_service,
+            cache_invalidation=cache_invalidation_service,
+            meal_value_insight_task_manager=task_manager,
+            meal_value_insight_cache=cache_service,
+            meal_value_insight_ai_manager=ai_manager,
+            meal_value_insight_event_bus=event_bus,
         ),
     )
     event_bus.register_handler(

--- a/src/api/routes/v1/meal_recommendation_route_support.py
+++ b/src/api/routes/v1/meal_recommendation_route_support.py
@@ -19,6 +19,7 @@ from src.api.schemas.response.meal_recommendation_responses import (
     MealRecommendationMacrosResponse,
     MealRecommendationPlanResponse,
     MealRecommendationPlanSummaryResponse,
+    MealRecommendationRelogResponse,
     MealRecommendationSlotDetailResponse,
     MealRecommendationSlotResponse,
     MealRecommendationSlotSummaryResponse,
@@ -56,6 +57,10 @@ class LogRecommendedMealRequest(BaseModel):
         if not normalized:
             raise ValueError("request_id is required")
         return normalized
+
+
+class RelogRecommendedMealRequest(LogRecommendedMealRequest):
+    """Idempotent request to materialize another meal from a logged slot."""
 
 
 class SkipMealRecommendationSlotRequest(BaseModel):
@@ -247,6 +252,19 @@ def to_slot_detail_response(
                 for alternative in slot.alternatives
             ],
         ),
+    )
+
+
+def to_relog_response(
+    plan_id: str,
+    slot,
+    meal_id: str,
+) -> MealRecommendationRelogResponse:
+    detail = to_slot_detail_response(plan_id, slot)
+    return MealRecommendationRelogResponse(
+        plan_id=detail.plan_id,
+        slot=detail.slot,
+        meal_id=meal_id,
     )
 
 

--- a/src/api/routes/v1/meal_recommendations.py
+++ b/src/api/routes/v1/meal_recommendations.py
@@ -19,21 +19,25 @@ from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
 from src.api.routes.v1.meal_recommendation_route_support import (
     LogRecommendedMealRequest,
+    RelogRecommendedMealRequest,
     SkipMealRecommendationSlotRequest,
     SwapMealRecommendationSlotRequest,
     capture_plan_events,
     capture_slot_event,
     record_operation_latency,
+    to_relog_response,
     to_slot_detail_response,
     to_summary_response,
 )
 from src.api.schemas.response.meal_recommendation_responses import (
     MealRecommendationPlanSummaryResponse,
+    MealRecommendationRelogResponse,
     MealRecommendationSlotDetailResponse,
 )
 from src.app.commands.meal_recommendation import (
     CreateThreeDayMealRecommendationCommand,
     LogRecommendedMealCommand,
+    RelogRecommendedMealCommand,
     SkipMealRecommendationSlotCommand,
     SwapMealRecommendationSlotCommand,
 )
@@ -253,6 +257,65 @@ async def log_recommended_meal(
     )
     metric_status = "success"
     record_operation_latency("log", started, metric_status)
+    return response
+
+
+@router.post(
+    "/{plan_id}/slots/{slot_id}/relog",
+    response_model=MealRecommendationRelogResponse,
+)
+@limiter.limit("20/minute")
+async def relog_recommended_meal(
+    request: Request,
+    plan_id: str,
+    slot_id: str,
+    body: RelogRecommendedMealRequest,
+    user_id: str = Depends(get_current_user_id),
+    event_bus=Depends(get_configured_event_bus),
+    analytics_service: MealRecommendationAnalyticsService = Depends(
+        get_meal_recommendation_analytics_service
+    ),
+    task_manager=Depends(get_optional_task_manager),
+    translation_service=Depends(get_text_translation_service),
+) -> MealRecommendationRelogResponse:
+    started = perf_counter()
+    metric_status = "error"
+    try:
+        result = await event_bus.send(
+            RelogRecommendedMealCommand(
+                user_id=user_id,
+                plan_id=plan_id,
+                slot_id=slot_id,
+                request_id=body.request_id,
+                language=get_request_language(request),
+            )
+        )
+    except MealRecommendationCreationError as exc:
+        metric_status = f"http_{exc.status_code}"
+        raise HTTPException(status_code=exc.status_code, detail=exc.public_detail) from exc
+    if not result.meal_id:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Unable to relog meal recommendation",
+        )
+    response = to_relog_response(
+        result.plan_id,
+        await localize_meal_recommendation_slot(
+            result.slot,
+            language=get_request_language(request),
+            translation_service=translation_service,
+        ),
+        result.meal_id,
+    )
+    await _capture_mutation_slot_event(
+        analytics_service=analytics_service,
+        user_id=user_id,
+        event="meal_relogged",
+        plan_id=result.plan_id,
+        task_manager=task_manager,
+    )
+    metric_status = "success"
+    record_operation_latency("relog", started, metric_status)
     return response
 
 

--- a/src/api/schemas/response/meal_recommendation_responses.py
+++ b/src/api/schemas/response/meal_recommendation_responses.py
@@ -103,6 +103,10 @@ class MealRecommendationSlotDetailResponse(BaseModel):
     slot: MealRecommendationSlotResponse
 
 
+class MealRecommendationRelogResponse(MealRecommendationSlotDetailResponse):
+    meal_id: str
+
+
 class MealRecommendationPlanResponse(BaseModel):
     id: str
     status: str

--- a/src/app/commands/meal_recommendation/__init__.py
+++ b/src/app/commands/meal_recommendation/__init__.py
@@ -4,6 +4,7 @@ from .create_three_day_meal_recommendation_command import (
     CreateThreeDayMealRecommendationCommand,
 )
 from .log_recommended_meal_command import LogRecommendedMealCommand
+from .relog_recommended_meal_command import RelogRecommendedMealCommand
 from .skip_meal_recommendation_slot_command import SkipMealRecommendationSlotCommand
 from .swap_meal_recommendation_slot_command import SwapMealRecommendationSlotCommand
 
@@ -11,5 +12,6 @@ __all__ = [
     "CreateThreeDayMealRecommendationCommand",
     "SwapMealRecommendationSlotCommand",
     "LogRecommendedMealCommand",
+    "RelogRecommendedMealCommand",
     "SkipMealRecommendationSlotCommand",
 ]

--- a/src/app/commands/meal_recommendation/relog_recommended_meal_command.py
+++ b/src/app/commands/meal_recommendation/relog_recommended_meal_command.py
@@ -1,0 +1,14 @@
+"""Command for logging another meal from an already logged catalog slot."""
+
+from dataclasses import dataclass
+
+from src.app.events.base import Command
+
+
+@dataclass
+class RelogRecommendedMealCommand(Command):
+    user_id: str
+    plan_id: str
+    slot_id: str
+    request_id: str
+    language: str = "en"

--- a/src/app/handlers/command_handlers/meal_recommendation/__init__.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/__init__.py
@@ -4,6 +4,7 @@ from .create_three_day_meal_recommendation_command_handler import (
     CreateThreeDayMealRecommendationCommandHandler,
 )
 from .log_recommended_meal_command_handler import LogRecommendedMealCommandHandler
+from .relog_recommended_meal_command_handler import RelogRecommendedMealCommandHandler
 from .skip_meal_recommendation_slot_command_handler import (
     SkipMealRecommendationSlotCommandHandler,
 )
@@ -15,5 +16,6 @@ __all__ = [
     "CreateThreeDayMealRecommendationCommandHandler",
     "SwapMealRecommendationSlotCommandHandler",
     "LogRecommendedMealCommandHandler",
+    "RelogRecommendedMealCommandHandler",
     "SkipMealRecommendationSlotCommandHandler",
 ]

--- a/src/app/handlers/command_handlers/meal_recommendation/relog_recommended_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_recommendation/relog_recommended_meal_command_handler.py
@@ -1,0 +1,157 @@
+"""Handler for logging another meal from an already logged catalog slot."""
+
+from __future__ import annotations
+
+import logging
+
+from src.app.commands.meal_recommendation import RelogRecommendedMealCommand
+from src.app.events.base import EventHandler, handles
+from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.app.services.meal_value_insight_scheduler import (
+    MealInsightEventBus,
+    MealInsightTaskScheduler,
+    schedule_value_insight_generation,
+)
+from src.app.services.recommended_meal_materialization_service import (
+    RecommendedMealMaterializationService,
+)
+from src.domain.model.meal import Meal
+from src.domain.model.meal_recommendation import (
+    PersistedMealRecommendationSlotMutationResult,
+)
+from src.domain.ports.cache_port import CachePort
+from src.domain.ports.meal_insight_ai_port import MealInsightAIPort
+from src.domain.services.meal_analysis.meal_translation_service import (
+    MealTranslationService,
+)
+from src.domain.utils.timezone_utils import user_today
+
+logger = logging.getLogger(__name__)
+
+
+@handles(RelogRecommendedMealCommand)
+class RelogRecommendedMealCommandHandler(
+    EventHandler[
+        RelogRecommendedMealCommand,
+        PersistedMealRecommendationSlotMutationResult,
+    ]
+):
+    def __init__(
+        self,
+        uow,
+        materializer: RecommendedMealMaterializationService | None = None,
+        meal_translation_service: MealTranslationService | None = None,
+        cache_invalidation: CacheInvalidationService | None = None,
+        meal_value_insight_task_manager: MealInsightTaskScheduler | None = None,
+        meal_value_insight_cache: CachePort | None = None,
+        meal_value_insight_ai_manager: MealInsightAIPort | None = None,
+        meal_value_insight_event_bus: MealInsightEventBus | None = None,
+    ):
+        self.uow = uow
+        self.materializer = materializer or RecommendedMealMaterializationService()
+        self.meal_translation_service = meal_translation_service
+        self.cache_invalidation = cache_invalidation
+        self.meal_value_insight_task_manager = meal_value_insight_task_manager
+        self.meal_value_insight_cache = meal_value_insight_cache
+        self.meal_value_insight_ai_manager = meal_value_insight_ai_manager
+        self.meal_value_insight_event_bus = meal_value_insight_event_bus
+
+    async def handle(
+        self, command: RelogRecommendedMealCommand
+    ) -> PersistedMealRecommendationSlotMutationResult:
+        saved_meal: Meal | None = None
+        meal_date = None
+
+        async with self.uow as uow:
+            plan, slot, replayed, replayed_meal_id = (
+                await uow.meal_recommendation_plans.claim_slot_relog(
+                    user_id=command.user_id,
+                    plan_id=command.plan_id,
+                    slot_id=command.slot_id,
+                    request_id=command.request_id,
+                )
+            )
+            if replayed:
+                result = PersistedMealRecommendationSlotMutationResult(
+                    plan_id=plan.id,
+                    user_id=plan.user_id,
+                    slot=slot,
+                    meal_id=replayed_meal_id,
+                )
+            else:
+                meal_date = user_today(plan.timezone)
+                meal = await self.materializer.materialize(
+                    uow,
+                    plan=plan,
+                    slot=slot,
+                    meal_date=meal_date,
+                )
+                result = await uow.meal_recommendation_plans.finalize_slot_relogged(
+                    user_id=command.user_id,
+                    plan_id=command.plan_id,
+                    slot_id=command.slot_id,
+                    request_id=command.request_id,
+                    meal_id=meal.meal_id,
+                )
+                saved_meal = meal
+
+        if saved_meal is not None:
+            if self.cache_invalidation is not None and meal_date is not None:
+                await self.cache_invalidation.after_meal_write(
+                    command.user_id, meal_date
+                )
+            await self._persist_request_language_translation(command, saved_meal)
+            self._schedule_value_insights(command, saved_meal)
+
+        return result
+
+    def _schedule_value_insights(
+        self, command: RelogRecommendedMealCommand, meal: Meal
+    ) -> None:
+        try:
+            schedule_value_insight_generation(
+                self.meal_value_insight_task_manager,
+                meal,
+                language=(command.language or "en").strip().lower() or "en",
+                cache_service=self.meal_value_insight_cache,
+                ai_manager=self.meal_value_insight_ai_manager,
+                event_bus=self.meal_value_insight_event_bus,
+                user_id=command.user_id,
+                source="catalog_relog",
+            )
+        except Exception as exc:
+            logger.warning(
+                "recommended meal relog insight schedule failed meal=%s error_type=%s",
+                meal.meal_id,
+                type(exc).__name__,
+            )
+
+    async def _persist_request_language_translation(
+        self,
+        command: RelogRecommendedMealCommand,
+        meal: Meal,
+    ) -> None:
+        language = (command.language or "en").strip().lower()
+        if language == "en" or self.meal_translation_service is None:
+            return
+
+        nutrition = getattr(meal, "nutrition", None)
+        food_items = list(getattr(nutrition, "food_items", None) or [])
+        dish_name = getattr(meal, "dish_name", None) or ""
+        if not dish_name and not food_items:
+            return
+
+        try:
+            await self.meal_translation_service.translate_meal(
+                meal=meal,
+                dish_name=dish_name,
+                food_items=food_items,
+                target_language=language,
+            )
+        except Exception as exc:
+            logger.warning(
+                "recommended meal relog translation failed meal=%s language=%s error_type=%s",
+                meal.meal_id,
+                language,
+                type(exc).__name__,
+            )

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from uuid import uuid4
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
@@ -29,6 +30,7 @@ class RecommendedMealMaterializationService:
         *,
         plan: PersistedMealRecommendationPlan,
         slot: PersistedMealRecommendationSlot,
+        meal_date: date | None = None,
     ) -> Meal:
         if slot.selected is None or slot.selected.catalog_meal is None:
             raise MealRecommendationNotFoundError
@@ -45,7 +47,7 @@ class RecommendedMealMaterializationService:
             )
             for ingredient in catalog_meal.ingredients
         ]
-        meal_time = noon_utc_for_date(slot.slot_date, plan.timezone)
+        meal_time = noon_utc_for_date(meal_date or slot.slot_date, plan.timezone)
         # Always attach a MealImage row. Production still enforces NOT NULL on
         # meal.image_id in some environments; image-less inserts 500 there.
         # Matches manual / AI-suggestion materialization (placeholder image).

--- a/src/domain/exceptions/meal_recommendation_exceptions.py
+++ b/src/domain/exceptions/meal_recommendation_exceptions.py
@@ -67,6 +67,13 @@ class MealRecommendationAlreadyLoggedError(MealRecommendationCreationError):
     status_code = 409
 
 
+class MealRecommendationNotLoggedError(MealRecommendationCreationError):
+    """Raised when relog is requested before the slot has been logged."""
+
+    public_detail = "Meal recommendation slot has not been logged yet"
+    status_code = 409
+
+
 class MealRecommendationTerminalStateError(MealRecommendationCreationError):
     """Raised when a terminal slot outcome already exists."""
 

--- a/src/domain/model/meal_recommendation/meal_recommendation_plan.py
+++ b/src/domain/model/meal_recommendation/meal_recommendation_plan.py
@@ -82,3 +82,4 @@ class PersistedMealRecommendationSlotMutationResult:
     user_id: str
     slot: PersistedMealRecommendationSlot
     outcome: str = "stored_candidate"
+    meal_id: str | None = None

--- a/src/domain/ports/meal_recommendation_plan_repository_port.py
+++ b/src/domain/ports/meal_recommendation_plan_repository_port.py
@@ -138,6 +138,34 @@ class MealRecommendationPlanRepositoryPort(ABC):
     ) -> PersistedMealRecommendationSlotMutationResult:
         """Attach a materialized meal to a claimed slot log and return the slot."""
 
+    @abstractmethod
+    async def claim_slot_relog(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+        slot_id: str,
+        request_id: str,
+    ) -> tuple[
+        PersistedMealRecommendationPlan,
+        PersistedMealRecommendationSlot,
+        bool,
+        str | None,
+    ]:
+        """Claim a relog request for an already logged slot."""
+
+    @abstractmethod
+    async def finalize_slot_relogged(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+        slot_id: str,
+        request_id: str,
+        meal_id: str,
+    ) -> PersistedMealRecommendationSlotMutationResult:
+        """Record a new meal for an already logged slot without replacing it."""
+
     async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
         """Clear recommendation links before a normal meal is hard-deleted.
 

--- a/src/infra/database/models/meal_recommendation/meal_recommendation_plan.py
+++ b/src/infra/database/models/meal_recommendation/meal_recommendation_plan.py
@@ -220,7 +220,7 @@ class MealRecommendationOperationORM(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "operation_type IN ('swap', 'log', 'skip')",
+            "operation_type IN ('swap', 'log', 'skip', 'relog')",
             name="ck_meal_recommendation_operations_type",
         ),
         CheckConstraint(
@@ -237,6 +237,9 @@ class MealRecommendationOperationORM(Base):
             "AND result_catalog_meal_id IS NOT NULL AND result_logged_meal_id IS NULL"
             ") OR ("
             "operation_type = 'log' AND result_logged_meal_id IS NOT NULL "
+            "AND result_catalog_meal_id IS NULL"
+            ") OR ("
+            "operation_type = 'relog' AND result_logged_meal_id IS NOT NULL "
             "AND result_catalog_meal_id IS NULL"
             ") OR ("
             "operation_type = 'skip' AND result_selection_version IS NULL "

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -18,6 +18,7 @@ from src.domain.exceptions.meal_recommendation_exceptions import (
     MealRecommendationIdempotencyConflictError,
     MealRecommendationInvalidAlternativeError,
     MealRecommendationNotFoundError,
+    MealRecommendationNotLoggedError,
     MealRecommendationPersistenceConflictError,
     MealRecommendationTerminalStateError,
     MealRecommendationVersionConflictError,
@@ -518,7 +519,96 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             slot=_rows_to_slot_detail(anchor, rows),
         )
 
-    async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
+    async def claim_slot_relog(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+        slot_id: str,
+        request_id: str,
+    ) -> tuple[
+        PersistedMealRecommendationPlan,
+        PersistedMealRecommendationSlot,
+        bool,
+        str | None,
+    ]:
+        replay = await self._get_operation_replay(
+            user_id=user_id, operation_type="relog", request_id=request_id
+        )
+        anchor, rows = await self._load_slot_for_update(
+            user_id=user_id, batch_id=plan_id, slot_id=slot_id
+        )
+        if not rows:
+            raise MealRecommendationNotFoundError
+        slot = _rows_to_slot_detail(anchor, rows)
+        plan = _plan_from_anchor_and_slot(anchor, slot)
+        if replay is not None:
+            if (
+                cast(str, replay.batch_id) != plan_id
+                or cast(str, replay.slot_id) != slot_id
+            ):
+                raise MealRecommendationIdempotencyConflictError
+            logged_meal_id = cast(str | None, getattr(replay, "result_logged_meal_id", None))
+            if not logged_meal_id:
+                raise MealRecommendationIdempotencyConflictError
+            if (
+                cast(str | None, getattr(replay, "request_fingerprint", None))
+                != _operation_fingerprint(
+                    plan_id=plan_id,
+                    slot_id=slot_id,
+                    meal_id=logged_meal_id,
+                )
+            ):
+                raise MealRecommendationIdempotencyConflictError
+            return plan, slot, True, logged_meal_id
+        selected = _selected_row(rows, slot_id)
+        if getattr(selected, "skipped_at", None):
+            raise MealRecommendationTerminalStateError
+        if not selected.logged_meal_id:
+            raise MealRecommendationNotLoggedError
+        return plan, slot, False, None
+
+    async def finalize_slot_relogged(
+        self,
+        *,
+        user_id: str,
+        plan_id: str,
+        slot_id: str,
+        request_id: str,
+        meal_id: str,
+    ) -> PersistedMealRecommendationSlotMutationResult:
+        anchor, rows = await self._load_slot_for_update(
+            user_id=user_id, batch_id=plan_id, slot_id=slot_id
+        )
+        if not rows:
+            raise MealRecommendationNotFoundError
+        selected = _selected_row(rows, slot_id)
+        if getattr(selected, "skipped_at", None):
+            raise MealRecommendationTerminalStateError
+        if not selected.logged_meal_id:
+            raise MealRecommendationNotLoggedError
+        self._session.add(
+            MealRecommendationOperationORM(
+                user_id=user_id,
+                batch_id=plan_id,
+                slot_id=slot_id,
+                operation_type="relog",
+                request_id=request_id,
+                request_fingerprint=_operation_fingerprint(
+                    plan_id=plan_id,
+                    slot_id=slot_id,
+                    meal_id=meal_id,
+                ),
+                result_logged_meal_id=meal_id,
+            )
+        )
+        await self._flush_operations()
+        return PersistedMealRecommendationSlotMutationResult(
+            plan_id=plan_id,
+            user_id=user_id,
+            slot=_rows_to_slot_detail(anchor, rows),
+            meal_id=meal_id,
+        )
         """Detach recommendation state from a meal about to be hard-deleted.
 
         ``logged_meal_id`` FKs use ON DELETE SET NULL. That leaves ``logged_at``

--- a/src/infra/repositories/meal_recommendation_plan_repository_async.py
+++ b/src/infra/repositories/meal_recommendation_plan_repository_async.py
@@ -231,9 +231,9 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             ]
             for row in active_rows:
                 row.retired_at = now  # type: ignore[assignment]
-            next_rank = max(
-                (cast(int, row.candidate_rank) for row in rows), default=0
-            ) + 1
+            next_rank = (
+                max((cast(int, row.candidate_rank) for row in rows), default=0) + 1
+            )
             new_rows = []
             for position, alternative in enumerate(replenishment_alternatives):
                 row = MealRecommendationORM(
@@ -307,12 +307,15 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
 
     async def get_slot_replenishment_context(
         self, *, user_id: str, plan_id: str, slot_id: str
-    ) -> tuple[
-        PersistedMealRecommendationSlot,
-        frozenset[str],
-        frozenset[str],
-        str,
-    ] | None:
+    ) -> (
+        tuple[
+            PersistedMealRecommendationSlot,
+            frozenset[str],
+            frozenset[str],
+            str,
+        ]
+        | None
+    ):
         rows = await self._load_batch(user_id=user_id, batch_id=plan_id)
         target_rows = [row for row in rows if cast(str, row.slot_id) == slot_id]
         if not target_rows:
@@ -446,16 +449,17 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
                 or cast(str, replay.slot_id) != slot_id
             ):
                 raise MealRecommendationIdempotencyConflictError
-            logged_meal_id = cast(str | None, getattr(replay, "result_logged_meal_id", None))
+            logged_meal_id = cast(
+                str | None, getattr(replay, "result_logged_meal_id", None)
+            )
             if not logged_meal_id:
                 raise MealRecommendationIdempotencyConflictError
-            if (
-                cast(str | None, getattr(replay, "request_fingerprint", None))
-                != _operation_fingerprint(
-                    plan_id=plan_id,
-                    slot_id=slot_id,
-                    meal_id=logged_meal_id,
-                )
+            if cast(
+                str | None, getattr(replay, "request_fingerprint", None)
+            ) != _operation_fingerprint(
+                plan_id=plan_id,
+                slot_id=slot_id,
+                meal_id=logged_meal_id,
             ):
                 raise MealRecommendationIdempotencyConflictError
             if slot.logged_meal_id != logged_meal_id:
@@ -548,16 +552,17 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
                 or cast(str, replay.slot_id) != slot_id
             ):
                 raise MealRecommendationIdempotencyConflictError
-            logged_meal_id = cast(str | None, getattr(replay, "result_logged_meal_id", None))
+            logged_meal_id = cast(
+                str | None, getattr(replay, "result_logged_meal_id", None)
+            )
             if not logged_meal_id:
                 raise MealRecommendationIdempotencyConflictError
-            if (
-                cast(str | None, getattr(replay, "request_fingerprint", None))
-                != _operation_fingerprint(
-                    plan_id=plan_id,
-                    slot_id=slot_id,
-                    meal_id=logged_meal_id,
-                )
+            if cast(
+                str | None, getattr(replay, "request_fingerprint", None)
+            ) != _operation_fingerprint(
+                plan_id=plan_id,
+                slot_id=slot_id,
+                meal_id=logged_meal_id,
             ):
                 raise MealRecommendationIdempotencyConflictError
             return plan, slot, True, logged_meal_id
@@ -609,6 +614,8 @@ class AsyncMealRecommendationPlanRepository(MealRecommendationPlanRepositoryPort
             slot=_rows_to_slot_detail(anchor, rows),
             meal_id=meal_id,
         )
+
+    async def clear_links_for_deleted_meal(self, *, meal_id: str) -> None:
         """Detach recommendation state from a meal about to be hard-deleted.
 
         ``logged_meal_id`` FKs use ON DELETE SET NULL. That leaves ``logged_at``
@@ -785,10 +792,16 @@ def _plan_to_rows(plan: PersistedMealRecommendationPlan) -> list[MealRecommendat
                     status=plan.status if candidate.id == plan.id else None,
                     timezone=plan.timezone if candidate.id == plan.id else None,
                     start_date=plan.start_date if candidate.id == plan.id else None,
-                    target_calories=plan.daily_calories if candidate.id == plan.id else None,
+                    target_calories=plan.daily_calories
+                    if candidate.id == plan.id
+                    else None,
                     operation=plan.operation if candidate.id == plan.id else None,
-                    idempotency_key=plan.idempotency_key if candidate.id == plan.id else None,
-                    request_fingerprint=plan.request_fingerprint if candidate.id == plan.id else None,
+                    idempotency_key=plan.idempotency_key
+                    if candidate.id == plan.id
+                    else None,
+                    request_fingerprint=plan.request_fingerprint
+                    if candidate.id == plan.id
+                    else None,
                 )
             )
     return rows
@@ -841,7 +854,10 @@ def _rows_to_plan(rows: list[MealRecommendationORM]) -> PersistedMealRecommendat
             PersistedMealRecommendationSlot(
                 id=cast(str, selected.slot_id),
                 slot_date=cast(date, selected.recommendation_date),
-                day_index=(cast(date, selected.recommendation_date) - cast(date, anchor.start_date)).days,
+                day_index=(
+                    cast(date, selected.recommendation_date)
+                    - cast(date, anchor.start_date)
+                ).days,
                 meal_type=cast(str, selected.meal_type),
                 catalog_meal_id=cast(str, selected.catalog_meal_id),
                 target_calories=cast(int, anchor.target_calories),
@@ -871,7 +887,9 @@ def _rows_to_plan(rows: list[MealRecommendationORM]) -> PersistedMealRecommendat
     )
 
 
-def _rows_to_summary(rows: list[MealRecommendationORM]) -> PersistedMealRecommendationPlan:
+def _rows_to_summary(
+    rows: list[MealRecommendationORM],
+) -> PersistedMealRecommendationPlan:
     anchor = _anchor_row(rows)
     if anchor is None:
         raise MealRecommendationNotFoundError
@@ -1013,10 +1031,14 @@ def _candidate_catalog_meal(row: MealRecommendationORM) -> CatalogMeal | None:
 
 
 def _anchor_row(rows: list[MealRecommendationORM]) -> MealRecommendationORM | None:
-    return next((row for row in rows if cast(str, row.id) == cast(str, row.batch_id)), None)
+    return next(
+        (row for row in rows if cast(str, row.id) == cast(str, row.batch_id)), None
+    )
 
 
-def _selected_row(rows: list[MealRecommendationORM], slot_id: str) -> MealRecommendationORM:
+def _selected_row(
+    rows: list[MealRecommendationORM], slot_id: str
+) -> MealRecommendationORM:
     for row in rows:
         if cast(str, row.slot_id) == slot_id and cast(bool, row.is_selected):
             return row

--- a/tests/migrations/test_catalog_recipe_tables_migration.py
+++ b/tests/migrations/test_catalog_recipe_tables_migration.py
@@ -66,6 +66,16 @@ def test_skip_state_is_forward_migration_not_deployed_baseline_edit() -> None:
     assert "operation_type = 'skip'" in skip_text
 
 
+def test_relog_operation_is_forward_migration() -> None:
+    relog_text = Path(
+        "migrations/versions/20260818000002_add_meal_recommendation_relog_operation.py"
+    ).read_text()
+
+    assert 'down_revision: str | None = "20260818000001"' in relog_text
+    assert "operation_type IN ('swap', 'log', 'skip', 'relog')" in relog_text
+    assert "operation_type = 'relog'" in relog_text
+
+
 def test_anchor_metadata_constraint_is_relaxed_forward() -> None:
     text = ANCHOR_METADATA_MIGRATION.read_text()
     upgrade_text = text.split("def upgrade", maxsplit=1)[1].split(

--- a/tests/unit/api/test_meal_recommendations_route.py
+++ b/tests/unit/api/test_meal_recommendations_route.py
@@ -9,18 +9,21 @@ from tests.unit.infra.repositories.test_meal_recommendation_plan_repository_asyn
 from src.api.routes.v1.meal_recommendation_route_support import to_response
 from src.api.routes.v1.meal_recommendations import (
     LogRecommendedMealRequest,
+    RelogRecommendedMealRequest,
     SkipMealRecommendationSlotRequest,
     SwapMealRecommendationSlotRequest,
     create_three_day_recommendations,
     get_meal_recommendation_plan,
     get_meal_recommendation_slot_detail,
     log_recommended_meal,
+    relog_recommended_meal,
     skip_meal_recommendation_slot,
     swap_meal_recommendation_slot,
 )
 from src.app.commands.meal_recommendation import (
     CreateThreeDayMealRecommendationCommand,
     LogRecommendedMealCommand,
+    RelogRecommendedMealCommand,
     SkipMealRecommendationSlotCommand,
     SwapMealRecommendationSlotCommand,
 )
@@ -54,6 +57,7 @@ class _EventBus:
             (
                 SwapMealRecommendationSlotCommand,
                 LogRecommendedMealCommand,
+                RelogRecommendedMealCommand,
                 SkipMealRecommendationSlotCommand,
             ),
         ):
@@ -61,6 +65,7 @@ class _EventBus:
                 plan_id="plan-1",
                 user_id="user-1",
                 slot=_plan().slots[0],
+                meal_id="meal-relog-1",
             )
         return _plan()
 
@@ -343,6 +348,32 @@ async def test_log_route_forwards_request_language_to_command():
 
 
 @pytest.mark.asyncio
+async def test_relog_route_sends_recommended_meal_command():
+    event_bus = _EventBus()
+
+    response = await relog_recommended_meal(
+        request=_request(language="vi"),
+        plan_id="plan-1",
+        slot_id="slot-1",
+        body=RelogRecommendedMealRequest(request_id="relog-1"),
+        user_id="user-1",
+        event_bus=event_bus,
+        analytics_service=_Analytics(),
+    )
+
+    command = next(
+        item
+        for item in event_bus.commands
+        if isinstance(item, RelogRecommendedMealCommand)
+    )
+    assert command.request_id == "relog-1"
+    assert command.language == "vi"
+    assert response.plan_id == "plan-1"
+    assert response.slot.id == "slot-1"
+    assert response.meal_id == "meal-relog-1"
+
+
+@pytest.mark.asyncio
 async def test_skip_route_sends_skip_slot_command():
     event_bus = _EventBus()
 
@@ -368,6 +399,7 @@ def test_mutation_routes_have_abuse_limits():
     for route in (
         swap_meal_recommendation_slot,
         log_recommended_meal,
+        relog_recommended_meal,
         skip_meal_recommendation_slot,
     ):
         assert getattr(route, "__wrapped__", None) is not None

--- a/tests/unit/app/handlers/test_meal_recommendation_handlers.py
+++ b/tests/unit/app/handlers/test_meal_recommendation_handlers.py
@@ -1,6 +1,6 @@
 from datetime import date
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from tests.unit.infra.repositories.test_meal_recommendation_plan_repository_async import (
@@ -10,6 +10,7 @@ from tests.unit.infra.repositories.test_meal_recommendation_plan_repository_asyn
 from src.app.commands.meal_recommendation import (
     CreateThreeDayMealRecommendationCommand,
     LogRecommendedMealCommand,
+    RelogRecommendedMealCommand,
     SkipMealRecommendationSlotCommand,
 )
 from src.app.handlers.command_handlers.meal_recommendation.create_three_day_meal_recommendation_command_handler import (
@@ -18,6 +19,9 @@ from src.app.handlers.command_handlers.meal_recommendation.create_three_day_meal
 )
 from src.app.handlers.command_handlers.meal_recommendation.log_recommended_meal_command_handler import (
     LogRecommendedMealCommandHandler,
+)
+from src.app.handlers.command_handlers.meal_recommendation.relog_recommended_meal_command_handler import (
+    RelogRecommendedMealCommandHandler,
 )
 from src.app.handlers.command_handlers.meal_recommendation.skip_meal_recommendation_slot_command_handler import (
     SkipMealRecommendationSlotCommandHandler,
@@ -87,6 +91,27 @@ class _LogPlanRepo(_PlanRepo):
                 plan_id="plan-1",
                 user_id="user-1",
                 slot=_plan().slots[0],
+            )
+        )
+
+
+class _RelogPlanRepo(_PlanRepo):
+    def __init__(self, *, replayed=False):
+        super().__init__()
+        self.claim_slot_relog = AsyncMock(
+            return_value=(
+                _plan(),
+                _plan().slots[0],
+                replayed,
+                "meal-replayed" if replayed else None,
+            )
+        )
+        self.finalize_slot_relogged = AsyncMock(
+            return_value=PersistedMealRecommendationSlotMutationResult(
+                plan_id="plan-1",
+                user_id="user-1",
+                slot=_plan().slots[0],
+                meal_id="meal-1",
             )
         )
 
@@ -427,3 +452,71 @@ async def test_skip_handler_skips_slot_without_materializing_meal():
         slot_id="slot-1",
         request_id="skip-1",
     )
+
+
+def _relog_command(*, language: str = "en") -> RelogRecommendedMealCommand:
+    return RelogRecommendedMealCommand(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="relog-1",
+        language=language,
+    )
+
+
+@pytest.mark.asyncio
+async def test_relog_handler_replays_without_materializing_duplicate_meal():
+    plans = _RelogPlanRepo(replayed=True)
+    materializer = _Materializer()
+    handler = RelogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+    )
+
+    result = await handler.handle(_relog_command())
+
+    assert result.meal_id == "meal-replayed"
+    materializer.materialize.assert_not_awaited()
+    plans.finalize_slot_relogged.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_relog_handler_materializes_today_and_schedules_insights():
+    plans = _RelogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    scheduler = MagicMock(return_value=True)
+    handler = RelogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+        meal_value_insight_task_manager=object(),
+        meal_value_insight_cache=object(),
+        meal_value_insight_ai_manager=object(),
+        meal_value_insight_event_bus=object(),
+    )
+
+    with (
+        patch(
+            "src.app.handlers.command_handlers.meal_recommendation."
+            "relog_recommended_meal_command_handler.user_today",
+            return_value=date(2026, 8, 18),
+        ),
+        patch(
+            "src.app.handlers.command_handlers.meal_recommendation."
+            "relog_recommended_meal_command_handler.schedule_value_insight_generation",
+            scheduler,
+        ),
+    ):
+        result = await handler.handle(_relog_command(language="vi"))
+
+    assert result.meal_id == "meal-1"
+    materializer.materialize.assert_awaited_once()
+    assert materializer.materialize.await_args.kwargs["meal_date"] == date(2026, 8, 18)
+    plans.finalize_slot_relogged.assert_awaited_once_with(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="relog-1",
+        meal_id="meal-1",
+    )
+    scheduler.assert_called_once()
+    assert scheduler.call_args.kwargs["source"] == "catalog_relog"

--- a/tests/unit/app/handlers/test_meal_recommendation_handlers.py
+++ b/tests/unit/app/handlers/test_meal_recommendation_handlers.py
@@ -85,7 +85,9 @@ class _ConflictPlanRepo(_PlanRepo):
 class _LogPlanRepo(_PlanRepo):
     def __init__(self, *, replayed=False):
         super().__init__()
-        self.claim_slot_log = AsyncMock(return_value=(_plan(), _plan().slots[0], replayed))
+        self.claim_slot_log = AsyncMock(
+            return_value=(_plan(), _plan().slots[0], replayed)
+        )
         self.finalize_slot_logged = AsyncMock(
             return_value=PersistedMealRecommendationSlotMutationResult(
                 plan_id="plan-1",
@@ -136,15 +138,18 @@ class _Materializer:
             {"id": "food-1", "name": "Rice"},
         )()
         nutrition = type("Nutrition", (), {"food_items": [food_item]})()
-        self.meal = meal or type(
-            "Meal",
-            (),
-            {
-                "meal_id": "meal-1",
-                "dish_name": "Rice Bowl",
-                "nutrition": nutrition,
-            },
-        )()
+        self.meal = (
+            meal
+            or type(
+                "Meal",
+                (),
+                {
+                    "meal_id": "meal-1",
+                    "dish_name": "Rice Bowl",
+                    "nutrition": nutrition,
+                },
+            )()
+        )
         self.materialize = AsyncMock(return_value=self.meal)
 
 
@@ -520,3 +525,22 @@ async def test_relog_handler_materializes_today_and_schedules_insights():
     )
     scheduler.assert_called_once()
     assert scheduler.call_args.kwargs["source"] == "catalog_relog"
+
+
+@pytest.mark.asyncio
+async def test_relog_handler_succeeds_when_insight_scheduling_raises():
+    plans = _RelogPlanRepo(replayed=False)
+    materializer = _Materializer()
+    handler = RelogRecommendedMealCommandHandler(
+        uow=_Uow(plans, _CatalogRepo()),
+        materializer=materializer,
+    )
+
+    with patch(
+        "src.app.handlers.command_handlers.meal_recommendation."
+        "relog_recommended_meal_command_handler.schedule_value_insight_generation",
+        side_effect=RuntimeError("scheduler down"),
+    ):
+        result = await handler.handle(_relog_command())
+
+    assert result.meal_id == "meal-1"

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -176,6 +176,21 @@ async def test_materializer_attaches_catalog_image_url_when_present():
 
 
 @pytest.mark.asyncio
+async def test_materializer_uses_explicit_meal_date_for_relog():
+    plan, slot = _plan_and_slot()
+
+    meal = await RecommendedMealMaterializationService().materialize(
+        _Uow(),
+        plan=plan,
+        slot=slot,
+        meal_date=date(2026, 8, 18),
+    )
+
+    assert meal.created_at.date() == date(2026, 8, 18)
+    assert meal.created_at.date() != slot.slot_date
+
+
+@pytest.mark.asyncio
 async def test_materializer_fails_with_public_error_when_selected_meal_missing():
     plan, slot = _plan_and_slot()
     slot = PersistedMealRecommendationSlot(

--- a/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
     MealRecommendationIdempotencyConflictError,
+    MealRecommendationNotLoggedError,
     MealRecommendationTerminalStateError,
 )
 from src.domain.model.meal_recommendation import (
@@ -610,6 +611,97 @@ async def test_claim_slot_log_rejects_skipped_slot():
             slot_id="slot-1",
             request_id="log-after-skip",
         )
+
+
+@pytest.mark.asyncio
+async def test_claim_slot_relog_rejects_unlogged_slot():
+    repo = _SlotMutationRepo()
+
+    with pytest.raises(MealRecommendationNotLoggedError):
+        await repo.claim_slot_relog(
+            user_id="user-1",
+            plan_id="plan-1",
+            slot_id="slot-1",
+            request_id="relog-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_claim_slot_relog_rejects_skipped_slot():
+    repo = _SlotMutationRepo(
+        selected_overrides={"skipped_at": datetime(2026, 7, 16)}
+    )
+
+    with pytest.raises(MealRecommendationTerminalStateError):
+        await repo.claim_slot_relog(
+            user_id="user-1",
+            plan_id="plan-1",
+            slot_id="slot-1",
+            request_id="relog-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_claim_slot_relog_allows_already_logged_slot():
+    repo = _SlotMutationRepo(selected_overrides={"logged_meal_id": "meal-original"})
+
+    plan, slot, replayed, meal_id = await repo.claim_slot_relog(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="relog-1",
+    )
+
+    assert replayed is False
+    assert meal_id is None
+    assert slot.logged_meal_id == "meal-original"
+    assert plan.slots[0].logged_meal_id == "meal-original"
+
+
+@pytest.mark.asyncio
+async def test_claim_slot_relog_replay_returns_stored_meal_id_without_replacing_slot():
+    repo = _SlotMutationRepo(
+        replay=SimpleNamespace(
+            batch_id="plan-1",
+            slot_id="slot-1",
+            request_fingerprint=_operation_fingerprint(
+                plan_id="plan-1",
+                slot_id="slot-1",
+                meal_id="meal-replayed",
+            ),
+            result_logged_meal_id="meal-replayed",
+        ),
+        selected_overrides={"logged_meal_id": "meal-original"},
+    )
+
+    plan, slot, replayed, meal_id = await repo.claim_slot_relog(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="relog-1",
+    )
+
+    assert replayed is True
+    assert meal_id == "meal-replayed"
+    assert slot.logged_meal_id == "meal-original"
+
+
+@pytest.mark.asyncio
+async def test_finalize_slot_relogged_keeps_original_logged_meal_id():
+    repo = _SlotMutationRepo(selected_overrides={"logged_meal_id": "meal-original"})
+
+    result = await repo.finalize_slot_relogged(
+        user_id="user-1",
+        plan_id="plan-1",
+        slot_id="slot-1",
+        request_id="relog-1",
+        meal_id="meal-new",
+    )
+
+    assert result.meal_id == "meal-new"
+    assert result.slot.logged_meal_id == "meal-original"
+    assert repo._session.added_rows[0].operation_type == "relog"
+    assert repo._session.added_rows[0].result_logged_meal_id == "meal-new"
 
 
 def _plan_to_candidate_rows(plan):

--- a/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
+++ b/tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py
@@ -628,9 +628,7 @@ async def test_claim_slot_relog_rejects_unlogged_slot():
 
 @pytest.mark.asyncio
 async def test_claim_slot_relog_rejects_skipped_slot():
-    repo = _SlotMutationRepo(
-        selected_overrides={"skipped_at": datetime(2026, 7, 16)}
-    )
+    repo = _SlotMutationRepo(selected_overrides={"skipped_at": datetime(2026, 7, 16)})
 
     with pytest.raises(MealRecommendationTerminalStateError):
         await repo.claim_slot_relog(
@@ -704,6 +702,19 @@ async def test_finalize_slot_relogged_keeps_original_logged_meal_id():
     assert repo._session.added_rows[0].result_logged_meal_id == "meal-new"
 
 
+@pytest.mark.asyncio
+async def test_clear_links_for_deleted_meal_clears_logged_state_and_operations():
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    repo = AsyncMealRecommendationPlanRepository(session)
+
+    await repo.clear_links_for_deleted_meal(meal_id="meal-1")
+
+    assert session.execute.await_count == 2
+    session.flush.assert_awaited_once()
+
+
 def _plan_to_candidate_rows(plan):
     rows = []
     for slot in plan.slots:
@@ -731,9 +742,13 @@ def _plan_to_candidate_rows(plan):
                     status=plan.status if candidate.id == plan.id else None,
                     timezone=plan.timezone if candidate.id == plan.id else None,
                     start_date=plan.start_date if candidate.id == plan.id else None,
-                    target_calories=plan.daily_calories if candidate.id == plan.id else None,
+                    target_calories=plan.daily_calories
+                    if candidate.id == plan.id
+                    else None,
                     operation=plan.operation if candidate.id == plan.id else None,
-                    idempotency_key=plan.idempotency_key if candidate.id == plan.id else None,
+                    idempotency_key=plan.idempotency_key
+                    if candidate.id == plan.id
+                    else None,
                     request_fingerprint=plan.request_fingerprint
                     if candidate.id == plan.id
                     else None,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `POST /v1/meal-recommendations/{plan_id}/slots/{slot_id}/relog` so a user can log the currently selected catalog recipe again **without** replacing the slot's original `logged_meal_id`.

This is Phase 2 of `plans/260818-2216-catalog-meal-log-insight-relog/`. Independent of the catalog-log-insight PR (#547); relog also warms value insights for the new meal.

## Behavior

- Relog requires the slot to already be logged (`409` if not logged; terminal skip still `409`).
- Creates a new READY meal dated to the user's today in the plan timezone.
- Records an idempotent `operation_type='relog'` row.
- Response is the changed-slot shape plus `meal_id` for the new meal.
- Best-effort insight warmup uses `source=catalog_relog`.
- Meal hard-delete still runs `clear_links_for_deleted_meal` (restored after the relog insert).

## Test plan

- `pytest tests/unit/app/handlers/test_meal_recommendation_handlers.py tests/unit/api/test_meal_recommendations_route.py tests/unit/infra/repositories/test_meal_recommendation_plan_repository_async.py tests/unit/app/services/test_recommended_meal_materialization_service.py tests/migrations/test_catalog_recipe_tables_migration.py`
- `ruff check` on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84d169e9-b79c-467c-84d7-8aba8dbb6b97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84d169e9-b79c-467c-84d7-8aba8dbb6b97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

