### PR TITLE
feat(meals): cache user scans so repeats return the same meal

### DIFF
--- a/migrations/versions/20260820000001_add_meal_user_image_scan_index.py
+++ b/migrations/versions/20260820000001_add_meal_user_image_scan_index.py
@@ -1,0 +1,28 @@
+"""Add index for user meal scan cache lookups by image_id.
+
+Revision ID: 20260820000001
+Revises: 20260819000001
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260820000001"
+down_revision: str | None = "20260819000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_meal_user_image_source",
+        "meal",
+        ["user_id", "image_id", "source"],
+        postgresql_where=sa.text("image_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_meal_user_image_source", table_name="meal")

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -532,6 +532,7 @@ def get_configured_event_bus() -> EventBus:
         DeleteMealCommandHandler(
             uow=AsyncUnitOfWork(),
             cache_invalidation=cache_invalidation_service,
+            cache=cache_service,
         ),
     )
 

--- a/src/app/handlers/command_handlers/delete_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/delete_meal_command_handler.py
@@ -13,7 +13,9 @@ from src.api.exceptions import AuthorizationException
 from src.app.commands.meal import DeleteMealCommand
 from src.app.events.base import EventHandler, handles
 from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.app.services.meal_scan_cache_service import MealScanCacheService
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
+from src.domain.ports.cache_port import CachePort
 from src.domain.utils.timezone_utils import utc_now
 
 logger = logging.getLogger(__name__)
@@ -27,13 +29,18 @@ class DeleteMealCommandHandler(EventHandler[DeleteMealCommand, dict[str, Any]]):
         self,
         uow: AsyncUnitOfWorkPort,
         cache_invalidation: CacheInvalidationService | None = None,
+        meal_scan_cache: MealScanCacheService | None = None,
+        cache: CachePort | None = None,
     ):
         self.uow = uow
         self.cache_invalidation = cache_invalidation
+        self.meal_scan_cache = meal_scan_cache or MealScanCacheService(uow, cache)
 
     async def handle(self, command: DeleteMealCommand) -> dict[str, Any]:
         """Handle meal deletion with data preservation."""
         deleted_kind = "meal"
+        scan_image_id: str | None = None
+        scan_source: str | None = None
         async with self.uow as uow:
             meal = await uow.meals.find_by_id(command.meal_id)
             if meal is not None:
@@ -41,6 +48,8 @@ class DeleteMealCommandHandler(EventHandler[DeleteMealCommand, dict[str, Any]]):
                     raise AuthorizationException(
                         "You do not have permission to delete this meal"
                     )
+                scan_image_id = meal.image.image_id if meal.image else None
+                scan_source = meal.source
                 # Recommended-meal logs set meal_recommendations.logged_meal_id
                 # with ON DELETE SET NULL. Clearing only the FK leaves logged_at
                 # set and violates ck_meal_recommendations_logged_coherent.
@@ -78,7 +87,16 @@ class DeleteMealCommandHandler(EventHandler[DeleteMealCommand, dict[str, Any]]):
                     command.user_id, log_date
                 )
             else:
-                await self.cache_invalidation.after_meal_write(command.user_id, log_date)
+                await self.cache_invalidation.after_meal_write(
+                    command.user_id, log_date
+                )
+
+        if deleted_kind == "meal":
+            await self.meal_scan_cache.invalidate(
+                user_id=command.user_id,
+                image_id=scan_image_id,
+                source=scan_source,
+            )
 
         return {
             "meal_id": command.meal_id,

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -14,6 +14,11 @@ from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.meal_analyze_workflow import MealAnalyzeWorkflow
+from src.app.services.meal_scan_cache_service import (
+    MealScanCacheService,
+    mark_scan_cache_hit,
+    scan_source_for_mode,
+)
 from src.domain.constants import MealDefaults
 from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal.meal_response_localization import (
@@ -65,6 +70,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         meal_value_insight_ai_manager: MealInsightAIPort | None = None,
         meal_analyze_workflow: MealAnalyzeWorkflow | None = None,
         meal_analyze_graph_enabled: bool = False,
+        meal_scan_cache: MealScanCacheService | None = None,
     ):
         self.uow = uow
         self.event_bus = event_bus
@@ -77,6 +83,9 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         self.meal_value_insight_ai_manager = meal_value_insight_ai_manager
         self.meal_analyze_workflow = meal_analyze_workflow
         self.meal_analyze_graph_enabled = meal_analyze_graph_enabled
+        self.meal_scan_cache = meal_scan_cache or MealScanCacheService(
+            uow, meal_value_insight_cache
+        )
 
     def _record_food_label_metric(
         self,
@@ -383,13 +392,43 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         except Exception:
             raise
 
+    async def _try_cached_scan(self, command: ScanByUrlCommand) -> Meal | None:
+        # User description changes analysis intent — do not reuse prior results.
+        if command.user_description:
+            return None
+        image_id = command.public_id.split("/")[-1]
+        source = scan_source_for_mode(command.scan_mode)
+        meal = await self.meal_scan_cache.get_by_image_id(
+            user_id=command.user_id,
+            image_id=image_id,
+            source=source,
+        )
+        if meal is None:
+            return None
+        return mark_scan_cache_hit(meal)
+
+    async def _remember_scan(self, command: ScanByUrlCommand, meal: Meal) -> None:
+        if meal.status != MealStatus.READY or meal.nutrition is None:
+            return
+        image_id = command.public_id.split("/")[-1]
+        await self.meal_scan_cache.remember_image_scan(
+            user_id=command.user_id,
+            image_id=image_id,
+            source=scan_source_for_mode(command.scan_mode),
+            meal_id=meal.meal_id,
+        )
+
     async def handle(self, command: ScanByUrlCommand) -> Meal:
         if not all([self.vision_service, self.gpt_parser]):
             raise RuntimeError("Required dependencies not configured")
 
+        cached = await self._try_cached_scan(command)
+        if cached is not None:
+            return cached
+
         if self.meal_analyze_graph_enabled:
             workflow = self.meal_analyze_workflow or MealAnalyzeWorkflow()
-            return await workflow.run_scan_by_url(
+            meal = await workflow.run_scan_by_url(
                 command,
                 self._handle_legacy_scan_by_url,
                 runtime=MealAnalyzeRuntime(
@@ -407,5 +446,8 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                     meal_translation_service=self.meal_translation_service,
                 ),
             )
+        else:
+            meal = await self._handle_legacy_scan_by_url(command)
 
-        return await self._handle_legacy_scan_by_url(command)
+        await self._remember_scan(command, meal)
+        return meal

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -13,6 +13,12 @@ from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.meal_analyze_workflow import MealAnalyzeWorkflow
+from src.app.services.meal_scan_cache_service import (
+    MealScanCacheService,
+    content_fingerprint,
+    mark_scan_cache_hit,
+    scan_source_for_mode,
+)
 from src.domain.exceptions.ai_exceptions import (
     AIVisionError,
     AIVisionFailureKind,
@@ -71,6 +77,7 @@ class UploadMealImageImmediatelyHandler(
         meal_value_insight_ai_manager: MealInsightAIPort | None = None,
         meal_analyze_workflow: MealAnalyzeWorkflow | None = None,
         meal_analyze_graph_enabled: bool = False,
+        meal_scan_cache: MealScanCacheService | None = None,
     ):
         self.uow = uow
         self.event_bus = event_bus
@@ -84,6 +91,9 @@ class UploadMealImageImmediatelyHandler(
         self.meal_value_insight_ai_manager = meal_value_insight_ai_manager
         self.meal_analyze_workflow = meal_analyze_workflow
         self.meal_analyze_graph_enabled = meal_analyze_graph_enabled
+        self.meal_scan_cache = meal_scan_cache or MealScanCacheService(
+            uow, meal_value_insight_cache
+        )
         if fast_path_policy is None:
             self._fast_path_policy = MealAnalyzeFastPathPolicy.from_settings(
                 get_settings()
@@ -174,8 +184,13 @@ class UploadMealImageImmediatelyHandler(
         """Reject incomplete same-call locale output before meal persistence."""
         if language == "en" or not isinstance(result, dict):
             return
-        structured_data = result.get("structured_data") if isinstance(result, dict) else None
-        if isinstance(structured_data, dict) and structured_data.get("is_food") is False:
+        structured_data = (
+            result.get("structured_data") if isinstance(result, dict) else None
+        )
+        if (
+            isinstance(structured_data, dict)
+            and structured_data.get("is_food") is False
+        ):
             return
         parse_meal_response_localization(
             structured_data,
@@ -375,6 +390,42 @@ class UploadMealImageImmediatelyHandler(
 
         return saved_meal
 
+    async def _try_cached_upload(
+        self, command: UploadMealImageImmediatelyCommand
+    ) -> Meal | None:
+        if command.user_description:
+            return None
+        fingerprint = content_fingerprint(command.file_contents)
+        meal = await self.meal_scan_cache.get_by_content_fingerprint(
+            user_id=command.user_id,
+            fingerprint=fingerprint,
+            source=scan_source_for_mode(command.scan_mode),
+        )
+        if meal is None:
+            return None
+        return mark_scan_cache_hit(meal)
+
+    async def _remember_upload(
+        self, command: UploadMealImageImmediatelyCommand, meal: Meal
+    ) -> None:
+        if meal.status != MealStatus.READY or meal.nutrition is None:
+            return
+        source = scan_source_for_mode(command.scan_mode)
+        fingerprint = content_fingerprint(command.file_contents)
+        await self.meal_scan_cache.remember_content_scan(
+            user_id=command.user_id,
+            fingerprint=fingerprint,
+            source=source,
+            meal_id=meal.meal_id,
+        )
+        if meal.image is not None:
+            await self.meal_scan_cache.remember_image_scan(
+                user_id=command.user_id,
+                image_id=meal.image.image_id,
+                source=source,
+                meal_id=meal.meal_id,
+            )
+
     async def handle(self, command: UploadMealImageImmediatelyCommand) -> Meal:
         """Handle immediate meal image upload and analysis."""
         if command.scan_mode == "food_label":
@@ -390,9 +441,13 @@ class UploadMealImageImmediatelyHandler(
         if not all([self.image_store, self.vision_service, self.gpt_parser]):
             raise RuntimeError("Required dependencies not configured")
 
+        cached = await self._try_cached_upload(command)
+        if cached is not None:
+            return cached
+
         if self.meal_analyze_graph_enabled:
             workflow = self.meal_analyze_workflow or MealAnalyzeWorkflow()
-            return await workflow.run_uploaded(
+            meal = await workflow.run_uploaded(
                 command,
                 self._handle_parallel_upload,
                 runtime=MealAnalyzeRuntime(
@@ -410,5 +465,8 @@ class UploadMealImageImmediatelyHandler(
                     max_vision_attempts=max(1, self._fast_path_policy.max_attempts),
                 ),
             )
+        else:
+            meal = await self._handle_parallel_upload(command)
 
-        return await self._handle_parallel_upload(command)
+        await self._remember_upload(command, meal)
+        return meal

--- a/src/app/services/meal_scan_cache_service.py
+++ b/src/app/services/meal_scan_cache_service.py
@@ -1,0 +1,221 @@
+"""Resolve and remember user meal scans so repeats return the same meal."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+from src.domain.cache.cache_keys import CacheKeys
+from src.domain.model.meal import Meal, MealStatus
+from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
+from src.domain.ports.cache_port import CachePort
+
+logger = logging.getLogger(__name__)
+
+
+def scan_source_for_mode(scan_mode: str) -> str:
+    """Map scan_mode to the persisted Meal.source value."""
+    return "food_label" if scan_mode == "food_label" else "scanner"
+
+
+def content_fingerprint(image_bytes: bytes) -> str:
+    """Stable fingerprint for raw upload bytes."""
+    return hashlib.sha256(image_bytes).hexdigest()
+
+
+class MealScanCacheService:
+    """User-scoped meal scan cache backed by Redis + durable meal rows."""
+
+    def __init__(
+        self,
+        uow: AsyncUnitOfWorkPort,
+        cache: CachePort | None = None,
+    ):
+        self._uow = uow
+        self._cache = cache
+
+    async def get_by_image_id(
+        self,
+        *,
+        user_id: str,
+        image_id: str,
+        source: str,
+    ) -> Meal | None:
+        """Return an existing READY meal for this user image scan, if any."""
+        cached_meal_id = await self._get_cached_meal_id(
+            user_id=user_id,
+            cache_identity=image_id,
+            source=source,
+        )
+        if cached_meal_id:
+            meal = await self._load_ready_meal(cached_meal_id, user_id=user_id)
+            if meal is not None:
+                logger.info(
+                    "[MEAL-SCAN-CACHE] hit redis user=%s image_id=%s meal=%s",
+                    user_id,
+                    image_id,
+                    meal.meal_id,
+                )
+                return meal
+
+        async with self._uow as uow:
+            meal = await uow.meals.find_ready_by_user_and_image_id(
+                user_id=user_id,
+                image_id=image_id,
+                source=source,
+            )
+        if meal is None:
+            return None
+
+        await self.remember(
+            user_id=user_id,
+            cache_identity=image_id,
+            source=source,
+            meal_id=meal.meal_id,
+        )
+        logger.info(
+            "[MEAL-SCAN-CACHE] hit db user=%s image_id=%s meal=%s",
+            user_id,
+            image_id,
+            meal.meal_id,
+        )
+        return meal
+
+    async def get_by_content_fingerprint(
+        self,
+        *,
+        user_id: str,
+        fingerprint: str,
+        source: str,
+    ) -> Meal | None:
+        """Return a READY meal previously cached for identical upload bytes."""
+        cached_meal_id = await self._get_cached_meal_id(
+            user_id=user_id,
+            cache_identity=f"sha256:{fingerprint}",
+            source=source,
+        )
+        if not cached_meal_id:
+            return None
+        meal = await self._load_ready_meal(cached_meal_id, user_id=user_id)
+        if meal is not None:
+            logger.info(
+                "[MEAL-SCAN-CACHE] hit content user=%s meal=%s",
+                user_id,
+                meal.meal_id,
+            )
+        return meal
+
+    async def remember(
+        self,
+        *,
+        user_id: str,
+        cache_identity: str,
+        source: str,
+        meal_id: str,
+    ) -> None:
+        """Store meal_id for a user scan identity."""
+        if not self._cache:
+            return
+        key, ttl = CacheKeys.user_meal_scan(user_id, cache_identity, source)
+        try:
+            await self._cache.set(key, meal_id, ttl)
+        except Exception as exc:
+            logger.warning(
+                "[MEAL-SCAN-CACHE] remember failed key=%s: %s",
+                key,
+                exc,
+            )
+
+    async def remember_image_scan(
+        self,
+        *,
+        user_id: str,
+        image_id: str,
+        source: str,
+        meal_id: str,
+    ) -> None:
+        await self.remember(
+            user_id=user_id,
+            cache_identity=image_id,
+            source=source,
+            meal_id=meal_id,
+        )
+
+    async def remember_content_scan(
+        self,
+        *,
+        user_id: str,
+        fingerprint: str,
+        source: str,
+        meal_id: str,
+    ) -> None:
+        await self.remember(
+            user_id=user_id,
+            cache_identity=f"sha256:{fingerprint}",
+            source=source,
+            meal_id=meal_id,
+        )
+
+    async def invalidate(
+        self,
+        *,
+        user_id: str,
+        image_id: str | None,
+        source: str | None,
+    ) -> None:
+        """Drop Redis entry when a cached scanned meal is deleted."""
+        if not self._cache or not image_id or not source:
+            return
+        key, _ = CacheKeys.user_meal_scan(user_id, image_id, source)
+        try:
+            await self._cache.invalidate(key)
+        except Exception as exc:
+            logger.warning(
+                "[MEAL-SCAN-CACHE] invalidate failed key=%s: %s",
+                key,
+                exc,
+            )
+
+    async def _get_cached_meal_id(
+        self,
+        *,
+        user_id: str,
+        cache_identity: str,
+        source: str,
+    ) -> str | None:
+        if not self._cache:
+            return None
+        key, _ = CacheKeys.user_meal_scan(user_id, cache_identity, source)
+        try:
+            value = await self._cache.get(key)
+        except Exception as exc:
+            logger.warning("[MEAL-SCAN-CACHE] get failed key=%s: %s", key, exc)
+            return None
+        if isinstance(value, str) and value:
+            return value
+        return None
+
+    async def _load_ready_meal(self, meal_id: str, *, user_id: str) -> Meal | None:
+        async with self._uow as uow:
+            meal = await uow.meals.find_by_id(meal_id)
+        if meal is None:
+            return None
+        if meal.user_id != user_id:
+            return None
+        if meal.status != MealStatus.READY:
+            return None
+        if meal.nutrition is None:
+            return None
+        return meal
+
+
+def mark_scan_cache_hit(meal: Meal) -> Meal:
+    """Annotate a meal so API callers can skip duplicate side effects."""
+    meal._meal_scan_cache_hit = True  # type: ignore[attr-defined]
+    meal._meal_value_insight_scheduled = True  # type: ignore[attr-defined]
+    return meal
+
+
+def is_scan_cache_hit(meal: Any) -> bool:
+    return bool(getattr(meal, "_meal_scan_cache_hit", False))

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -174,5 +174,19 @@ class CacheKeys:
         return (f"user:{user_id}:metrics", CacheKeys.TTL_1_DAY)
 
     @staticmethod
+    def user_meal_scan(
+        user_id: str, cache_identity: str, source: str
+    ) -> tuple[str, int]:
+        """Cache key for a user's scanned meal by image/content identity.
+
+        Maps to meal_id so repeat scans return the same READY meal without
+        re-running vision. 30-day TTL; durable fallback is the meal row.
+        """
+        return (
+            f"user:{user_id}:meal_scan:{source}:{cache_identity}",
+            CacheKeys.TTL_30_DAYS,
+        )
+
+    @staticmethod
     def pattern_for_user(user_id: str) -> str:
         return f"user:{user_id}:*"

--- a/src/domain/ports/meal_repository_port.py
+++ b/src/domain/ports/meal_repository_port.py
@@ -39,6 +39,21 @@ class MealRepositoryPort(ABC):
         """
         pass
 
+    async def find_ready_by_user_and_image_id(
+        self,
+        *,
+        user_id: str,
+        image_id: str,
+        source: str | None = None,
+        projection: Any = None,
+    ) -> Meal | None:
+        """Return the newest READY meal for a user+image scan, if any.
+
+        Used so repeat scans of the same Cloudinary asset return the same meal
+        instead of re-running vision and creating duplicates.
+        """
+        return None
+
     @abstractmethod
     async def find_by_status(self, status: MealStatus, limit: int = 10) -> list[Meal]:
         """

--- a/src/infra/database/models/meal/meal.py
+++ b/src/infra/database/models/meal/meal.py
@@ -9,9 +9,11 @@ from sqlalchemy import (
     DateTime,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
+    text,
 )
 from sqlalchemy.orm import relationship
 
@@ -24,6 +26,15 @@ class MealORM(Base, TimestampMixin):
     """Database model for meals."""
 
     __tablename__ = "meal"
+    __table_args__ = (
+        Index(
+            "ix_meal_user_image_source",
+            "user_id",
+            "image_id",
+            "source",
+            postgresql_where=text("image_id IS NOT NULL"),
+        ),
+    )
 
     # Primary key
     meal_id = Column(String(36), primary_key=True)

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -206,6 +206,33 @@ class AsyncMealRepository(MealRepositoryPort):
         db_meal = result.unique().scalars().first()
         return meal_orm_to_domain(db_meal) if db_meal else None
 
+    async def find_ready_by_user_and_image_id(
+        self,
+        *,
+        user_id: str,
+        image_id: str,
+        source: str | None = None,
+        projection: MealProjection = MealProjection.FULL,
+    ) -> Meal | None:
+        stmt = (
+            select(MealORM)
+            .options(*_PROJECTION_OPTS[projection])
+            .where(
+                MealORM.user_id == user_id,
+                MealORM.image_id == image_id,
+                MealORM.status == MealStatusEnum.READY,
+                MealORM.ready_at.is_not(None),
+                MealORM.nutrition.has(),
+            )
+            .order_by(MealORM.ready_at.desc(), MealORM.created_at.desc())
+            .limit(1)
+        )
+        if source is not None:
+            stmt = stmt.where(MealORM.source == source)
+        result = await self.session.execute(stmt)
+        db_meal = result.unique().scalars().first()
+        return meal_orm_to_domain(db_meal) if db_meal else None
+
     async def find_by_id_for_update(
         self, meal_id: str, projection: MealProjection = MealProjection.FULL
     ) -> Meal | None:
@@ -218,9 +245,7 @@ class AsyncMealRepository(MealRepositoryPort):
         """
         # Step 1: lock the meal row without any joins.
         lock_result = await self.session.execute(
-            select(MealORM.meal_id)
-            .where(MealORM.meal_id == meal_id)
-            .with_for_update()
+            select(MealORM.meal_id).where(MealORM.meal_id == meal_id).with_for_update()
         )
         if lock_result.scalar_one_or_none() is None:
             return None

--- a/tests/fixtures/fakes/fake_meal_repository.py
+++ b/tests/fixtures/fakes/fake_meal_repository.py
@@ -22,6 +22,33 @@ class FakeMealRepository(MealRepositoryPort):
         """Find a meal by ID."""
         return self._meals.get(meal_id)
 
+    async def find_ready_by_user_and_image_id(
+        self,
+        *,
+        user_id: str,
+        image_id: str,
+        source: str | None = None,
+        projection: Any = None,
+    ) -> Optional[Meal]:
+        """Return newest READY meal for a user+image scan."""
+        matches = [
+            meal
+            for meal in self._meals.values()
+            if meal.user_id == user_id
+            and meal.status == MealStatus.READY
+            and meal.nutrition is not None
+            and meal.image is not None
+            and meal.image.image_id == image_id
+            and (source is None or meal.source == source)
+        ]
+        if not matches:
+            return None
+        matches.sort(
+            key=lambda meal: meal.ready_at or meal.created_at,
+            reverse=True,
+        )
+        return matches[0]
+
     async def find_by_status(self, status: MealStatus, limit: int = 10) -> List[Meal]:
         """Find meals by status."""
         return [meal for meal in self._meals.values() if meal.status == status][:limit]

--- a/tests/unit/handlers/command_handlers/test_ai_output_validation_error_propagation.py
+++ b/tests/unit/handlers/command_handlers/test_ai_output_validation_error_propagation.py
@@ -59,6 +59,9 @@ async def test_scan_by_url_handler_propagates_ai_validation_error():
     mock_uow.__aexit__ = AsyncMock(return_value=False)
     mock_uow.users = MagicMock()
     mock_uow.users.get_user_timezone = AsyncMock(return_value="UTC")
+    mock_uow.meals = MagicMock()
+    mock_uow.meals.find_ready_by_user_and_image_id = AsyncMock(return_value=None)
+    mock_uow.meals.find_by_id = AsyncMock(return_value=None)
 
     handler = ScanByUrlCommandHandler(
         uow=mock_uow,

--- a/tests/unit/handlers/command_handlers/test_food_guard_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_food_guard_command_handlers.py
@@ -21,6 +21,7 @@ def _uow_with_timezone() -> MagicMock:
     uow.meals = MagicMock()
     uow.meals.save = AsyncMock()
     uow.meals.find_by_id = AsyncMock()
+    uow.meals.find_ready_by_user_and_image_id = AsyncMock(return_value=None)
     uow.commit = AsyncMock()
     return uow
 

--- a/tests/unit/handlers/command_handlers/test_meal_scan_cache.py
+++ b/tests/unit/handlers/command_handlers/test_meal_scan_cache.py
@@ -1,0 +1,224 @@
+"""Unit tests for user meal scan caching."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
+from src.app.handlers.command_handlers.scan_by_url_command_handler import (
+    ScanByUrlCommandHandler,
+)
+from src.app.services.meal_scan_cache_service import (
+    MealScanCacheService,
+    content_fingerprint,
+    scan_source_for_mode,
+)
+from src.domain.cache.cache_keys import CacheKeys
+from src.domain.model.meal import Meal, MealImage, MealStatus
+from src.domain.model.nutrition import Nutrition
+from src.domain.model.nutrition.macros import Macros
+from src.domain.parsers.vision_response_parser import VisionResponseParser
+
+_IMAGE_URL = "https://res.cloudinary.com/test/image/upload/v1/mealtrack/food.jpg"
+_PUBLIC_ID = "mealtrack/1325c7ca-e012-4df3-b0b4-55bfaeb55eb0"
+_IMAGE_ID = "1325c7ca-e012-4df3-b0b4-55bfaeb55eb0"
+_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _nutrition() -> Nutrition:
+    return Nutrition(
+        macros=Macros(protein=20, carbs=30, fat=5, fiber=2, sugar=1),
+        food_items=[],
+    )
+
+
+def _ready_meal(*, meal_id: str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa") -> Meal:
+    return Meal(
+        meal_id=meal_id,
+        user_id=_USER_ID,
+        status=MealStatus.READY,
+        created_at=datetime.now(timezone.utc),
+        image=MealImage(
+            image_id=_IMAGE_ID,
+            format="jpeg",
+            size_bytes=1024,
+            url=_IMAGE_URL,
+        ),
+        source="scanner",
+        dish_name="Cached Salad",
+        ready_at=datetime.now(timezone.utc),
+        nutrition=_nutrition(),
+    )
+
+
+def _make_uow(*, existing: Meal | None = None) -> MagicMock:
+    uow = MagicMock()
+    uow.__aenter__ = AsyncMock(return_value=uow)
+    uow.__aexit__ = AsyncMock(return_value=False)
+    uow.users = MagicMock()
+    uow.users.get_user_timezone = AsyncMock(return_value="UTC")
+    uow.meals = MagicMock()
+    saved_meals: list[Meal] = []
+
+    async def capture_meal(meal):
+        saved_meals.append(meal)
+        return meal
+
+    uow.meals.save = AsyncMock(side_effect=capture_meal)
+    uow.meals.find_by_id = AsyncMock(
+        side_effect=lambda mid, **kw: (
+            existing
+            if existing and existing.meal_id == mid
+            else (saved_meals[-1] if saved_meals else None)
+        )
+    )
+    uow.meals.find_ready_by_user_and_image_id = AsyncMock(return_value=existing)
+    uow.commit = AsyncMock()
+    uow._saved_meals = saved_meals
+    return uow
+
+
+def _install_fake_image_download(monkeypatch) -> None:
+    from src.app.handlers.command_handlers import scan_by_url_command_handler as module
+
+    class FakeResponse:
+        def __init__(self, content: bytes):
+            self.content = content
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            return FakeResponse(b"fake-image-bytes")
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda timeout: FakeClient())
+    monkeypatch.setattr(module, "compress_image", lambda raw_bytes: raw_bytes)
+
+
+@pytest.mark.asyncio
+async def test_scan_by_url_returns_cached_meal_without_vision(monkeypatch):
+    _install_fake_image_download(monkeypatch)
+    existing = _ready_meal()
+    uow = _make_uow(existing=existing)
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    handler = ScanByUrlCommandHandler(
+        uow=uow,
+        event_bus=MagicMock(),
+        vision_service=MagicMock(),
+        gpt_parser=VisionResponseParser(),
+        meal_value_insight_cache=cache,
+    )
+    handler.vision_service.analyze = AsyncMock()
+
+    first = await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id=_PUBLIC_ID,
+        )
+    )
+    second = await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id=_PUBLIC_ID,
+        )
+    )
+
+    assert first.meal_id == existing.meal_id
+    assert second.meal_id == existing.meal_id
+    handler.vision_service.analyze.assert_not_awaited()
+    uow.meals.save.assert_not_awaited()
+    assert getattr(first, "_meal_scan_cache_hit", False) is True
+
+
+@pytest.mark.asyncio
+async def test_scan_by_url_remembers_meal_in_redis_after_create(monkeypatch):
+    _install_fake_image_download(monkeypatch)
+    uow = _make_uow()
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    handler = ScanByUrlCommandHandler(
+        uow=uow,
+        event_bus=MagicMock(),
+        vision_service=MagicMock(),
+        gpt_parser=VisionResponseParser(),
+        meal_value_insight_cache=cache,
+        cache_invalidation=MagicMock(after_meal_write=AsyncMock()),
+    )
+    handler.vision_service.analyze = AsyncMock(
+        return_value={
+            "structured_data": {
+                "is_food": True,
+                "dish_name": "Rice Bowl",
+                "foods": [
+                    {
+                        "name": "Rice",
+                        "quantity_g": 150,
+                        "macros": {
+                            "protein_g": 4,
+                            "carbs_g": 40,
+                            "fat_g": 1,
+                            "fiber_g": 1,
+                            "sugar_g": 0,
+                        },
+                    }
+                ],
+            }
+        }
+    )
+
+    meal = await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id=_PUBLIC_ID,
+        )
+    )
+
+    key, ttl = CacheKeys.user_meal_scan(_USER_ID, _IMAGE_ID, "scanner")
+    cache.set.assert_awaited()
+    assert cache.set.await_args.args[0] == key
+    assert cache.set.await_args.args[1] == meal.meal_id
+    assert cache.set.await_args.args[2] == ttl
+
+
+@pytest.mark.asyncio
+async def test_scan_cache_service_redis_hit_loads_meal():
+    existing = _ready_meal()
+    uow = _make_uow(existing=existing)
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=existing.meal_id)
+    cache.set = AsyncMock()
+    service = MealScanCacheService(uow, cache)
+
+    meal = await service.get_by_image_id(
+        user_id=_USER_ID,
+        image_id=_IMAGE_ID,
+        source="scanner",
+    )
+
+    assert meal is not None
+    assert meal.meal_id == existing.meal_id
+    uow.meals.find_ready_by_user_and_image_id.assert_not_awaited()
+
+
+def test_content_fingerprint_is_stable():
+    assert content_fingerprint(b"abc") == content_fingerprint(b"abc")
+    assert content_fingerprint(b"abc") != content_fingerprint(b"abd")
+
+
+def test_scan_source_for_mode():
+    assert scan_source_for_mode("scanner") == "scanner"
+    assert scan_source_for_mode("food_label") == "food_label"

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -286,13 +286,14 @@ async def test_scan_by_url_uses_workflow_only_when_graph_enabled():
     workflow = MagicMock()
     workflow.run_scan_by_url = AsyncMock(return_value=expected_meal)
     handler = ScanByUrlCommandHandler(
-        uow=MagicMock(),
+        uow=_make_uow(),
         event_bus=MagicMock(),
         vision_service=MagicMock(),
         gpt_parser=MagicMock(),
         meal_analyze_workflow=workflow,
         meal_analyze_graph_enabled=True,
     )
+    handler._remember_scan = AsyncMock()
     command = ScanByUrlCommand(
         user_id=_USER_ID,
         image_url=_IMAGE_URL,
@@ -311,7 +312,7 @@ async def test_scan_by_url_graph_disabled_keeps_legacy_path():
     workflow = MagicMock()
     workflow.run_scan_by_url = AsyncMock()
     handler = ScanByUrlCommandHandler(
-        uow=MagicMock(),
+        uow=_make_uow(),
         event_bus=MagicMock(),
         vision_service=MagicMock(),
         gpt_parser=MagicMock(),
@@ -319,6 +320,7 @@ async def test_scan_by_url_graph_disabled_keeps_legacy_path():
         meal_analyze_graph_enabled=False,
     )
     handler._handle_legacy_scan_by_url = AsyncMock(return_value="legacy-result")
+    handler._remember_scan = AsyncMock()
     command = ScanByUrlCommand(
         user_id=_USER_ID,
         image_url=_IMAGE_URL,

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -31,6 +31,7 @@ def _make_uow() -> MagicMock:
 
     uow.meals.save = AsyncMock(side_effect=capture_meal)
     uow.meals.find_by_id = AsyncMock(side_effect=lambda mid, **kw: saved_meals[-1])
+    uow.meals.find_ready_by_user_and_image_id = AsyncMock(return_value=None)
     uow.hydration_entries = MagicMock()
     uow.hydration_entries.add = AsyncMock(side_effect=lambda entry: entry)
     uow.commit = AsyncMock()

--- a/tests/unit/handlers/command_handlers/test_upload_image_consistency.py
+++ b/tests/unit/handlers/command_handlers/test_upload_image_consistency.py
@@ -308,6 +308,7 @@ async def test_upload_uses_workflow_only_when_graph_enabled():
         meal_analyze_workflow=workflow,
         meal_analyze_graph_enabled=True,
     )
+    handler._remember_upload = AsyncMock()
     command = UploadMealImageImmediatelyCommand(
         user_id="00000000-0000-0000-0000-000000000001",
         file_contents=b"fake-image-bytes",
@@ -335,6 +336,7 @@ async def test_upload_graph_disabled_keeps_legacy_path():
         meal_analyze_graph_enabled=False,
     )
     handler._handle_parallel_upload = AsyncMock(return_value="legacy-result")
+    handler._remember_upload = AsyncMock()
     command = UploadMealImageImmediatelyCommand(
         user_id="00000000-0000-0000-0000-000000000001",
         file_contents=b"fake-image-bytes",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Repeat meal scans for the same user now return the existing READY meal instead of re-running vision and creating duplicates.

## Behavior
- **scan-by-url / food-label**: cache key is `(user_id, image_id, source)`; Redis stores `meal_id`, DB is durable fallback via `find_ready_by_user_and_image_id`
- **upload-immediately**: identical bytes reuse a Redis content SHA-256 mapping (and also remember `image_id`)
- Skips cache when `user_description` is present (different analysis intent)
- Deletes invalidate the scan Redis entry

## Notes
- Adds index `ix_meal_user_image_source` for lookup performance
- Migration: `20260820000001_add_meal_user_image_scan_index.py`

## Verification
- `pytest tests/unit --cov=src --cov-fail-under=65` — 2629 passed, coverage 79.93%
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02020-9b1d-7d8e-8931-4a6ea8cb73cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02020-9b1d-7d8e-8931-4a6ea8cb73cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

