### PR TITLE
fix(meal-edit): accept legacy v2 meal overrides

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -150,6 +150,9 @@ handler/schema when implementing; the bullets below are the durable WHY.
   `nutrition_override` and per-item `nutrition_override` /
   `clear_nutrition_override`. Overrides are absolute user values while set;
   clearing restores source/macro-derived nutrition without rewriting source rows.
+- `override_intent` omission is normalized only for top-level meal overrides
+  from legacy v2 clients; item-level overrides still require nested explicit
+  intent.
 - `custom_nutrition` on non-USDA ingredients is per-100g macros; calories stay
   macro-derived (fiber-aware), which is distinct from absolute overrides.
 - Manual meal v2 save failures now split between validation and provider trust

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -154,6 +154,10 @@ handler/schema when implementing; the bullets below are the durable WHY.
   override is present, the override payload itself implies user intent and the
   backend normalizes the marker automatically. Nutrition values and owned-item
   constraints remain validated.
+- Meal ingredient updates and removals accept override metadata without requiring
+  a separate intent marker. Removal is identified by the owned item id; extra
+  edit fields do not change the removal operation. Adds with override metadata
+  remain rejected because an add does not target an owned item.
 - `custom_nutrition` on non-USDA ingredients is per-100g macros; calories stay
   macro-derived (fiber-aware), which is distinct from absolute overrides.
 - Manual meal v2 save failures now split between validation and provider trust

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -150,9 +150,10 @@ handler/schema when implementing; the bullets below are the durable WHY.
   `nutrition_override` and per-item `nutrition_override` /
   `clear_nutrition_override`. Overrides are absolute user values while set;
   clearing restores source/macro-derived nutrition without rewriting source rows.
-- `override_intent` omission is normalized only for top-level meal overrides
-  from legacy v2 clients; item-level overrides still require nested explicit
-  intent.
+- `override_intent` is compatibility metadata. When a meal-level or item-level
+  override is present, the override payload itself implies user intent and the
+  backend normalizes the marker automatically. Nutrition values and owned-item
+  constraints remain validated.
 - `custom_nutrition` on non-USDA ingredients is per-100g macros; calories stay
   macro-derived (fiber-aware), which is distinct from absolute overrides.
 - Manual meal v2 save failures now split between validation and provider trust

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -420,17 +420,19 @@ class CustomNutritionRequest(BaseModel):
     """
 
     protein_per_100g: float = Field(
-        ..., ge=0, le=100, description="Protein per 100g in grams"
+        ..., allow_inf_nan=False, description="Protein per 100g in grams"
     )
     carbs_per_100g: float = Field(
-        ..., ge=0, le=100, description="Carbohydrates per 100g in grams"
+        ..., allow_inf_nan=False, description="Carbohydrates per 100g in grams"
     )
-    fat_per_100g: float = Field(..., ge=0, le=100, description="Fat per 100g in grams")
+    fat_per_100g: float = Field(
+        ..., allow_inf_nan=False, description="Fat per 100g in grams"
+    )
     fiber_per_100g: float = Field(
-        0.0, ge=0, le=100, description="Fiber per 100g in grams"
+        0.0, allow_inf_nan=False, description="Fiber per 100g in grams"
     )
     sugar_per_100g: float = Field(
-        0.0, ge=0, le=100, description="Sugar per 100g in grams"
+        0.0, allow_inf_nan=False, description="Sugar per 100g in grams"
     )
 
     @property
@@ -461,10 +463,10 @@ class CustomNutritionRequest(BaseModel):
 class NutritionOverrideRequest(BaseModel):
     """Absolute values that intentionally bypass nutrition recalculation."""
 
-    calories: float = Field(..., ge=0, allow_inf_nan=False)
-    protein: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
-    carbs: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
-    fat: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
+    calories: float = Field(..., allow_inf_nan=False)
+    protein: float = Field(..., allow_inf_nan=False)
+    carbs: float = Field(..., allow_inf_nan=False)
+    fat: float = Field(..., allow_inf_nan=False)
 
 
 class EditMealIngredientsRequest(BaseModel):

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -420,19 +420,19 @@ class CustomNutritionRequest(BaseModel):
     """
 
     protein_per_100g: float = Field(
-        ..., allow_inf_nan=False, description="Protein per 100g in grams"
+        ..., ge=0, allow_inf_nan=False, description="Protein per 100g in grams"
     )
     carbs_per_100g: float = Field(
-        ..., allow_inf_nan=False, description="Carbohydrates per 100g in grams"
+        ..., ge=0, allow_inf_nan=False, description="Carbohydrates per 100g in grams"
     )
     fat_per_100g: float = Field(
-        ..., allow_inf_nan=False, description="Fat per 100g in grams"
+        ..., ge=0, allow_inf_nan=False, description="Fat per 100g in grams"
     )
     fiber_per_100g: float = Field(
-        0.0, allow_inf_nan=False, description="Fiber per 100g in grams"
+        0.0, ge=0, allow_inf_nan=False, description="Fiber per 100g in grams"
     )
     sugar_per_100g: float = Field(
-        0.0, allow_inf_nan=False, description="Sugar per 100g in grams"
+        0.0, ge=0, allow_inf_nan=False, description="Sugar per 100g in grams"
     )
 
     @property
@@ -463,10 +463,10 @@ class CustomNutritionRequest(BaseModel):
 class NutritionOverrideRequest(BaseModel):
     """Absolute values that intentionally bypass nutrition recalculation."""
 
-    calories: float = Field(..., allow_inf_nan=False)
-    protein: float = Field(..., allow_inf_nan=False)
-    carbs: float = Field(..., allow_inf_nan=False)
-    fat: float = Field(..., allow_inf_nan=False)
+    calories: float = Field(..., ge=0, allow_inf_nan=False)
+    protein: float = Field(..., ge=0, allow_inf_nan=False)
+    carbs: float = Field(..., ge=0, allow_inf_nan=False)
+    fat: float = Field(..., ge=0, allow_inf_nan=False)
 
 
 class EditMealIngredientsRequest(BaseModel):

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -514,18 +514,18 @@ class EditMealIngredientsRequest(BaseModel):
         )
         if self.nutrition_contract_version not in (None, 2):
             raise ValueError("unsupported nutrition_contract_version")
+        for change in self.food_item_changes:
+            if change.action != "update" and (
+                change.nutrition_override is not None or change.clear_nutrition_override
+            ):
+                raise ValueError("nutrition override requires an owned item update")
         if self.nutrition_contract_version != 2:
             if has_v2_fields or self.override_intent is not None:
                 raise ValueError("v2 fields require nutrition_contract_version=2")
             return self
         if self.nutrition_override is not None:
-            # Older v2 clients sent the absolute meal values but did not yet
-            # serialize the intent marker. The override payload itself is the
-            # explicit user action for this legacy shape.
-            if self.override_intent is None:
-                self.override_intent = "user_entered"
-            elif self.override_intent != "user_entered":
-                raise ValueError("meal override requires override_intent=user_entered")
+            # The absolute override payload is itself the user's intent.
+            self.override_intent = "user_entered"
 
         for change in self.food_item_changes:
             identity_fields = (
@@ -554,12 +554,18 @@ class EditMealIngredientsRequest(BaseModel):
             if not change.id and change.action == "update":
                 raise ValueError("v2 update requires an owned item id")
             if change.nutrition_override is not None:
-                if change.override_intent != "user_entered" or any(
-                    value is not None for value in identity_fields
-                ):
+                change.override_intent = "user_entered"
+                if change.action != "update" or not change.id:
+                    raise ValueError(
+                        "v2 nutrition override requires an owned item update"
+                    )
+                if any(value is not None for value in identity_fields):
                     raise ValueError("item override cannot replace source nutrition")
             elif change.clear_nutrition_override:
-                if change.override_intent != "user_entered" or any(
+                change.override_intent = "user_entered"
+                if change.action != "update" or not change.id:
+                    raise ValueError("v2 clear-override requires an owned item update")
+                if any(
                     value is not None
                     for value in (
                         change.name,

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -514,11 +514,6 @@ class EditMealIngredientsRequest(BaseModel):
         )
         if self.nutrition_contract_version not in (None, 2):
             raise ValueError("unsupported nutrition_contract_version")
-        for change in self.food_item_changes:
-            if change.action == "add" and (
-                change.nutrition_override is not None or change.clear_nutrition_override
-            ):
-                raise ValueError("nutrition override requires an owned item update")
         if self.nutrition_contract_version != 2:
             if has_v2_fields or self.override_intent is not None:
                 raise ValueError("v2 fields require nutrition_contract_version=2")
@@ -528,6 +523,8 @@ class EditMealIngredientsRequest(BaseModel):
             self.override_intent = "user_entered"
 
         for change in self.food_item_changes:
+            if change.nutrition_override is not None or change.clear_nutrition_override:
+                change.override_intent = "user_entered"
             identity_fields = (
                 change.food_reference_id,
                 change.fdc_id,
@@ -542,24 +539,18 @@ class EditMealIngredientsRequest(BaseModel):
 
             if not change.id and change.action == "update":
                 raise ValueError("v2 update requires an owned item id")
-            if change.nutrition_override is not None:
-                change.override_intent = "user_entered"
-                if change.action != "update" or not change.id:
-                    raise ValueError(
-                        "v2 nutrition override requires an owned item update"
-                    )
-                if any(value is not None for value in identity_fields):
-                    raise ValueError("item override cannot replace source nutrition")
-            elif change.clear_nutrition_override:
-                change.override_intent = "user_entered"
-                if change.action != "update" or not change.id:
-                    raise ValueError("v2 clear-override requires an owned item update")
-                if any(value is not None for value in identity_fields):
-                    raise ValueError("item clear cannot replace source nutrition")
-            elif change.action == "add":
+            if change.action == "add":
                 if change.origin is None:
                     raise ValueError("v2 add requires origin")
                 _validate_change_origin(change)
+                continue
+
+            if change.nutrition_override is not None:
+                if any(value is not None for value in identity_fields):
+                    raise ValueError("item override cannot replace source nutrition")
+            elif change.clear_nutrition_override:
+                if any(value is not None for value in identity_fields):
+                    raise ValueError("item clear cannot replace source nutrition")
             elif change.origin is not None:
                 _validate_change_origin(change)
             elif change.origin is None:

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -515,7 +515,7 @@ class EditMealIngredientsRequest(BaseModel):
         if self.nutrition_contract_version not in (None, 2):
             raise ValueError("unsupported nutrition_contract_version")
         for change in self.food_item_changes:
-            if change.action != "update" and (
+            if change.action == "add" and (
                 change.nutrition_override is not None or change.clear_nutrition_override
             ):
                 raise ValueError("nutrition override requires an owned item update")
@@ -536,19 +536,8 @@ class EditMealIngredientsRequest(BaseModel):
                 change.food_id,
             )
             if change.action == "remove":
-                if (
-                    not change.id
-                    or change.name is not None
-                    or change.quantity is not None
-                    or change.unit is not None
-                    or change.custom_nutrition is not None
-                    or change.nutrition_override is not None
-                    or change.clear_nutrition_override
-                    or change.override_intent is not None
-                    or change.allowed_units
-                    or any(value is not None for value in identity_fields)
-                ):
-                    raise ValueError("v2 remove accepts only the owned item id")
+                if not change.id:
+                    raise ValueError("v2 remove requires an owned food item id")
                 continue
 
             if not change.id and change.action == "update":
@@ -565,17 +554,8 @@ class EditMealIngredientsRequest(BaseModel):
                 change.override_intent = "user_entered"
                 if change.action != "update" or not change.id:
                     raise ValueError("v2 clear-override requires an owned item update")
-                if any(
-                    value is not None
-                    for value in (
-                        change.name,
-                        change.quantity,
-                        change.unit,
-                        change.custom_nutrition,
-                        *identity_fields,
-                    )
-                ):
-                    raise ValueError("v2 clear-override accepts only the owned item id")
+                if any(value is not None for value in identity_fields):
+                    raise ValueError("item clear cannot replace source nutrition")
             elif change.action == "add":
                 if change.origin is None:
                     raise ValueError("v2 add requires origin")

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -488,7 +488,6 @@ class EditMealIngredientsRequest(BaseModel):
     override_intent: Optional[Literal["user_entered"]] = Field(None)
     food_item_changes: list[FoodItemChangeRequest] = Field(
         default_factory=list,
-        max_length=50,
         description="List of ingredient changes",
     )
 

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -518,11 +518,14 @@ class EditMealIngredientsRequest(BaseModel):
             if has_v2_fields or self.override_intent is not None:
                 raise ValueError("v2 fields require nutrition_contract_version=2")
             return self
-        if (
-            self.nutrition_override is not None
-            and self.override_intent != "user_entered"
-        ):
-            raise ValueError("meal override requires override_intent=user_entered")
+        if self.nutrition_override is not None:
+            # Older v2 clients sent the absolute meal values but did not yet
+            # serialize the intent marker. The override payload itself is the
+            # explicit user action for this legacy shape.
+            if self.override_intent is None:
+                self.override_intent = "user_entered"
+            elif self.override_intent != "user_entered":
+                raise ValueError("meal override requires override_intent=user_entered")
 
         for change in self.food_item_changes:
             identity_fields = (

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -485,8 +485,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         resolved_items_out=None,
     ):
         """Resolve source changes from backend references before strategies run."""
-        if len(changes) > 50:
-            raise ValueError("meal edits cannot contain more than 50 item changes")
         current_by_id = {item.id: item for item in current_food_items}
         prepared = []
         resolved_items = []

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -81,8 +81,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
                 if meal.status != MealStatus.READY:
                     raise ValidationException("Meal must be in READY status to edit")
-                for change in command.food_item_changes:
-                    self._validate_item_override_action(change)
                 reservation = await self._reserve_v2_write(command, uow)
                 if reservation and reservation.state == "replay":
                     if reservation.target_meal_id != command.meal_id:
@@ -447,13 +445,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 )
             return await self._reserve_v2_write(command, uow)
 
-    @staticmethod
-    def _validate_item_override_action(change):
-        if change.action == "add" and (
-            change.nutrition_override is not None or change.clear_nutrition_override
-        ):
-            raise ValueError("nutrition override requires an owned item update")
-
     async def _release_v2_write(self, reservation):
         async with self.uow_factory() as uow:
             await uow.meal_write_operations.release(reservation)
@@ -500,7 +491,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         prepared = []
         resolved_items = []
         for change in changes:
-            self._validate_item_override_action(change)
             if change.action == "remove":
                 if change.id not in current_by_id:
                     raise ValueError("v2 remove requires an owned food item id")
@@ -512,11 +502,8 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
             ):
                 raise ValueError("v2 update requires an owned food item id")
 
-            if change.nutrition_override is not None or change.clear_nutrition_override:
-                if not change.id:
-                    raise ValueError("nutrition override requires an owned item update")
-                prepared.append(change)
-                continue
+            if change.action == "add" and change.origin is None:
+                raise ValueError("v2 add requires origin")
 
             if change.origin is not None:
                 existing = current_by_id.get(change.id)
@@ -563,8 +550,11 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 )
                 continue
 
-            if change.action == "add":
-                raise ValueError("v2 add requires origin")
+            if change.nutrition_override is not None or change.clear_nutrition_override:
+                if change.action == "update" and not change.id:
+                    raise ValueError("nutrition override requires an owned item update")
+                prepared.append(change)
+                continue
 
             existing = current_by_id[change.id]
             prepared.append(self._canonicalize_snapshot_unit(existing, change))

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -449,7 +449,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
     @staticmethod
     def _validate_item_override_action(change):
-        if change.action != "update" and (
+        if change.action == "add" and (
             change.nutrition_override is not None or change.clear_nutrition_override
         ):
             raise ValueError("nutrition override requires an owned item update")

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -81,15 +81,8 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
                 if meal.status != MealStatus.READY:
                     raise ValidationException("Meal must be in READY status to edit")
-                if command.nutrition_contract_version == 2:
-                    if (
-                        command.nutrition_override
-                        and command.override_intent != "user_entered"
-                    ):
-                        raise ValidationException(
-                            "meal nutrition override requires explicit user intent"
-                        )
-
+                for change in command.food_item_changes:
+                    self._validate_item_override_action(change)
                 reservation = await self._reserve_v2_write(command, uow)
                 if reservation and reservation.state == "replay":
                     if reservation.target_meal_id != command.meal_id:
@@ -442,10 +435,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
             )
         if meal.status != MealStatus.READY:
             raise ValidationException("Meal must be in READY status to edit")
-        if command.nutrition_override and command.override_intent != "user_entered":
-            raise ValidationException(
-                "meal nutrition override requires explicit user intent"
-            )
         return meal
 
     async def _reserve_v2_write_short(self, command):
@@ -457,6 +446,13 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                     limit=100,
                 )
             return await self._reserve_v2_write(command, uow)
+
+    @staticmethod
+    def _validate_item_override_action(change):
+        if change.action != "update" and (
+            change.nutrition_override is not None or change.clear_nutrition_override
+        ):
+            raise ValueError("nutrition override requires an owned item update")
 
     async def _release_v2_write(self, reservation):
         async with self.uow_factory() as uow:
@@ -504,6 +500,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         prepared = []
         resolved_items = []
         for change in changes:
+            self._validate_item_override_action(change)
             if change.action == "remove":
                 if change.id not in current_by_id:
                     raise ValueError("v2 remove requires an owned food item id")
@@ -517,13 +514,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
             if change.nutrition_override is not None or change.clear_nutrition_override:
                 if not change.id:
-                    raise ValueError(
-                        "nutrition override requires an owned food item id"
-                    )
-                if change.override_intent != "user_entered":
-                    raise ValueError(
-                        "food item nutrition override requires explicit user intent"
-                    )
+                    raise ValueError("nutrition override requires an owned item update")
                 prepared.append(change)
                 continue
 

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -529,8 +529,11 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
         ),
     )
 
+    sent = []
+
     class _EditBus:
         async def send(self, msg):
+            sent.append(msg)
             if isinstance(msg, EditMealCommand):
                 return {"success": True}
             return meal
@@ -543,6 +546,12 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
             "dish_name": "Updated Dish",
             "food_item_changes": [],
             "nutrition_contract_version": 2,
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            },
         },
         headers={
             "X-Nutrition-Contract-Version": "2",
@@ -558,6 +567,8 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
     assert body["meal_detail"]["meal_id"] == meal_id
     assert body["meal_detail"]["dish_name"] == "Updated Dish"
     assert body["meal_detail"]["food_items"][0]["name"] == "Salmon"
+    edit_command = next(m for m in sent if isinstance(m, EditMealCommand))
+    assert edit_command.override_intent == "user_entered"
 
 
 def test_meals_streak_smoke(client: TestClient):

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -81,9 +81,7 @@ def test_v2_prepared_source_item_requires_and_keeps_snapshot():
             _v2_create_item(
                 custom_nutrition=nutrition,
                 source_snapshot=snapshot,
-                allowed_units=[
-                    {"unit": "g", "gram_weight": 1, "description": "1 g"}
-                ],
+                allowed_units=[{"unit": "g", "gram_weight": 1, "description": "1 g"}],
             )
         ],
     )
@@ -217,20 +215,70 @@ def test_v2_source_replacement_without_portion_fields_is_still_rejected():
         )
 
 
-def test_v2_item_override_requires_explicit_user_intent():
-    with pytest.raises(ValidationError):
+def test_v2_item_override_defaults_user_intent():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "update",
+                "id": "item-1",
+                "nutrition_override": {
+                    "calories": 500,
+                    "protein": 20,
+                    "carbs": 30,
+                    "fat": 15,
+                },
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].override_intent == "user_entered"
+
+
+def test_v2_clear_item_override_defaults_user_intent():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "update",
+                "id": "item-1",
+                "clear_nutrition_override": True,
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].override_intent == "user_entered"
+
+
+@pytest.mark.parametrize(
+    "nutrition_contract_version",
+    [None, 2],
+)
+@pytest.mark.parametrize(
+    "override_fields",
+    [
+        {
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            }
+        },
+        {"clear_nutrition_override": True},
+    ],
+)
+def test_item_override_actions_reject_non_update(
+    nutrition_contract_version, override_fields
+):
+    with pytest.raises(ValidationError, match="owned item update"):
         EditMealIngredientsRequest(
-            nutrition_contract_version=2,
+            nutrition_contract_version=nutrition_contract_version,
             food_item_changes=[
                 {
-                    "action": "update",
-                    "id": "item-1",
-                    "nutrition_override": {
-                        "calories": 500,
-                        "protein": 20,
-                        "carbs": 30,
-                        "fat": 15,
-                    },
+                    "action": "add",
+                    "id": "client-generated-id",
+                    **override_fields,
                 }
             ],
         )

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -388,16 +388,26 @@ def test_v2_meal_override_without_intent_is_compatible_with_legacy_clients():
     assert request.override_intent == "user_entered"
 
 
-def test_nutrition_override_accepts_user_entered_values_without_range_guards():
+def test_nutrition_override_rejects_negative_values():
+    with pytest.raises(ValidationError):
+        NutritionOverrideRequest(
+            calories=500,
+            protein=-1,
+            carbs=3000,
+            fat=1500,
+        )
+
+
+def test_nutrition_override_accepts_large_nonnegative_values():
     request = NutritionOverrideRequest(
-        calories=-500,
-        protein=-1,
+        calories=100000,
+        protein=5000,
         carbs=3000,
         fat=1500,
     )
 
-    assert request.calories == -500
-    assert request.protein == -1
+    assert request.calories == 100000
+    assert request.protein == 5000
     assert request.carbs == 3000
     assert request.fat == 1500
 

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -129,18 +129,52 @@ def test_v2_create_rejects_missing_version_mismatched_ids_and_missing_custom_dat
         CreateManualMealFromFoodsRequest.model_validate(payload)
 
 
-def test_v2_remove_rejects_nutrition_and_source_fields():
-    with pytest.raises(ValidationError):
-        EditMealIngredientsRequest(
-            nutrition_contract_version=2,
-            food_item_changes=[
-                {
-                    "action": "remove",
-                    "id": "item-1",
-                    "quantity": 100,
-                }
-            ],
-        )
+def test_v2_remove_accepts_extra_edit_fields():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "remove",
+                "id": "item-1",
+                "name": "Ignored name",
+                "quantity": 100,
+                "unit": "g",
+                "nutrition_override": {
+                    "calories": 500,
+                    "protein": 20,
+                    "carbs": 30,
+                    "fat": 15,
+                },
+                "clear_nutrition_override": True,
+                "food_reference_id": 42,
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].id == "item-1"
+
+
+@pytest.mark.parametrize("nutrition_contract_version", [None, 2])
+def test_remove_override_is_accepted_for_legacy_and_v2_clients(
+    nutrition_contract_version,
+):
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=nutrition_contract_version,
+        food_item_changes=[
+            {
+                "action": "remove",
+                "id": "item-1",
+                "nutrition_override": {
+                    "calories": 500,
+                    "protein": 20,
+                    "carbs": 30,
+                    "fat": 15,
+                },
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].id == "item-1"
 
 
 def test_v2_quantity_update_strips_legacy_source_echoes():
@@ -248,6 +282,25 @@ def test_v2_clear_item_override_defaults_user_intent():
     )
 
     assert request.food_item_changes[0].override_intent == "user_entered"
+
+
+def test_v2_clear_item_override_accepts_quantity_edit():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "update",
+                "id": "item-1",
+                "quantity": 200,
+                "unit": "g",
+                "clear_nutrition_override": True,
+            }
+        ],
+    )
+
+    change = request.food_item_changes[0]
+    assert change.quantity == 200
+    assert change.override_intent == "user_entered"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -217,7 +217,7 @@ def test_v2_source_replacement_without_portion_fields_is_still_rejected():
         )
 
 
-def test_v2_override_requires_explicit_user_intent():
+def test_v2_item_override_requires_explicit_user_intent():
     with pytest.raises(ValidationError):
         EditMealIngredientsRequest(
             nutrition_contract_version=2,
@@ -234,6 +234,20 @@ def test_v2_override_requires_explicit_user_intent():
                 }
             ],
         )
+
+
+def test_v2_meal_override_without_intent_is_compatible_with_legacy_clients():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        nutrition_override={
+            "calories": 500,
+            "protein": 20,
+            "carbs": 30,
+            "fat": 15,
+        },
+    )
+
+    assert request.override_intent == "user_entered"
 
 
 def test_nutrition_override_rejects_negative_absolute_values():

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -304,9 +304,36 @@ def test_v2_clear_item_override_accepts_quantity_edit():
 
 
 @pytest.mark.parametrize(
-    "nutrition_contract_version",
-    [None, 2],
+    "override_fields",
+    [
+        {
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            }
+        },
+        {"clear_nutrition_override": True},
+    ],
 )
+def test_legacy_add_accepts_item_override_actions(override_fields):
+    request = EditMealIngredientsRequest(
+        food_item_changes=[
+            {
+                "action": "add",
+                "id": "client-generated-id",
+                "name": "Rau xao",
+                "quantity": 100,
+                "unit": "g",
+                **override_fields,
+            }
+        ]
+    )
+
+    assert request.food_item_changes[0].id == "client-generated-id"
+
+
 @pytest.mark.parametrize(
     "override_fields",
     [
@@ -321,20 +348,30 @@ def test_v2_clear_item_override_accepts_quantity_edit():
         {"clear_nutrition_override": True},
     ],
 )
-def test_item_override_actions_reject_non_update(
-    nutrition_contract_version, override_fields
-):
-    with pytest.raises(ValidationError, match="owned item update"):
-        EditMealIngredientsRequest(
-            nutrition_contract_version=nutrition_contract_version,
-            food_item_changes=[
-                {
-                    "action": "add",
-                    "id": "client-generated-id",
-                    **override_fields,
-                }
-            ],
-        )
+def test_v2_add_accepts_item_override_actions(override_fields):
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "add",
+                "id": "client-generated-id",
+                "origin": "custom",
+                "name": "Rau xao",
+                "quantity": 100,
+                "unit": "g",
+                "custom_nutrition": {
+                    "protein_per_100g": 2,
+                    "carbs_per_100g": 8,
+                    "fat_per_100g": 1,
+                },
+                **override_fields,
+            }
+        ],
+    )
+
+    change = request.food_item_changes[0]
+    assert change.id == "client-generated-id"
+    assert change.override_intent == "user_entered"
 
 
 def test_v2_meal_override_without_intent_is_compatible_with_legacy_clients():

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -388,14 +388,18 @@ def test_v2_meal_override_without_intent_is_compatible_with_legacy_clients():
     assert request.override_intent == "user_entered"
 
 
-def test_nutrition_override_rejects_negative_absolute_values():
-    with pytest.raises(ValidationError):
-        NutritionOverrideRequest(
-            calories=500,
-            protein=-1,
-            carbs=30,
-            fat=15,
-        )
+def test_nutrition_override_accepts_user_entered_values_without_range_guards():
+    request = NutritionOverrideRequest(
+        calories=-500,
+        protein=-1,
+        carbs=3000,
+        fat=1500,
+    )
+
+    assert request.calories == -500
+    assert request.protein == -1
+    assert request.carbs == 3000
+    assert request.fat == 1500
 
 
 def test_nutrition_override_accepts_absolute_calories_above_density_bound():

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -204,12 +204,11 @@ class TestCustomNutritionRequest:
         assert request.carbs_per_100g == 25.0
         assert request.fat_per_100g == 8.0
 
-    def test_negative_protein_is_user_editable(self):
-        request = CustomNutritionRequest(
-            protein_per_100g=-5.0, carbs_per_100g=25.0, fat_per_100g=8.0
-        )
-
-        assert request.protein_per_100g == -5.0
+    def test_negative_protein_is_rejected(self):
+        with pytest.raises(ValidationError):
+            CustomNutritionRequest(
+                protein_per_100g=-5.0, carbs_per_100g=25.0, fat_per_100g=8.0
+            )
 
     def test_protein_above_density_limit_is_user_editable(self):
         request = CustomNutritionRequest(

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -444,6 +444,15 @@ class TestEditMealIngredientsRequest:
         with pytest.raises(ValidationError):
             EditMealIngredientsRequest()
 
+    def test_accepts_more_than_fifty_item_changes(self):
+        request = EditMealIngredientsRequest(
+            food_item_changes=[
+                {"action": "remove", "id": str(index)} for index in range(51)
+            ]
+        )
+
+        assert len(request.food_item_changes) == 51
+
     def test_dish_name_too_long(self):
         """Test dish name too long validation."""
         # Arrange & Act & Assert

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -204,23 +204,21 @@ class TestCustomNutritionRequest:
         assert request.carbs_per_100g == 25.0
         assert request.fat_per_100g == 8.0
 
-    def test_negative_protein(self):
-        """Test negative protein validation."""
-        # Arrange & Act & Assert
-        with pytest.raises(ValidationError):
-            CustomNutritionRequest(
-                protein_per_100g=-5.0, carbs_per_100g=25.0, fat_per_100g=8.0
-            )
+    def test_negative_protein_is_user_editable(self):
+        request = CustomNutritionRequest(
+            protein_per_100g=-5.0, carbs_per_100g=25.0, fat_per_100g=8.0
+        )
 
-    def test_protein_too_high(self):
-        """Test protein too high validation."""
-        # Arrange & Act & Assert
-        with pytest.raises(ValidationError):
-            CustomNutritionRequest(
-                protein_per_100g=150.0,  # Over 100 limit
-                carbs_per_100g=25.0,
-                fat_per_100g=8.0,
-            )
+        assert request.protein_per_100g == -5.0
+
+    def test_protein_above_density_limit_is_user_editable(self):
+        request = CustomNutritionRequest(
+            protein_per_100g=150.0,
+            carbs_per_100g=25.0,
+            fat_per_100g=8.0,
+        )
+
+        assert request.protein_per_100g == 150.0
 
 
 @pytest.mark.unit

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -242,10 +242,27 @@ async def test_v2_item_override_does_not_require_intent_in_handler():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("clear_override", [False, True])
-async def test_v2_item_override_rejects_add_action_in_handler(clear_override):
+async def test_v2_item_override_allows_add_action_in_handler(clear_override):
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
     change = FoodItemChange(
         action="add",
         id="client-generated-id",
+        name="Rau xao",
+        quantity=100,
+        unit="g",
+        origin="custom",
+        custom_nutrition=CustomNutritionData(
+            calories_per_100g=51,
+            protein_per_100g=2,
+            carbs_per_100g=8,
+            fat_per_100g=1,
+        ),
         clear_nutrition_override=clear_override,
         nutrition_override=(
             None
@@ -253,10 +270,21 @@ async def test_v2_item_override_rejects_add_action_in_handler(clear_override):
             else NutritionOverride(calories=500, protein=20, carbs=30, fat=15)
         ),
     )
-    handler = EditMealCommandHandler(uow=None)
+    handler = EditMealCommandHandler(
+        uow=None,
+        nutrition_resolver=_PassthroughResolver(),
+    )
 
-    with pytest.raises(ValueError, match="owned item update"):
-        handler._validate_item_override_action(change)
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+    added = next(item for item in updated if item.name == "Rau xao")
+
+    if clear_override:
+        assert added.nutrition_override is None
+    else:
+        assert added.nutrition_override.calories == 500
 
 
 @pytest.mark.asyncio
@@ -272,9 +300,7 @@ async def test_v2_item_override_allows_remove_action_in_handler(clear_override):
             else NutritionOverride(calories=500, protein=20, carbs=30, fat=15)
         ),
     )
-    handler = EditMealCommandHandler(uow=None)
-
-    handler._validate_item_override_action(change)
+    assert change.action == "remove"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -4,10 +4,15 @@ from types import SimpleNamespace
 import pytest
 
 from src.app.commands.meal import FoodItemChange
+from src.app.commands.meal.edit_meal_command import EditMealCommand
 from src.app.handlers.command_handlers.edit_meal_command_handler import (
     EditMealCommandHandler,
 )
-from src.domain.model.meal.food_item_change import CustomNutritionData
+from src.domain.model.meal.food_item_change import (
+    CustomNutritionData,
+    NutritionOverride,
+)
+from src.domain.model.meal.meal import MealStatus
 from src.domain.model.nutrition import FoodItem, Macros
 
 
@@ -205,3 +210,89 @@ async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy()
     assert updated[0].quantity == pytest.approx(100)
     assert updated[0].unit == "g"
     assert updated[0].macros.protein == pytest.approx(2.7)
+
+
+@pytest.mark.asyncio
+async def test_v2_item_override_does_not_require_intent_in_handler():
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="update",
+        id="item-1",
+        nutrition_override=NutritionOverride(
+            calories=500,
+            protein=20,
+            carbs=30,
+            fat=15,
+        ),
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+
+    assert prepared[0].nutrition_override.calories == 500
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("clear_override", [False, True])
+async def test_v2_item_override_rejects_add_action_in_handler(clear_override):
+    change = FoodItemChange(
+        action="add",
+        id="client-generated-id",
+        clear_nutrition_override=clear_override,
+        nutrition_override=(
+            None
+            if clear_override
+            else NutritionOverride(calories=500, protein=20, carbs=30, fat=15)
+        ),
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    with pytest.raises(ValueError, match="owned item update"):
+        handler._validate_item_override_action(change)
+
+
+@pytest.mark.asyncio
+async def test_v2_meal_override_does_not_require_intent_in_preflight():
+    class _Meals:
+        async def find_by_id(self, meal_id, projection=None):
+            return SimpleNamespace(
+                meal_id=meal_id,
+                user_id="user-1",
+                status=MealStatus.READY,
+                nutrition=SimpleNamespace(),
+            )
+
+    class _UowContext:
+        async def __aenter__(self):
+            return SimpleNamespace(meals=_Meals())
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    handler = EditMealCommandHandler(
+        uow=None,
+        uow_factory=lambda: _UowContext(),
+    )
+    command = EditMealCommand(
+        meal_id="meal-1",
+        user_id="user-1",
+        nutrition_contract_version=2,
+        nutrition_override=NutritionOverride(
+            calories=500,
+            protein=20,
+            carbs=30,
+            fat=15,
+        ),
+    )
+
+    meal = await handler._preflight_v2_meal(command)
+
+    assert meal.meal_id == "meal-1"

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -260,6 +260,58 @@ async def test_v2_item_override_rejects_add_action_in_handler(clear_override):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("clear_override", [False, True])
+async def test_v2_item_override_allows_remove_action_in_handler(clear_override):
+    change = FoodItemChange(
+        action="remove",
+        id="item-1",
+        clear_nutrition_override=clear_override,
+        nutrition_override=(
+            None
+            if clear_override
+            else NutritionOverride(calories=500, protein=20, carbs=30, fat=15)
+        ),
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    handler._validate_item_override_action(change)
+
+
+@pytest.mark.asyncio
+async def test_v2_remove_ignores_extra_override_fields_when_applying():
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="remove",
+        id="item-1",
+        quantity=200,
+        nutrition_override=NutritionOverride(
+            calories=500,
+            protein=20,
+            carbs=30,
+            fat=15,
+        ),
+    )
+    handler = EditMealCommandHandler(
+        uow=None,
+        nutrition_resolver=_PassthroughResolver(),
+    )
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+
+    assert prepared == [change]
+    assert updated == []
+
+
+@pytest.mark.asyncio
 async def test_v2_meal_override_does_not_require_intent_in_preflight():
     class _Meals:
         async def find_by_id(self, meal_id, projection=None):


### PR DESCRIPTION
Root cause: the backend treated the redundant override_intent marker as a gate, so clients sending the actual nutrition_override payload could still receive a validation error.\n\nFix:\n- infer override_intent=user_entered whenever a v2 meal/item override payload is present\n- allow add, update, and remove actions to carry override metadata without a separate intent marker\n- allow add + nutrition_override after resolving the v2 source/custom origin\n- allow user-entered nutrition values without density or upper-bound business checks\n- reject negative and non-finite nutrition values\n- remove the per-request item-change count cap for meal edits\n- remove uses the owned item id; extra edit fields do not change the removal operation\n- keep meal/item ownership and structural action validation\n\nValidation: 75 targeted contract/handler/request tests, 2590 unit tests, 79.92% coverage, compileall, targeted ruff format/check, and git diff --check.\n\nNote: full live deployment/production verification is not included.