### PR TITLE
fix(hydration): prefer poured volume in activities and localize drink names

### DIFF
--- a/src/app/handlers/query_handlers/get_bulk_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_bulk_activities_query_handler.py
@@ -76,6 +76,30 @@ def _build_hydration_activity(meal: Meal, language: str = "en") -> dict[str, Any
     }
 
 
+def _build_hydration_entry_activity(entry, language: str = "en") -> dict[str, Any]:
+    return {
+        "id": entry.id,
+        "type": "hydration",
+        "timestamp": format_iso_utc(entry.logged_at),
+        "title": localized_name_for_catalog_name(entry.drink_name_snapshot, language)
+        or entry.drink_name_snapshot
+        or "Water",
+        "emoji": entry.emoji_snapshot or "💧",
+        "meal_type": "hydration",
+        "calories": round(entry.calories, 1),
+        "macros": {
+            "protein": round(entry.protein_g or 0, 1),
+            "carbs": round(entry.carbs_g or 0, 1),
+            "fat": round(entry.fat_g or 0, 1),
+        },
+        "quantity": entry.credited_ml,
+        "volume_ml": entry.volume_ml,
+        "status": "completed",
+        "image_url": entry.image_url,
+        "source": entry.source,
+    }
+
+
 @handles(GetBulkActivitiesQuery)
 class GetBulkActivitiesQueryHandler(
     EventHandler[GetBulkActivitiesQuery, dict[str, list[dict[str, Any]]]]
@@ -99,9 +123,18 @@ class GetBulkActivitiesQueryHandler(
                 user_timezone=user_tz_str,
                 projection=MealProjection.FULL_WITH_TRANSLATIONS,
             )
+            hydration_entries = await uow.hydration_entries.find_by_date_range(
+                user_id=query.user_id,
+                start_date=query.start_date,
+                end_date=query.end_date,
+                user_timezone=user_tz_str,
+            )
 
         language = query.language or "en"
         result: dict[str, list[dict[str, Any]]] = {}
+        covered_meal_ids = {
+            entry.legacy_meal_id for entry in hydration_entries if entry.legacy_meal_id
+        }
 
         for meal in meals:
             if meal.status not in _ACTIVE_STATUSES:
@@ -110,8 +143,16 @@ class GetBulkActivitiesQueryHandler(
             if local_date not in result:
                 result[local_date] = []
             if meal.meal_type == "hydration":
+                if meal.meal_id in covered_meal_ids:
+                    continue
                 result[local_date].append(_build_hydration_activity(meal, language))
             else:
                 result[local_date].append(_build_meal_activity(meal, language))
+
+        for entry in hydration_entries:
+            local_date = entry.logged_at.astimezone(tz).date().isoformat()
+            if local_date not in result:
+                result[local_date] = []
+            result[local_date].append(_build_hydration_entry_activity(entry, language))
 
         return result

--- a/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
@@ -113,29 +113,31 @@ class GetDailyActivitiesQueryHandler(
                 user_id=query.user_id,
                 user_timezone=user_tz_str,
             )
-            meal_activities = [
-                (
-                    self._build_hydration_activity(item, query.language or "en")
-                    if item.meal_type == "hydration"
-                    else self._build_meal_activity(
-                        item, query.target_date, query.language
-                    )
-                )
-                for item in items
-            ]
-
-            # Include hydration_entries not already covered by a meal row (legacy_meal_id dedup).
-            # Pre-Phase-3d entries have legacy_meal_id set → skip (meal row already in feed).
-            # Post-Phase-3d LogCaloricDrink entries have legacy_meal_id=None → include.
-            meal_id_set = {item.meal_id for item in items}
             hydration_entries = await uow.hydration_entries.find_by_date(
                 local_date,
                 user_id=query.user_id,
                 user_timezone=user_tz_str,
             )
-            for entry in hydration_entries:
-                if entry.legacy_meal_id and entry.legacy_meal_id in meal_id_set:
+            covered_meal_ids = {
+                entry.legacy_meal_id
+                for entry in hydration_entries
+                if entry.legacy_meal_id
+            }
+
+            meal_activities: list[dict[str, Any]] = []
+            for item in items:
+                if item.meal_type == "hydration":
+                    if item.meal_id in covered_meal_ids:
+                        continue
+                    meal_activities.append(
+                        self._build_hydration_activity(item, query.language or "en")
+                    )
                     continue
+                meal_activities.append(
+                    self._build_meal_activity(item, query.target_date, query.language)
+                )
+
+            for entry in hydration_entries:
                 meal_activities.append(
                     self._build_hydration_entry_activity(entry, query.language or "en")
                 )

--- a/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
@@ -16,6 +16,7 @@ from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition.macros import Macros
 from src.domain.model.user import MacroPreset, MacroTargets
 from src.domain.ports.cache_port import CachePort
+from src.domain.services.hydration_goal_service import resolve_hydration_goal_ml
 from src.domain.services.meal_calorie_service import effective_meal_calories
 from src.domain.services.tdee_service import TdeeCalculationService
 from src.domain.services.weekly_budget_service import WeeklyBudgetService
@@ -168,14 +169,10 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, dict[str, Any
                         user_id=query.user_id,
                         user_timezone=user_tz_str,
                     )
-                # Get water goal from profile (default 2000 if not set)
                 user_profile = await uow.users.get_profile(UUID(query.user_id))
                 water_goal_ml = (
-                    user_profile.daily_water_goal_ml
+                    resolve_hydration_goal_ml(user_profile)
                     if user_profile
-                    and hasattr(user_profile, "daily_water_goal_ml")
-                    and user_profile.daily_water_goal_ml is not None
-                    and user_profile.daily_water_goal_ml > 0
                     else 2000
                 )
             except Exception as exc:

--- a/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
+++ b/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
@@ -13,6 +13,7 @@ from src.app.queries.progress import GetJourneyProgressQuery
 from src.app.queries.tdee import GetUserTdeeQuery
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.cache_port import CachePort
+from src.domain.services.hydration_goal_service import resolve_hydration_goal_ml
 from src.domain.services.journey_progress_rules import (
     estimate_timeline_days,
     journey_period_start,
@@ -80,7 +81,7 @@ class GetJourneyProgressQueryHandler(
                 period_start,
                 min(now, period_end),
             )
-            water_goal_ml = profile.daily_water_goal_ml or 2000
+            water_goal_ml = resolve_hydration_goal_ml(profile)
 
         target_calories, target_protein_g = await self._load_targets(query.user_id)
         return calculate_journey_progress(

--- a/src/domain/services/hydration_catalog_service.py
+++ b/src/domain/services/hydration_catalog_service.py
@@ -196,13 +196,13 @@ DRINK_CATALOG["scanned"] = Drink(
 _DRINK_TRANSLATIONS: dict[str, dict[str, dict[str, str | None]]] = {
     "vi": {
         "water": {"name": "Nước lọc", "sub": None},
-        "sparkling": {"name": "Nước soda", "sub": "Có ga"},
+        "sparkling": {"name": "Nước có ga", "sub": "Có ga"},
         "tea": {"name": "Trà", "sub": None},
         "coffee": {"name": "Cà phê", "sub": None},
         "electrolyte": {"name": "Nước điện giải", "sub": "Nước thể thao"},
         "milk-tea": {"name": "Trà sữa", "sub": "Trân châu"},
         "coke": {"name": "Nước ngọt", "sub": "Có ga"},
-        "coke-zero": {"name": "Coke Zero", "sub": "Không đường"},
+        "coke-zero": {"name": "Coca/Pepsi Zero", "sub": "Không đường"},
         "oj": {"name": "Nước ép", "sub": "Ép tươi"},
         "smoothie": {"name": "Sinh tố", "sub": "Hỗn hợp Açaí"},
         "energy": {"name": "Nước tăng lực", "sub": "Red Bull"},
@@ -214,6 +214,12 @@ _DRINK_TRANSLATIONS: dict[str, dict[str, dict[str, str | None]]] = {
 _DRINK_IDS_BY_ENGLISH_NAME: dict[str, str] = {
     drink.name.lower(): drink.id for drink in _DRINKS
 }
+_DRINK_IDS_BY_ENGLISH_NAME.update(
+    {
+        "coke zero": "coke-zero",
+        "coca/pepsi zero": "coke-zero",
+    }
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/domain/services/test_hydration_catalog_service.py
+++ b/tests/unit/domain/services/test_hydration_catalog_service.py
@@ -1,0 +1,27 @@
+from src.domain.services.hydration_catalog_service import (
+    find_by_id,
+    localized_name,
+    localized_name_for_catalog_name,
+)
+
+
+def test_coke_zero_canonical_name_stays_english():
+    drink = find_by_id("coke-zero")
+    assert drink is not None
+    assert drink.name == "Coke Zero"
+
+
+def test_coke_zero_vietnamese_uses_coca_pepsi_zero():
+    drink = find_by_id("coke-zero")
+    assert localized_name(drink, "vi") == "Coca/Pepsi Zero"
+
+
+def test_sparkling_vietnamese_uses_co_ga():
+    drink = find_by_id("sparkling")
+    assert localized_name(drink, "vi") == "Nước có ga"
+
+
+def test_legacy_snapshots_still_localizes():
+    assert localized_name_for_catalog_name("Coke Zero", "vi") == "Coca/Pepsi Zero"
+    assert localized_name_for_catalog_name("Coca/Pepsi Zero", "en") == "Coke Zero"
+    assert localized_name_for_catalog_name("Coke Zero", "en") == "Coke Zero"


### PR DESCRIPTION
## Summary
- Prefer `hydration_entries` over legacy meal rows in daily and bulk activities so today's log returns poured `volume_ml` instead of credited meal quantity.
- Localize Vietnamese drink names to match mobile (`Coca/Pepsi Zero`, `Nước có ga`) and keep English snapshots resolving to the same catalog ids.
- Use `resolve_hydration_goal_ml` for daily macros and journey progress so the water goal matches the rest of hydration.

## Test plan
- [ ] Log a caloric drink, then GET daily/bulk activities and confirm the row uses the hydration entry (`volume_ml` = poured, `quantity` = credited).
- [ ] Confirm a legacy meal-backed hydration row is omitted when a matching `legacy_meal_id` entry exists (no duplicate).
- [ ] Request activities with `Accept-Language: vi` and confirm Coke Zero / sparkling labels.
- [ ] Confirm daily macros and journey progress water goals follow `resolve_hydration_goal_ml` (custom override, else 35 ml/kg).
- [x] `pytest tests/unit/domain/services/test_hydration_catalog_service.py tests/unit/domain/services/test_hydration_goal_service.py tests/unit/domain/test_user_specific_activities.py`


Made with [Cursor](https://cursor.com)