### PR TITLE
feat(translation): localize food-label scan display names

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -159,9 +159,6 @@ from src.app.handlers.query_handlers.get_activities_presence_query_handler impor
 from src.app.handlers.query_handlers.get_cheat_days_query_handler import (
     GetCheatDaysQueryHandler,
 )
-from src.app.handlers.query_handlers.list_logged_catalog_meals_query_handler import (
-    ListLoggedCatalogMealsQueryHandler,
-)
 from src.app.handlers.query_handlers.get_meal_recommendation_plan_query_handler import (
     GetMealRecommendationPlanQueryHandler,
 )
@@ -173,6 +170,9 @@ from src.app.handlers.query_handlers.get_nutrition_bulk_query_handler import (
 )
 from src.app.handlers.query_handlers.get_weight_entries_query_handler import (
     GetWeightEntriesQueryHandler,
+)
+from src.app.handlers.query_handlers.list_logged_catalog_meals_query_handler import (
+    ListLoggedCatalogMealsQueryHandler,
 )
 from src.app.queries.activity import GetBulkActivitiesQuery, GetDailyActivitiesQuery
 from src.app.queries.cheat_day import GetCheatDaysQuery
@@ -481,6 +481,7 @@ def get_configured_event_bus() -> EventBus:
             vision_service=vision_service,
             gpt_parser=gpt_parser,
             meal_translation_service=meal_translation_service,
+            text_translation_service=text_translation_service,
             cache_invalidation=cache_invalidation_service,
             meal_value_insight_task_manager=task_manager,
             meal_value_insight_cache=cache_service,

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -432,9 +432,10 @@ class MealMapper:
     @staticmethod
     def has_persisted_image_display_names(meal: Meal) -> bool:
         """Return whether an image meal can trust its stored display names."""
-        return getattr(meal, "source", None) == "scanner" and not getattr(
-            meal, "translations", None
-        )
+        return getattr(meal, "source", None) in {
+            "scanner",
+            "food_label",
+        } and not getattr(meal, "translations", None)
 
     @staticmethod
     def _raw_response_localization_language(meal: Meal) -> str | None:

--- a/src/app/graphs/meal_analyze/nodes.py
+++ b/src/app/graphs/meal_analyze/nodes.py
@@ -13,6 +13,7 @@ from src.app.graphs.meal_analyze.quality_gate import (
 )
 from src.app.graphs.meal_analyze.runtime import AcquiredImage, MealAnalyzeRuntime
 from src.app.graphs.meal_analyze.state import MealAnalyzeGraphState
+from src.app.services.food_label_localizer import localize_food_label_display
 from src.domain.constants import MealDefaults
 from src.domain.exceptions.ai_exceptions import (
     AIVisionError,
@@ -244,7 +245,9 @@ async def _analyze_and_validate_locale(runtime: MealAnalyzeRuntime, operation):
         runtime.localization = None
         return result
 
-    structured_data = result.get("structured_data") if isinstance(result, dict) else None
+    structured_data = (
+        result.get("structured_data") if isinstance(result, dict) else None
+    )
     if isinstance(structured_data, dict) and structured_data.get("is_food") is False:
         runtime.localization = None
         return result
@@ -320,6 +323,12 @@ async def parse_nutrition(
                 ),
                 error_code="NOT_FOOD_LABEL_IMAGE",
             )
+        runtime.nutrition, runtime.label_metadata = await localize_food_label_display(
+            nutrition=runtime.nutrition,
+            metadata=runtime.label_metadata,
+            language=runtime.command.language,
+            translation_service=runtime.text_translation_service,
+        )
         return {"nutrition_parsed": True}
 
     if not runtime.gpt_parser.parse_is_food(runtime.vision_result):

--- a/src/app/graphs/meal_analyze/runtime.py
+++ b/src/app/graphs/meal_analyze/runtime.py
@@ -53,8 +53,12 @@ class MealAnalyzeRuntime:
     image_store: ImageStorePort | None = None
     download_image_bytes: Callable[[str], Awaitable[bytes]] | None = None
     compress_image: Callable[[bytes], bytes] = default_compress_image
-    image_id_factory: Callable[[], str] = field(default_factory=lambda: lambda: str(uuid4()))
-    meal_id_factory: Callable[[], str] = field(default_factory=lambda: lambda: str(uuid4()))
+    image_id_factory: Callable[[], str] = field(
+        default_factory=lambda: lambda: str(uuid4())
+    )
+    meal_id_factory: Callable[[], str] = field(
+        default_factory=lambda: lambda: str(uuid4())
+    )
     vision_service: VisionAIServicePort | None = None
     gpt_parser: Any | None = None
     uow: Any | None = None
@@ -63,8 +67,11 @@ class MealAnalyzeRuntime:
     meal_value_insight_cache: CachePort | None = None
     meal_value_insight_ai_manager: MealInsightAIPort | None = None
     event_bus: MealInsightEventBus | None = None
-    meal_value_insight_scheduler: Callable[..., bool] = schedule_value_insight_generation
+    meal_value_insight_scheduler: Callable[..., bool] = (
+        schedule_value_insight_generation
+    )
     meal_translation_service: MealTranslationService | None = None
+    text_translation_service: Any | None = None
     food_reference_validation_service: FoodReferenceValidationService | None = None
     fatsecret_validation_enabled: bool = False
     max_vision_attempts: int = 1

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -13,6 +13,7 @@ from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
 from src.app.services.cache_invalidation_service import CacheInvalidationService
+from src.app.services.food_label_localizer import localize_food_label_display
 from src.app.services.meal_analyze_workflow import MealAnalyzeWorkflow
 from src.domain.constants import MealDefaults
 from src.domain.model.meal import Meal, MealImage, MealStatus
@@ -59,6 +60,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         vision_service: VisionAIServicePort = None,
         gpt_parser: GPTResponseParser = None,
         meal_translation_service: MealTranslationService | None = None,
+        text_translation_service: Any | None = None,
         cache_invalidation: CacheInvalidationService | None = None,
         meal_value_insight_task_manager: Any | None = None,
         meal_value_insight_cache: CachePort | None = None,
@@ -71,6 +73,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         self.vision_service = vision_service
         self.gpt_parser = gpt_parser
         self.meal_translation_service = meal_translation_service
+        self.text_translation_service = text_translation_service
         self.cache_invalidation = cache_invalidation
         self.meal_value_insight_task_manager = meal_value_insight_task_manager
         self.meal_value_insight_cache = meal_value_insight_cache
@@ -265,6 +268,12 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                         ),
                         error_code="NOT_FOOD_LABEL_IMAGE",
                     )
+                nutrition, label_metadata = await localize_food_label_display(
+                    nutrition=nutrition,
+                    metadata=label_metadata,
+                    language=command.language,
+                    translation_service=self.text_translation_service,
+                )
 
                 meal = Meal(
                     meal_id=str(uuid4()),
@@ -405,6 +414,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                     meal_value_insight_ai_manager=self.meal_value_insight_ai_manager,
                     event_bus=self.event_bus,
                     meal_translation_service=self.meal_translation_service,
+                    text_translation_service=self.text_translation_service,
                 ),
             )
 

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -229,14 +229,14 @@ class LookupBarcodeQueryHandler(
             )
             if estimate:
                 log_hit("fatsecret_name_estimate", estimate)
-                return estimate
+                return await self._maybe_translate(estimate, query.language)
 
         if brave_result and self._has_nutrition(brave_result):
             estimate = self._estimate_result(
                 brave_result, scanned_barcode, "brave_search"
             )
             log_hit("brave_search", estimate)
-            return estimate
+            return await self._maybe_translate(estimate, query.language)
         if self.brave_search and not brave_result:
             miss_reasons.append("brave_empty")
 
@@ -245,7 +245,7 @@ class LookupBarcodeQueryHandler(
         )
         if estimate:
             log_hit("ai_estimate", estimate)
-            return estimate
+            return await self._maybe_translate(estimate, query.language)
 
         miss_reasons.append("ai_estimate_empty")
         logger.warning(

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -10,6 +10,7 @@ from typing import Any
 from src.app.events.base import EventHandler, handles
 from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 from src.app.services.food_name_localizer import (
+    needs_display_localization,
     translate_food_texts,
     translated_values,
 )
@@ -25,6 +26,7 @@ from src.infra.adapters.open_food_facts_service import OpenFoodFactsService
 logger = logging.getLogger(__name__)
 
 TRUSTED_CACHE_SOURCES = {"fatsecret", "openfoodfacts", "usda_fdc", "cache", None}
+ENGLISH_CANONICAL_CACHE_SOURCES = frozenset({"fatsecret", "usda_fdc"})
 
 
 def _gs1_prefix_hint(barcode: str) -> str:
@@ -32,7 +34,9 @@ def _gs1_prefix_hint(barcode: str) -> str:
 
 
 @handles(LookupBarcodeQuery)
-class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] | None]):
+class LookupBarcodeQueryHandler(
+    EventHandler[LookupBarcodeQuery, dict[str, Any] | None]
+):
     """Handler for looking up product by barcode with fallback providers."""
 
     def __init__(
@@ -85,15 +89,26 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         partial_name: str | None = None
 
         cached = await self._get_cached_product(aliases)
-        if cached and self._has_nutrition(cached) and self._is_trusted_cached_row(cached):
+        if (
+            cached
+            and self._has_nutrition(cached)
+            and self._is_trusted_cached_row(cached)
+        ):
             provider_source = cached.get("source")
             cached["provider_source"] = provider_source
             cached["source"] = "cache"
             cached["barcode"] = scanned_barcode
             log_hit("cache", cached)
-            # Cached rows have no source-locale provenance.  They remain
-            # canonical rather than being mislabeled as English.
-            return await self._maybe_translate(cached, query.language)
+            # FatSecret/USDA rows are acquired in English. Other cached rows may
+            # lack provenance, so only localize leftover English display text.
+            cache_source_language = (
+                "en" if provider_source in ENGLISH_CANONICAL_CACHE_SOURCES else None
+            )
+            return await self._maybe_translate(
+                cached,
+                query.language,
+                source_language=cache_source_language,
+            )
         if cached:
             partial_name = cached.get("name")
             reason = (
@@ -121,13 +136,19 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
                 language="en",
             ),
         )
-        if fat_secret_result and self._has_nutrition(fat_secret_result) and self._has_name(fat_secret_result):
+        if (
+            fat_secret_result
+            and self._has_nutrition(fat_secret_result)
+            and self._has_name(fat_secret_result)
+        ):
             result = self._trusted_provider_result(
                 fat_secret_result, query.barcode, scanned_barcode, "fatsecret"
             )
             await self._cache_result(result, cache_barcode=query.barcode)
             log_hit("fatsecret", result)
-            return await self._maybe_translate(result, query.language, source_language="en")
+            return await self._maybe_translate(
+                result, query.language, source_language="en"
+            )
         if fat_secret_result:
             partial_name = partial_name or fat_secret_result.get("name")
             miss_reasons.append(
@@ -139,7 +160,11 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
             miss_reasons.append("fatsecret_empty")
 
         off_result = await self._first_barcode_hit(aliases, self.off.get_product)
-        if off_result and self._has_nutrition(off_result) and self._has_name(off_result):
+        if (
+            off_result
+            and self._has_nutrition(off_result)
+            and self._has_name(off_result)
+        ):
             off_result = dict(off_result)
             source_language = off_result.pop("source_language", None)
             result = self._trusted_provider_result(
@@ -160,8 +185,14 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         else:
             miss_reasons.append("openfoodfacts_empty")
 
-        fdc_result = await self._get_fdc_product(aliases, query.barcode, scanned_barcode)
-        if fdc_result and self._has_nutrition(fdc_result) and self._has_name(fdc_result):
+        fdc_result = await self._get_fdc_product(
+            aliases, query.barcode, scanned_barcode
+        )
+        if (
+            fdc_result
+            and self._has_nutrition(fdc_result)
+            and self._has_name(fdc_result)
+        ):
             await self._cache_result(fdc_result, cache_barcode=query.barcode)
             log_hit("usda_fdc", fdc_result)
             return await self._maybe_translate(
@@ -201,13 +232,17 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
                 return estimate
 
         if brave_result and self._has_nutrition(brave_result):
-            estimate = self._estimate_result(brave_result, scanned_barcode, "brave_search")
+            estimate = self._estimate_result(
+                brave_result, scanned_barcode, "brave_search"
+            )
             log_hit("brave_search", estimate)
             return estimate
         if self.brave_search and not brave_result:
             miss_reasons.append("brave_empty")
 
-        estimate = await self._ai_estimate(scanned_barcode, query.language, partial_name)
+        estimate = await self._ai_estimate(
+            scanned_barcode, query.language, partial_name
+        )
         if estimate:
             log_hit("ai_estimate", estimate)
             return estimate
@@ -240,7 +275,10 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
 
     @staticmethod
     def _is_trusted_cached_row(result: dict[str, Any]) -> bool:
-        return bool(result.get("is_verified")) or result.get("source") in TRUSTED_CACHE_SOURCES
+        return (
+            bool(result.get("is_verified"))
+            or result.get("source") in TRUSTED_CACHE_SOURCES
+        )
 
     async def _first_barcode_hit(self, aliases, fetch):
         for alias in aliases:
@@ -296,7 +334,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         for item in fs_results or []:
             if self._has_nutrition(item):
                 item["name"] = brave_name or item.get("name")
-                return self._estimate_result(item, scanned_barcode, "fatsecret_name_search")
+                return self._estimate_result(
+                    item, scanned_barcode, "fatsecret_name_search"
+                )
         return None
 
     def _trusted_provider_result(
@@ -381,16 +421,21 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         language: str,
         source_language: str | None = None,
     ) -> dict[str, Any]:
-        """Translate a known-English provider projection for presentation only."""
-        if (
-            language == "en"
-            or source_language != "en"
-            or not self.translation_service
-            or not result.get("name")
+        """Translate known-English or leftover-English names for presentation."""
+        name = result.get("name")
+        if language == "en" or not self.translation_service or not name:
+            return result
+
+        # Proven English sources always localize. Unknown provenance only
+        # localizes when the display name still looks like leftover English,
+        # so printed non-English product names are not mangled.
+        if source_language != "en" and not (
+            source_language is None and needs_display_localization(str(name), language)
         ):
             return result
+
         translated = await translate_food_texts(
-            [str(result["name"])],
+            [str(name)],
             target_language=language,
             translation_service=self.translation_service,
         )
@@ -399,11 +444,13 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
             TranslationOutcome.PARTIAL,
         }:
             localized = dict(result)
-            localized["name"] = translated_values([str(result["name"])], translated)[0]
+            localized["name"] = translated_values([str(name)], translated)[0]
             return localized
         return result
 
-    async def _get_cached_product(self, aliases: tuple[str, ...]) -> dict[str, Any] | None:
+    async def _get_cached_product(
+        self, aliases: tuple[str, ...]
+    ) -> dict[str, Any] | None:
         candidates: list[dict[str, Any]] = []
         for barcode in aliases:
             cached = await self._get_cached_product_by_barcode(barcode)

--- a/src/app/services/food_label_localizer.py
+++ b/src/app/services/food_label_localizer.py
@@ -1,0 +1,91 @@
+"""Presentation localization for food-label scan display names."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from src.app.services.food_display_name import needs_display_localization
+from src.app.services.food_name_localizer import (
+    translate_food_texts,
+    translated_values,
+)
+from src.domain.model.nutrition import FoodItem, Nutrition
+from src.domain.model.translation_result import TranslationOutcome
+
+__all__ = ["localize_food_label_display"]
+
+
+async def localize_food_label_display(
+    *,
+    nutrition: Nutrition,
+    metadata: dict[str, Any] | None,
+    language: str,
+    translation_service: Any | None,
+) -> tuple[Nutrition, dict[str, Any] | None]:
+    """Localize leftover English food-label names for the request language.
+
+    Printed non-English product names stay as-is. English leftovers are
+    translated for presentation and persisted on the meal so Today's Meals
+    and meal detail can trust the stored display names (same contract as
+    scanner meals).
+    """
+
+    normalized = (language or "en").strip().lower()
+    if normalized == "en" or translation_service is None:
+        return nutrition, metadata
+
+    food_items = list(getattr(nutrition, "food_items", None) or [])
+    metadata_dict = dict(metadata) if isinstance(metadata, dict) else None
+    product_name = None
+    if metadata_dict is not None:
+        raw_product_name = metadata_dict.get("product_name")
+        if isinstance(raw_product_name, str):
+            product_name = raw_product_name
+
+    originals: list[str] = []
+    if product_name and needs_display_localization(product_name, normalized):
+        originals.append(product_name)
+    for item in food_items:
+        name = getattr(item, "name", None)
+        if (
+            isinstance(name, str)
+            and name.strip()
+            and needs_display_localization(name, normalized)
+            and name not in originals
+        ):
+            originals.append(name)
+
+    if not originals:
+        return nutrition, metadata_dict
+
+    result = await translate_food_texts(
+        originals,
+        target_language=normalized,
+        translation_service=translation_service,
+    )
+    if result.outcome not in {
+        TranslationOutcome.TRANSLATED,
+        TranslationOutcome.PARTIAL,
+    }:
+        return nutrition, metadata_dict
+
+    localized_by_source = dict(
+        zip(originals, translated_values(originals, result), strict=False)
+    )
+
+    if metadata_dict is not None and product_name in localized_by_source:
+        localized_product = localized_by_source[product_name]
+        if isinstance(localized_product, str) and localized_product.strip():
+            metadata_dict["product_name"] = localized_product.strip()
+
+    localized_items: list[FoodItem] = []
+    for item in food_items:
+        name = getattr(item, "name", None)
+        replacement = localized_by_source.get(name) if isinstance(name, str) else None
+        if isinstance(replacement, str) and replacement.strip():
+            localized_items.append(replace(item, name=replacement.strip()))
+        else:
+            localized_items.append(item)
+
+    return replace(nutrition, food_items=localized_items), metadata_dict

--- a/tests/unit/api/test_meals_read_translation.py
+++ b/tests/unit/api/test_meals_read_translation.py
@@ -126,6 +126,28 @@ async def test_ensure_requested_translation_keeps_persisted_image_names():
 
 
 @pytest.mark.asyncio
+async def test_ensure_requested_translation_keeps_persisted_food_label_names():
+    meal = _meal()
+    meal.source = "food_label"
+    event_bus = _EventBus()
+    translation_service = type("TranslationService", (), {})()
+    translation_service.translate_meal = AsyncMock()
+    query = GetMealByIdQuery(meal_id=meal.meal_id, user_id=meal.user_id)
+
+    result = await meals_read._ensure_requested_meal_translation(
+        meal=meal,
+        language="vi",
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=translation_service,
+    )
+
+    assert result is meal
+    translation_service.translate_meal.assert_not_awaited()
+    assert event_bus.queries == []
+
+
+@pytest.mark.asyncio
 async def test_ensure_requested_translation_does_not_call_provider_for_current_cache():
     meal = _meal()
     meal_translation = _translation(meal)

--- a/tests/unit/app/services/test_food_label_localizer.py
+++ b/tests/unit/app/services/test_food_label_localizer.py
@@ -1,0 +1,137 @@
+"""Tests for food-label display localization."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.app.services.food_label_localizer import localize_food_label_display
+from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+from src.domain.model.translation_result import TranslationOutcome, TranslationResult
+
+
+def _nutrition(name: str = "Protein Bar") -> Nutrition:
+    return Nutrition(
+        macros=Macros(protein=20, carbs=20, fat=8),
+        food_items=[
+            FoodItem(
+                id="item-1",
+                name=name,
+                quantity=55,
+                unit="g",
+                macros=Macros(protein=20, carbs=20, fat=8),
+            )
+        ],
+        confidence_score=0.9,
+    )
+
+
+def _metadata(product_name: str = "Protein Bar") -> dict:
+    return {
+        "is_food_label": True,
+        "product_name": product_name,
+        "brand": "Example",
+        "serving_size": {"display_text": "1 bar (55g)", "grams": 55},
+        "servings_per_package": 8,
+        "label_calories_per_serving": 230,
+        "confidence": 0.9,
+        "label_notes": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_localizes_english_food_label_names_for_non_english_request():
+    service = AsyncMock()
+    service.translate_texts.return_value = TranslationResult(
+        ("Thanh protein",),
+        TranslationOutcome.TRANSLATED,
+        "en",
+        "vi",
+    )
+
+    nutrition, metadata = await localize_food_label_display(
+        nutrition=_nutrition(),
+        metadata=_metadata(),
+        language="vi",
+        translation_service=service,
+    )
+
+    assert nutrition.food_items[0].name == "Thanh protein"
+    assert metadata["product_name"] == "Thanh protein"
+    service.translate_texts.assert_awaited_once_with(["Protein Bar"], "en", "vi")
+
+
+@pytest.mark.asyncio
+async def test_keeps_printed_non_english_product_names_without_translation():
+    service = AsyncMock()
+
+    nutrition, metadata = await localize_food_label_display(
+        nutrition=_nutrition("Thịt bò"),
+        metadata=_metadata("Thịt bò"),
+        language="vi",
+        translation_service=service,
+    )
+
+    assert nutrition.food_items[0].name == "Thịt bò"
+    assert metadata["product_name"] == "Thịt bò"
+    service.translate_texts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_english_request_skips_translation():
+    service = AsyncMock()
+    original = _nutrition()
+
+    nutrition, metadata = await localize_food_label_display(
+        nutrition=original,
+        metadata=_metadata(),
+        language="en",
+        translation_service=service,
+    )
+
+    assert nutrition is original
+    assert metadata["product_name"] == "Protein Bar"
+    service.translate_texts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_translation_keeps_canonical_names():
+    service = AsyncMock()
+    service.translate_texts.return_value = TranslationResult.unavailable(
+        ("Protein Bar",),
+        source_language="en",
+        target_language="vi",
+    )
+    original = _nutrition()
+    original_metadata = _metadata()
+
+    nutrition, metadata = await localize_food_label_display(
+        nutrition=original,
+        metadata=original_metadata,
+        language="vi",
+        translation_service=service,
+    )
+
+    assert nutrition.food_items[0].name == "Protein Bar"
+    assert metadata["product_name"] == "Protein Bar"
+    # Metadata dict may be copied, but values stay canonical.
+    assert metadata is not original_metadata or metadata == original_metadata
+
+
+@pytest.mark.asyncio
+async def test_dedupes_identical_product_and_food_item_names():
+    service = AsyncMock()
+    service.translate_texts.return_value = TranslationResult(
+        ("Thanh protein",),
+        TranslationOutcome.TRANSLATED,
+        "en",
+        "vi",
+    )
+
+    await localize_food_label_display(
+        nutrition=_nutrition("Protein Bar"),
+        metadata=_metadata("Protein Bar"),
+        language="vi",
+        translation_service=service,
+    )
+
+    service.translate_texts.assert_awaited_once_with(["Protein Bar"], "en", "vi")

--- a/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
+++ b/tests/unit/handlers/command_handlers/test_scan_by_url_beverage_routing.py
@@ -3,8 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from src.api.exceptions import ValidationException
 
+from src.api.exceptions import ValidationException
 from src.app.commands.meal.scan_by_url_command import ScanByUrlCommand
 from src.app.handlers.command_handlers.scan_by_url_command_handler import (
     ScanByUrlCommandHandler,
@@ -196,6 +196,73 @@ async def test_scan_by_url_food_label_uses_crop_image_ai_without_ocr(
         "crop_strategy: food_label_visible_frame_v1" in call.args[1].get_user_message()
     )
     vision_service.analyze.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scan_by_url_food_label_localizes_english_product_name(monkeypatch):
+    _install_fake_image_download(
+        monkeypatch, responses={_IMAGE_URL: b"full-image-bytes"}
+    )
+    uow = _make_uow()
+    cache = MagicMock()
+    cache.after_meal_write = AsyncMock()
+    vision_service = MagicMock()
+    vision_service.analyze_with_strategy = AsyncMock(
+        return_value={
+            "structured_data": {
+                "is_food_label": True,
+                "product_name": "Protein Bar",
+                "brand": None,
+                "serving_size": {"display_text": "55g", "grams": 55},
+                "servings_per_package": 1,
+                "label_calories_per_serving": 230,
+                "macros_per_serving": {
+                    "protein_g": 20,
+                    "carbs_g": 20,
+                    "fat_g": 8,
+                    "fiber_g": 0,
+                    "sugar_g": 0,
+                },
+                "confidence": 0.9,
+                "label_notes": [],
+            }
+        }
+    )
+    translator = AsyncMock()
+    from src.domain.model.translation_result import (
+        TranslationOutcome,
+        TranslationResult,
+    )
+
+    translator.translate_texts.return_value = TranslationResult(
+        ("Thanh protein",),
+        TranslationOutcome.TRANSLATED,
+        "en",
+        "vi",
+    )
+    handler = ScanByUrlCommandHandler(
+        uow=uow,
+        event_bus=MagicMock(),
+        vision_service=vision_service,
+        gpt_parser=VisionResponseParser(),
+        text_translation_service=translator,
+        cache_invalidation=cache,
+    )
+
+    result = await handler.handle(
+        ScanByUrlCommand(
+            user_id=_USER_ID,
+            image_url=_IMAGE_URL,
+            public_id="mealtrack/00000000-0000-0000-0000-000000000099",
+            scan_mode="food_label",
+            language="vi",
+        )
+    )
+
+    assert result.source == "food_label"
+    assert result.food_label_metadata["product_name"] == "Thanh protein"
+    assert result.nutrition.food_items[0].name == "Thanh protein"
+    translator.translate_texts.assert_awaited_once_with(["Protein Bar"], "en", "vi")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
@@ -172,7 +172,7 @@ async def test_non_english_openfoodfacts_english_name_is_localized_without_persi
 
 
 @pytest.mark.asyncio
-async def test_cached_barcode_without_source_provenance_stays_canonical():
+async def test_cached_english_barcode_name_is_localized_for_non_english_request():
     repo = _FoodReferenceRepo(
         {
             "123": {
@@ -181,6 +181,31 @@ async def test_cached_barcode_without_source_provenance_stays_canonical():
                 "protein_100g": 2.7,
                 "carbs_100g": 28,
                 "fat_100g": 0.3,
+                "source": "fatsecret",
+                "is_verified": True,
+            }
+        }
+    )
+    handler = _handler(repo, translation_service=_NeutralTranslator())
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["name"] == "Cơm gạo lứt"
+    assert result["source"] == "cache"
+
+
+@pytest.mark.asyncio
+async def test_cached_non_english_barcode_name_stays_canonical():
+    repo = _FoodReferenceRepo(
+        {
+            "123": {
+                "barcode": "123",
+                "name": "Cơm gạo lứt",
+                "protein_100g": 2.7,
+                "carbs_100g": 28,
+                "fat_100g": 0.3,
+                "source": "openfoodfacts",
+                "is_verified": True,
             }
         }
     )
@@ -189,7 +214,7 @@ async def test_cached_barcode_without_source_provenance_stays_canonical():
 
     result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
 
-    assert result["name"] == "Brown Rice"
+    assert result["name"] == "Cơm gạo lứt"
     translator.translate_texts.assert_not_awaited()
 
 

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
@@ -53,3 +53,46 @@ async def test_non_english_first_scan_keeps_english_cache_for_later_english_read
 
     assert english["name"] == "Brown Rice"
     assert english["source"] == "cache"
+
+
+@pytest.mark.asyncio
+async def test_cached_fatsecret_hit_localizes_for_vietnamese_request():
+    repo = _FoodReferenceRepo(
+        {
+            "123": {
+                "barcode": "123",
+                "name": "Brown Rice",
+                "protein_100g": 2.7,
+                "carbs_100g": 28,
+                "fat_100g": 0.3,
+                "source": "fatsecret",
+                "is_verified": True,
+            }
+        }
+    )
+    handler = _handler(repo, translation_service=_NeutralTranslator())
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["source"] == "cache"
+    assert result["name"] == "Cơm gạo lứt"
+
+
+@pytest.mark.asyncio
+async def test_cached_unknown_source_english_name_still_localizes():
+    repo = _FoodReferenceRepo(
+        {
+            "123": {
+                "barcode": "123",
+                "name": "Brown Rice",
+                "protein_100g": 2.7,
+                "carbs_100g": 28,
+                "fat_100g": 0.3,
+            }
+        }
+    )
+    handler = _handler(repo, translation_service=_NeutralTranslator())
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["name"] == "Cơm gạo lứt"

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
@@ -96,3 +96,129 @@ async def test_cached_unknown_source_english_name_still_localizes():
     result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
 
     assert result["name"] == "Cơm gạo lứt"
+
+
+@pytest.mark.asyncio
+async def test_brave_estimate_localizes_leftover_english_name():
+    repo = _FoodReferenceRepo()
+    fat_secret = AsyncMock()
+    fat_secret.get_product.return_value = None
+    fat_secret.search_foods.return_value = []
+    off = AsyncMock()
+    off.get_product.return_value = None
+    brave = AsyncMock()
+    brave.get_product.return_value = {
+        "name": "Brown Rice",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+        brave_search_service=brave,
+        translation_service=_NeutralTranslator(),
+    )
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["source"] == "brave_search"
+    assert result["name"] == "Cơm gạo lứt"
+    assert result["is_estimate"] is True
+
+
+@pytest.mark.asyncio
+async def test_brave_estimate_keeps_already_localized_name():
+    repo = _FoodReferenceRepo()
+    fat_secret = AsyncMock()
+    fat_secret.get_product.return_value = None
+    fat_secret.search_foods.return_value = []
+    off = AsyncMock()
+    off.get_product.return_value = None
+    brave = AsyncMock()
+    brave.get_product.return_value = {
+        "name": "Cơm gạo lứt",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    translator = AsyncMock()
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+        brave_search_service=brave,
+        translation_service=translator,
+    )
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["name"] == "Cơm gạo lứt"
+    translator.translate_texts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ai_estimate_localizes_leftover_english_name():
+    repo = _FoodReferenceRepo()
+    fat_secret = AsyncMock()
+    fat_secret.get_product.return_value = None
+    fat_secret.search_foods.return_value = []
+    off = AsyncMock()
+    off.get_product.return_value = None
+    meal_gen = AsyncMock()
+    meal_gen.generate_meal_plan_async.return_value = {
+        "is_food": True,
+        "name": "Brown Rice",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+        meal_generation_service=meal_gen,
+        translation_service=_NeutralTranslator(),
+    )
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["source"] == "ai_estimate"
+    assert result["name"] == "Cơm gạo lứt"
+
+
+@pytest.mark.asyncio
+async def test_fatsecret_name_estimate_localizes_leftover_english_brave_name():
+    repo = _FoodReferenceRepo()
+    fat_secret = AsyncMock()
+    fat_secret.get_product.return_value = None
+    fat_secret.search_foods.return_value = [
+        {
+            "name": "Some FS Match",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+        }
+    ]
+    off = AsyncMock()
+    off.get_product.return_value = None
+    brave = AsyncMock()
+    brave.get_product.return_value = {
+        "name": "Brown Rice",
+        "protein_100g": None,
+        "carbs_100g": None,
+        "fat_100g": None,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+        brave_search_service=brave,
+        translation_service=_NeutralTranslator(),
+    )
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+
+    assert result["source"] == "fatsecret_name_search"
+    assert result["name"] == "Cơm gạo lứt"

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
@@ -1,0 +1,55 @@
+"""Barcode translation regressions for canonical cache vs localized response."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from tests.unit.handlers.query_handlers.test_lookup_barcode_query_handler_async import (
+    _FoodReferenceRepo,
+    _handler,
+    _NeutralTranslator,
+)
+
+from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
+
+
+@pytest.mark.asyncio
+async def test_non_english_first_scan_keeps_english_cache_for_later_english_read():
+    """Vietnamese first-writer must not poison the global barcode cache."""
+    repo = _FoodReferenceRepo()
+    fat_secret = AsyncMock()
+    fat_secret.get_product.return_value = {
+        "barcode": "123",
+        "name": "Brown Rice",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        translation_service=_NeutralTranslator(),
+    )
+
+    vietnamese = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
+    assert vietnamese["name"] == "Cơm gạo lứt"
+    assert repo.upserts[0]["name"] == "Brown Rice"
+
+    # Simulate cache hit from the English canonical upsert.
+    repo.cached = {
+        "123": {
+            "barcode": "123",
+            "name": "Brown Rice",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+            "source": "fatsecret",
+            "is_verified": True,
+        }
+    }
+    english_handler = _handler(repo, fat_secret_service=AsyncMock())
+    english = await english_handler.handle(
+        LookupBarcodeQuery(barcode="123", language="en")
+    )
+
+    assert english["name"] == "Brown Rice"
+    assert english["source"] == "cache"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Vietnamese barcode scans were still returning English product names. Fresh FatSecret/FDC hits could localize, but **cache hits and Brave/AI estimate fallbacks skipped translation**.

## Changes
- **Barcode cache:** localize FatSecret/USDA cache hits; for unknown provenance, only translate leftover English display names
- **Barcode estimates:** run Brave, FatSecret-name, and AI estimate responses through the same leftover-English localization path
- **Food-label:** translate leftover English product/food-item names after vision parse and trust stored display names on read
- Add regressions for Vietnamese cache hits, Brave/AI estimates, and non-English-first → English-read cache safety

## Verification
- `pytest tests/unit/handlers/query_handlers/test_lookup_barcode_*.py` — 18 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0202a-7f06-7c09-8d07-e1e0910fa761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0202a-7f06-7c09-8d07-e1e0910fa761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

