### PR TITLE
fix(food-label): skip oversized localized display names

### DIFF
--- a/src/app/services/food_label_localizer.py
+++ b/src/app/services/food_label_localizer.py
@@ -15,6 +15,18 @@ from src.domain.model.translation_result import TranslationOutcome
 
 __all__ = ["localize_food_label_display"]
 
+_MAX_FOOD_LABEL_DISPLAY_NAME_LENGTH = 200
+
+
+def _bounded_display_name(value: Any) -> str | None:
+    """Return a non-empty display name within the FoodItem name contract."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped or len(stripped) > _MAX_FOOD_LABEL_DISPLAY_NAME_LENGTH:
+        return None
+    return stripped
+
 
 async def localize_food_label_display(
     *,
@@ -28,7 +40,8 @@ async def localize_food_label_display(
     Printed non-English product names stay as-is. English leftovers are
     translated for presentation and persisted on the meal so Today's Meals
     and meal detail can trust the stored display names (same contract as
-    scanner meals).
+    scanner meals). Oversized translations are skipped so localization never
+    fails the parent food-label scan.
     """
 
     normalized = (language or "en").strip().lower()
@@ -75,16 +88,20 @@ async def localize_food_label_display(
     )
 
     if metadata_dict is not None and product_name in localized_by_source:
-        localized_product = localized_by_source[product_name]
-        if isinstance(localized_product, str) and localized_product.strip():
-            metadata_dict["product_name"] = localized_product.strip()
+        localized_product = _bounded_display_name(localized_by_source[product_name])
+        if localized_product is not None:
+            metadata_dict["product_name"] = localized_product
 
     localized_items: list[FoodItem] = []
     for item in food_items:
         name = getattr(item, "name", None)
-        replacement = localized_by_source.get(name) if isinstance(name, str) else None
-        if isinstance(replacement, str) and replacement.strip():
-            localized_items.append(replace(item, name=replacement.strip()))
+        replacement = (
+            _bounded_display_name(localized_by_source.get(name))
+            if isinstance(name, str)
+            else None
+        )
+        if replacement is not None:
+            localized_items.append(replace(item, name=replacement))
         else:
             localized_items.append(item)
 

--- a/tests/unit/app/services/test_food_label_localizer.py
+++ b/tests/unit/app/services/test_food_label_localizer.py
@@ -135,3 +135,25 @@ async def test_dedupes_identical_product_and_food_item_names():
     )
 
     service.translate_texts.assert_awaited_once_with(["Protein Bar"], "en", "vi")
+
+
+@pytest.mark.asyncio
+async def test_oversized_translated_name_keeps_canonical_and_does_not_raise():
+    service = AsyncMock()
+    oversized = "A" * 201
+    service.translate_texts.return_value = TranslationResult(
+        (oversized,),
+        TranslationOutcome.TRANSLATED,
+        "en",
+        "vi",
+    )
+
+    nutrition, metadata = await localize_food_label_display(
+        nutrition=_nutrition(),
+        metadata=_metadata(),
+        language="vi",
+        translation_service=service,
+    )
+
+    assert nutrition.food_items[0].name == "Protein Bar"
+    assert metadata["product_name"] == "Protein Bar"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Real bug from the merged localization PR: `localize_food_label_display` applied translated names via `dataclasses.replace` without checking `FoodItem`'s 200-character name limit. An oversized translation would raise `ValueError` and fail the food-label scan.

## Fix
- Bound localized display names to the FoodItem contract (1–200 chars after strip)
- Skip oversized/empty translations and keep the canonical name
- Cover with a regression test

## Verification
- `pytest tests/unit/app/services/test_food_label_localizer.py` — 6 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0202a-7f06-7c09-8d07-e1e0910fa761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0202a-7f06-7c09-8d07-e1e0910fa761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

