### PR TITLE
fix(meal-catalog): keep log nutrition and move slot recalc off the request

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -709,6 +709,7 @@ def get_configured_event_bus() -> EventBus:
                 history_projector=recommendation_history,
             ),
             insight_scheduler=_schedule_catalog_log_insights,
+            task_manager=task_manager,
         ),
     )
     event_bus.register_handler(

--- a/src/api/routes/v1/meal_catalog.py
+++ b/src/api/routes/v1/meal_catalog.py
@@ -47,6 +47,9 @@ async def list_meal_catalog(
     q: str | None = Query(None, max_length=160),
     cuisine: str | None = Query(None, max_length=80),
     meal_type: MealType | None = Query(None),
+    shuffle_seed: str | None = Query(
+        None, min_length=1, max_length=64, pattern=r"^[A-Za-z0-9_-]+$"
+    ),
     user_id: str = Depends(get_current_user_id),
     service: CatalogMealBrowseService = Depends(get_catalog_meal_browse_service),
 ) -> MealCatalogListResponse:
@@ -84,6 +87,7 @@ async def list_meal_catalog(
             daily_calories=daily_calories,
             start_date=start_date,
             timezone=timezone,
+            shuffle_seed=shuffle_seed,
         )
     except CatalogPopularityUnavailableError as exc:
         raise HTTPException(
@@ -114,7 +118,10 @@ async def list_meal_catalog(
 @router.get(
     "/{catalog_id}",
     response_model=MealCatalogItemResponse,
-    responses={404: {"description": "Catalog meal not found"}, 503: {"description": "Catalog is unavailable"}},
+    responses={
+        404: {"description": "Catalog meal not found"},
+        503: {"description": "Catalog is unavailable"},
+    },
 )
 async def get_meal_catalog_detail(
     catalog_id: str,

--- a/src/api/routes/v1/meals_read.py
+++ b/src/api/routes/v1/meals_read.py
@@ -150,6 +150,10 @@ async def _source_nutrition_by_food_reference(meal, food_reference_repository):
     if not food_reference_ids:
         return {}
 
+    batch_loader = getattr(food_reference_repository, "get_nutrition_projections", None)
+    if batch_loader is not None:
+        return await batch_loader(list(food_reference_ids))
+
     source_nutrition = {}
     for food_reference_id in food_reference_ids:
         reference = await food_reference_repository.get_nutrition_projection(

--- a/src/app/handlers/command_handlers/meal_catalog/log_catalog_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_catalog/log_catalog_meal_command_handler.py
@@ -76,13 +76,13 @@ class LogCatalogMealCommandHandler(
         write_started = time.perf_counter()
         result = await self._write(command, catalog_meal)
         write_ms = (time.perf_counter() - write_started) * 1000
+        await persist_meal_translation(
+            self.meal_translation_service, result.meal, command.language
+        )
         if self.cache_invalidation is not None:
             await self.cache_invalidation.after_meal_write(
                 command.user_id, command.meal_date
             )
-        await persist_meal_translation(
-            self.meal_translation_service, result.meal, command.language
-        )
         if self.recalculator is not None:
             await self._defer(
                 f"catalog-log-recalc:{command.request_id}",

--- a/src/app/handlers/command_handlers/meal_catalog/log_catalog_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/meal_catalog/log_catalog_meal_command_handler.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import time
+from collections.abc import Coroutine
 from datetime import date
+from typing import Any
 
 from src.api.exceptions import ConflictException, ResourceNotFoundException
 from src.app.commands.meal_catalog import LogCatalogMealCommand
@@ -22,6 +26,8 @@ from src.domain.services.meal_analysis.meal_translation_service import (
     MealTranslationService,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def catalog_log_fingerprint(
     catalog_meal_id: str, meal_date: date, meal_type: str
@@ -37,7 +43,9 @@ def catalog_log_fingerprint(
 
 
 @handles(LogCatalogMealCommand)
-class LogCatalogMealCommandHandler(EventHandler[LogCatalogMealCommand, LogCatalogMealResult]):
+class LogCatalogMealCommandHandler(
+    EventHandler[LogCatalogMealCommand, LogCatalogMealResult]
+):
     def __init__(
         self,
         uow,
@@ -48,6 +56,7 @@ class LogCatalogMealCommandHandler(EventHandler[LogCatalogMealCommand, LogCatalo
         cache_invalidation: CacheInvalidationService | None = None,
         recalculator: RemainingRecommendationRecalculator | None = None,
         insight_scheduler=None,
+        task_manager=None,
     ) -> None:
         self.uow = uow
         self.browse_service = browse_service
@@ -56,6 +65,7 @@ class LogCatalogMealCommandHandler(EventHandler[LogCatalogMealCommand, LogCatalo
         self.cache_invalidation = cache_invalidation
         self.recalculator = recalculator
         self.insight_scheduler = insight_scheduler
+        self.task_manager = task_manager
 
     async def handle(self, command: LogCatalogMealCommand) -> LogCatalogMealResult:
         try:
@@ -63,7 +73,9 @@ class LogCatalogMealCommandHandler(EventHandler[LogCatalogMealCommand, LogCatalo
         except KeyError as exc:
             raise ResourceNotFoundException("Catalog meal not found") from exc
 
+        write_started = time.perf_counter()
         result = await self._write(command, catalog_meal)
+        write_ms = (time.perf_counter() - write_started) * 1000
         if self.cache_invalidation is not None:
             await self.cache_invalidation.after_meal_write(
                 command.user_id, command.meal_date
@@ -72,16 +84,33 @@ class LogCatalogMealCommandHandler(EventHandler[LogCatalogMealCommand, LogCatalo
             self.meal_translation_service, result.meal, command.language
         )
         if self.recalculator is not None:
-            await self.recalculator.recalculate(
-                user_id=command.user_id,
-                meal_date=command.meal_date,
-                logged_catalog_meal_id=command.catalog_meal_id,
-                logged_slot_id=result.slot_id,
-                request_id=command.request_id,
+            await self._defer(
+                f"catalog-log-recalc:{command.request_id}",
+                self.recalculator.recalculate(
+                    user_id=command.user_id,
+                    meal_date=command.meal_date,
+                    logged_catalog_meal_id=command.catalog_meal_id,
+                    logged_slot_id=result.slot_id,
+                    request_id=command.request_id,
+                ),
             )
         if self.insight_scheduler is not None:
             self.insight_scheduler(result.meal, command)
+        logger.info(
+            "catalog_log.timing meal_id=%s write_ms=%.0f background=%s",
+            result.meal_id,
+            write_ms,
+            self.task_manager is not None,
+        )
         return result
+
+    async def _defer(self, name: str, coro: Coroutine[Any, Any, Any]) -> None:
+        """Run isolated post-log work in the background when a task manager exists."""
+
+        if self.task_manager is not None:
+            self.task_manager.spawn(name, coro)
+            return
+        await coro
 
     async def _write(self, command, catalog_meal) -> LogCatalogMealResult:
         async with self.uow as uow:

--- a/src/app/services/catalog_meal_browse_service.py
+++ b/src/app/services/catalog_meal_browse_service.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from typing import Any, Literal
 
 from src.app.services.catalog_meal_browse_ranking import (
+    CatalogPopularityUnavailableError,
     diversity_rank,
     filter_meals,
     rank_popular,
@@ -83,37 +84,48 @@ class CatalogMealBrowseService:
         daily_calories: int | None = None,
         start_date: date | None = None,
         timezone: str | None = None,
+        shuffle_seed: str | None = None,
     ) -> CatalogBrowsePage:
         async with self._uow_factory() as uow:
+            if feed is CatalogFeed.POPULAR:
+                page = await uow.catalog_recipes.list_popular_page(
+                    limit=limit,
+                    offset=offset,
+                    query=query,
+                    cuisine=cuisine,
+                    meal_type=meal_type,
+                    shuffle_seed=shuffle_seed,
+                )
+                if not page.any_ranked or page.unranked_count > 0:
+                    raise CatalogPopularityUnavailableError
+                return CatalogBrowsePage(
+                    items=page.items,
+                    total=page.total,
+                    feed=feed,
+                    ranking_source="curated",
+                    fallback=False,
+                )
             snapshot = await self._get_snapshot(uow)
             candidates = filter_meals(snapshot.meals, query, cuisine, meal_type)
             popularity_configured = any(
                 meal.popularity_rank is not None for meal in snapshot.meals
             )
-            fallback = False
-            if feed is CatalogFeed.POPULAR:
-                ranked = rank_popular(
-                    candidates, popularity_configured=popularity_configured
-                )
-            else:
-                ranked, fallback = await self._rank_for_you(
-                    uow,
-                    snapshot,
-                    candidates,
-                    user_id=user_id,
-                    meal_type=meal_type,
-                    daily_calories=daily_calories,
-                    start_date=start_date,
-                    timezone=timezone,
-                    popularity_configured=popularity_configured,
-                )
+            ranked, fallback = await self._rank_for_you(
+                uow,
+                snapshot,
+                candidates,
+                user_id=user_id,
+                meal_type=meal_type,
+                daily_calories=daily_calories,
+                start_date=start_date,
+                timezone=timezone,
+                popularity_configured=popularity_configured,
+            )
             return CatalogBrowsePage(
                 items=tuple(ranked[offset : offset + limit]),
                 total=len(ranked),
                 feed=feed,
-                ranking_source="curated"
-                if fallback or feed is CatalogFeed.POPULAR
-                else "personalized",
+                ranking_source="personalized" if not fallback else "curated",
                 fallback=fallback,
             )
 

--- a/src/app/services/catalog_meal_browse_service.py
+++ b/src/app/services/catalog_meal_browse_service.py
@@ -111,16 +111,17 @@ class CatalogMealBrowseService:
                 items=tuple(ranked[offset : offset + limit]),
                 total=len(ranked),
                 feed=feed,
-                ranking_source="curated" if fallback or feed is CatalogFeed.POPULAR else "personalized",
+                ranking_source="curated"
+                if fallback or feed is CatalogFeed.POPULAR
+                else "personalized",
                 fallback=fallback,
             )
 
     async def get_meal(self, catalog_id: str) -> CatalogMeal:
+        """Load one catalog meal by id without rebuilding the browse snapshot."""
+
         async with self._uow_factory() as uow:
-            snapshot = await self._get_snapshot(uow)
-            meal = next(
-                (item for item in snapshot.meals if item.id == catalog_id), None
-            )
+            meal = await uow.catalog_recipes.get_meal(catalog_id)
             if meal is None:
                 raise KeyError(catalog_id)
             return meal

--- a/src/app/services/catalog_meal_response_localizer.py
+++ b/src/app/services/catalog_meal_response_localizer.py
@@ -7,7 +7,13 @@ from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any, Protocol
 
-from src.app.services.food_name_localizer import translate_for_presentation
+from cachetools import TTLCache
+
+from src.app.services.food_name_localizer import (
+    translate_for_presentation,
+    translation_is_cacheable,
+)
+from src.domain.constants.translation_limits import iter_translation_batches
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
     PersistedMealRecommendationCandidate,
@@ -17,6 +23,16 @@ from src.domain.model.meal_recommendation import (
 from src.domain.model.translation_result import TranslationOutcome
 
 logger = logging.getLogger(__name__)
+
+_CATALOG_TRANSLATION_CACHE: TTLCache[tuple[str, str], str] = TTLCache(
+    maxsize=4096, ttl=6 * 3600
+)
+
+
+def clear_catalog_presentation_cache() -> None:
+    """Reset process-local catalog presentation translations. Tests only."""
+
+    _CATALOG_TRANSLATION_CACHE.clear()
 
 
 class TextTranslationService(Protocol):
@@ -36,11 +52,7 @@ async def localize_meal_recommendation_plan(
     if language == "en" or translation_service is None:
         return plan
 
-    meals = [
-        meal
-        for slot in plan.slots
-        for meal in _slot_catalog_meals(slot)
-    ]
+    meals = [meal for slot in plan.slots for meal in _slot_catalog_meals(slot)]
     localized_meals = await _localized_meals(
         meals,
         language=language,
@@ -55,6 +67,30 @@ async def localize_meal_recommendation_plan(
             _replace_slot_catalog_meals(slot, localized_meals) for slot in plan.slots
         ),
     )
+
+
+async def localize_catalog_meals(
+    meals: Iterable[CatalogMeal],
+    *,
+    language: str,
+    translation_service: TextTranslationService | None,
+    include_ingredients: bool = True,
+) -> tuple[CatalogMeal, ...]:
+    """Return localized presentation copies of catalog meals."""
+
+    original = tuple(meals)
+    if language == "en" or translation_service is None or not original:
+        return original
+
+    localized_meals = await _localized_meals(
+        list(original),
+        language=language,
+        translation_service=translation_service,
+        include_ingredients=include_ingredients,
+    )
+    if localized_meals is None:
+        return original
+    return tuple(localized_meals.get(meal.id, meal) for meal in original)
 
 
 async def localize_meal_recommendation_slot(
@@ -79,7 +115,9 @@ async def localize_meal_recommendation_slot(
     return _replace_slot_catalog_meals(slot, localized_meals)
 
 
-def _slot_catalog_meals(slot: PersistedMealRecommendationSlot) -> tuple[CatalogMeal, ...]:
+def _slot_catalog_meals(
+    slot: PersistedMealRecommendationSlot,
+) -> tuple[CatalogMeal, ...]:
     candidates = (slot.selected, *slot.alternatives)
     return tuple(
         candidate.catalog_meal
@@ -93,44 +131,74 @@ async def _localized_meals(
     *,
     language: str,
     translation_service: TextTranslationService,
+    include_ingredients: bool = True,
 ) -> dict[str, CatalogMeal] | None:
     unique_meals = {meal.id: meal for meal in meals}
-    texts = _unique_display_texts(unique_meals.values())
+    texts = _unique_display_texts(
+        unique_meals.values(), include_ingredients=include_ingredients
+    )
     if not texts:
         return dict(unique_meals)
 
-    try:
-        result = await translate_for_presentation(translation_service, texts, language)
-    except Exception as exc:
-        logger.warning(
-            "catalog response translation failed language=%s error_type=%s",
-            language,
-            type(exc).__name__,
-        )
+    translations: dict[str, str] = {}
+    missing: list[str] = []
+    for text in texts:
+        cached = _CATALOG_TRANSLATION_CACHE.get((language, text))
+        if cached is not None:
+            translations[text] = cached
+        else:
+            missing.append(text)
+
+    if missing:
+        try:
+            for batch in iter_translation_batches(missing):
+                result = await translate_for_presentation(
+                    translation_service, batch, language
+                )
+                if result.outcome is TranslationOutcome.UNAVAILABLE:
+                    continue
+                cacheable = translation_is_cacheable(result)
+                for index, text in enumerate(batch):
+                    translated = (
+                        result.items[index] if index < len(result.items) else text
+                    )
+                    translations[text] = translated
+                    if cacheable:
+                        _CATALOG_TRANSLATION_CACHE[(language, text)] = translated
+        except Exception as exc:
+            logger.warning(
+                "catalog response translation failed language=%s error_type=%s",
+                language,
+                type(exc).__name__,
+            )
+            if not translations:
+                return None
+
+    if missing and not translations:
         return None
 
-    if result.outcome is TranslationOutcome.UNAVAILABLE:
-        return None
-
-    translations = {
-        text: result.items[index] if index < len(result.items) else text
-        for index, text in enumerate(texts)
-    }
+    for text in texts:
+        translations.setdefault(text, text)
     return {
         meal_id: _replace_meal_display_text(meal, translations)
         for meal_id, meal in unique_meals.items()
     }
 
 
-def _unique_display_texts(meals: Iterable[CatalogMeal]) -> list[str]:
+def _unique_display_texts(
+    meals: Iterable[CatalogMeal],
+    *,
+    include_ingredients: bool = True,
+) -> list[str]:
     texts: list[str] = []
     for meal in meals:
         _append_unique(texts, meal.name)
         _append_unique(texts, meal.cuisine)
         if meal.description:
             _append_unique(texts, meal.description)
-        for ingredient in meal.ingredients:
-            _append_unique(texts, ingredient.display_name)
+        if include_ingredients:
+            for ingredient in meal.ingredients:
+                _append_unique(texts, ingredient.display_name)
     return texts
 
 
@@ -191,5 +259,7 @@ def _replace_candidate_catalog_meal(
         return candidate
     return replace(
         candidate,
-        catalog_meal=localized_meals.get(candidate.catalog_meal.id, candidate.catalog_meal),
+        catalog_meal=localized_meals.get(
+            candidate.catalog_meal.id, candidate.catalog_meal
+        ),
     )

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -11,14 +11,38 @@ from src.domain.exceptions.meal_recommendation_exceptions import (
 from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal_recommendation import (
     CatalogMeal,
+    CatalogMealIngredient,
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
 from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
+from src.domain.services.meal_recommendation.ingredient_quantity_conversion_service import (
+    IngredientQuantityConversionError,
+    IngredientQuantityConversionService,
+)
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
 # mealimage.url is VARCHAR(255); keep inserts valid when catalog URLs are longer.
 _MEAL_IMAGE_URL_MAX_LEN = 255
+_CATALOG_CONVERTER = IngredientQuantityConversionService(
+    allow_unverified=True,
+    allow_unapproved_sources=True,
+    allow_implausible_macros=True,
+    allow_common_unit_fallbacks=True,
+)
+_WEIGHT_UNITS_TO_GRAMS = {
+    "g": 1.0,
+    "gram": 1.0,
+    "grams": 1.0,
+    "kg": 1000.0,
+    "oz": 28.35,
+    "lb": 453.6,
+    "ml": 1.0,
+    "l": 1000.0,
+}
 
 
 class RecommendedMealMaterializationService:
@@ -53,17 +77,16 @@ class RecommendedMealMaterializationService:
         meal_type: str,
         timezone: str,
     ) -> Meal:
+        projections = await _load_nutrition_projections(uow, catalog_meal)
         food_items = [
-            FoodItem(
-                id=str(uuid4()),
-                name=ingredient.name,
-                quantity=float(ingredient.quantity),
-                unit=ingredient.unit,
-                macros=Macros(protein=0, carbs=0, fat=0, fiber=0, sugar=0),
-                food_reference_id=ingredient.food_reference_id,
+            _food_item_for_ingredient(
+                ingredient,
+                projections.get(ingredient.food_reference_id),
             )
             for ingredient in catalog_meal.ingredients
         ]
+        if _needs_catalog_macro_fallback(food_items):
+            food_items = _distribute_catalog_macros(food_items, catalog_meal)
         meal_time = noon_utc_for_date(meal_date, timezone)
         meal = Meal(
             meal_id=str(uuid4()),
@@ -90,7 +113,7 @@ class RecommendedMealMaterializationService:
 
 
 def _meal_image_for_catalog(catalog_meal: CatalogMeal) -> MealImage:
-    """Build a mealimage row from catalog URL, or a placeholder when absent."""
+    """Build a meal image row from catalog URL, or a placeholder when absent."""
 
     raw_url = (catalog_meal.image_url or "").strip() or None
     url = raw_url if raw_url and len(raw_url) <= _MEAL_IMAGE_URL_MAX_LEN else None
@@ -100,3 +123,105 @@ def _meal_image_for_catalog(catalog_meal: CatalogMeal) -> MealImage:
         size_bytes=1,
         url=url,
     )
+
+
+async def _load_nutrition_projections(
+    uow,
+    catalog_meal: CatalogMeal,
+) -> dict[int, FoodReferenceNutritionProjection]:
+    food_reference_ids = [
+        ingredient.food_reference_id for ingredient in catalog_meal.ingredients
+    ]
+    if not food_reference_ids:
+        return {}
+    repo = getattr(uow, "food_references", None)
+    loader = getattr(repo, "get_nutrition_projections", None)
+    if loader is None:
+        return {}
+    return await loader(food_reference_ids)
+
+
+def _food_item_for_ingredient(
+    ingredient: CatalogMealIngredient,
+    projection: FoodReferenceNutritionProjection | None,
+) -> FoodItem:
+    return FoodItem(
+        id=str(uuid4()),
+        name=ingredient.name,
+        quantity=float(ingredient.quantity),
+        unit=ingredient.unit,
+        macros=_macros_from_projection(ingredient, projection),
+        food_reference_id=ingredient.food_reference_id,
+    )
+
+
+def _macros_from_projection(
+    ingredient: CatalogMealIngredient,
+    projection: FoodReferenceNutritionProjection | None,
+) -> Macros:
+    if projection is None:
+        return Macros(protein=0, carbs=0, fat=0, fiber=0, sugar=0)
+    try:
+        resolved = _CATALOG_CONVERTER.resolve(
+            reference=projection,
+            quantity=float(ingredient.quantity),
+            unit=ingredient.unit,
+            display_name=ingredient.name,
+        )
+    except IngredientQuantityConversionError:
+        return Macros(protein=0, carbs=0, fat=0, fiber=0, sugar=0)
+    return Macros(
+        protein=resolved.protein,
+        carbs=resolved.carbs,
+        fat=resolved.fat,
+        fiber=resolved.fiber,
+        sugar=resolved.sugar,
+    )
+
+
+def _needs_catalog_macro_fallback(food_items: list[FoodItem]) -> bool:
+    if not food_items:
+        return False
+    return all(
+        item.macros.protein == 0 and item.macros.carbs == 0 and item.macros.fat == 0
+        for item in food_items
+    )
+
+
+def _distribute_catalog_macros(
+    food_items: list[FoodItem],
+    catalog_meal: CatalogMeal,
+) -> list[FoodItem]:
+    total_weight = sum(_estimated_grams(item) for item in food_items)
+    if total_weight <= 0:
+        return food_items
+    protein = float(catalog_meal.protein_g)
+    carbs = float(catalog_meal.carbs_g)
+    fat = float(catalog_meal.fat_g)
+    fiber = float(catalog_meal.fiber_g)
+    sugar = float(catalog_meal.sugar_g)
+    distributed: list[FoodItem] = []
+    for item in food_items:
+        ratio = _estimated_grams(item) / total_weight
+        distributed.append(
+            FoodItem(
+                id=item.id,
+                name=item.name,
+                quantity=item.quantity,
+                unit=item.unit,
+                macros=Macros(
+                    protein=round(protein * ratio, 1),
+                    carbs=round(carbs * ratio, 1),
+                    fat=round(fat * ratio, 1),
+                    fiber=round(fiber * ratio, 1),
+                    sugar=round(sugar * ratio, 1),
+                ),
+                food_reference_id=item.food_reference_id,
+            )
+        )
+    return distributed
+
+
+def _estimated_grams(item: FoodItem) -> float:
+    unit = (item.unit or "").lower().strip()
+    return item.quantity * _WEIGHT_UNITS_TO_GRAMS.get(unit, 1.0)

--- a/src/app/services/remaining_recommendation_recalculator.py
+++ b/src/app/services/remaining_recommendation_recalculator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from datetime import date
 
 from src.domain.exceptions.meal_recommendation_exceptions import (
@@ -47,6 +48,7 @@ class RemainingRecommendationRecalculator:
     ) -> None:
         try:
             async with self._uow_factory() as uow:
+                started = time.perf_counter()
                 plan_id = await uow.meal_recommendation_plans.find_active_plan_id(
                     user_id=user_id
                 )
@@ -79,6 +81,14 @@ class RemainingRecommendationRecalculator:
                         slot=slot,
                         request_id=f"{request_id}:recalc:{index}",
                     )
+                logger.info(
+                    "recommendation_recalc.timing user_id=%s date=%s "
+                    "duplicates=%s elapsed_ms=%.0f",
+                    user_id,
+                    meal_date,
+                    len(duplicates),
+                    (time.perf_counter() - started) * 1000,
+                )
         except MealRecommendationCreationError:
             logger.info(
                 "recommendation_recalc_skipped user_id=%s date=%s",

--- a/src/domain/constants/translation_limits.py
+++ b/src/domain/constants/translation_limits.py
@@ -16,3 +16,27 @@ def translation_batch_within_limits(texts: list[str] | tuple[str, ...]) -> bool:
         all(size <= MAX_TRANSLATION_ITEM_BYTES for size in item_sizes)
         and sum(item_sizes) <= MAX_TRANSLATION_BATCH_BYTES
     )
+
+
+def iter_translation_batches(texts: list[str] | tuple[str, ...]) -> list[list[str]]:
+    """Split texts into provider-safe batches without dropping in-limit items."""
+
+    batches: list[list[str]] = []
+    current: list[str] = []
+    current_bytes = 0
+    for text in texts:
+        size = len(text.encode("utf-8"))
+        if size > MAX_TRANSLATION_ITEM_BYTES:
+            continue
+        if current and (
+            len(current) >= MAX_TRANSLATION_ITEMS
+            or current_bytes + size > MAX_TRANSLATION_BATCH_BYTES
+        ):
+            batches.append(current)
+            current = []
+            current_bytes = 0
+        current.append(text)
+        current_bytes += size
+    if current:
+        batches.append(current)
+    return batches

--- a/src/domain/ports/catalog_recipe_repository_port.py
+++ b/src/domain/ports/catalog_recipe_repository_port.py
@@ -64,6 +64,16 @@ class CatalogMealRevision:
     food_reference_updated_at: datetime | None
 
 
+@dataclass(frozen=True)
+class CatalogPopularPage:
+    """One ranked popular-feed page plus ranking-gate counts."""
+
+    items: tuple[CatalogMeal, ...]
+    total: int
+    any_ranked: bool
+    unranked_count: int
+
+
 class CatalogMealRepositoryPort(ABC):
     """Read/write contract for catalog meals during the rework."""
 
@@ -75,6 +85,19 @@ class CatalogMealRepositoryPort(ABC):
         meal_type: str | None = None,
     ) -> list[CatalogMeal]:
         """Return active catalog meals."""
+
+    @abstractmethod
+    async def list_popular_page(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        query: str | None = None,
+        cuisine: str | None = None,
+        meal_type: str | None = None,
+        shuffle_seed: str | None = None,
+    ) -> CatalogPopularPage:
+        """Return one popularity-ranked page without loading the full catalog."""
 
     @abstractmethod
     async def get_active_catalog_revision(self) -> CatalogMealRevision:

--- a/src/infra/repositories/catalog_recipe_repository_async.py
+++ b/src/infra/repositories/catalog_recipe_repository_async.py
@@ -6,7 +6,7 @@ import unicodedata
 from decimal import Decimal
 from typing import cast
 
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import and_, func, or_, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -20,6 +20,7 @@ from src.domain.ports.catalog_recipe_repository_port import (
     CatalogMealSeedExisting,
     CatalogMealSeedSignature,
     CatalogMealSeedWrite,
+    CatalogPopularPage,
 )
 from src.domain.services.meal_recommendation.ingredient_quantity_conversion_service import (
     IngredientQuantityConversionService,
@@ -68,6 +69,55 @@ class AsyncCatalogMealRepository(CatalogMealRepositoryPort):
 
         result = await self._session.execute(stmt)
         return [_meal_to_domain(row) for row in result.scalars().unique().all()]
+
+    async def list_popular_page(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        query: str | None = None,
+        cuisine: str | None = None,
+        meal_type: str | None = None,
+        shuffle_seed: str | None = None,
+    ) -> CatalogPopularPage:
+        match = _browse_match_clause(query=query, cuisine=cuisine, meal_type=meal_type)
+        stats = await self._session.execute(
+            select(
+                func.coalesce(
+                    func.bool_or(MealCatalogORM.popularity_rank.is_not(None)), False
+                ),
+                func.count().filter(match),
+                func.count().filter(
+                    and_(match, MealCatalogORM.popularity_rank.is_(None))
+                ),
+            ).where(MealCatalogORM.is_active.is_(True))
+        )
+        any_ranked, total, unranked_count = stats.one()
+        if not any_ranked or int(unranked_count or 0) > 0:
+            return CatalogPopularPage(
+                items=(),
+                total=int(total or 0),
+                any_ranked=bool(any_ranked),
+                unranked_count=int(unranked_count or 0),
+            )
+
+        result = await self._session.execute(
+            select(MealCatalogORM)
+            .where(MealCatalogORM.is_active.is_(True))
+            .where(match)
+            .options(_catalog_meal_load_options())
+            .order_by(*_popular_order(shuffle_seed))
+            .offset(offset)
+            .limit(limit)
+        )
+        return CatalogPopularPage(
+            items=tuple(
+                _meal_to_domain(row) for row in result.scalars().unique().all()
+            ),
+            total=int(total or 0),
+            any_ranked=True,
+            unranked_count=0,
+        )
 
     async def get_active_catalog_revision(self) -> CatalogMealRevision:
         result = await self._session.execute(
@@ -164,7 +214,9 @@ class AsyncCatalogMealRepository(CatalogMealRepositoryPort):
 
     async def lock_seed_import(self) -> None:
         await self._session.execute(
-            select(func.pg_advisory_xact_lock(func.hashtext("meal_catalog_seed_import")))
+            select(
+                func.pg_advisory_xact_lock(func.hashtext("meal_catalog_seed_import"))
+            )
         )
 
     async def list_seed_signatures(self) -> list[CatalogMealSeedSignature]:
@@ -186,6 +238,43 @@ class AsyncCatalogMealRepository(CatalogMealRepositoryPort):
             )
             for row in result.scalars().unique().all()
         ]
+
+
+def _browse_match_clause(
+    *, query: str | None, cuisine: str | None, meal_type: str | None
+):
+    clauses = []
+    if cuisine is not None:
+        clauses.append(func.lower(MealCatalogORM.cuisine) == cuisine.strip().casefold())
+    if meal_type is not None:
+        clauses.append(_meal_type_column(meal_type).is_(True))
+    needle = (query or "").strip().casefold()
+    if needle:
+        pattern = f"%{_escape_like(needle)}%"
+        clauses.append(
+            or_(
+                func.lower(MealCatalogORM.name).like(pattern, escape="\\"),
+                func.lower(MealCatalogORM.cuisine).like(pattern, escape="\\"),
+            )
+        )
+    return and_(*clauses) if clauses else true()
+
+
+def _popular_order(shuffle_seed: str | None):
+    if shuffle_seed:
+        return (
+            func.md5(func.concat(MealCatalogORM.id, ":", shuffle_seed)).asc(),
+            MealCatalogORM.id.asc(),
+        )
+    return (
+        MealCatalogORM.popularity_rank.asc(),
+        func.lower(MealCatalogORM.name).asc(),
+        MealCatalogORM.id.asc(),
+    )
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _meal_type_column(meal_type: str):

--- a/tests/unit/api/test_meal_catalog_route.py
+++ b/tests/unit/api/test_meal_catalog_route.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.exceptions import ExternalServiceException
+from src.api.middleware.accept_language import AcceptLanguageMiddleware
 from src.api.routes.v1 import meal_catalog as meal_catalog_route
 from src.api.routes.v1.meal_catalog import router
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
@@ -65,6 +66,7 @@ class _Service:
 
 def _app() -> FastAPI:
     app = FastAPI()
+    app.add_middleware(AcceptLanguageMiddleware)
     app.include_router(router)
     app.dependency_overrides[get_current_user_id] = lambda: "user-1"
     app.dependency_overrides[get_configured_event_bus] = lambda: object()
@@ -87,6 +89,42 @@ def test_list_returns_mobile_catalog_projection_without_list_ingredients():
     assert body["items"][0]["ingredients"] == []
     assert body["feed"] == "popular"
     assert body["ranking_source"] == "curated"
+
+
+def test_list_keeps_canonical_english_names():
+    response = TestClient(_app()).get(
+        "/v1/meal-catalog",
+        headers={"Accept-Language": "vi"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["name"] == "Japanese Egg Rice"
+
+
+def test_list_forwards_shuffle_seed():
+    captured: dict = {}
+
+    class _CapturingService(_Service):
+        async def list_meals(self, **kwargs):
+            captured.update(kwargs)
+            return await super().list_meals(**kwargs)
+
+    app = _app()
+    from src.api.base_dependencies import get_catalog_meal_browse_service
+
+    app.dependency_overrides[get_catalog_meal_browse_service] = lambda: (
+        _CapturingService()
+    )
+    response = TestClient(app).get("/v1/meal-catalog?shuffle_seed=refresh-a")
+
+    assert response.status_code == 200
+    assert captured["shuffle_seed"] == "refresh-a"
+
+
+def test_list_rejects_invalid_shuffle_seed():
+    response = TestClient(_app()).get("/v1/meal-catalog?shuffle_seed=bad seed!")
+
+    assert response.status_code == 422
 
 
 def test_popular_list_does_not_initialize_event_bus(monkeypatch):
@@ -124,7 +162,9 @@ async def test_for_you_context_marks_weekly_budget_read_only():
     )
 
     assert context[2] == 2000
-    budget_query = next(query for query in sent if isinstance(query, GetWeeklyBudgetQuery))
+    budget_query = next(
+        query for query in sent if isinstance(query, GetWeeklyBudgetQuery)
+    )
     assert budget_query.read_only is True
 
 
@@ -182,8 +222,8 @@ def test_for_you_endpoint_falls_back_to_popular_when_target_is_unavailable(monke
     from src.api.base_dependencies import get_catalog_meal_browse_service
 
     app = _app()
-    app.dependency_overrides[get_catalog_meal_browse_service] = (
-        lambda: _FallbackService()
+    app.dependency_overrides[get_catalog_meal_browse_service] = lambda: (
+        _FallbackService()
     )
     monkeypatch.setattr(meal_catalog_route, "get_configured_event_bus", lambda: _Bus())
 

--- a/tests/unit/app/handlers/test_catalog_meal_log_handler.py
+++ b/tests/unit/app/handlers/test_catalog_meal_log_handler.py
@@ -121,13 +121,16 @@ class _Browse:
         return self.meal
 
 
-def _handler(uow, browse, log_service, cache=None, recalculator=None):
+def _handler(
+    uow, browse, log_service, cache=None, recalculator=None, task_manager=None
+):
     return LogCatalogMealCommandHandler(
         uow=uow,
         browse_service=browse,
         log_service=log_service,
         cache_invalidation=cache,
         recalculator=recalculator,
+        task_manager=task_manager,
     )
 
 
@@ -167,6 +170,36 @@ async def test_prefer_slot_logs_matching_unlogged_slot():
 
 
 @pytest.mark.asyncio
+async def test_recalculate_is_backgrounded_when_task_manager_present():
+    log_service = AsyncMock()
+    log_service.execute = AsyncMock(
+        return_value=_result(logged_via="slot", plan_id="plan-1", slot_id="slot-1")
+    )
+    recalculator = SimpleNamespace(recalculate=AsyncMock())
+    spawned: list[str] = []
+
+    class _Tasks:
+        def spawn(self, name, coro):
+            spawned.append(name)
+            coro.close()
+
+    handler = _handler(
+        _Uow(),
+        _Browse(),
+        log_service,
+        recalculator=recalculator,
+        task_manager=_Tasks(),
+    )
+
+    result = await handler.handle(_command())
+
+    assert result.meal_id == "meal-1"
+    assert spawned == ["catalog-log-recalc:req-1"]
+    recalculator.recalculate.assert_called_once()
+    recalculator.recalculate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_standalone_when_no_matching_slot():
     log_service = AsyncMock()
     log_service.execute = AsyncMock(return_value=_result(logged_via="catalog"))
@@ -194,9 +227,7 @@ async def test_replay_returns_stored_body_without_second_log():
 
 @pytest.mark.asyncio
 async def test_incomplete_replay_payload_is_409_not_key_error():
-    writes = _WriteOps(
-        _Reservation(state="replay", response={"meal_id": "meal-1"})
-    )
+    writes = _WriteOps(_Reservation(state="replay", response={"meal_id": "meal-1"}))
     handler = _handler(_Uow(writes=writes), _Browse(), AsyncMock())
 
     with pytest.raises(ConflictException) as exc_info:

--- a/tests/unit/app/handlers/test_catalog_meal_log_handler.py
+++ b/tests/unit/app/handlers/test_catalog_meal_log_handler.py
@@ -122,12 +122,19 @@ class _Browse:
 
 
 def _handler(
-    uow, browse, log_service, cache=None, recalculator=None, task_manager=None
+    uow,
+    browse,
+    log_service,
+    cache=None,
+    recalculator=None,
+    task_manager=None,
+    translation=None,
 ):
     return LogCatalogMealCommandHandler(
         uow=uow,
         browse_service=browse,
         log_service=log_service,
+        meal_translation_service=translation,
         cache_invalidation=cache,
         recalculator=recalculator,
         task_manager=task_manager,
@@ -167,6 +174,33 @@ async def test_prefer_slot_logs_matching_unlogged_slot():
     assert result.plan_id == "plan-1"
     cache.after_meal_write.assert_awaited_once_with("user-1", date(2026, 8, 18))
     recalculator.recalculate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_translates_before_cache_invalidation():
+    order: list[str] = []
+    log_service = AsyncMock()
+    log_service.execute = AsyncMock(return_value=_result())
+
+    class _Translation:
+        async def translate_meal(self, **kwargs):
+            order.append("translate")
+
+    class _Cache:
+        async def after_meal_write(self, user_id, meal_date):
+            order.append("cache")
+
+    handler = _handler(
+        _Uow(),
+        _Browse(),
+        log_service,
+        cache=_Cache(),
+        translation=_Translation(),
+    )
+
+    await handler.handle(_command(language="vi"))
+
+    assert order == ["translate", "cache"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_catalog_meal_browse_service.py
+++ b/tests/unit/app/services/test_catalog_meal_browse_service.py
@@ -50,8 +50,12 @@ class _Uow:
         self.meals = SimpleNamespace(
             aggregate_linked_ingredient_history=self._aggregate_history
         )
+        self.catalog_recipes = SimpleNamespace(get_meal=self._get_meal)
         self.meal_rows = meals
         self.writes = []
+
+    async def _get_meal(self, catalog_id):
+        return next((meal for meal in self.meal_rows if meal.id == catalog_id), None)
 
     async def _aggregate_history(self, **kwargs):
         return []
@@ -241,3 +245,23 @@ async def test_cold_start_for_you_falls_back_to_popular():
     assert page.fallback is True
     assert page.ranking_source == "curated"
     assert [meal.id for meal in page.items] == ["meal-a"]
+
+
+@pytest.mark.asyncio
+async def test_get_meal_loads_one_row_without_snapshot():
+    meals = [_meal("meal-a", rank=1, food_reference_id=1)]
+    snapshot = _Snapshot(meals)
+    service = CatalogMealBrowseService(
+        uow_factory=_UowFactory(_Uow(meals)),
+        snapshot_service=snapshot,
+        history_projector=_History(),
+        scoring=_Scoring(),
+        diversity=_Diversity(),
+    )
+    snapshot.get_snapshot = None  # would fail if browse snapshot path is used
+
+    meal = await service.get_meal("meal-a")
+
+    assert meal.id == "meal-a"
+    with pytest.raises(KeyError):
+        await service.get_meal("missing")

--- a/tests/unit/app/services/test_catalog_meal_browse_service.py
+++ b/tests/unit/app/services/test_catalog_meal_browse_service.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from hashlib import md5
 from types import SimpleNamespace
 
 import pytest
@@ -16,6 +17,10 @@ from src.domain.services.meal_recommendation.ingredient_affinity_service import 
     IngredientAffinityProfile,
 )
 from src.domain.services.meal_recommendation.recipe_scoring_service import RecipeScore
+
+
+def _shuffle_key(meal_id: str, seed: str) -> str:
+    return md5(f"{meal_id}:{seed}".encode()).hexdigest()
 
 
 def _meal(meal_id: str, *, rank: int | None, food_reference_id: int) -> CatalogMeal:
@@ -50,12 +55,56 @@ class _Uow:
         self.meals = SimpleNamespace(
             aggregate_linked_ingredient_history=self._aggregate_history
         )
-        self.catalog_recipes = SimpleNamespace(get_meal=self._get_meal)
+        self.catalog_recipes = SimpleNamespace(
+            get_meal=self._get_meal,
+            list_popular_page=self._list_popular_page,
+        )
         self.meal_rows = meals
         self.writes = []
 
     async def _get_meal(self, catalog_id):
         return next((meal for meal in self.meal_rows if meal.id == catalog_id), None)
+
+    async def _list_popular_page(
+        self,
+        *,
+        limit,
+        offset,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+        shuffle_seed=None,
+    ):
+        from src.app.services.catalog_meal_browse_ranking import filter_meals
+        from src.domain.ports.catalog_recipe_repository_port import CatalogPopularPage
+
+        candidates = filter_meals(tuple(self.meal_rows), query, cuisine, meal_type)
+        if shuffle_seed:
+            ranked = sorted(
+                candidates,
+                key=lambda meal: (
+                    _shuffle_key(meal.id, shuffle_seed),
+                    meal.id,
+                ),
+            )
+        else:
+            ranked = sorted(
+                candidates,
+                key=lambda meal: (
+                    meal.popularity_rank is None,
+                    meal.popularity_rank or 0,
+                    meal.name.casefold(),
+                    meal.id,
+                ),
+            )
+        return CatalogPopularPage(
+            items=tuple(ranked[offset : offset + limit]),
+            total=len(candidates),
+            any_ranked=any(meal.popularity_rank is not None for meal in self.meal_rows),
+            unranked_count=sum(
+                1 for meal in candidates if meal.popularity_rank is None
+            ),
+        )
 
     async def _aggregate_history(self, **kwargs):
         return []
@@ -147,6 +196,91 @@ async def test_popular_feed_uses_curated_rank_then_stable_ties_and_paginates_aft
     assert page.total == 3
     assert page.ranking_source == "curated"
     assert page.fallback is False
+
+
+@pytest.mark.asyncio
+async def test_popular_feed_shuffle_seed_is_stable_across_pages():
+    meals = [
+        _meal("meal-a", rank=1, food_reference_id=1),
+        _meal("meal-b", rank=2, food_reference_id=2),
+        _meal("meal-c", rank=3, food_reference_id=3),
+        _meal("meal-d", rank=4, food_reference_id=4),
+        _meal("meal-e", rank=5, food_reference_id=5),
+    ]
+    service = _service(meals)
+    expected = [
+        meal_id
+        for meal_id, _ in sorted(
+            ((meal.id, _shuffle_key(meal.id, "refresh-a")) for meal in meals),
+            key=lambda item: (item[1], item[0]),
+        )
+    ]
+
+    page_one = await service.list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.POPULAR,
+        limit=2,
+        offset=0,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+        shuffle_seed="refresh-a",
+    )
+    page_two = await service.list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.POPULAR,
+        limit=2,
+        offset=2,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+        shuffle_seed="refresh-a",
+    )
+    other_seed = await service.list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.POPULAR,
+        limit=20,
+        offset=0,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+        shuffle_seed="refresh-b",
+    )
+
+    assert [meal.id for meal in page_one.items] + [
+        meal.id for meal in page_two.items
+    ] == expected[:4]
+    assert [meal.id for meal in other_seed.items] != expected
+
+
+@pytest.mark.asyncio
+async def test_popular_feed_does_not_load_catalog_snapshot():
+    meals = [_meal("meal-a", rank=1, food_reference_id=1)]
+    snapshot = _Snapshot(meals)
+
+    async def _fail_snapshot(_uow):
+        raise AssertionError("popular feed must not rebuild the catalog snapshot")
+
+    snapshot.get_snapshot = _fail_snapshot
+    service = CatalogMealBrowseService(
+        uow_factory=_UowFactory(_Uow(meals)),
+        snapshot_service=snapshot,
+        history_projector=_History(),
+        scoring=_Scoring(),
+        diversity=_Diversity(),
+    )
+
+    page = await service.list_meals(
+        user_id="user-a",
+        feed=CatalogFeed.POPULAR,
+        limit=20,
+        offset=0,
+        query=None,
+        cuisine=None,
+        meal_type=None,
+    )
+
+    assert [meal.id for meal in page.items] == ["meal-a"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_catalog_meal_response_localizer.py
+++ b/tests/unit/app/services/test_catalog_meal_response_localizer.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 import pytest
 
 from src.app.services.catalog_meal_response_localizer import (
+    clear_catalog_presentation_cache,
+    localize_catalog_meals,
     localize_meal_recommendation_plan,
     localize_meal_recommendation_slot,
 )
@@ -14,6 +16,7 @@ from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
+from src.domain.model.translation_result import TranslationOutcome, TranslationResult
 
 
 class _Translator:
@@ -34,6 +37,30 @@ class _FailingTranslator:
 class _ShortTranslator:
     async def translate_texts(self, texts: list[str], target_lang: str) -> list[str]:
         return ["Cơm tô"]
+
+
+class _CacheableTranslator:
+    def __init__(self, translations: dict[str, str]) -> None:
+        self.translations = translations
+        self.calls: list[list[str]] = []
+
+    async def translate_texts(
+        self, texts: list[str], source_language: str, target_language: str
+    ) -> TranslationResult:
+        self.calls.append(list(texts))
+        return TranslationResult(
+            tuple(self.translations.get(text, text) for text in texts),
+            TranslationOutcome.TRANSLATED,
+            source_language,
+            target_language,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_translation_cache():
+    clear_catalog_presentation_cache()
+    yield
+    clear_catalog_presentation_cache()
 
 
 def _meal(meal_id: str, name: str = "Rice Bowl") -> CatalogMeal:
@@ -61,7 +88,9 @@ def _meal(meal_id: str, name: str = "Rice Bowl") -> CatalogMeal:
     )
 
 
-def _slot(meal: CatalogMeal, alternative: CatalogMeal | None = None) -> PersistedMealRecommendationSlot:
+def _slot(
+    meal: CatalogMeal, alternative: CatalogMeal | None = None
+) -> PersistedMealRecommendationSlot:
     selected = PersistedMealRecommendationCandidate(
         id="candidate-1",
         slot_id="slot-1",
@@ -156,13 +185,92 @@ async def test_localize_plan_skips_english_and_missing_translation_service():
     )
     translator = _Translator({})
 
-    assert await localize_meal_recommendation_plan(
-        plan, language="en", translation_service=translator
-    ) is plan
-    assert await localize_meal_recommendation_plan(
-        plan, language="vi", translation_service=None
-    ) is plan
+    assert (
+        await localize_meal_recommendation_plan(
+            plan, language="en", translation_service=translator
+        )
+        is plan
+    )
+    assert (
+        await localize_meal_recommendation_plan(
+            plan, language="vi", translation_service=None
+        )
+        is plan
+    )
     assert translator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_localize_catalog_meals_translates_names_and_can_skip_ingredients():
+    meal = _meal("meal-1")
+    translator = _Translator(
+        {
+            "Rice Bowl": "Cơm tô",
+            "Vietnamese": "Việt Nam",
+            "Warm rice with vegetables": "Cơm nóng với rau",
+            "Rice": "Gạo",
+        }
+    )
+
+    without_ingredients = await localize_catalog_meals(
+        (meal,),
+        language="vi",
+        translation_service=translator,
+        include_ingredients=False,
+    )
+    with_ingredients = await localize_catalog_meals(
+        (meal,),
+        language="vi",
+        translation_service=translator,
+        include_ingredients=True,
+    )
+
+    assert without_ingredients[0].name == "Cơm tô"
+    assert without_ingredients[0].cuisine == "Việt Nam"
+    assert without_ingredients[0].description == "Cơm nóng với rau"
+    assert without_ingredients[0].ingredients[0].display_name == "Rice"
+    assert with_ingredients[0].ingredients[0].display_name == "Gạo"
+    assert "Rice" not in translator.calls[0][0]
+    assert "Rice" in translator.calls[1][0]
+
+
+@pytest.mark.asyncio
+async def test_localize_catalog_meals_batches_page_then_reuses_cache():
+    meals = (
+        _meal("meal-1"),
+        _meal("meal-2", name="Chicken Soup"),
+    )
+    translator = _CacheableTranslator(
+        {
+            "Rice Bowl": "Cơm tô",
+            "Chicken Soup": "Súp gà",
+            "Vietnamese": "Việt Nam",
+            "Warm rice with vegetables": "Cơm nóng với rau",
+        }
+    )
+
+    first = await localize_catalog_meals(
+        meals,
+        language="vi",
+        translation_service=translator,
+        include_ingredients=False,
+    )
+    second = await localize_catalog_meals(
+        meals,
+        language="vi",
+        translation_service=translator,
+        include_ingredients=False,
+    )
+
+    assert [meal.name for meal in first] == ["Cơm tô", "Súp gà"]
+    assert [meal.name for meal in second] == ["Cơm tô", "Súp gà"]
+    assert len(translator.calls) == 1
+    assert translator.calls[0] == [
+        "Rice Bowl",
+        "Vietnamese",
+        "Warm rice with vegetables",
+        "Chicken Soup",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -16,6 +16,9 @@ from src.domain.model.meal_recommendation import (
     PersistedMealRecommendationPlan,
     PersistedMealRecommendationSlot,
 )
+from src.domain.ports.food_reference_repository_port import (
+    FoodReferenceNutritionProjection,
+)
 
 
 class _CatalogRepo:
@@ -58,10 +61,24 @@ class _MealRepo:
         return meal
 
 
+class _FoodRefRepo:
+    def __init__(self, projections: dict[int, FoodReferenceNutritionProjection]):
+        self._projections = projections
+
+    async def get_nutrition_projections(self, food_reference_ids, *, for_update=False):
+        return {
+            food_id: self._projections[food_id]
+            for food_id in food_reference_ids
+            if food_id in self._projections
+        }
+
+
 class _Uow:
-    def __init__(self, catalog_recipes=None):
+    def __init__(self, catalog_recipes=None, food_references=None):
         self.catalog_recipes = catalog_recipes or _CatalogRepo()
         self.meals = _MealRepo()
+        if food_references is not None:
+            self.food_references = food_references
 
 
 def _plan_and_slot():
@@ -137,10 +154,50 @@ async def test_materializer_preserves_food_reference_ids_and_macro_snapshot():
     assert meal.nutrition is not None
     assert meal.nutrition.macros.protein == 30
     assert meal.nutrition.food_items[0].food_reference_id == 123
+    item = meal.nutrition.food_items[0]
+    assert item.macros.protein == 30
+    assert item.macros.carbs == 50
+    assert item.macros.fat == 10
+    assert item.macros.fiber == 5
+    assert item.calories > 0
     # Placeholder image keeps inserts valid when meal.image_id is NOT NULL.
     assert meal.image is not None
     assert meal.image.url is None
     assert meal.image.size_bytes == 1
+
+
+@pytest.mark.asyncio
+async def test_materializer_scales_food_reference_macros_onto_items():
+    plan, slot = _plan_and_slot()
+    uow = _Uow(
+        food_references=_FoodRefRepo(
+            {
+                123: FoodReferenceNutritionProjection(
+                    id=123,
+                    name="Ingredient",
+                    source="catalog_seed",
+                    is_verified=True,
+                    protein_100g=31.0,
+                    carbs_100g=0.0,
+                    fat_100g=3.6,
+                    fiber_100g=0.0,
+                    sugar_100g=0.0,
+                    density_g_ml=1.0,
+                )
+            }
+        )
+    )
+
+    meal = await RecommendedMealMaterializationService().materialize(
+        uow,
+        plan=plan,
+        slot=slot,
+    )
+
+    item = meal.nutrition.food_items[0]
+    assert item.macros.protein == pytest.approx(31.0)
+    assert item.macros.fat == pytest.approx(3.6)
+    assert item.calories == pytest.approx(31.0 * 4 + 3.6 * 9)
 
 
 @pytest.mark.asyncio
@@ -178,9 +235,7 @@ async def test_materializer_attaches_catalog_image_url_when_present():
 @pytest.mark.asyncio
 async def test_materializer_fails_with_public_error_when_selected_meal_missing():
     plan, slot = _plan_and_slot()
-    slot = PersistedMealRecommendationSlot(
-        **{**slot.__dict__, "selected": None}
-    )
+    slot = PersistedMealRecommendationSlot(**{**slot.__dict__, "selected": None})
 
     with pytest.raises(MealRecommendationNotFoundError):
         await RecommendedMealMaterializationService().materialize(

--- a/tests/unit/domain/constants/test_translation_limits.py
+++ b/tests/unit/domain/constants/test_translation_limits.py
@@ -2,6 +2,7 @@ from src.domain.constants.translation_limits import (
     MAX_TRANSLATION_BATCH_BYTES,
     MAX_TRANSLATION_ITEM_BYTES,
     MAX_TRANSLATION_ITEMS,
+    iter_translation_batches,
     translation_batch_within_limits,
 )
 
@@ -14,3 +15,12 @@ def test_translation_limits_are_provider_neutral():
     assert not translation_batch_within_limits(["a" * 4097])
     assert not translation_batch_within_limits(["a"] * 129)
 
+
+def test_iter_translation_batches_splits_over_item_count():
+    texts = [f"item-{index}" for index in range(MAX_TRANSLATION_ITEMS + 2)]
+
+    batches = iter_translation_batches(texts)
+
+    assert len(batches) == 2
+    assert len(batches[0]) == MAX_TRANSLATION_ITEMS
+    assert batches[1] == ["item-128", "item-129"]

--- a/tests/unit/infra/repositories/test_catalog_recipe_repository_async.py
+++ b/tests/unit/infra/repositories/test_catalog_recipe_repository_async.py
@@ -23,6 +23,9 @@ class _Result:
         self._rows = rows or []
         self._one = one
 
+    def one(self):
+        return self._one
+
     def scalars(self):
         return _Scalars(self._rows)
 
@@ -74,6 +77,7 @@ def _meal_row():
     row.dinner_eligible = False
     row.snack_eligible = False
     row.is_active = True
+    row.popularity_rank = 1
     row.ingredients = [ingredient]
     return row
 
@@ -96,6 +100,44 @@ async def test_list_active_meals_filters_by_cuisine_and_meal_type():
     assert "meal_catalog.is_active" in statement
     assert "meal_catalog.cuisine" in statement
     assert "meal_catalog.breakfast_eligible" in statement
+
+
+@pytest.mark.asyncio
+async def test_list_popular_page_orders_by_rank_and_skips_snapshot_scan():
+    session = _AsyncSession([_Result(one=(True, 1, 0)), _Result(rows=[_meal_row()])])
+    repo = AsyncCatalogMealRepository(session)
+
+    page = await repo.list_popular_page(
+        limit=20,
+        offset=0,
+        query="rice",
+        cuisine="vietnamese",
+        meal_type="breakfast",
+    )
+
+    assert page.total == 1
+    assert page.any_ranked is True
+    assert page.unranked_count == 0
+    assert page.items[0].id == "catalog-1"
+    statement = str(session.statement)
+    assert "meal_catalog.popularity_rank" in statement
+    assert "LIMIT" in statement.upper() or "limit" in statement
+
+
+@pytest.mark.asyncio
+async def test_list_popular_page_orders_by_shuffle_seed_when_provided():
+    session = _AsyncSession([_Result(one=(True, 1, 0)), _Result(rows=[_meal_row()])])
+    repo = AsyncCatalogMealRepository(session)
+
+    page = await repo.list_popular_page(
+        limit=20,
+        offset=0,
+        shuffle_seed="refresh-a",
+    )
+
+    assert page.items[0].id == "catalog-1"
+    statement = str(session.statement)
+    assert "md5" in statement.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Catalog logs copy scaled food-reference nutrition onto meal items so logged meals are not 0 kcal.
- Remaining-recommendation slot replenishment runs in the background after log; translation still completes on the request path.
- `get_meal` loads one catalog row instead of the full browse snapshot; meal GET batches food-reference nutrition lookups.

## Test plan
- [ ] `pytest tests/unit/app/handlers/test_catalog_meal_log_handler.py tests/unit/app/services/test_catalog_meal_browse_service.py tests/unit/app/services/test_recommended_meal_materialization_service.py`
- [ ] Log a catalog recipe and confirm the response returns before recommendation recalc finishes (`catalog_log.timing` with `background=True`)
- [ ] Logged meal detail shows non-zero item calories
- [ ] Non-English log still persists the translated name before the client lands on Home


Made with [Cursor](https://cursor.com)