### PR TITLE
fix(meals): keep scan photos on meal detail

### DIFF
--- a/migrations/versions/20260820000002_widen_mealimage_url.py
+++ b/migrations/versions/20260820000002_widen_mealimage_url.py
@@ -1,0 +1,36 @@
+"""Widen mealimage.url so Cloudinary / CDN URLs are not truncated.
+
+Revision ID: 20260820000002
+Revises: 20260819000001
+Create Date: 2026-08-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260820000002"
+down_revision: str | None = "20260819000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "mealimage",
+        "url",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=1024),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "mealimage",
+        "url",
+        existing_type=sa.String(length=1024),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/migrations/versions/20260820000002_widen_mealimage_url.py
+++ b/migrations/versions/20260820000002_widen_mealimage_url.py
@@ -1,4 +1,4 @@
-"""Widen mealimage.url so Cloudinary / CDN URLs are not truncated.
+"""Widen mealimage.url to Text so CDN URLs are not truncated.
 
 Revision ID: 20260820000002
 Revises: 20260819000001
@@ -21,7 +21,7 @@ def upgrade() -> None:
         "mealimage",
         "url",
         existing_type=sa.String(length=255),
-        type_=sa.String(length=1024),
+        type_=sa.Text(),
         existing_nullable=True,
     )
 
@@ -30,7 +30,7 @@ def downgrade() -> None:
     op.alter_column(
         "mealimage",
         "url",
-        existing_type=sa.String(length=1024),
+        existing_type=sa.Text(),
         type_=sa.String(length=255),
         existing_nullable=True,
     )

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -88,7 +88,9 @@ class MealMapper:
 
         Args:
             meal: Meal domain model
-            image_url: Optional image URL
+            image_url: Optional image URL. When omitted, falls back to the
+                persisted ``meal.image.url`` so callers cannot accidentally drop
+                the photo on meal-detail responses.
             target_language: ISO 639-1 code; if provided and a cached
                 translation exists, translated fields are applied to the response.
 
@@ -101,6 +103,9 @@ class MealMapper:
             NutritionOverrideResponse,
             TranslatedFoodItemResponse,
         )
+
+        if not image_url and meal.image and meal.image.url:
+            image_url = meal.image.url
 
         # Map food items from nutrition if available
         food_items = []

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -104,8 +104,10 @@ class MealMapper:
             TranslatedFoodItemResponse,
         )
 
-        if not image_url and meal.image and meal.image.url:
-            image_url = meal.image.url
+        if not image_url:
+            persisted_image = getattr(meal, "image", None)
+            if persisted_image is not None:
+                image_url = getattr(persisted_image, "url", None)
 
         # Map food items from nutrition if available
         food_items = []

--- a/src/api/routes/v1/meal_scan_by_url.py
+++ b/src/api/routes/v1/meal_scan_by_url.py
@@ -150,6 +150,9 @@ async def _scan_by_url(
         )
 
     response_image_url = meal.image.url if meal.image else None
+    # Prefer the just-validated request URL if persistence dropped it.
+    if not response_image_url:
+        response_image_url = image_url
     if not getattr(meal, "_meal_value_insight_scheduled", False):
         schedule_value_insight_generation(
             task_manager,

--- a/src/api/routes/v1/meal_scan_by_url.py
+++ b/src/api/routes/v1/meal_scan_by_url.py
@@ -149,7 +149,7 @@ async def _scan_by_url(
             details={"error_message": error_message},
         )
 
-    response_image_url = meal.image.url if meal.image else None
+    response_image_url = getattr(getattr(meal, "image", None), "url", None)
     # Prefer the just-validated request URL if persistence dropped it.
     if not response_image_url:
         response_image_url = image_url

--- a/src/api/routes/v1/meals_edit.py
+++ b/src/api/routes/v1/meals_edit.py
@@ -189,8 +189,10 @@ async def update_meal_ingredients(
     )
     if payload.nutrition_contract_version == 2:
         result = dict(result)
+        image_url = meal.image.url if meal.image else None
         result["meal_detail"] = MealMapper.to_detailed_response(
             meal,
+            image_url,
             target_language=get_request_language(request),
         )
     return result

--- a/src/api/routes/v1/meals_edit.py
+++ b/src/api/routes/v1/meals_edit.py
@@ -189,7 +189,7 @@ async def update_meal_ingredients(
     )
     if payload.nutrition_contract_version == 2:
         result = dict(result)
-        image_url = meal.image.url if meal.image else None
+        image_url = getattr(getattr(meal, "image", None), "url", None)
         result["meal_detail"] = MealMapper.to_detailed_response(
             meal,
             image_url,

--- a/src/api/routes/v1/meals_manual_text.py
+++ b/src/api/routes/v1/meals_manual_text.py
@@ -223,7 +223,7 @@ async def create_manual_meal(
             created_at=meal.created_at,
             meal_detail=MealMapper.to_detailed_response(
                 meal,
-                image_url=meal.image.url if meal.image else None,
+                image_url=getattr(getattr(meal, "image", None), "url", None),
                 target_language=get_request_language(request),
             ),
         )

--- a/src/api/routes/v1/meals_manual_text.py
+++ b/src/api/routes/v1/meals_manual_text.py
@@ -74,18 +74,14 @@ async def create_manual_meal(
     ),
     x_app_version: str | None = Header(default=None, alias="X-App-Version"),
     x_platform: str | None = Header(default=None, alias="X-Platform"),
-    idempotency_key_header: str | None = Header(
-        default=None, alias="Idempotency-Key"
-    ),
+    idempotency_key_header: str | None = Header(default=None, alias="Idempotency-Key"),
 ) -> ManualMealCreationResponse:
     """
     Create a manual meal from USDA FDC items.
 
     Authentication required: User ID is automatically extracted from the Firebase token.
     """
-    x_nutrition_contract_version = _unwrap_direct_header(
-        x_nutrition_contract_version
-    )
+    x_nutrition_contract_version = _unwrap_direct_header(x_nutrition_contract_version)
     x_app_version = _unwrap_direct_header(x_app_version)
     x_platform = _unwrap_direct_header(x_platform)
     idempotency_key = _unwrap_direct_header(idempotency_key_header)
@@ -227,6 +223,7 @@ async def create_manual_meal(
             created_at=meal.created_at,
             meal_detail=MealMapper.to_detailed_response(
                 meal,
+                image_url=meal.image.url if meal.image else None,
                 target_language=get_request_language(request),
             ),
         )

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -25,8 +25,6 @@ from src.domain.services.meal_recommendation.ingredient_quantity_conversion_serv
 )
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
-# mealimage.url is VARCHAR(1024); keep inserts valid if a URL somehow exceeds it.
-_MEAL_IMAGE_URL_MAX_LEN = 1024
 _CATALOG_CONVERTER = IngredientQuantityConversionService(
     allow_unverified=True,
     allow_unapproved_sources=True,
@@ -115,8 +113,7 @@ class RecommendedMealMaterializationService:
 def _meal_image_for_catalog(catalog_meal: CatalogMeal) -> MealImage:
     """Build a meal image row from catalog URL, or a placeholder when absent."""
 
-    raw_url = (catalog_meal.image_url or "").strip() or None
-    url = raw_url if raw_url and len(raw_url) <= _MEAL_IMAGE_URL_MAX_LEN else None
+    url = (catalog_meal.image_url or "").strip() or None
     return MealImage(
         image_id=str(uuid4()),
         format="jpeg",

--- a/src/app/services/recommended_meal_materialization_service.py
+++ b/src/app/services/recommended_meal_materialization_service.py
@@ -25,8 +25,8 @@ from src.domain.services.meal_recommendation.ingredient_quantity_conversion_serv
 )
 from src.domain.utils.timezone_utils import noon_utc_for_date
 
-# mealimage.url is VARCHAR(255); keep inserts valid when catalog URLs are longer.
-_MEAL_IMAGE_URL_MAX_LEN = 255
+# mealimage.url is VARCHAR(1024); keep inserts valid if a URL somehow exceeds it.
+_MEAL_IMAGE_URL_MAX_LEN = 1024
 _CATALOG_CONVERTER = IngredientQuantityConversionService(
     allow_unverified=True,
     allow_unapproved_sources=True,

--- a/src/infra/database/models/meal/meal_image.py
+++ b/src/infra/database/models/meal/meal_image.py
@@ -2,7 +2,7 @@
 Meal image model for storing image metadata.
 """
 
-from sqlalchemy import Column, String, Integer
+from sqlalchemy import Column, Integer, String, Text
 
 from src.infra.database.base import Base
 from src.infra.database.models.base import TimestampMixin
@@ -19,4 +19,4 @@ class MealImageORM(Base, TimestampMixin):
     size_bytes = Column(Integer, nullable=False)
     width = Column(Integer, nullable=True)  # Changed to nullable
     height = Column(Integer, nullable=True)  # Changed to nullable
-    url = Column(String(1024), nullable=True)  # Cloudinary / CDN image URL
+    url = Column(Text, nullable=True)  # Cloudinary / CDN image URL

--- a/src/infra/database/models/meal/meal_image.py
+++ b/src/infra/database/models/meal/meal_image.py
@@ -19,4 +19,4 @@ class MealImageORM(Base, TimestampMixin):
     size_bytes = Column(Integer, nullable=False)
     width = Column(Integer, nullable=True)  # Changed to nullable
     height = Column(Integer, nullable=True)  # Changed to nullable
-    url = Column(String(255), nullable=True)  # Optional URL to the image
+    url = Column(String(1024), nullable=True)  # Cloudinary / CDN image URL

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, noload, selectinload
 
 from src.domain.model.meal import Meal, MealStatus
+from src.domain.model.meal.meal_image import MealImage as DomainMealImage
 from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition import Nutrition
 from src.domain.model.nutrition.macros import Macros
@@ -120,19 +121,7 @@ class AsyncMealRepository(MealRepositoryPort):
 
             # Update image association/URL if changed.
             if meal.image:
-                img_result = await self.session.execute(
-                    select(MealImageORM).where(
-                        MealImageORM.image_id == meal.image.image_id
-                    )
-                )
-                existing_image = img_result.scalars().first()
-                if existing_image:
-                    if existing_image.url != meal.image.url:
-                        existing_image.url = meal.image.url
-                else:
-                    existing_image = meal_image_domain_to_orm(meal.image)
-                    self.session.add(existing_image)
-                    await self.session.flush()
+                existing_image = await self._upsert_meal_image(meal.image)
                 existing_meal.image_id = str(meal.image.image_id)
                 existing_meal.image = existing_image
             else:
@@ -151,48 +140,21 @@ class AsyncMealRepository(MealRepositoryPort):
                     )
 
             await self.session.flush()
-            # Re-fetch with eager loading so mapper can access nutrition/food_items
-            result2 = await self.session.execute(
-                select(MealORM)
-                .options(
-                    selectinload(MealORM.nutrition).selectinload(
-                        NutritionORM.food_items
-                    ),
-                    selectinload(MealORM.instruction_steps),
-                )
-                .where(MealORM.meal_id == meal.meal_id)
+            return await self._reload_meal_domain(
+                meal.meal_id, fallback_image=meal.image
             )
-            existing_meal = result2.scalars().first()
-            return meal_orm_to_domain(existing_meal)
         else:
             db_meal = meal_domain_to_orm(meal)
             if meal.image:
-                img_result = await self.session.execute(
-                    select(MealImageORM).where(
-                        MealImageORM.image_id == meal.image.image_id
-                    )
-                )
-                if not img_result.scalars().first():
-                    db_image = meal_image_domain_to_orm(meal.image)
-                    self.session.add(db_image)
-                    await self.session.flush()
+                db_image = await self._upsert_meal_image(meal.image)
                 db_meal.image_id = str(meal.image.image_id)
+                db_meal.image = db_image
 
             self.session.add(db_meal)
             await self.session.flush()
-            # Re-fetch with eager loading after flush
-            result2 = await self.session.execute(
-                select(MealORM)
-                .options(
-                    selectinload(MealORM.nutrition).selectinload(
-                        NutritionORM.food_items
-                    ),
-                    selectinload(MealORM.instruction_steps),
-                )
-                .where(MealORM.meal_id == db_meal.meal_id)
+            return await self._reload_meal_domain(
+                db_meal.meal_id, fallback_image=meal.image
             )
-            db_meal = result2.scalars().first()
-            return meal_orm_to_domain(db_meal)
 
     async def find_by_id(
         self, meal_id: str, projection: MealProjection = MealProjection.FULL
@@ -218,9 +180,7 @@ class AsyncMealRepository(MealRepositoryPort):
         """
         # Step 1: lock the meal row without any joins.
         lock_result = await self.session.execute(
-            select(MealORM.meal_id)
-            .where(MealORM.meal_id == meal_id)
-            .with_for_update()
+            select(MealORM.meal_id).where(MealORM.meal_id == meal_id).with_for_update()
         )
         if lock_result.scalar_one_or_none() is None:
             return None
@@ -639,6 +599,53 @@ class AsyncMealRepository(MealRepositoryPort):
             for catalog_meal_id, logged_at in result.all()
             if catalog_meal_id is not None
         )
+
+    async def _upsert_meal_image(self, image: DomainMealImage) -> MealImageORM:
+        """Insert or update a mealimage row, always refreshing a non-empty URL."""
+        img_result = await self.session.execute(
+            select(MealImageORM).where(MealImageORM.image_id == image.image_id)
+        )
+        existing_image = img_result.scalars().first()
+        if existing_image:
+            if image.url and existing_image.url != image.url:
+                existing_image.url = image.url
+            if image.format:
+                existing_image.format = image.format
+            if image.size_bytes:
+                existing_image.size_bytes = image.size_bytes
+            if image.width is not None:
+                existing_image.width = image.width
+            if image.height is not None:
+                existing_image.height = image.height
+            return existing_image
+
+        db_image = meal_image_domain_to_orm(image)
+        self.session.add(db_image)
+        await self.session.flush()
+        return db_image
+
+    async def _reload_meal_domain(
+        self, meal_id: str, *, fallback_image: DomainMealImage | None = None
+    ) -> Meal:
+        """Reload a meal with image/nutrition eager-loaded after write."""
+        result = await self.session.execute(
+            select(MealORM)
+            .options(
+                joinedload(MealORM.image),
+                selectinload(MealORM.nutrition).selectinload(NutritionORM.food_items),
+                selectinload(MealORM.instruction_steps),
+            )
+            .where(MealORM.meal_id == meal_id)
+        )
+        db_meal = result.unique().scalars().first()
+        mapped = meal_orm_to_domain(db_meal)
+        # Defensive: identity-map edge cases can drop the joined image on write.
+        # Keep the caller's verified image URL so scan/detail responses stay in sync.
+        if fallback_image and (
+            mapped.image is None or (fallback_image.url and not mapped.image.url)
+        ):
+            return mapped.with_image(fallback_image)
+        return mapped
 
     async def _update_nutrition(
         self, db_nutrition: NutritionORM, domain_nutrition: Nutrition

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -175,6 +175,33 @@ class TestMealMapper:
         # total_weight_grams is calculated from food items
         assert result.total_weight_grams == 350 or result.total_weight_grams is None
 
+    def test_to_detailed_response_falls_back_to_meal_image_url(self):
+        """Meal detail must keep the photo when callers omit image_url."""
+        image = MealImage(
+            url="https://res.cloudinary.com/demo/image/upload/v1/mealtrack/abc.jpg",
+            image_id=str(uuid.uuid4()),
+            format="jpeg",
+            size_bytes=2048,
+        )
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=image,
+            dish_name="Pho",
+            ready_at=datetime(2025, 1, 15, 14, 0),
+            created_at=datetime(2025, 1, 15, 13, 30),
+            nutrition=Nutrition(
+                macros=Macros(protein=20, carbs=40, fat=10),
+                food_items=[],
+            ),
+            source="scanner",
+        )
+
+        result = MealMapper.to_detailed_response(meal, target_language="en")
+
+        assert result.image_url == image.url
+
     def test_to_detailed_response_includes_canonical_source_nutrition(self):
         item = FoodItem(
             id="item-1",
@@ -902,7 +929,9 @@ class TestMealMapper:
         assert custom.carbs_per_100g == pytest.approx(0.7)
         assert custom.fat_per_100g == pytest.approx(9.6)
 
-    def test_to_detailed_response_custom_nutrition_does_not_treat_nhanh_as_one_gram(self):
+    def test_to_detailed_response_custom_nutrition_does_not_treat_nhanh_as_one_gram(
+        self,
+    ):
         """Unknown culinary units must not explode per-100g calories 100x."""
         food_items = [
             FoodItem(

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -240,10 +240,9 @@ async def test_materializer_keeps_long_catalog_image_urls():
     long_url = (
         "https://res.cloudinary.com/demo/image/upload/"
         "c_fill,w_1200,h_1200,q_auto:good,f_auto,fl_progressive/"
-        "v1720000000/mealtrack/" + ("catalog-meal-" + "x" * 200) + ".jpg"
+        "v1720000000/mealtrack/" + ("catalog-meal-" + "x" * 1200) + ".jpg"
     )
-    assert len(long_url) > 255
-    assert len(long_url) <= 1024
+    assert len(long_url) > 1024
     slot = PersistedMealRecommendationSlot(
         **{
             **slot.__dict__,

--- a/tests/unit/app/services/test_recommended_meal_materialization_service.py
+++ b/tests/unit/app/services/test_recommended_meal_materialization_service.py
@@ -233,6 +233,45 @@ async def test_materializer_attaches_catalog_image_url_when_present():
 
 
 @pytest.mark.asyncio
+async def test_materializer_keeps_long_catalog_image_urls():
+    plan, slot = _plan_and_slot()
+    catalog_meal = slot.selected.catalog_meal
+    assert catalog_meal is not None
+    long_url = (
+        "https://res.cloudinary.com/demo/image/upload/"
+        "c_fill,w_1200,h_1200,q_auto:good,f_auto,fl_progressive/"
+        "v1720000000/mealtrack/" + ("catalog-meal-" + "x" * 200) + ".jpg"
+    )
+    assert len(long_url) > 255
+    assert len(long_url) <= 1024
+    slot = PersistedMealRecommendationSlot(
+        **{
+            **slot.__dict__,
+            "selected": PersistedMealRecommendationCandidate(
+                **{
+                    **slot.selected.__dict__,
+                    "catalog_meal": CatalogMeal(
+                        **{
+                            **catalog_meal.__dict__,
+                            "image_url": long_url,
+                        }
+                    ),
+                }
+            ),
+        }
+    )
+
+    meal = await RecommendedMealMaterializationService().materialize(
+        _Uow(),
+        plan=plan,
+        slot=slot,
+    )
+
+    assert meal.image is not None
+    assert meal.image.url == long_url
+
+
+@pytest.mark.asyncio
 async def test_materializer_fails_with_public_error_when_selected_meal_missing():
     plan, slot = _plan_and_slot()
     slot = PersistedMealRecommendationSlot(**{**slot.__dict__, "selected": None})

--- a/tests/unit/infra/repositories/test_meal_repository_image_upsert.py
+++ b/tests/unit/infra/repositories/test_meal_repository_image_upsert.py
@@ -1,0 +1,71 @@
+"""Unit tests for mealimage upsert / reload helpers on AsyncMealRepository."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.domain.model.meal import MealImage
+from src.infra.repositories.meal_repository_async import AsyncMealRepository
+
+
+@pytest.mark.asyncio
+async def test_upsert_meal_image_updates_url_on_existing_row():
+    repo = AsyncMealRepository(session=MagicMock())
+    existing = SimpleNamespace(
+        image_id="11111111-1111-1111-1111-111111111111",
+        url=None,
+        format="jpeg",
+        size_bytes=1,
+        width=None,
+        height=None,
+    )
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = existing
+    repo.session.execute = AsyncMock(return_value=result)
+
+    image = MealImage(
+        image_id=existing.image_id,
+        format="jpeg",
+        size_bytes=4096,
+        url="https://res.cloudinary.com/demo/image/upload/v1/mealtrack/abc.jpg",
+    )
+
+    saved = await repo._upsert_meal_image(image)
+
+    assert saved is existing
+    assert existing.url == image.url
+    assert existing.size_bytes == 4096
+    repo.session.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reload_meal_domain_falls_back_to_caller_image(monkeypatch):
+    repo = AsyncMealRepository(session=MagicMock())
+    meal_id = str(uuid4())
+    mapped = MagicMock()
+    mapped.image = None
+    mapped.with_image = MagicMock(
+        side_effect=lambda image: SimpleNamespace(image=image)
+    )
+
+    result = MagicMock()
+    result.unique.return_value.scalars.return_value.first.return_value = object()
+    repo.session.execute = AsyncMock(return_value=result)
+    monkeypatch.setattr(
+        "src.infra.repositories.meal_repository_async.meal_orm_to_domain",
+        lambda _orm: mapped,
+    )
+
+    fallback = MealImage(
+        image_id=str(uuid4()),
+        format="jpeg",
+        size_bytes=2048,
+        url="https://res.cloudinary.com/demo/image/upload/v1/mealtrack/scan.jpg",
+    )
+
+    reloaded = await repo._reload_meal_domain(meal_id, fallback_image=fallback)
+
+    assert reloaded.image is fallback
+    mapped.with_image.assert_called_once_with(fallback)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Keeps meal photos on detail responses after scan/save, and stores image URLs without a fixed length cap.

## Root causes
- Meal save could leave `mealimage.url` null/stale; post-save reload did not always eager-load image
- `MealMapper.to_detailed_response` ignored persisted `meal.image.url` when callers omitted `image_url`
- `mealimage.url` was `VARCHAR(255)` — longer CDN URLs were discarded
- Some response paths used bare `meal.image` access, which 500s on SimpleNamespace test doubles

## Changes
- Upsert + reload meal images with URL refresh and `joinedload`
- Mapper/route fallbacks via safe `getattr` for `meal.image.url`
- Widen `mealimage.url` to unbounded `Text` (migration `20260820000002`), matching catalog/cache image URL columns
- Remove app-level URL length truncation in catalog materialization

## Test plan
- [x] Unit: durable manual meal replay
- [x] Unit: meal mapper image fallback
- [x] Unit: long catalog image URL (>1024) kept
- [ ] CI Pipeline green on branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02029-2177-7c16-9a60-08b8ccd76954?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02029-2177-7c16-9a60-08b8ccd76954&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

