### PR TITLE
fix(capabilities): enable barcode meal writes

### DIFF
--- a/src/api/routes/v1/capabilities.py
+++ b/src/api/routes/v1/capabilities.py
@@ -9,6 +9,7 @@ from src.infra.services.durable_write_service import (
 
 router = APIRouter(prefix="/v1/capabilities", tags=["capabilities"])
 
+
 @router.get("/durable-writes")
 async def durable_write_capabilities() -> dict[str, object]:
     """Advertise v2 writes only when their durable storage is migrated."""
@@ -34,6 +35,11 @@ async def durable_write_capabilities() -> dict[str, object]:
         "retention_days": RETENTION_DAYS,
         "actions": {
             "manual_meal_create": {
+                "supported": True,
+                "header": "Idempotency-Key",
+                "exact_replay": True,
+            },
+            "barcode_meal_create": {
                 "supported": True,
                 "header": "Idempotency-Key",
                 "exact_replay": True,

--- a/tests/unit/api/test_capabilities_durable_writes.py
+++ b/tests/unit/api/test_capabilities_durable_writes.py
@@ -18,6 +18,9 @@ async def test_durable_write_capabilities_advertise_legacy_and_v2_contracts():
     assert body["retention_days"] == 14
     assert body["actions"]["manual_meal_create"]["supported"] is True
     assert body["actions"]["manual_meal_create"]["header"] == "Idempotency-Key"
+    assert body["actions"]["barcode_meal_create"]["supported"] is True
+    assert body["actions"]["barcode_meal_create"]["header"] == "Idempotency-Key"
+    assert body["actions"]["barcode_meal_create"]["exact_replay"] is True
     assert body["actions"]["weight_sync"]["supported"] is False
     assert body["actions"]["weight_sync"]["reason"] == "client_entry_id_mapping_pending"
     assert body["durable_writes"] is True


### PR DESCRIPTION
## Summary
- advertise the `barcode_meal_create` capability used by the mobile barcode flow
- preserve the existing `create_manual_meal` operation contract
- add regression assertions for the capability shape

## Root cause
The mobile client checks `actions.barcode_meal_create.supported` before calling `/foods/barcode/{barcode}`. Production and staging returned the durable-write capability response without that action, so the client immediately showed the generic failure card and never reached FatSecret or the barcode lookup handler.

## Validation
- `.venv/bin/pytest -q tests/unit/api/test_capabilities_durable_writes.py`
- `.venv/bin/pytest -q tests/unit/api` (505 passed)
- pre-push full unit suite: 2598 passed
- Ruff format/check, compileall, and mypy passed

No mobile changes are required; the existing mobile guard is intentional and will proceed once the backend advertises the capability.