### PR TITLE
fix(barcode): reject nameless provider results

### DIFF
--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -32,13 +32,15 @@ def _gs1_prefix_hint(barcode: str) -> str:
 
 
 @handles(LookupBarcodeQuery)
-class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] | None]):
+class LookupBarcodeQueryHandler(
+    EventHandler[LookupBarcodeQuery, dict[str, Any] | None]
+):
     """Handler for looking up product by barcode with fallback providers."""
 
     def __init__(
         self,
         open_food_facts_service: OpenFoodFactsService,
-        fat_secret_service: FatSecretService,
+        fat_secret_service: FatSecretService | None,
         food_reference_repository: Any | None = None,
         async_uow_factory: Any | None = None,
         translation_service: Any | None = None,
@@ -85,7 +87,11 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         partial_name: str | None = None
 
         cached = await self._get_cached_product(aliases)
-        if cached and self._has_nutrition(cached) and self._is_trusted_cached_row(cached):
+        if (
+            cached
+            and self._has_nutrition(cached)
+            and self._is_trusted_cached_row(cached)
+        ):
             provider_source = cached.get("source")
             cached["provider_source"] = provider_source
             cached["source"] = "cache"
@@ -113,21 +119,29 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         # A global barcode row must always be acquired in canonical English.
         # Request-locale provider output cannot safely be persisted globally.
         region = "US"
-        fat_secret_result = await self._first_barcode_hit(
-            aliases,
-            lambda alias: self.fat_secret.get_product(
-                alias,
-                region=region,
-                language="en",
-            ),
-        )
-        if fat_secret_result and self._has_nutrition(fat_secret_result) and self._has_name(fat_secret_result):
+        fat_secret_result = None
+        if self.fat_secret is not None:
+            fat_secret_result = await self._first_barcode_hit(
+                aliases,
+                lambda alias: self.fat_secret.get_product(
+                    alias,
+                    region=region,
+                    language="en",
+                ),
+            )
+        if (
+            fat_secret_result
+            and self._has_nutrition(fat_secret_result)
+            and self._has_name(fat_secret_result)
+        ):
             result = self._trusted_provider_result(
                 fat_secret_result, query.barcode, scanned_barcode, "fatsecret"
             )
             await self._cache_result(result, cache_barcode=query.barcode)
             log_hit("fatsecret", result)
-            return await self._maybe_translate(result, query.language, source_language="en")
+            return await self._maybe_translate(
+                result, query.language, source_language="en"
+            )
         if fat_secret_result:
             partial_name = partial_name or fat_secret_result.get("name")
             miss_reasons.append(
@@ -136,10 +150,18 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
                 else "fatsecret_partial_no_name"
             )
         else:
-            miss_reasons.append("fatsecret_empty")
+            miss_reasons.append(
+                "fatsecret_empty"
+                if self.fat_secret is not None
+                else "fatsecret_not_configured"
+            )
 
         off_result = await self._first_barcode_hit(aliases, self.off.get_product)
-        if off_result and self._has_nutrition(off_result) and self._has_name(off_result):
+        if (
+            off_result
+            and self._has_nutrition(off_result)
+            and self._has_name(off_result)
+        ):
             off_result = dict(off_result)
             source_language = off_result.pop("source_language", None)
             result = self._trusted_provider_result(
@@ -160,8 +182,14 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         else:
             miss_reasons.append("openfoodfacts_empty")
 
-        fdc_result = await self._get_fdc_product(aliases, query.barcode, scanned_barcode)
-        if fdc_result and self._has_nutrition(fdc_result) and self._has_name(fdc_result):
+        fdc_result = await self._get_fdc_product(
+            aliases, query.barcode, scanned_barcode
+        )
+        if (
+            fdc_result
+            and self._has_nutrition(fdc_result)
+            and self._has_name(fdc_result)
+        ):
             await self._cache_result(fdc_result, cache_barcode=query.barcode)
             log_hit("usda_fdc", fdc_result)
             return await self._maybe_translate(
@@ -201,13 +229,17 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
                 return estimate
 
         if brave_result and self._has_nutrition(brave_result):
-            estimate = self._estimate_result(brave_result, scanned_barcode, "brave_search")
+            estimate = self._estimate_result(
+                brave_result, scanned_barcode, "brave_search"
+            )
             log_hit("brave_search", estimate)
             return estimate
         if self.brave_search and not brave_result:
             miss_reasons.append("brave_empty")
 
-        estimate = await self._ai_estimate(scanned_barcode, query.language, partial_name)
+        estimate = await self._ai_estimate(
+            scanned_barcode, query.language, partial_name
+        )
         if estimate:
             log_hit("ai_estimate", estimate)
             return estimate
@@ -240,7 +272,10 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
 
     @staticmethod
     def _is_trusted_cached_row(result: dict[str, Any]) -> bool:
-        return bool(result.get("is_verified")) or result.get("source") in TRUSTED_CACHE_SOURCES
+        return (
+            bool(result.get("is_verified"))
+            or result.get("source") in TRUSTED_CACHE_SOURCES
+        )
 
     async def _first_barcode_hit(self, aliases, fetch):
         for alias in aliases:
@@ -278,6 +313,8 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         scanned_barcode: str,
         barcode_ref: str,
     ) -> dict[str, Any] | None:
+        if self.fat_secret is None:
+            return None
         try:
             fs_results = await self.fat_secret.search_foods(
                 brave_name,
@@ -296,7 +333,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         for item in fs_results or []:
             if self._has_nutrition(item):
                 item["name"] = brave_name or item.get("name")
-                return self._estimate_result(item, scanned_barcode, "fatsecret_name_search")
+                return self._estimate_result(
+                    item, scanned_barcode, "fatsecret_name_search"
+                )
         return None
 
     def _trusted_provider_result(
@@ -403,7 +442,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
             return localized
         return result
 
-    async def _get_cached_product(self, aliases: tuple[str, ...]) -> dict[str, Any] | None:
+    async def _get_cached_product(
+        self, aliases: tuple[str, ...]
+    ) -> dict[str, Any] | None:
         candidates: list[dict[str, Any]] = []
         for barcode in aliases:
             cached = await self._get_cached_product_by_barcode(barcode)

--- a/src/domain/services/meal_suggestion/ingredient_nutrition_resolver.py
+++ b/src/domain/services/meal_suggestion/ingredient_nutrition_resolver.py
@@ -51,6 +51,10 @@ class IngredientNutritionResolver:
         Returns None if fatsecret returns no results, hits rate limits,
         or raises any network exception.
         """
+        if self._fs is None:
+            logger.debug("fatsecret provider unavailable for ingredient '%s'", name)
+            return None
+
         try:
             results: List[Dict[str, Any]] = await self._fs.search_foods(
                 query=name, max_results=5

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -271,7 +271,9 @@ class FatSecretService:
             error = result.get("error")
             if error:
                 error_code = (
-                    error.get("code") if isinstance(error, dict) else type(error).__name__
+                    error.get("code")
+                    if isinstance(error, dict)
+                    else type(error).__name__
                 )
                 logger.warning(
                     "fatsecret API error response received: code=%s", error_code
@@ -535,22 +537,18 @@ class FatSecretService:
 _fat_secret_service: FatSecretService | None = None
 
 
-def get_fat_secret_service() -> FatSecretService:
-    """Get singleton instance of FatSecretService."""
+def get_fat_secret_service() -> FatSecretService | None:
+    """Get the optional FatSecret service when credentials are configured."""
     global _fat_secret_service
     if _fat_secret_service is None:
-        # Use OAuth 2.0 credentials if available, otherwise fall back to OAuth 1.0
         client_id = settings.FATSECRET_CLIENT_ID
         client_secret = settings.FATSECRET_CLIENT_SECRET
 
         if not client_id or not client_secret:
-            # Fall back to OAuth 1.0 (legacy)
             logger.warning(
-                "fatsecret OAuth 2.0 credentials not configured, OAuth 1.0 not supported"
+                "fatsecret credentials not configured; provider will be skipped"
             )
-            raise ValueError(
-                "FATSECRET_CLIENT_ID and FATSECRET_CLIENT_SECRET must be set for OAuth 2.0"
-            )
+            return None
 
         _fat_secret_service = FatSecretService(
             client_id=client_id,

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -535,23 +535,26 @@ class FatSecretService:
 
 
 _fat_secret_service: FatSecretService | None = None
+_fat_secret_service_initialized = False
 
 
 def get_fat_secret_service() -> FatSecretService | None:
     """Get the optional FatSecret service when credentials are configured."""
-    global _fat_secret_service
-    if _fat_secret_service is None:
-        client_id = settings.FATSECRET_CLIENT_ID
-        client_secret = settings.FATSECRET_CLIENT_SECRET
+    global _fat_secret_service, _fat_secret_service_initialized
+    if _fat_secret_service_initialized:
+        return _fat_secret_service
 
-        if not client_id or not client_secret:
-            logger.warning(
-                "fatsecret credentials not configured; provider will be skipped"
-            )
-            return None
+    client_id = settings.FATSECRET_CLIENT_ID
+    client_secret = settings.FATSECRET_CLIENT_SECRET
 
-        _fat_secret_service = FatSecretService(
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+    if not client_id or not client_secret:
+        logger.warning("fatsecret credentials not configured; provider will be skipped")
+        _fat_secret_service_initialized = True
+        return None
+
+    _fat_secret_service = FatSecretService(
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    _fat_secret_service_initialized = True
     return _fat_secret_service

--- a/tests/unit/domain/services/meal_suggestion/test_ingredient_nutrition_resolver.py
+++ b/tests/unit/domain/services/meal_suggestion/test_ingredient_nutrition_resolver.py
@@ -77,6 +77,16 @@ def resolver(mock_fatsecret, mock_repo):
 
 
 @pytest.mark.asyncio
+async def test_resolve_returns_none_when_fatsecret_is_unavailable(mock_repo):
+    resolver = IngredientNutritionResolver(fatsecret=None, food_ref_repo=mock_repo)
+
+    result = await resolver.resolve("chicken breast")
+
+    assert result is None
+    mock_repo.upsert_by_normalized_name.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_resolve_chicken_breast_returns_macros(
     resolver, mock_fatsecret, mock_repo
 ):

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
@@ -197,6 +197,29 @@ async def test_lookup_barcode_uses_openfoodfacts_when_fatsecret_is_unavailable()
 
 
 @pytest.mark.asyncio
+async def test_lookup_barcode_rejects_openfoodfacts_result_without_name():
+    repo = _FoodReferenceRepo()
+    off = AsyncMock()
+    off.get_product.return_value = {
+        "name": None,
+        "barcode": "0036000291452",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=None,
+        open_food_facts_service=off,
+    )
+
+    result = await handler.handle(_query())
+
+    assert result is None
+    assert repo.upserts == []
+
+
+@pytest.mark.asyncio
 async def test_cached_barcode_without_source_provenance_stays_canonical():
     repo = _FoodReferenceRepo(
         {

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
@@ -172,6 +172,31 @@ async def test_non_english_openfoodfacts_english_name_is_localized_without_persi
 
 
 @pytest.mark.asyncio
+async def test_lookup_barcode_uses_openfoodfacts_when_fatsecret_is_unavailable():
+    repo = _FoodReferenceRepo()
+    fat_secret = None
+    off = AsyncMock()
+    off.get_product.return_value = {
+        "name": "Brown Rice",
+        "barcode": "0036000291452",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+    )
+
+    result = await handler.handle(_query())
+
+    assert result is not None
+    assert result["source"] == "openfoodfacts"
+    assert result["name"] == "Brown Rice"
+
+
+@pytest.mark.asyncio
 async def test_cached_barcode_without_source_provenance_stays_canonical():
     repo = _FoodReferenceRepo(
         {

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -28,10 +28,17 @@ class _Client:
 @pytest.mark.unit
 def test_fatsecret_provider_is_optional_when_credentials_are_missing(monkeypatch):
     monkeypatch.setattr(fat_secret_module, "_fat_secret_service", None)
+    monkeypatch.setattr(fat_secret_module, "_fat_secret_service_initialized", False)
     monkeypatch.setattr(fat_secret_module.settings, "FATSECRET_CLIENT_ID", None)
     monkeypatch.setattr(fat_secret_module.settings, "FATSECRET_CLIENT_SECRET", None)
+    warning = Mock()
+    monkeypatch.setattr(fat_secret_module.logger, "warning", warning)
 
     assert fat_secret_module.get_fat_secret_service() is None
+    assert fat_secret_module.get_fat_secret_service() is None
+    warning.assert_called_once_with(
+        "fatsecret credentials not configured; provider will be skipped"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import src.infra.adapters.fat_secret_service as fat_secret_module
 from src.infra.adapters.fat_secret_service import FatSecretService
 
 
@@ -22,6 +23,15 @@ class _Client:
     async def post(self, *args, **kwargs):
         self.post_calls.append((args, kwargs))
         return _Response()
+
+
+@pytest.mark.unit
+def test_fatsecret_provider_is_optional_when_credentials_are_missing(monkeypatch):
+    monkeypatch.setattr(fat_secret_module, "_fat_secret_service", None)
+    monkeypatch.setattr(fat_secret_module.settings, "FATSECRET_CLIENT_ID", None)
+    monkeypatch.setattr(fat_secret_module.settings, "FATSECRET_CLIENT_SECRET", None)
+
+    assert fat_secret_module.get_fat_secret_service() is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Prevent barcode lookups from returning provider payloads without the required product name.
- Continue the provider cascade instead of allowing `BarcodeProductResponse` validation to raise a 500.
- Add regression coverage for nameless OpenFoodFacts results.
- Treat missing FatSecret credentials as a non-fatal optional-provider condition as defensive hardening.

## Production Evidence
Sentry issue `PYTHON-ES` recorded production barcode failures where FatSecret returned HTTP 200, OpenFoodFacts returned HTTP 200, and the handler returned an OpenFoodFacts payload with `name=None`. The route then raised `BarcodeProductResponse` validation error. The last recorded occurrence was 2026-08-10, before the current delivery branch's nameless-result guard.

## Linked Issues
- No linked GitHub issues.
- Related production issue: [PYTHON-ES](https://nutree-ai.sentry.io/issues/PYTHON-ES)

## Pre-Landing Review
No critical findings. The review confirmed the provider guards and identified no production-blocking defects.

## Test Results
- [x] Focused barcode and route tests — 28 passed
- [x] Full push-hook unit suite — 2598 passed, 43 warnings
- [x] Changed-scope mypy passed before the test-only follow-up commit

## Changes
- 6 files changed, 142 insertions(+), 31 deletions(-)

## Ship Mode
- Mode: official
- Target: main

## Release Gate
- Deploy the merged revision and run an authenticated barcode endpoint smoke test in the target environment.
- Verify a barcode whose provider response has no name returns a controlled fallback/404, never a 500.
- Physical mobile scanner/device behavior was not tested in this backend checkout.
