### PR TITLE
feat(meals): cache same food across different photo angles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,11 @@ SENTRY_SEND_PII=false
 # ---------------------------------------------------------------------------
 MEAL_ANALYZE_MAX_ATTEMPTS=2
 MEAL_ANALYZE_MAX_OUTPUT_TOKENS=700
+# Reuse prior meal analysis when the same food is scanned from a new angle
+# (AI visual identity + scene signature). OpenAI prompt cache does NOT do this.
+MEAL_SCAN_VISUAL_CACHE_ENABLED=false
+MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD=0.82
+MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE=0.55
 
 # ---------------------------------------------------------------------------
 # Referral System (Multi-Currency)

--- a/migrations/versions/20260820000001_add_meal_scan_visual_identity.py
+++ b/migrations/versions/20260820000001_add_meal_scan_visual_identity.py
@@ -1,0 +1,91 @@
+"""Add meal_scan_visual_identity for angle-tolerant meal scan reuse.
+
+Revision ID: 20260820000001
+Revises: 20260819000001
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260820000001"
+down_revision: str | None = "20260819000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "meal_scan_visual_identity",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("meal_id", sa.String(length=36), nullable=False),
+        sa.Column("source", sa.String(length=20), nullable=False),
+        sa.Column("dish_slug", sa.String(length=128), nullable=False),
+        sa.Column(
+            "ingredients",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("container", sa.String(length=64), nullable=True),
+        sa.Column("background", sa.String(length=64), nullable=True),
+        sa.Column("identity_key", sa.String(length=255), nullable=False),
+        sa.Column(
+            "scene_signature",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["meal_id"],
+            ["meal.meal_id"],
+            name="fk_meal_scan_visual_identity_meal",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_meal_scan_visual_identity_user",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(
+        "ix_meal_scan_visual_identity_user_source_dish",
+        "meal_scan_visual_identity",
+        ["user_id", "source", "dish_slug"],
+    )
+    op.create_index(
+        "ix_meal_scan_visual_identity_user_identity_key",
+        "meal_scan_visual_identity",
+        ["user_id", "identity_key"],
+    )
+    op.create_index(
+        "ix_meal_scan_visual_identity_meal_id",
+        "meal_scan_visual_identity",
+        ["meal_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_meal_scan_visual_identity_meal_id",
+        table_name="meal_scan_visual_identity",
+    )
+    op.drop_index(
+        "ix_meal_scan_visual_identity_user_identity_key",
+        table_name="meal_scan_visual_identity",
+    )
+    op.drop_index(
+        "ix_meal_scan_visual_identity_user_source_dish",
+        table_name="meal_scan_visual_identity",
+    )
+    op.drop_table("meal_scan_visual_identity")

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -159,9 +159,6 @@ from src.app.handlers.query_handlers.get_activities_presence_query_handler impor
 from src.app.handlers.query_handlers.get_cheat_days_query_handler import (
     GetCheatDaysQueryHandler,
 )
-from src.app.handlers.query_handlers.list_logged_catalog_meals_query_handler import (
-    ListLoggedCatalogMealsQueryHandler,
-)
 from src.app.handlers.query_handlers.get_meal_recommendation_plan_query_handler import (
     GetMealRecommendationPlanQueryHandler,
 )
@@ -173,6 +170,9 @@ from src.app.handlers.query_handlers.get_nutrition_bulk_query_handler import (
 )
 from src.app.handlers.query_handlers.get_weight_entries_query_handler import (
     GetWeightEntriesQueryHandler,
+)
+from src.app.handlers.query_handlers.list_logged_catalog_meals_query_handler import (
+    ListLoggedCatalogMealsQueryHandler,
 )
 from src.app.queries.activity import GetBulkActivitiesQuery, GetDailyActivitiesQuery
 from src.app.queries.cheat_day import GetCheatDaysQuery
@@ -216,6 +216,7 @@ from src.app.queries.weight import GetWeightEntriesQuery
 from src.app.services.meal_recommendation_history_projector import (
     MealRecommendationHistoryProjector,
 )
+from src.app.services.meal_scan_visual_cache_service import MealScanVisualCacheService
 from src.domain.ports.food_reference_repository_port import (
     FoodReferenceSearchProjection,
 )
@@ -471,6 +472,15 @@ def get_configured_event_bus() -> EventBus:
             meal_value_insight_ai_manager=ai_manager,
             meal_analyze_workflow=meal_analyze_workflow,
             meal_analyze_graph_enabled=graph_settings["graph_enabled"],
+            meal_scan_visual_cache=MealScanVisualCacheService(
+                AsyncUnitOfWork(),
+                vision_service,
+                enabled=bool(settings.MEAL_SCAN_VISUAL_CACHE_ENABLED),
+                match_threshold=float(settings.MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD),
+                min_identity_confidence=float(
+                    settings.MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE
+                ),
+            ),
         ),
     )
     event_bus.register_handler(
@@ -487,6 +497,15 @@ def get_configured_event_bus() -> EventBus:
             meal_value_insight_ai_manager=ai_manager,
             meal_analyze_workflow=meal_analyze_workflow,
             meal_analyze_graph_enabled=graph_settings["graph_enabled"],
+            meal_scan_visual_cache=MealScanVisualCacheService(
+                AsyncUnitOfWork(),
+                vision_service,
+                enabled=bool(settings.MEAL_SCAN_VISUAL_CACHE_ENABLED),
+                match_threshold=float(settings.MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD),
+                min_identity_confidence=float(
+                    settings.MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE
+                ),
+            ),
         ),
     )
 

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -47,7 +47,6 @@ from src.domain.utils.timezone_utils import (
     noon_utc_for_date,
     utc_now,
 )
-from src.infra.config.settings import get_settings
 from src.observability import capture_message, distribution_metric, increment_metric
 
 logger = logging.getLogger(__name__)
@@ -86,15 +85,12 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         if meal_scan_visual_cache is not None:
             self.meal_scan_visual_cache = meal_scan_visual_cache
         else:
-            settings = get_settings()
+            # DI should inject a configured cache; default keeps the feature off
+            # so app handlers do not import infra settings.
             self.meal_scan_visual_cache = MealScanVisualCacheService(
                 uow,
                 vision_service,
-                enabled=bool(settings.MEAL_SCAN_VISUAL_CACHE_ENABLED),
-                match_threshold=float(settings.MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD),
-                min_identity_confidence=float(
-                    settings.MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE
-                ),
+                enabled=False,
             )
 
     def _record_food_label_metric(

--- a/src/app/handlers/command_handlers/scan_by_url_command_handler.py
+++ b/src/app/handlers/command_handlers/scan_by_url_command_handler.py
@@ -14,6 +14,10 @@ from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.meal_analyze_workflow import MealAnalyzeWorkflow
+from src.app.services.meal_scan_visual_cache_service import (
+    MealScanVisualCacheService,
+    scan_source_for_mode,
+)
 from src.domain.constants import MealDefaults
 from src.domain.model.meal import Meal, MealImage, MealStatus
 from src.domain.model.meal.meal_response_localization import (
@@ -43,6 +47,7 @@ from src.domain.utils.timezone_utils import (
     noon_utc_for_date,
     utc_now,
 )
+from src.infra.config.settings import get_settings
 from src.observability import capture_message, distribution_metric, increment_metric
 
 logger = logging.getLogger(__name__)
@@ -65,6 +70,7 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         meal_value_insight_ai_manager: MealInsightAIPort | None = None,
         meal_analyze_workflow: MealAnalyzeWorkflow | None = None,
         meal_analyze_graph_enabled: bool = False,
+        meal_scan_visual_cache: MealScanVisualCacheService | None = None,
     ):
         self.uow = uow
         self.event_bus = event_bus
@@ -77,6 +83,19 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         self.meal_value_insight_ai_manager = meal_value_insight_ai_manager
         self.meal_analyze_workflow = meal_analyze_workflow
         self.meal_analyze_graph_enabled = meal_analyze_graph_enabled
+        if meal_scan_visual_cache is not None:
+            self.meal_scan_visual_cache = meal_scan_visual_cache
+        else:
+            settings = get_settings()
+            self.meal_scan_visual_cache = MealScanVisualCacheService(
+                uow,
+                vision_service,
+                enabled=bool(settings.MEAL_SCAN_VISUAL_CACHE_ENABLED),
+                match_threshold=float(settings.MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD),
+                min_identity_confidence=float(
+                    settings.MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE
+                ),
+            )
 
     def _record_food_label_metric(
         self,
@@ -387,9 +406,25 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
         if not all([self.vision_service, self.gpt_parser]):
             raise RuntimeError("Required dependencies not configured")
 
+        source = scan_source_for_mode(command.scan_mode)
+        raw_bytes: bytes | None = None
+        if (
+            command.scan_mode != "food_label"
+            and not command.user_description
+            and self.meal_scan_visual_cache.enabled
+        ):
+            raw_bytes = await self._download_image_bytes(command.image_url)
+            cached = await self.meal_scan_visual_cache.try_resolve(
+                user_id=command.user_id,
+                image_bytes=raw_bytes,
+                source=source,
+            )
+            if cached is not None:
+                return cached
+
         if self.meal_analyze_graph_enabled:
             workflow = self.meal_analyze_workflow or MealAnalyzeWorkflow()
-            return await workflow.run_scan_by_url(
+            meal = await workflow.run_scan_by_url(
                 command,
                 self._handle_legacy_scan_by_url,
                 runtime=MealAnalyzeRuntime(
@@ -407,5 +442,22 @@ class ScanByUrlCommandHandler(EventHandler[ScanByUrlCommand, Meal]):
                     meal_translation_service=self.meal_translation_service,
                 ),
             )
+        else:
+            meal = await self._handle_legacy_scan_by_url(command)
 
-        return await self._handle_legacy_scan_by_url(command)
+        if self.meal_scan_visual_cache.enabled:
+            if raw_bytes is None:
+                try:
+                    raw_bytes = await self._download_image_bytes(command.image_url)
+                except Exception as exc:
+                    logger.warning(
+                        "[MEAL-VISUAL-CACHE] remember download failed: %s", exc
+                    )
+                    return meal
+            await self.meal_scan_visual_cache.remember(
+                user_id=command.user_id,
+                meal=meal,
+                image_bytes=raw_bytes,
+                source=source,
+            )
+        return meal

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -92,15 +92,10 @@ class UploadMealImageImmediatelyHandler(
         if meal_scan_visual_cache is not None:
             self.meal_scan_visual_cache = meal_scan_visual_cache
         else:
-            settings = get_settings()
             self.meal_scan_visual_cache = MealScanVisualCacheService(
                 uow,
                 vision_service,
-                enabled=bool(settings.MEAL_SCAN_VISUAL_CACHE_ENABLED),
-                match_threshold=float(settings.MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD),
-                min_identity_confidence=float(
-                    settings.MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE
-                ),
+                enabled=False,
             )
         if fast_path_policy is None:
             self._fast_path_policy = MealAnalyzeFastPathPolicy.from_settings(

--- a/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
+++ b/src/app/handlers/command_handlers/upload_meal_image_immediately_command_handler.py
@@ -13,6 +13,10 @@ from src.app.events.base import EventHandler, handles
 from src.app.graphs.meal_analyze.runtime import MealAnalyzeRuntime
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.meal_analyze_workflow import MealAnalyzeWorkflow
+from src.app.services.meal_scan_visual_cache_service import (
+    MealScanVisualCacheService,
+    scan_source_for_mode,
+)
 from src.domain.exceptions.ai_exceptions import (
     AIVisionError,
     AIVisionFailureKind,
@@ -71,6 +75,7 @@ class UploadMealImageImmediatelyHandler(
         meal_value_insight_ai_manager: MealInsightAIPort | None = None,
         meal_analyze_workflow: MealAnalyzeWorkflow | None = None,
         meal_analyze_graph_enabled: bool = False,
+        meal_scan_visual_cache: MealScanVisualCacheService | None = None,
     ):
         self.uow = uow
         self.event_bus = event_bus
@@ -84,6 +89,19 @@ class UploadMealImageImmediatelyHandler(
         self.meal_value_insight_ai_manager = meal_value_insight_ai_manager
         self.meal_analyze_workflow = meal_analyze_workflow
         self.meal_analyze_graph_enabled = meal_analyze_graph_enabled
+        if meal_scan_visual_cache is not None:
+            self.meal_scan_visual_cache = meal_scan_visual_cache
+        else:
+            settings = get_settings()
+            self.meal_scan_visual_cache = MealScanVisualCacheService(
+                uow,
+                vision_service,
+                enabled=bool(settings.MEAL_SCAN_VISUAL_CACHE_ENABLED),
+                match_threshold=float(settings.MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD),
+                min_identity_confidence=float(
+                    settings.MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE
+                ),
+            )
         if fast_path_policy is None:
             self._fast_path_policy = MealAnalyzeFastPathPolicy.from_settings(
                 get_settings()
@@ -174,8 +192,13 @@ class UploadMealImageImmediatelyHandler(
         """Reject incomplete same-call locale output before meal persistence."""
         if language == "en" or not isinstance(result, dict):
             return
-        structured_data = result.get("structured_data") if isinstance(result, dict) else None
-        if isinstance(structured_data, dict) and structured_data.get("is_food") is False:
+        structured_data = (
+            result.get("structured_data") if isinstance(result, dict) else None
+        )
+        if (
+            isinstance(structured_data, dict)
+            and structured_data.get("is_food") is False
+        ):
             return
         parse_meal_response_localization(
             structured_data,
@@ -390,9 +413,19 @@ class UploadMealImageImmediatelyHandler(
         if not all([self.image_store, self.vision_service, self.gpt_parser]):
             raise RuntimeError("Required dependencies not configured")
 
+        source = scan_source_for_mode(command.scan_mode)
+        if not command.user_description and self.meal_scan_visual_cache.enabled:
+            cached = await self.meal_scan_visual_cache.try_resolve(
+                user_id=command.user_id,
+                image_bytes=command.file_contents,
+                source=source,
+            )
+            if cached is not None:
+                return cached
+
         if self.meal_analyze_graph_enabled:
             workflow = self.meal_analyze_workflow or MealAnalyzeWorkflow()
-            return await workflow.run_uploaded(
+            meal = await workflow.run_uploaded(
                 command,
                 self._handle_parallel_upload,
                 runtime=MealAnalyzeRuntime(
@@ -410,5 +443,13 @@ class UploadMealImageImmediatelyHandler(
                     max_vision_attempts=max(1, self._fast_path_policy.max_attempts),
                 ),
             )
+        else:
+            meal = await self._handle_parallel_upload(command)
 
-        return await self._handle_parallel_upload(command)
+        await self.meal_scan_visual_cache.remember(
+            user_id=command.user_id,
+            meal=meal,
+            image_bytes=command.file_contents,
+            source=source,
+        )
+        return meal

--- a/src/app/services/meal_scan_visual_cache_service.py
+++ b/src/app/services/meal_scan_visual_cache_service.py
@@ -1,0 +1,406 @@
+"""Angle-tolerant meal scan cache via AI visual identity + scene signature.
+
+OpenAI prompt caching only reuses system-prompt prefixes for cost. It does not
+return the same meal for different photos. This service asks a cheap vision
+pass for an angle-invariant identity, compares scene color signatures, and
+reuses the prior READY meal when both signals agree.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from uuid import uuid4
+
+from src.domain.model.meal import Meal, MealStatus
+from src.domain.model.meal_scan_visual_identity import (
+    MealScanVisualIdentity,
+    ParsedVisualIdentity,
+)
+from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
+from src.domain.ports.vision_ai_service_port import VisionAIServicePort
+from src.domain.strategies.meal_analysis_strategy import FoodVisualIdentityStrategy
+from src.domain.utils.scene_signature import (
+    build_scene_signature,
+    ingredient_jaccard,
+    scene_cosine_similarity,
+)
+from src.domain.utils.timezone_utils import utc_now
+from src.observability import increment_metric
+
+logger = logging.getLogger(__name__)
+
+_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def scan_source_for_mode(scan_mode: str) -> str:
+    return "food_label" if scan_mode == "food_label" else "scanner"
+
+
+def _slug(value: str | None, *, fallback: str = "unknown") -> str:
+    if not value:
+        return fallback
+    cleaned = _SLUG_RE.sub("_", value.strip().lower()).strip("_")
+    return cleaned[:128] or fallback
+
+
+def build_identity_key(
+    *,
+    dish_slug: str,
+    ingredients: list[str] | tuple[str, ...],
+    container: str | None,
+    background: str | None,
+) -> str:
+    ingredient_part = ",".join(sorted({_slug(i) for i in ingredients if i}))
+    return "|".join(
+        (
+            _slug(dish_slug),
+            ingredient_part,
+            _slug(container, fallback=""),
+            _slug(background, fallback=""),
+        )
+    )
+
+
+def parse_visual_identity(
+    vision_result: dict[str, Any] | Any,
+) -> ParsedVisualIdentity | None:
+    if not isinstance(vision_result, dict):
+        return None
+    structured = vision_result.get("structured_data")
+    payload = structured if isinstance(structured, dict) else vision_result
+    if not isinstance(payload, dict):
+        return None
+
+    is_food = payload.get("is_food", True)
+    if is_food is False:
+        return ParsedVisualIdentity(
+            dish_slug="not_food",
+            ingredients=(),
+            container=None,
+            background=None,
+            identity_key="not_food",
+            is_food=False,
+            confidence=float(payload.get("confidence") or 0.0),
+        )
+
+    dish_slug = _slug(str(payload.get("dish_slug") or payload.get("dish_name") or ""))
+    raw_ingredients = payload.get("ingredients") or []
+    if not isinstance(raw_ingredients, list):
+        raw_ingredients = []
+    ingredients = tuple(
+        sorted({_slug(str(item)) for item in raw_ingredients if str(item).strip()})
+    )
+    container = payload.get("container")
+    background = payload.get("background")
+    container_slug = _slug(str(container), fallback="") if container else None
+    background_slug = _slug(str(background), fallback="") if background else None
+    if container_slug == "":
+        container_slug = None
+    if background_slug == "":
+        background_slug = None
+    identity_key = build_identity_key(
+        dish_slug=dish_slug,
+        ingredients=ingredients,
+        container=container_slug,
+        background=background_slug,
+    )
+    return ParsedVisualIdentity(
+        dish_slug=dish_slug,
+        ingredients=ingredients,
+        container=container_slug,
+        background=background_slug,
+        identity_key=identity_key,
+        is_food=True,
+        confidence=float(payload.get("confidence") or 0.0),
+    )
+
+
+def score_visual_match(
+    *,
+    parsed: ParsedVisualIdentity,
+    candidate: MealScanVisualIdentity,
+    scene_signature: list[float],
+) -> float:
+    if parsed.dish_slug != candidate.dish_slug:
+        return 0.0
+    scene = scene_cosine_similarity(scene_signature, candidate.scene_signature)
+    ingredients = ingredient_jaccard(parsed.ingredients, candidate.ingredients)
+    container = (
+        1.0
+        if parsed.container
+        and candidate.container
+        and parsed.container == candidate.container
+        else 0.5
+        if not parsed.container or not candidate.container
+        else 0.0
+    )
+    background = (
+        1.0
+        if parsed.background
+        and candidate.background
+        and parsed.background == candidate.background
+        else 0.5
+        if not parsed.background or not candidate.background
+        else 0.0
+    )
+    # Scene + ingredients dominate; container/background break ties.
+    return (
+        (0.45 * scene) + (0.35 * ingredients) + (0.10 * container) + (0.10 * background)
+    )
+
+
+def mark_scan_cache_hit(meal: Meal) -> Meal:
+    meal._meal_scan_cache_hit = True  # type: ignore[attr-defined]
+    meal._meal_value_insight_scheduled = True  # type: ignore[attr-defined]
+    return meal
+
+
+class MealScanVisualCacheService:
+    """Resolve prior meals for re-scans of the same food at new angles."""
+
+    def __init__(
+        self,
+        uow: AsyncUnitOfWorkPort,
+        vision_service: VisionAIServicePort | None = None,
+        *,
+        enabled: bool = False,
+        match_threshold: float = 0.82,
+        min_identity_confidence: float = 0.55,
+    ):
+        self._uow = uow
+        self._vision_service = vision_service
+        self._enabled = enabled
+        self._match_threshold = match_threshold
+        self._min_identity_confidence = min_identity_confidence
+        self._last_parsed: ParsedVisualIdentity | None = None
+        self._last_scene_signature: list[float] | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled and self._vision_service is not None
+
+    async def try_resolve(
+        self,
+        *,
+        user_id: str,
+        image_bytes: bytes,
+        source: str,
+    ) -> Meal | None:
+        if not self.enabled:
+            return None
+        try:
+            return await self._try_resolve_inner(
+                user_id=user_id,
+                image_bytes=image_bytes,
+                source=source,
+            )
+        except Exception as exc:
+            logger.warning("[MEAL-VISUAL-CACHE] resolve failed: %s", exc)
+            return None
+
+    async def _try_resolve_inner(
+        self,
+        *,
+        user_id: str,
+        image_bytes: bytes,
+        source: str,
+    ) -> Meal | None:
+        if source == "food_label":
+            return None
+
+        async with self._uow as uow:
+            repo = getattr(uow, "meal_scan_visual_identities", None)
+            if repo is None:
+                return None
+            prior_count = await repo.count_for_user_source(
+                user_id=user_id, source=source
+            )
+        if not isinstance(prior_count, int) or prior_count <= 0:
+            return None
+
+        try:
+            scene_signature = build_scene_signature(image_bytes)
+        except Exception as exc:
+            logger.warning("[MEAL-VISUAL-CACHE] scene signature failed: %s", exc)
+            return None
+
+        assert self._vision_service is not None
+        try:
+            vision_result = await self._vision_service.analyze_with_strategy(  # type: ignore[attr-defined]
+                image_bytes,
+                FoodVisualIdentityStrategy(),
+            )
+        except Exception as exc:
+            logger.warning("[MEAL-VISUAL-CACHE] identity vision failed: %s", exc)
+            increment_metric(
+                "meal_scan.visual_cache.identity_failure",
+                attributes={"component": "meal_scan_visual_cache"},
+            )
+            return None
+
+        parsed = parse_visual_identity(vision_result)
+        if parsed is None or not parsed.is_food:
+            return None
+        if parsed.confidence < self._min_identity_confidence:
+            return None
+
+        async with self._uow as uow:
+            repo = uow.meal_scan_visual_identities
+            exact = await repo.find_by_identity_key(
+                user_id=user_id,
+                identity_key=parsed.identity_key,
+                source=source,
+            )
+            candidates = exact or await repo.list_by_user_source_dish(
+                user_id=user_id,
+                source=source,
+                dish_slug=parsed.dish_slug,
+            )
+
+        best: MealScanVisualIdentity | None = None
+        best_score = 0.0
+        for candidate in candidates:
+            if not isinstance(candidate, MealScanVisualIdentity):
+                continue
+            score = score_visual_match(
+                parsed=parsed,
+                candidate=candidate,
+                scene_signature=scene_signature,
+            )
+            if score > best_score:
+                best_score = score
+                best = candidate
+
+        self._last_parsed = parsed
+        self._last_scene_signature = scene_signature
+
+        if best is None or best_score < self._match_threshold:
+            increment_metric(
+                "meal_scan.visual_cache.miss",
+                attributes={"component": "meal_scan_visual_cache"},
+            )
+            return None
+
+        async with self._uow as uow:
+            meal = await uow.meals.find_by_id(best.meal_id)
+        if not isinstance(meal, Meal):
+            return None
+        if meal.user_id != user_id:
+            return None
+        if meal.status != MealStatus.READY or meal.nutrition is None:
+            return None
+
+        increment_metric(
+            "meal_scan.visual_cache.hit",
+            attributes={"component": "meal_scan_visual_cache"},
+        )
+        logger.info(
+            "[MEAL-VISUAL-CACHE] hit user=%s meal=%s score=%.3f identity=%s",
+            user_id,
+            meal.meal_id,
+            best_score,
+            parsed.identity_key,
+        )
+        return mark_scan_cache_hit(meal)
+
+    async def remember(
+        self,
+        *,
+        user_id: str,
+        meal: Meal,
+        image_bytes: bytes,
+        source: str,
+        vision_identity: ParsedVisualIdentity | None = None,
+    ) -> None:
+        if not self.enabled:
+            return
+        try:
+            await self._remember_inner(
+                user_id=user_id,
+                meal=meal,
+                image_bytes=image_bytes,
+                source=source,
+                vision_identity=vision_identity,
+            )
+        except Exception as exc:
+            logger.warning("[MEAL-VISUAL-CACHE] remember failed: %s", exc)
+
+    async def _remember_inner(
+        self,
+        *,
+        user_id: str,
+        meal: Meal,
+        image_bytes: bytes,
+        source: str,
+        vision_identity: ParsedVisualIdentity | None = None,
+    ) -> None:
+        if source == "food_label":
+            return
+        if meal.status != MealStatus.READY or meal.nutrition is None:
+            return
+
+        parsed = vision_identity or self._last_parsed
+        scene_signature = self._last_scene_signature
+        self._last_parsed = None
+        self._last_scene_signature = None
+
+        if parsed is None:
+            dish_slug = _slug(meal.dish_name)
+            ingredients: list[str] = []
+            if meal.nutrition and meal.nutrition.food_items:
+                ingredients = [
+                    _slug(item.name)
+                    for item in meal.nutrition.food_items
+                    if getattr(item, "name", None)
+                ]
+            parsed = ParsedVisualIdentity(
+                dish_slug=dish_slug,
+                ingredients=tuple(sorted(set(ingredients))),
+                container=None,
+                background=None,
+                identity_key=build_identity_key(
+                    dish_slug=dish_slug,
+                    ingredients=ingredients,
+                    container=None,
+                    background=None,
+                ),
+                is_food=True,
+                confidence=0.5,
+            )
+        if not parsed.is_food or parsed.dish_slug in {"", "unknown", "not_food"}:
+            return
+
+        if scene_signature is None:
+            try:
+                scene_signature = build_scene_signature(image_bytes)
+            except Exception as exc:
+                logger.warning("[MEAL-VISUAL-CACHE] remember scene failed: %s", exc)
+                return
+
+        identity = MealScanVisualIdentity(
+            id=str(uuid4()),
+            user_id=user_id,
+            meal_id=meal.meal_id,
+            source=source,
+            dish_slug=parsed.dish_slug,
+            ingredients=parsed.ingredients,
+            container=parsed.container,
+            background=parsed.background,
+            identity_key=parsed.identity_key,
+            scene_signature=tuple(scene_signature),
+            created_at=utc_now(),
+        )
+        async with self._uow as uow:
+            repo = getattr(uow, "meal_scan_visual_identities", None)
+            if repo is None:
+                return
+            await repo.save(identity)
+            await uow.commit()
+        logger.info(
+            "[MEAL-VISUAL-CACHE] remembered user=%s meal=%s identity=%s",
+            user_id,
+            meal.meal_id,
+            parsed.identity_key,
+        )

--- a/src/domain/model/meal_scan_visual_identity.py
+++ b/src/domain/model/meal_scan_visual_identity.py
@@ -1,0 +1,36 @@
+"""Domain model for meal-scan visual identity matching."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class MealScanVisualIdentity:
+    """Angle-tolerant fingerprint for a user's scanned meal photo."""
+
+    id: str
+    user_id: str
+    meal_id: str
+    source: str
+    dish_slug: str
+    ingredients: tuple[str, ...] = field(default_factory=tuple)
+    container: str | None = None
+    background: str | None = None
+    identity_key: str = ""
+    scene_signature: tuple[float, ...] = field(default_factory=tuple)
+    created_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ParsedVisualIdentity:
+    """Parsed lightweight vision identity for a photo."""
+
+    dish_slug: str
+    ingredients: tuple[str, ...]
+    container: str | None
+    background: str | None
+    identity_key: str
+    is_food: bool = True
+    confidence: float = 0.0

--- a/src/domain/ports/async_unit_of_work_port.py
+++ b/src/domain/ports/async_unit_of_work_port.py
@@ -47,6 +47,7 @@ class AsyncUnitOfWorkPort(ABC):
     promo_codes: Any
     referrals: Any
     meal_write_operations: Any
+    meal_scan_visual_identities: Any
 
     @abstractmethod
     async def __aenter__(self) -> AsyncUnitOfWorkPort:

--- a/src/domain/ports/meal_scan_visual_identity_repository_port.py
+++ b/src/domain/ports/meal_scan_visual_identity_repository_port.py
@@ -1,0 +1,33 @@
+"""Port for meal scan visual identity persistence."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from src.domain.model.meal_scan_visual_identity import MealScanVisualIdentity
+
+
+class MealScanVisualIdentityRepositoryPort(Protocol):
+    async def save(self, identity: MealScanVisualIdentity) -> MealScanVisualIdentity: ...
+
+    async def list_by_user_source_dish(
+        self,
+        *,
+        user_id: str,
+        source: str,
+        dish_slug: str,
+        limit: int = 20,
+    ) -> list[MealScanVisualIdentity]: ...
+
+    async def find_by_identity_key(
+        self,
+        *,
+        user_id: str,
+        identity_key: str,
+        source: str,
+        limit: int = 5,
+    ) -> list[MealScanVisualIdentity]: ...
+
+    async def delete_by_meal_id(self, meal_id: str) -> None: ...
+
+    async def count_for_user_source(self, *, user_id: str, source: str) -> int: ...

--- a/src/domain/strategies/meal_analysis_strategy.py
+++ b/src/domain/strategies/meal_analysis_strategy.py
@@ -346,6 +346,52 @@ class UserContextAwareAnalysisStrategy(MealAnalysisStrategy):
         return "UserContextAware"
 
 
+class FoodVisualIdentityStrategy(MealAnalysisStrategy):
+    """Cheap vision pass for angle-tolerant meal identity matching.
+
+    Ignores camera angle / zoom and focuses on the dish, ingredients, container,
+    and background so re-scans of the same plated food can reuse prior analysis.
+    """
+
+    def get_analysis_prompt(self) -> str:
+        return """You identify plated food for cache matching across camera angles.
+Return JSON only. No markdown.
+
+GOAL:
+Decide whether two photos show the SAME physical serving of food even if the
+camera angle, zoom, or framing changed. Background context matters.
+
+RESPONSE FORMAT:
+{
+  "is_food": true,
+  "dish_slug": "chicken_rice_bowl",
+  "ingredients": ["chicken", "rice", "broccoli"],
+  "container": "white_bowl",
+  "background": "wooden_table",
+  "confidence": 0.86
+}
+
+RULES:
+- dish_slug: lowercase snake_case English name for the dish. Stable across angles.
+- ingredients: 1-8 lowercase English ingredient tokens, sorted alphabetically.
+- container: short snake_case token (white_plate, ceramic_bowl, takeout_box, …) or null.
+- background: short snake_case token for the dominant surface/setting
+  (wooden_table, marble_counter, restaurant_booth, outdoor_picnic, …) or null.
+- Ignore hand position, slight shadows, and camera rotation.
+- If the image is not food, set is_food=false, dish_slug="not_food", ingredients=[],
+  confidence<=0.2.
+"""
+
+    def get_user_message(self) -> str:
+        return (
+            "Identify this plated food for cache matching. "
+            "Ignore camera angle; keep dish, ingredients, container, and background stable."
+        )
+
+    def get_strategy_name(self) -> str:
+        return "FoodVisualIdentity"
+
+
 class AnalysisStrategyFactory:
     """
     Factory class for creating meal analysis strategies.

--- a/src/domain/utils/scene_signature.py
+++ b/src/domain/utils/scene_signature.py
@@ -1,0 +1,68 @@
+"""Build a compact scene signature from meal photo bytes.
+
+The signature is intentionally coarse so moderate camera-angle changes of the
+same plated food on the same background still score highly, while clearly
+different scenes do not.
+"""
+
+from __future__ import annotations
+
+import math
+from io import BytesIO
+
+from PIL import Image
+
+SCENE_GRID = 4
+SCENE_DIM = SCENE_GRID * SCENE_GRID * 3  # 48 floats in 0..1
+
+
+def build_scene_signature(image_bytes: bytes) -> list[float]:
+    """Return a unit-ish 4x4 average-RGB grid signature."""
+    with Image.open(BytesIO(image_bytes)) as img:
+        rgb = img.convert("RGB")
+        # Slight center bias: crop 10% borders so extreme wide-angle edges matter less
+        w, h = rgb.size
+        left = int(w * 0.08)
+        top = int(h * 0.08)
+        right = max(left + 1, int(w * 0.92))
+        bottom = max(top + 1, int(h * 0.92))
+        cropped = rgb.crop((left, top, right, bottom))
+        small = cropped.resize((SCENE_GRID, SCENE_GRID), Image.Resampling.BOX)
+
+    values: list[float] = []
+    for y in range(SCENE_GRID):
+        for x in range(SCENE_GRID):
+            r, g, b = small.getpixel((x, y))
+            values.extend((r / 255.0, g / 255.0, b / 255.0))
+    return values
+
+
+def scene_cosine_similarity(
+    left: list[float] | tuple[float, ...], right: list[float] | tuple[float, ...]
+) -> float:
+    """Cosine similarity in [0, 1] for two scene signatures."""
+    if not left or not right or len(left) != len(right):
+        return 0.0
+    dot = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for a, b in zip(left, right, strict=True):
+        dot += a * b
+        left_norm += a * a
+        right_norm += b * b
+    if left_norm <= 0.0 or right_norm <= 0.0:
+        return 0.0
+    return max(0.0, min(1.0, dot / (math.sqrt(left_norm) * math.sqrt(right_norm))))
+
+
+def ingredient_jaccard(
+    left: list[str] | tuple[str, ...],
+    right: list[str] | tuple[str, ...],
+) -> float:
+    left_set = {item.strip().lower() for item in left if item and item.strip()}
+    right_set = {item.strip().lower() for item in right if item and item.strip()}
+    if not left_set and not right_set:
+        return 1.0
+    if not left_set or not right_set:
+        return 0.0
+    return len(left_set & right_set) / len(left_set | right_set)

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -300,6 +300,25 @@ class Settings(BaseSettings):
         default="v1",
         description="Meal analysis graph version emitted in workflow state.",
     )
+    MEAL_SCAN_VISUAL_CACHE_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Reuse a prior READY meal when a new scan looks like the same food "
+            "at a different camera angle (AI visual identity + scene signature)."
+        ),
+    )
+    MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD: float = Field(
+        default=0.82,
+        ge=0.5,
+        le=1.0,
+        description="Minimum combined score to reuse a prior scanned meal.",
+    )
+    MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE: float = Field(
+        default=0.55,
+        ge=0.0,
+        le=1.0,
+        description="Minimum AI identity confidence required before matching.",
+    )
     PARSE_TEXT_STRUCTURED_REFERENCE_ENABLED: bool = Field(
         default=False,
         description="Enable structured local/FatSecret resolution for parse-text.",

--- a/src/infra/database/models/__init__.py
+++ b/src/infra/database/models/__init__.py
@@ -47,6 +47,7 @@ from .meal_recommendation import (
     MealRecommendationOperationORM,
     MealRecommendationORM,
 )
+from .meal_scan_visual_identity import MealScanVisualIdentityORM
 from .meal_write_operation import MealWriteOperationORM
 
 # Notification models
@@ -137,6 +138,7 @@ __all__ = [
     "MealImageORM",
     "MealInstructionStepORM",
     "MealWriteOperationORM",
+    "MealScanVisualIdentityORM",
     "MealTranslationORM",
     "FoodItemTranslationORM",
     # Test models

--- a/src/infra/database/models/meal_scan_visual_identity.py
+++ b/src/infra/database/models/meal_scan_visual_identity.py
@@ -1,0 +1,37 @@
+"""ORM for angle-tolerant meal scan visual identities."""
+
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, String
+from sqlalchemy.sql import func
+
+from src.infra.database.base import Base
+
+
+class MealScanVisualIdentityORM(Base):
+    """Stores AI visual identity + scene signature for a scanned meal."""
+
+    __tablename__ = "meal_scan_visual_identity"
+
+    id = Column(String(36), primary_key=True)
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    meal_id = Column(
+        String(36),
+        ForeignKey("meal.meal_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source = Column(String(20), nullable=False)
+    dish_slug = Column(String(128), nullable=False)
+    ingredients = Column(JSON, nullable=False, default=list)
+    container = Column(String(64), nullable=True)
+    background = Column(String(64), nullable=True)
+    identity_key = Column(String(255), nullable=False)
+    scene_signature = Column(JSON, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/src/infra/database/uow_async.py
+++ b/src/infra/database/uow_async.py
@@ -32,6 +32,9 @@ from src.infra.repositories.meal_recommendation_plan_repository_async import (
     AsyncMealRecommendationPlanRepository,
 )
 from src.infra.repositories.meal_repository_async import AsyncMealRepository
+from src.infra.repositories.meal_scan_visual_identity_repository_async import (
+    AsyncMealScanVisualIdentityRepository,
+)
 from src.infra.repositories.meal_translation_repository_async import (
     AsyncMealTranslationRepository,
 )
@@ -142,6 +145,9 @@ class AsyncUnitOfWork(AsyncUnitOfWorkPort):
         self.referrals = ReferralRepository(session)
         self.affiliate_outbox = AffiliateEventOutboxRepository(session)
         self.meal_write_operations = AsyncMealWriteOperationRepository(session)
+        self.meal_scan_visual_identities = AsyncMealScanVisualIdentityRepository(
+            session
+        )
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         session = self.session

--- a/src/infra/repositories/meal_scan_visual_identity_repository_async.py
+++ b/src/infra/repositories/meal_scan_visual_identity_repository_async.py
@@ -1,0 +1,112 @@
+"""Async repository for meal scan visual identities."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.model.meal_scan_visual_identity import MealScanVisualIdentity
+from src.infra.database.models.meal_scan_visual_identity import (
+    MealScanVisualIdentityORM,
+)
+
+
+def _to_domain(row: MealScanVisualIdentityORM) -> MealScanVisualIdentity:
+    ingredients = row.ingredients or []
+    if not isinstance(ingredients, list):
+        ingredients = []
+    signature = row.scene_signature or []
+    return MealScanVisualIdentity(
+        id=row.id,
+        user_id=row.user_id,
+        meal_id=row.meal_id,
+        source=row.source,
+        dish_slug=row.dish_slug,
+        ingredients=tuple(str(item) for item in ingredients),
+        container=row.container,
+        background=row.background,
+        identity_key=row.identity_key,
+        scene_signature=tuple(float(v) for v in signature),
+        created_at=row.created_at,
+    )
+
+
+class AsyncMealScanVisualIdentityRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def save(self, identity: MealScanVisualIdentity) -> MealScanVisualIdentity:
+        row = MealScanVisualIdentityORM(
+            id=identity.id,
+            user_id=identity.user_id,
+            meal_id=identity.meal_id,
+            source=identity.source,
+            dish_slug=identity.dish_slug,
+            ingredients=list(identity.ingredients),
+            container=identity.container,
+            background=identity.background,
+            identity_key=identity.identity_key,
+            scene_signature=list(identity.scene_signature),
+            created_at=identity.created_at,
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return _to_domain(row)
+
+    async def list_by_user_source_dish(
+        self,
+        *,
+        user_id: str,
+        source: str,
+        dish_slug: str,
+        limit: int = 20,
+    ) -> list[MealScanVisualIdentity]:
+        result = await self.session.execute(
+            select(MealScanVisualIdentityORM)
+            .where(
+                MealScanVisualIdentityORM.user_id == user_id,
+                MealScanVisualIdentityORM.source == source,
+                MealScanVisualIdentityORM.dish_slug == dish_slug,
+            )
+            .order_by(MealScanVisualIdentityORM.created_at.desc())
+            .limit(limit)
+        )
+        return [_to_domain(row) for row in result.scalars().all()]
+
+    async def find_by_identity_key(
+        self,
+        *,
+        user_id: str,
+        identity_key: str,
+        source: str,
+        limit: int = 5,
+    ) -> list[MealScanVisualIdentity]:
+        result = await self.session.execute(
+            select(MealScanVisualIdentityORM)
+            .where(
+                MealScanVisualIdentityORM.user_id == user_id,
+                MealScanVisualIdentityORM.source == source,
+                MealScanVisualIdentityORM.identity_key == identity_key,
+            )
+            .order_by(MealScanVisualIdentityORM.created_at.desc())
+            .limit(limit)
+        )
+        return [_to_domain(row) for row in result.scalars().all()]
+
+    async def delete_by_meal_id(self, meal_id: str) -> None:
+        await self.session.execute(
+            delete(MealScanVisualIdentityORM).where(
+                MealScanVisualIdentityORM.meal_id == meal_id
+            )
+        )
+
+    async def count_for_user_source(self, *, user_id: str, source: str) -> int:
+        result = await self.session.execute(
+            select(func.count())
+            .select_from(MealScanVisualIdentityORM)
+            .where(
+                MealScanVisualIdentityORM.user_id == user_id,
+                MealScanVisualIdentityORM.source == source,
+            )
+        )
+        return int(result.scalar_one())

--- a/tests/unit/app/services/test_meal_scan_visual_cache_service.py
+++ b/tests/unit/app/services/test_meal_scan_visual_cache_service.py
@@ -1,0 +1,103 @@
+"""Unit tests for angle-tolerant meal scan visual cache."""
+
+from datetime import datetime, timezone
+from io import BytesIO
+from uuid import uuid4
+
+from PIL import Image
+
+from src.app.services.meal_scan_visual_cache_service import (
+    build_identity_key,
+    parse_visual_identity,
+    score_visual_match,
+)
+from src.domain.model.meal_scan_visual_identity import (
+    MealScanVisualIdentity,
+    ParsedVisualIdentity,
+)
+from src.domain.utils.scene_signature import (
+    build_scene_signature,
+    ingredient_jaccard,
+    scene_cosine_similarity,
+)
+
+
+def _jpeg_bytes(color: tuple[int, int, int], size: tuple[int, int] = (64, 64)) -> bytes:
+    img = Image.new("RGB", size, color)
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def test_scene_signature_is_stable_for_same_image():
+    data = _jpeg_bytes((180, 120, 60))
+    left = build_scene_signature(data)
+    right = build_scene_signature(data)
+    assert len(left) == 48
+    assert scene_cosine_similarity(left, right) > 0.99
+
+
+def test_scene_signature_differs_for_different_backgrounds():
+    warm = build_scene_signature(_jpeg_bytes((200, 150, 80)))
+    cool = build_scene_signature(_jpeg_bytes((40, 80, 180)))
+    assert scene_cosine_similarity(warm, cool) < 0.9
+
+
+def test_ingredient_jaccard():
+    assert ingredient_jaccard(["rice", "chicken"], ["chicken", "rice"]) == 1.0
+    assert ingredient_jaccard(["rice"], ["chicken"]) == 0.0
+
+
+def test_parse_visual_identity_builds_stable_key():
+    parsed = parse_visual_identity(
+        {
+            "structured_data": {
+                "is_food": True,
+                "dish_slug": "Chicken Rice Bowl",
+                "ingredients": ["Rice", "Chicken", "broccoli"],
+                "container": "White Bowl",
+                "background": "Wooden Table",
+                "confidence": 0.9,
+            }
+        }
+    )
+    assert parsed is not None
+    assert parsed.dish_slug == "chicken_rice_bowl"
+    assert parsed.ingredients == ("broccoli", "chicken", "rice")
+    assert parsed.identity_key == build_identity_key(
+        dish_slug="chicken_rice_bowl",
+        ingredients=["broccoli", "chicken", "rice"],
+        container="white_bowl",
+        background="wooden_table",
+    )
+
+
+def test_score_visual_match_prefers_same_scene_and_ingredients():
+    parsed = ParsedVisualIdentity(
+        dish_slug="chicken_rice_bowl",
+        ingredients=("broccoli", "chicken", "rice"),
+        container="white_bowl",
+        background="wooden_table",
+        identity_key="k",
+        confidence=0.9,
+    )
+    signature = build_scene_signature(_jpeg_bytes((200, 150, 80)))
+    candidate = MealScanVisualIdentity(
+        id=str(uuid4()),
+        user_id=str(uuid4()),
+        meal_id=str(uuid4()),
+        source="scanner",
+        dish_slug="chicken_rice_bowl",
+        ingredients=("broccoli", "chicken", "rice"),
+        container="white_bowl",
+        background="wooden_table",
+        identity_key="k",
+        scene_signature=tuple(signature),
+        created_at=datetime.now(timezone.utc),
+    )
+    score = score_visual_match(
+        parsed=parsed,
+        candidate=candidate,
+        scene_signature=signature,
+    )
+    assert score >= 0.95


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closed #557 (exact `image_id` / byte-hash cache) — that does not help when the user photographs the **same food from a different angle**.

OpenAI/ChatGPT **prompt caching** also does not solve this: it only reuses the shared system-prompt prefix for cost. It does not return the same meal/nutrition for different photos.

This PR adds **angle-tolerant visual matching**:
1. Cheap AI identity pass (`dish_slug`, ingredients, container, background) that ignores camera angle
2. PIL scene signature (4×4 RGB grid) so the same background/table still scores high
3. Combined score ≥ threshold → return the prior READY meal (skip full nutrition vision)

## Enable
```
MEAL_SCAN_VISUAL_CACHE_ENABLED=true
MEAL_SCAN_VISUAL_CACHE_MATCH_THRESHOLD=0.82
MEAL_SCAN_VISUAL_CACHE_MIN_IDENTITY_CONFIDENCE=0.55
```

## Migration
`20260820000001_add_meal_scan_visual_identity`

## Verification
- `pytest tests/unit --cov=src --cov-fail-under=65` — 2629 passed
- `lint-imports` — 4 contracts kept

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02020-9b1d-7d8e-8931-4a6ea8cb73cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02020-9b1d-7d8e-8931-4a6ea8cb73cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

