### PR TITLE
chore(release): merge main into delivery

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -150,6 +150,14 @@ handler/schema when implementing; the bullets below are the durable WHY.
   `nutrition_override` and per-item `nutrition_override` /
   `clear_nutrition_override`. Overrides are absolute user values while set;
   clearing restores source/macro-derived nutrition without rewriting source rows.
+- `override_intent` is compatibility metadata. When a meal-level or item-level
+  override is present, the override payload itself implies user intent and the
+  backend normalizes the marker automatically. Nutrition values and owned-item
+  constraints remain validated.
+- Meal ingredient updates and removals accept override metadata without requiring
+  a separate intent marker. Removal is identified by the owned item id; extra
+  edit fields do not change the removal operation. Adds with override metadata
+  remain rejected because an add does not target an owned item.
 - `custom_nutrition` on non-USDA ingredients is per-100g macros; calories stay
   macro-derived (fiber-aware), which is distinct from absolute overrides.
 - Manual meal v2 save failures now split between validation and provider trust

--- a/src/api/routes/v1/capabilities.py
+++ b/src/api/routes/v1/capabilities.py
@@ -9,6 +9,7 @@ from src.infra.services.durable_write_service import (
 
 router = APIRouter(prefix="/v1/capabilities", tags=["capabilities"])
 
+
 @router.get("/durable-writes")
 async def durable_write_capabilities() -> dict[str, object]:
     """Advertise v2 writes only when their durable storage is migrated."""
@@ -34,6 +35,11 @@ async def durable_write_capabilities() -> dict[str, object]:
         "retention_days": RETENTION_DAYS,
         "actions": {
             "manual_meal_create": {
+                "supported": True,
+                "header": "Idempotency-Key",
+                "exact_replay": True,
+            },
+            "barcode_meal_create": {
                 "supported": True,
                 "header": "Idempotency-Key",
                 "exact_replay": True,

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -420,17 +420,19 @@ class CustomNutritionRequest(BaseModel):
     """
 
     protein_per_100g: float = Field(
-        ..., ge=0, le=100, description="Protein per 100g in grams"
+        ..., ge=0, allow_inf_nan=False, description="Protein per 100g in grams"
     )
     carbs_per_100g: float = Field(
-        ..., ge=0, le=100, description="Carbohydrates per 100g in grams"
+        ..., ge=0, allow_inf_nan=False, description="Carbohydrates per 100g in grams"
     )
-    fat_per_100g: float = Field(..., ge=0, le=100, description="Fat per 100g in grams")
+    fat_per_100g: float = Field(
+        ..., ge=0, allow_inf_nan=False, description="Fat per 100g in grams"
+    )
     fiber_per_100g: float = Field(
-        0.0, ge=0, le=100, description="Fiber per 100g in grams"
+        0.0, ge=0, allow_inf_nan=False, description="Fiber per 100g in grams"
     )
     sugar_per_100g: float = Field(
-        0.0, ge=0, le=100, description="Sugar per 100g in grams"
+        0.0, ge=0, allow_inf_nan=False, description="Sugar per 100g in grams"
     )
 
     @property
@@ -462,9 +464,9 @@ class NutritionOverrideRequest(BaseModel):
     """Absolute values that intentionally bypass nutrition recalculation."""
 
     calories: float = Field(..., ge=0, allow_inf_nan=False)
-    protein: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
-    carbs: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
-    fat: float = Field(..., ge=0, le=1000, allow_inf_nan=False)
+    protein: float = Field(..., ge=0, allow_inf_nan=False)
+    carbs: float = Field(..., ge=0, allow_inf_nan=False)
+    fat: float = Field(..., ge=0, allow_inf_nan=False)
 
 
 class EditMealIngredientsRequest(BaseModel):
@@ -486,7 +488,6 @@ class EditMealIngredientsRequest(BaseModel):
     override_intent: Optional[Literal["user_entered"]] = Field(None)
     food_item_changes: list[FoodItemChangeRequest] = Field(
         default_factory=list,
-        max_length=50,
         description="List of ingredient changes",
     )
 
@@ -518,13 +519,13 @@ class EditMealIngredientsRequest(BaseModel):
             if has_v2_fields or self.override_intent is not None:
                 raise ValueError("v2 fields require nutrition_contract_version=2")
             return self
-        if (
-            self.nutrition_override is not None
-            and self.override_intent != "user_entered"
-        ):
-            raise ValueError("meal override requires override_intent=user_entered")
+        if self.nutrition_override is not None:
+            # The absolute override payload is itself the user's intent.
+            self.override_intent = "user_entered"
 
         for change in self.food_item_changes:
+            if change.nutrition_override is not None or change.clear_nutrition_override:
+                change.override_intent = "user_entered"
             identity_fields = (
                 change.food_reference_id,
                 change.fdc_id,
@@ -533,44 +534,24 @@ class EditMealIngredientsRequest(BaseModel):
                 change.food_id,
             )
             if change.action == "remove":
-                if (
-                    not change.id
-                    or change.name is not None
-                    or change.quantity is not None
-                    or change.unit is not None
-                    or change.custom_nutrition is not None
-                    or change.nutrition_override is not None
-                    or change.clear_nutrition_override
-                    or change.override_intent is not None
-                    or change.allowed_units
-                    or any(value is not None for value in identity_fields)
-                ):
-                    raise ValueError("v2 remove accepts only the owned item id")
+                if not change.id:
+                    raise ValueError("v2 remove requires an owned food item id")
                 continue
 
             if not change.id and change.action == "update":
                 raise ValueError("v2 update requires an owned item id")
-            if change.nutrition_override is not None:
-                if change.override_intent != "user_entered" or any(
-                    value is not None for value in identity_fields
-                ):
-                    raise ValueError("item override cannot replace source nutrition")
-            elif change.clear_nutrition_override:
-                if change.override_intent != "user_entered" or any(
-                    value is not None
-                    for value in (
-                        change.name,
-                        change.quantity,
-                        change.unit,
-                        change.custom_nutrition,
-                        *identity_fields,
-                    )
-                ):
-                    raise ValueError("v2 clear-override accepts only the owned item id")
-            elif change.action == "add":
+            if change.action == "add":
                 if change.origin is None:
                     raise ValueError("v2 add requires origin")
                 _validate_change_origin(change)
+                continue
+
+            if change.nutrition_override is not None:
+                if any(value is not None for value in identity_fields):
+                    raise ValueError("item override cannot replace source nutrition")
+            elif change.clear_nutrition_override:
+                if any(value is not None for value in identity_fields):
+                    raise ValueError("item clear cannot replace source nutrition")
             elif change.origin is not None:
                 _validate_change_origin(change)
             elif change.origin is None:

--- a/src/api/schemas/response/barcode_product_response.py
+++ b/src/api/schemas/response/barcode_product_response.py
@@ -35,6 +35,13 @@ class BarcodeProductResponse(BaseModel):
     food_reference_id: Optional[int] = Field(
         None, description="Food reference table ID"
     )
+    origin: str | None = Field(None, description="Canonical nutrition origin")
+    source_namespace: str | None = Field(
+        None, description="Opaque provider source namespace"
+    )
+    source_food_id: str | None = Field(
+        None, description="Opaque provider food identifier"
+    )
     is_estimate: bool = Field(
         False, description="True when macros are AI-estimated, user should verify"
     )

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -81,15 +81,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
                 if meal.status != MealStatus.READY:
                     raise ValidationException("Meal must be in READY status to edit")
-                if command.nutrition_contract_version == 2:
-                    if (
-                        command.nutrition_override
-                        and command.override_intent != "user_entered"
-                    ):
-                        raise ValidationException(
-                            "meal nutrition override requires explicit user intent"
-                        )
-
                 reservation = await self._reserve_v2_write(command, uow)
                 if reservation and reservation.state == "replay":
                     if reservation.target_meal_id != command.meal_id:
@@ -442,10 +433,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
             )
         if meal.status != MealStatus.READY:
             raise ValidationException("Meal must be in READY status to edit")
-        if command.nutrition_override and command.override_intent != "user_entered":
-            raise ValidationException(
-                "meal nutrition override requires explicit user intent"
-            )
         return meal
 
     async def _reserve_v2_write_short(self, command):
@@ -498,8 +485,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
         resolved_items_out=None,
     ):
         """Resolve source changes from backend references before strategies run."""
-        if len(changes) > 50:
-            raise ValueError("meal edits cannot contain more than 50 item changes")
         current_by_id = {item.id: item for item in current_food_items}
         prepared = []
         resolved_items = []
@@ -515,17 +500,8 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
             ):
                 raise ValueError("v2 update requires an owned food item id")
 
-            if change.nutrition_override is not None or change.clear_nutrition_override:
-                if not change.id:
-                    raise ValueError(
-                        "nutrition override requires an owned food item id"
-                    )
-                if change.override_intent != "user_entered":
-                    raise ValueError(
-                        "food item nutrition override requires explicit user intent"
-                    )
-                prepared.append(change)
-                continue
+            if change.action == "add" and change.origin is None:
+                raise ValueError("v2 add requires origin")
 
             if change.origin is not None:
                 existing = current_by_id.get(change.id)
@@ -572,8 +548,11 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 )
                 continue
 
-            if change.action == "add":
-                raise ValueError("v2 add requires origin")
+            if change.nutrition_override is not None or change.clear_nutrition_override:
+                if change.action == "update" and not change.id:
+                    raise ValueError("nutrition override requires an owned item update")
+                prepared.append(change)
+                continue
 
             existing = current_by_id[change.id]
             prepared.append(self._canonicalize_snapshot_unit(existing, change))

--- a/src/app/handlers/query_handlers/get_bulk_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_bulk_activities_query_handler.py
@@ -76,6 +76,30 @@ def _build_hydration_activity(meal: Meal, language: str = "en") -> dict[str, Any
     }
 
 
+def _build_hydration_entry_activity(entry, language: str = "en") -> dict[str, Any]:
+    return {
+        "id": entry.id,
+        "type": "hydration",
+        "timestamp": format_iso_utc(entry.logged_at),
+        "title": localized_name_for_catalog_name(entry.drink_name_snapshot, language)
+        or entry.drink_name_snapshot
+        or "Water",
+        "emoji": entry.emoji_snapshot or "💧",
+        "meal_type": "hydration",
+        "calories": round(entry.calories, 1),
+        "macros": {
+            "protein": round(entry.protein_g or 0, 1),
+            "carbs": round(entry.carbs_g or 0, 1),
+            "fat": round(entry.fat_g or 0, 1),
+        },
+        "quantity": entry.credited_ml,
+        "volume_ml": entry.volume_ml,
+        "status": "completed",
+        "image_url": entry.image_url,
+        "source": entry.source,
+    }
+
+
 @handles(GetBulkActivitiesQuery)
 class GetBulkActivitiesQueryHandler(
     EventHandler[GetBulkActivitiesQuery, dict[str, list[dict[str, Any]]]]
@@ -99,9 +123,18 @@ class GetBulkActivitiesQueryHandler(
                 user_timezone=user_tz_str,
                 projection=MealProjection.FULL_WITH_TRANSLATIONS,
             )
+            hydration_entries = await uow.hydration_entries.find_by_date_range(
+                user_id=query.user_id,
+                start_date=query.start_date,
+                end_date=query.end_date,
+                user_timezone=user_tz_str,
+            )
 
         language = query.language or "en"
         result: dict[str, list[dict[str, Any]]] = {}
+        covered_meal_ids = {
+            entry.legacy_meal_id for entry in hydration_entries if entry.legacy_meal_id
+        }
 
         for meal in meals:
             if meal.status not in _ACTIVE_STATUSES:
@@ -110,8 +143,16 @@ class GetBulkActivitiesQueryHandler(
             if local_date not in result:
                 result[local_date] = []
             if meal.meal_type == "hydration":
+                if meal.meal_id in covered_meal_ids:
+                    continue
                 result[local_date].append(_build_hydration_activity(meal, language))
             else:
                 result[local_date].append(_build_meal_activity(meal, language))
+
+        for entry in hydration_entries:
+            local_date = entry.logged_at.astimezone(tz).date().isoformat()
+            if local_date not in result:
+                result[local_date] = []
+            result[local_date].append(_build_hydration_entry_activity(entry, language))
 
         return result

--- a/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_activities_query_handler.py
@@ -113,29 +113,31 @@ class GetDailyActivitiesQueryHandler(
                 user_id=query.user_id,
                 user_timezone=user_tz_str,
             )
-            meal_activities = [
-                (
-                    self._build_hydration_activity(item, query.language or "en")
-                    if item.meal_type == "hydration"
-                    else self._build_meal_activity(
-                        item, query.target_date, query.language
-                    )
-                )
-                for item in items
-            ]
-
-            # Include hydration_entries not already covered by a meal row (legacy_meal_id dedup).
-            # Pre-Phase-3d entries have legacy_meal_id set → skip (meal row already in feed).
-            # Post-Phase-3d LogCaloricDrink entries have legacy_meal_id=None → include.
-            meal_id_set = {item.meal_id for item in items}
             hydration_entries = await uow.hydration_entries.find_by_date(
                 local_date,
                 user_id=query.user_id,
                 user_timezone=user_tz_str,
             )
-            for entry in hydration_entries:
-                if entry.legacy_meal_id and entry.legacy_meal_id in meal_id_set:
+            covered_meal_ids = {
+                entry.legacy_meal_id
+                for entry in hydration_entries
+                if entry.legacy_meal_id
+            }
+
+            meal_activities: list[dict[str, Any]] = []
+            for item in items:
+                if item.meal_type == "hydration":
+                    if item.meal_id in covered_meal_ids:
+                        continue
+                    meal_activities.append(
+                        self._build_hydration_activity(item, query.language or "en")
+                    )
                     continue
+                meal_activities.append(
+                    self._build_meal_activity(item, query.target_date, query.language)
+                )
+
+            for entry in hydration_entries:
                 meal_activities.append(
                     self._build_hydration_entry_activity(entry, query.language or "en")
                 )

--- a/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
+++ b/src/app/handlers/query_handlers/get_daily_macros_query_handler.py
@@ -16,6 +16,7 @@ from src.domain.model.meal_projection import MealProjection
 from src.domain.model.nutrition.macros import Macros
 from src.domain.model.user import MacroPreset, MacroTargets
 from src.domain.ports.cache_port import CachePort
+from src.domain.services.hydration_goal_service import resolve_hydration_goal_ml
 from src.domain.services.meal_calorie_service import effective_meal_calories
 from src.domain.services.tdee_service import TdeeCalculationService
 from src.domain.services.weekly_budget_service import WeeklyBudgetService
@@ -168,14 +169,10 @@ class GetDailyMacrosQueryHandler(EventHandler[GetDailyMacrosQuery, dict[str, Any
                         user_id=query.user_id,
                         user_timezone=user_tz_str,
                     )
-                # Get water goal from profile (default 2000 if not set)
                 user_profile = await uow.users.get_profile(UUID(query.user_id))
                 water_goal_ml = (
-                    user_profile.daily_water_goal_ml
+                    resolve_hydration_goal_ml(user_profile)
                     if user_profile
-                    and hasattr(user_profile, "daily_water_goal_ml")
-                    and user_profile.daily_water_goal_ml is not None
-                    and user_profile.daily_water_goal_ml > 0
                     else 2000
                 )
             except Exception as exc:

--- a/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
+++ b/src/app/handlers/query_handlers/get_journey_progress_query_handler.py
@@ -13,6 +13,7 @@ from src.app.queries.progress import GetJourneyProgressQuery
 from src.app.queries.tdee import GetUserTdeeQuery
 from src.domain.ports.async_unit_of_work_port import AsyncUnitOfWorkPort
 from src.domain.ports.cache_port import CachePort
+from src.domain.services.hydration_goal_service import resolve_hydration_goal_ml
 from src.domain.services.journey_progress_rules import (
     estimate_timeline_days,
     journey_period_start,
@@ -80,7 +81,7 @@ class GetJourneyProgressQueryHandler(
                 period_start,
                 min(now, period_end),
             )
-            water_goal_ml = profile.daily_water_goal_ml or 2000
+            water_goal_ml = resolve_hydration_goal_ml(profile)
 
         target_calories, target_protein_g = await self._load_targets(query.user_id)
         return calculate_journey_progress(

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -32,13 +32,15 @@ def _gs1_prefix_hint(barcode: str) -> str:
 
 
 @handles(LookupBarcodeQuery)
-class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] | None]):
+class LookupBarcodeQueryHandler(
+    EventHandler[LookupBarcodeQuery, dict[str, Any] | None]
+):
     """Handler for looking up product by barcode with fallback providers."""
 
     def __init__(
         self,
         open_food_facts_service: OpenFoodFactsService,
-        fat_secret_service: FatSecretService,
+        fat_secret_service: FatSecretService | None,
         food_reference_repository: Any | None = None,
         async_uow_factory: Any | None = None,
         translation_service: Any | None = None,
@@ -85,7 +87,11 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         partial_name: str | None = None
 
         cached = await self._get_cached_product(aliases)
-        if cached and self._has_nutrition(cached) and self._is_trusted_cached_row(cached):
+        if (
+            cached
+            and self._has_nutrition(cached)
+            and self._is_trusted_cached_row(cached)
+        ):
             provider_source = cached.get("source")
             cached["provider_source"] = provider_source
             cached["source"] = "cache"
@@ -113,21 +119,29 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         # A global barcode row must always be acquired in canonical English.
         # Request-locale provider output cannot safely be persisted globally.
         region = "US"
-        fat_secret_result = await self._first_barcode_hit(
-            aliases,
-            lambda alias: self.fat_secret.get_product(
-                alias,
-                region=region,
-                language="en",
-            ),
-        )
-        if fat_secret_result and self._has_nutrition(fat_secret_result) and self._has_name(fat_secret_result):
+        fat_secret_result = None
+        if self.fat_secret is not None:
+            fat_secret_result = await self._first_barcode_hit(
+                aliases,
+                lambda alias: self.fat_secret.get_product(
+                    alias,
+                    region=region,
+                    language="en",
+                ),
+            )
+        if (
+            fat_secret_result
+            and self._has_nutrition(fat_secret_result)
+            and self._has_name(fat_secret_result)
+        ):
             result = self._trusted_provider_result(
                 fat_secret_result, query.barcode, scanned_barcode, "fatsecret"
             )
             await self._cache_result(result, cache_barcode=query.barcode)
             log_hit("fatsecret", result)
-            return await self._maybe_translate(result, query.language, source_language="en")
+            return await self._maybe_translate(
+                result, query.language, source_language="en"
+            )
         if fat_secret_result:
             partial_name = partial_name or fat_secret_result.get("name")
             miss_reasons.append(
@@ -136,10 +150,18 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
                 else "fatsecret_partial_no_name"
             )
         else:
-            miss_reasons.append("fatsecret_empty")
+            miss_reasons.append(
+                "fatsecret_empty"
+                if self.fat_secret is not None
+                else "fatsecret_not_configured"
+            )
 
         off_result = await self._first_barcode_hit(aliases, self.off.get_product)
-        if off_result and self._has_nutrition(off_result) and self._has_name(off_result):
+        if (
+            off_result
+            and self._has_nutrition(off_result)
+            and self._has_name(off_result)
+        ):
             off_result = dict(off_result)
             source_language = off_result.pop("source_language", None)
             result = self._trusted_provider_result(
@@ -160,8 +182,14 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         else:
             miss_reasons.append("openfoodfacts_empty")
 
-        fdc_result = await self._get_fdc_product(aliases, query.barcode, scanned_barcode)
-        if fdc_result and self._has_nutrition(fdc_result) and self._has_name(fdc_result):
+        fdc_result = await self._get_fdc_product(
+            aliases, query.barcode, scanned_barcode
+        )
+        if (
+            fdc_result
+            and self._has_nutrition(fdc_result)
+            and self._has_name(fdc_result)
+        ):
             await self._cache_result(fdc_result, cache_barcode=query.barcode)
             log_hit("usda_fdc", fdc_result)
             return await self._maybe_translate(
@@ -201,13 +229,17 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
                 return estimate
 
         if brave_result and self._has_nutrition(brave_result):
-            estimate = self._estimate_result(brave_result, scanned_barcode, "brave_search")
+            estimate = self._estimate_result(
+                brave_result, scanned_barcode, "brave_search"
+            )
             log_hit("brave_search", estimate)
             return estimate
         if self.brave_search and not brave_result:
             miss_reasons.append("brave_empty")
 
-        estimate = await self._ai_estimate(scanned_barcode, query.language, partial_name)
+        estimate = await self._ai_estimate(
+            scanned_barcode, query.language, partial_name
+        )
         if estimate:
             log_hit("ai_estimate", estimate)
             return estimate
@@ -240,7 +272,10 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
 
     @staticmethod
     def _is_trusted_cached_row(result: dict[str, Any]) -> bool:
-        return bool(result.get("is_verified")) or result.get("source") in TRUSTED_CACHE_SOURCES
+        return (
+            bool(result.get("is_verified"))
+            or result.get("source") in TRUSTED_CACHE_SOURCES
+        )
 
     async def _first_barcode_hit(self, aliases, fetch):
         for alias in aliases:
@@ -278,6 +313,8 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         scanned_barcode: str,
         barcode_ref: str,
     ) -> dict[str, Any] | None:
+        if self.fat_secret is None:
+            return None
         try:
             fs_results = await self.fat_secret.search_foods(
                 brave_name,
@@ -296,7 +333,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
         for item in fs_results or []:
             if self._has_nutrition(item):
                 item["name"] = brave_name or item.get("name")
-                return self._estimate_result(item, scanned_barcode, "fatsecret_name_search")
+                return self._estimate_result(
+                    item, scanned_barcode, "fatsecret_name_search"
+                )
         return None
 
     def _trusted_provider_result(
@@ -403,7 +442,9 @@ class LookupBarcodeQueryHandler(EventHandler[LookupBarcodeQuery, dict[str, Any] 
             return localized
         return result
 
-    async def _get_cached_product(self, aliases: tuple[str, ...]) -> dict[str, Any] | None:
+    async def _get_cached_product(
+        self, aliases: tuple[str, ...]
+    ) -> dict[str, Any] | None:
         candidates: list[dict[str, Any]] = []
         for barcode in aliases:
             cached = await self._get_cached_product_by_barcode(barcode)

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -92,14 +92,17 @@ class LookupBarcodeQueryHandler(
             and self._has_nutrition(cached)
             and self._is_trusted_cached_row(cached)
         ):
-            provider_source = cached.get("source")
-            cached["provider_source"] = provider_source
-            cached["source"] = "cache"
-            cached["barcode"] = scanned_barcode
-            log_hit("cache", cached)
-            # Cached rows have no source-locale provenance.  They remain
-            # canonical rather than being mislabeled as English.
-            return await self._maybe_translate(cached, query.language)
+            cached_product = self._canonicalize_cached_product(cached)
+            if cached_product is not None:
+                provider_source = cached_product.get("source")
+                cached_product["provider_source"] = provider_source
+                cached_product["source"] = "cache"
+                cached_product["barcode"] = scanned_barcode
+                log_hit("cache", cached_product)
+                # Cached rows have no source-locale provenance.  They remain
+                # canonical rather than being mislabeled as English.
+                return await self._maybe_translate(cached_product, query.language)
+            miss_reasons.append("cache_missing_source_identity")
         if cached:
             partial_name = cached.get("name")
             reason = (
@@ -276,6 +279,34 @@ class LookupBarcodeQueryHandler(
             bool(result.get("is_verified"))
             or result.get("source") in TRUSTED_CACHE_SOURCES
         )
+
+    @staticmethod
+    def _canonicalize_cached_product(
+        result: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Attach a durable identity before returning a cached barcode row."""
+        cached = dict(result)
+        reference_id = cached.get("id") or cached.get("food_reference_id")
+        if reference_id is not None:
+            try:
+                reference_id = int(reference_id)
+            except (TypeError, ValueError):
+                reference_id = None
+        if reference_id is not None:
+            cached.update(
+                {
+                    "food_reference_id": reference_id,
+                    "origin": "local",
+                    "source_namespace": "food_reference",
+                    "source_food_id": str(reference_id),
+                }
+            )
+            return cached
+
+        if cached.get("source_namespace") and cached.get("source_food_id"):
+            cached["origin"] = "provider"
+            return cached
+        return None
 
     async def _first_barcode_hit(self, aliases, fetch):
         for alias in aliases:

--- a/src/domain/services/hydration_catalog_service.py
+++ b/src/domain/services/hydration_catalog_service.py
@@ -196,13 +196,13 @@ DRINK_CATALOG["scanned"] = Drink(
 _DRINK_TRANSLATIONS: dict[str, dict[str, dict[str, str | None]]] = {
     "vi": {
         "water": {"name": "Nước lọc", "sub": None},
-        "sparkling": {"name": "Nước soda", "sub": "Có ga"},
+        "sparkling": {"name": "Nước có ga", "sub": "Có ga"},
         "tea": {"name": "Trà", "sub": None},
         "coffee": {"name": "Cà phê", "sub": None},
         "electrolyte": {"name": "Nước điện giải", "sub": "Nước thể thao"},
         "milk-tea": {"name": "Trà sữa", "sub": "Trân châu"},
         "coke": {"name": "Nước ngọt", "sub": "Có ga"},
-        "coke-zero": {"name": "Coke Zero", "sub": "Không đường"},
+        "coke-zero": {"name": "Coca/Pepsi Zero", "sub": "Không đường"},
         "oj": {"name": "Nước ép", "sub": "Ép tươi"},
         "smoothie": {"name": "Sinh tố", "sub": "Hỗn hợp Açaí"},
         "energy": {"name": "Nước tăng lực", "sub": "Red Bull"},
@@ -214,6 +214,12 @@ _DRINK_TRANSLATIONS: dict[str, dict[str, dict[str, str | None]]] = {
 _DRINK_IDS_BY_ENGLISH_NAME: dict[str, str] = {
     drink.name.lower(): drink.id for drink in _DRINKS
 }
+_DRINK_IDS_BY_ENGLISH_NAME.update(
+    {
+        "coke zero": "coke-zero",
+        "coca/pepsi zero": "coke-zero",
+    }
+)
 
 
 # ---------------------------------------------------------------------------

--- a/src/domain/services/meal_suggestion/ingredient_nutrition_resolver.py
+++ b/src/domain/services/meal_suggestion/ingredient_nutrition_resolver.py
@@ -51,6 +51,10 @@ class IngredientNutritionResolver:
         Returns None if fatsecret returns no results, hits rate limits,
         or raises any network exception.
         """
+        if self._fs is None:
+            logger.debug("fatsecret provider unavailable for ingredient '%s'", name)
+            return None
+
         try:
             results: List[Dict[str, Any]] = await self._fs.search_foods(
                 query=name, max_results=5

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -193,7 +193,12 @@ class FatSecretService:
             if not food_details:
                 return None
 
-            return self._map_product(food_details, normalized_barcode)
+            food_data = food_details.get("food", food_details)
+            return self._map_product(
+                food_data,
+                normalized_barcode,
+                source_food_id=str(food_id),
+            )
         except Exception as e:
             logger.warning(
                 "fatsecret API error for barcode lookup: %s", type(e).__name__
@@ -420,14 +425,30 @@ class FatSecretService:
             provider_100g_label=True,
         ) or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
 
-    def _map_product(self, food: dict[str, Any], barcode: str) -> dict[str, Any]:
+    def _map_product(
+        self,
+        food: dict[str, Any],
+        barcode: str,
+        source_food_id: str | None = None,
+    ) -> dict[str, Any]:
         """Map fatsecret response to clean dict."""
+        resolved_source_food_id = str(
+            source_food_id or food.get("food_id") or ""
+        ).strip()
+        provider_identity: dict[str, str] = {}
+        if resolved_source_food_id:
+            provider_identity = {
+                "origin": "provider",
+                "source_namespace": "fatsecret",
+                "source_food_id": resolved_source_food_id,
+            }
         serving = self._select_per_100g_serving(food)
         if not isinstance(serving, dict):
             return {
                 "name": food.get("food_name", ""),
                 "brand": food.get("brand_name"),
                 "barcode": barcode,
+                **provider_identity,
                 "calories_100g": None,
                 "protein_100g": None,
                 "carbs_100g": None,
@@ -443,6 +464,7 @@ class FatSecretService:
                 "name": food.get("food_name", ""),
                 "brand": food.get("brand_name"),
                 "barcode": barcode,
+                **provider_identity,
                 "calories_100g": self._calc_per_100g(
                     serving.get("calories"), metric_amount
                 ),

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -271,7 +271,9 @@ class FatSecretService:
             error = result.get("error")
             if error:
                 error_code = (
-                    error.get("code") if isinstance(error, dict) else type(error).__name__
+                    error.get("code")
+                    if isinstance(error, dict)
+                    else type(error).__name__
                 )
                 logger.warning(
                     "fatsecret API error response received: code=%s", error_code
@@ -533,27 +535,26 @@ class FatSecretService:
 
 
 _fat_secret_service: FatSecretService | None = None
+_fat_secret_service_initialized = False
 
 
-def get_fat_secret_service() -> FatSecretService:
-    """Get singleton instance of FatSecretService."""
-    global _fat_secret_service
-    if _fat_secret_service is None:
-        # Use OAuth 2.0 credentials if available, otherwise fall back to OAuth 1.0
-        client_id = settings.FATSECRET_CLIENT_ID
-        client_secret = settings.FATSECRET_CLIENT_SECRET
+def get_fat_secret_service() -> FatSecretService | None:
+    """Get the optional FatSecret service when credentials are configured."""
+    global _fat_secret_service, _fat_secret_service_initialized
+    if _fat_secret_service_initialized:
+        return _fat_secret_service
 
-        if not client_id or not client_secret:
-            # Fall back to OAuth 1.0 (legacy)
-            logger.warning(
-                "fatsecret OAuth 2.0 credentials not configured, OAuth 1.0 not supported"
-            )
-            raise ValueError(
-                "FATSECRET_CLIENT_ID and FATSECRET_CLIENT_SECRET must be set for OAuth 2.0"
-            )
+    client_id = settings.FATSECRET_CLIENT_ID
+    client_secret = settings.FATSECRET_CLIENT_SECRET
 
-        _fat_secret_service = FatSecretService(
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+    if not client_id or not client_secret:
+        logger.warning("fatsecret credentials not configured; provider will be skipped")
+        _fat_secret_service_initialized = True
+        return None
+
+    _fat_secret_service = FatSecretService(
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    _fat_secret_service_initialized = True
     return _fat_secret_service

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -529,8 +529,11 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
         ),
     )
 
+    sent = []
+
     class _EditBus:
         async def send(self, msg):
+            sent.append(msg)
             if isinstance(msg, EditMealCommand):
                 return {"success": True}
             return meal
@@ -543,6 +546,12 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
             "dish_name": "Updated Dish",
             "food_item_changes": [],
             "nutrition_contract_version": 2,
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            },
         },
         headers={
             "X-Nutrition-Contract-Version": "2",
@@ -558,6 +567,8 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
     assert body["meal_detail"]["meal_id"] == meal_id
     assert body["meal_detail"]["dish_name"] == "Updated Dish"
     assert body["meal_detail"]["food_items"][0]["name"] == "Salmon"
+    edit_command = next(m for m in sent if isinstance(m, EditMealCommand))
+    assert edit_command.override_intent == "user_entered"
 
 
 def test_meals_streak_smoke(client: TestClient):

--- a/tests/unit/api/test_capabilities_durable_writes.py
+++ b/tests/unit/api/test_capabilities_durable_writes.py
@@ -18,6 +18,9 @@ async def test_durable_write_capabilities_advertise_legacy_and_v2_contracts():
     assert body["retention_days"] == 14
     assert body["actions"]["manual_meal_create"]["supported"] is True
     assert body["actions"]["manual_meal_create"]["header"] == "Idempotency-Key"
+    assert body["actions"]["barcode_meal_create"]["supported"] is True
+    assert body["actions"]["barcode_meal_create"]["header"] == "Idempotency-Key"
+    assert body["actions"]["barcode_meal_create"]["exact_replay"] is True
     assert body["actions"]["weight_sync"]["supported"] is False
     assert body["actions"]["weight_sync"]["reason"] == "client_entry_id_mapping_pending"
     assert body["durable_writes"] is True

--- a/tests/unit/api/test_foods_auth_and_rate_limits.py
+++ b/tests/unit/api/test_foods_auth_and_rate_limits.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from src.api.dependencies.auth import get_current_user_id
 from src.api.routes.v1 import feature_flags, foods
+from src.api.schemas.response.barcode_product_response import BarcodeProductResponse
 
 
 def _app(*, authenticated: bool) -> FastAPI:
@@ -45,3 +46,19 @@ def test_provider_backed_food_routes_are_limiter_wrapped():
         foods.lookup_barcode,
     ):
         assert getattr(route, "__wrapped__", None) is not None
+
+
+def test_barcode_response_preserves_provider_identity():
+    response = BarcodeProductResponse(
+        name="Whole Grain Cheerios",
+        barcode="036000291452",
+        origin="provider",
+        source_namespace="fatsecret",
+        source_food_id="50953",
+    )
+
+    payload = response.model_dump()
+
+    assert payload["origin"] == "provider"
+    assert payload["source_namespace"] == "fatsecret"
+    assert payload["source_food_id"] == "50953"

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -81,9 +81,7 @@ def test_v2_prepared_source_item_requires_and_keeps_snapshot():
             _v2_create_item(
                 custom_nutrition=nutrition,
                 source_snapshot=snapshot,
-                allowed_units=[
-                    {"unit": "g", "gram_weight": 1, "description": "1 g"}
-                ],
+                allowed_units=[{"unit": "g", "gram_weight": 1, "description": "1 g"}],
             )
         ],
     )
@@ -131,18 +129,52 @@ def test_v2_create_rejects_missing_version_mismatched_ids_and_missing_custom_dat
         CreateManualMealFromFoodsRequest.model_validate(payload)
 
 
-def test_v2_remove_rejects_nutrition_and_source_fields():
-    with pytest.raises(ValidationError):
-        EditMealIngredientsRequest(
-            nutrition_contract_version=2,
-            food_item_changes=[
-                {
-                    "action": "remove",
-                    "id": "item-1",
-                    "quantity": 100,
-                }
-            ],
-        )
+def test_v2_remove_accepts_extra_edit_fields():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "remove",
+                "id": "item-1",
+                "name": "Ignored name",
+                "quantity": 100,
+                "unit": "g",
+                "nutrition_override": {
+                    "calories": 500,
+                    "protein": 20,
+                    "carbs": 30,
+                    "fat": 15,
+                },
+                "clear_nutrition_override": True,
+                "food_reference_id": 42,
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].id == "item-1"
+
+
+@pytest.mark.parametrize("nutrition_contract_version", [None, 2])
+def test_remove_override_is_accepted_for_legacy_and_v2_clients(
+    nutrition_contract_version,
+):
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=nutrition_contract_version,
+        food_item_changes=[
+            {
+                "action": "remove",
+                "id": "item-1",
+                "nutrition_override": {
+                    "calories": 500,
+                    "protein": 20,
+                    "carbs": 30,
+                    "fat": 15,
+                },
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].id == "item-1"
 
 
 def test_v2_quantity_update_strips_legacy_source_echoes():
@@ -217,33 +249,167 @@ def test_v2_source_replacement_without_portion_fields_is_still_rejected():
         )
 
 
-def test_v2_override_requires_explicit_user_intent():
-    with pytest.raises(ValidationError):
-        EditMealIngredientsRequest(
-            nutrition_contract_version=2,
-            food_item_changes=[
-                {
-                    "action": "update",
-                    "id": "item-1",
-                    "nutrition_override": {
-                        "calories": 500,
-                        "protein": 20,
-                        "carbs": 30,
-                        "fat": 15,
-                    },
-                }
-            ],
-        )
+def test_v2_item_override_defaults_user_intent():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "update",
+                "id": "item-1",
+                "nutrition_override": {
+                    "calories": 500,
+                    "protein": 20,
+                    "carbs": 30,
+                    "fat": 15,
+                },
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].override_intent == "user_entered"
 
 
-def test_nutrition_override_rejects_negative_absolute_values():
+def test_v2_clear_item_override_defaults_user_intent():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "update",
+                "id": "item-1",
+                "clear_nutrition_override": True,
+            }
+        ],
+    )
+
+    assert request.food_item_changes[0].override_intent == "user_entered"
+
+
+def test_v2_clear_item_override_accepts_quantity_edit():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "update",
+                "id": "item-1",
+                "quantity": 200,
+                "unit": "g",
+                "clear_nutrition_override": True,
+            }
+        ],
+    )
+
+    change = request.food_item_changes[0]
+    assert change.quantity == 200
+    assert change.override_intent == "user_entered"
+
+
+@pytest.mark.parametrize(
+    "override_fields",
+    [
+        {
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            }
+        },
+        {"clear_nutrition_override": True},
+    ],
+)
+def test_legacy_add_accepts_item_override_actions(override_fields):
+    request = EditMealIngredientsRequest(
+        food_item_changes=[
+            {
+                "action": "add",
+                "id": "client-generated-id",
+                "name": "Rau xao",
+                "quantity": 100,
+                "unit": "g",
+                **override_fields,
+            }
+        ]
+    )
+
+    assert request.food_item_changes[0].id == "client-generated-id"
+
+
+@pytest.mark.parametrize(
+    "override_fields",
+    [
+        {
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            }
+        },
+        {"clear_nutrition_override": True},
+    ],
+)
+def test_v2_add_accepts_item_override_actions(override_fields):
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        food_item_changes=[
+            {
+                "action": "add",
+                "id": "client-generated-id",
+                "origin": "custom",
+                "name": "Rau xao",
+                "quantity": 100,
+                "unit": "g",
+                "custom_nutrition": {
+                    "protein_per_100g": 2,
+                    "carbs_per_100g": 8,
+                    "fat_per_100g": 1,
+                },
+                **override_fields,
+            }
+        ],
+    )
+
+    change = request.food_item_changes[0]
+    assert change.id == "client-generated-id"
+    assert change.override_intent == "user_entered"
+
+
+def test_v2_meal_override_without_intent_is_compatible_with_legacy_clients():
+    request = EditMealIngredientsRequest(
+        nutrition_contract_version=2,
+        nutrition_override={
+            "calories": 500,
+            "protein": 20,
+            "carbs": 30,
+            "fat": 15,
+        },
+    )
+
+    assert request.override_intent == "user_entered"
+
+
+def test_nutrition_override_rejects_negative_values():
     with pytest.raises(ValidationError):
         NutritionOverrideRequest(
             calories=500,
             protein=-1,
-            carbs=30,
-            fat=15,
+            carbs=3000,
+            fat=1500,
         )
+
+
+def test_nutrition_override_accepts_large_nonnegative_values():
+    request = NutritionOverrideRequest(
+        calories=100000,
+        protein=5000,
+        carbs=3000,
+        fat=1500,
+    )
+
+    assert request.calories == 100000
+    assert request.protein == 5000
+    assert request.carbs == 3000
+    assert request.fat == 1500
 
 
 def test_nutrition_override_accepts_absolute_calories_above_density_bound():

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -204,23 +204,20 @@ class TestCustomNutritionRequest:
         assert request.carbs_per_100g == 25.0
         assert request.fat_per_100g == 8.0
 
-    def test_negative_protein(self):
-        """Test negative protein validation."""
-        # Arrange & Act & Assert
+    def test_negative_protein_is_rejected(self):
         with pytest.raises(ValidationError):
             CustomNutritionRequest(
                 protein_per_100g=-5.0, carbs_per_100g=25.0, fat_per_100g=8.0
             )
 
-    def test_protein_too_high(self):
-        """Test protein too high validation."""
-        # Arrange & Act & Assert
-        with pytest.raises(ValidationError):
-            CustomNutritionRequest(
-                protein_per_100g=150.0,  # Over 100 limit
-                carbs_per_100g=25.0,
-                fat_per_100g=8.0,
-            )
+    def test_protein_above_density_limit_is_user_editable(self):
+        request = CustomNutritionRequest(
+            protein_per_100g=150.0,
+            carbs_per_100g=25.0,
+            fat_per_100g=8.0,
+        )
+
+        assert request.protein_per_100g == 150.0
 
 
 @pytest.mark.unit
@@ -446,6 +443,15 @@ class TestEditMealIngredientsRequest:
         """Test empty edit requests are rejected."""
         with pytest.raises(ValidationError):
             EditMealIngredientsRequest()
+
+    def test_accepts_more_than_fifty_item_changes(self):
+        request = EditMealIngredientsRequest(
+            food_item_changes=[
+                {"action": "remove", "id": str(index)} for index in range(51)
+            ]
+        )
+
+        assert len(request.food_item_changes) == 51
 
     def test_dish_name_too_long(self):
         """Test dish name too long validation."""

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -4,10 +4,15 @@ from types import SimpleNamespace
 import pytest
 
 from src.app.commands.meal import FoodItemChange
+from src.app.commands.meal.edit_meal_command import EditMealCommand
 from src.app.handlers.command_handlers.edit_meal_command_handler import (
     EditMealCommandHandler,
 )
-from src.domain.model.meal.food_item_change import CustomNutritionData
+from src.domain.model.meal.food_item_change import (
+    CustomNutritionData,
+    NutritionOverride,
+)
+from src.domain.model.meal.meal import MealStatus
 from src.domain.model.nutrition import FoodItem, Macros
 
 
@@ -205,3 +210,167 @@ async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy()
     assert updated[0].quantity == pytest.approx(100)
     assert updated[0].unit == "g"
     assert updated[0].macros.protein == pytest.approx(2.7)
+
+
+@pytest.mark.asyncio
+async def test_v2_item_override_does_not_require_intent_in_handler():
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="update",
+        id="item-1",
+        nutrition_override=NutritionOverride(
+            calories=500,
+            protein=20,
+            carbs=30,
+            fat=15,
+        ),
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+
+    assert prepared[0].nutrition_override.calories == 500
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("clear_override", [False, True])
+async def test_v2_item_override_allows_add_action_in_handler(clear_override):
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="add",
+        id="client-generated-id",
+        name="Rau xao",
+        quantity=100,
+        unit="g",
+        origin="custom",
+        custom_nutrition=CustomNutritionData(
+            calories_per_100g=51,
+            protein_per_100g=2,
+            carbs_per_100g=8,
+            fat_per_100g=1,
+        ),
+        clear_nutrition_override=clear_override,
+        nutrition_override=(
+            None
+            if clear_override
+            else NutritionOverride(calories=500, protein=20, carbs=30, fat=15)
+        ),
+    )
+    handler = EditMealCommandHandler(
+        uow=None,
+        nutrition_resolver=_PassthroughResolver(),
+    )
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+    added = next(item for item in updated if item.name == "Rau xao")
+
+    if clear_override:
+        assert added.nutrition_override is None
+    else:
+        assert added.nutrition_override.calories == 500
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("clear_override", [False, True])
+async def test_v2_item_override_allows_remove_action_in_handler(clear_override):
+    change = FoodItemChange(
+        action="remove",
+        id="item-1",
+        clear_nutrition_override=clear_override,
+        nutrition_override=(
+            None
+            if clear_override
+            else NutritionOverride(calories=500, protein=20, carbs=30, fat=15)
+        ),
+    )
+    assert change.action == "remove"
+
+
+@pytest.mark.asyncio
+async def test_v2_remove_ignores_extra_override_fields_when_applying():
+    current = FoodItem(
+        id="item-1",
+        name="Rice",
+        quantity=100,
+        unit="g",
+        macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
+    )
+    change = FoodItemChange(
+        action="remove",
+        id="item-1",
+        quantity=200,
+        nutrition_override=NutritionOverride(
+            calories=500,
+            protein=20,
+            carbs=30,
+            fat=15,
+        ),
+    )
+    handler = EditMealCommandHandler(
+        uow=None,
+        nutrition_resolver=_PassthroughResolver(),
+    )
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+    updated = await handler._apply_food_item_changes([current], prepared)
+
+    assert prepared == [change]
+    assert updated == []
+
+
+@pytest.mark.asyncio
+async def test_v2_meal_override_does_not_require_intent_in_preflight():
+    class _Meals:
+        async def find_by_id(self, meal_id, projection=None):
+            return SimpleNamespace(
+                meal_id=meal_id,
+                user_id="user-1",
+                status=MealStatus.READY,
+                nutrition=SimpleNamespace(),
+            )
+
+    class _UowContext:
+        async def __aenter__(self):
+            return SimpleNamespace(meals=_Meals())
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    handler = EditMealCommandHandler(
+        uow=None,
+        uow_factory=lambda: _UowContext(),
+    )
+    command = EditMealCommand(
+        meal_id="meal-1",
+        user_id="user-1",
+        nutrition_contract_version=2,
+        nutrition_override=NutritionOverride(
+            calories=500,
+            protein=20,
+            carbs=30,
+            fat=15,
+        ),
+    )
+
+    meal = await handler._preflight_v2_meal(command)
+
+    assert meal.meal_id == "meal-1"

--- a/tests/unit/domain/services/meal_suggestion/test_ingredient_nutrition_resolver.py
+++ b/tests/unit/domain/services/meal_suggestion/test_ingredient_nutrition_resolver.py
@@ -77,6 +77,16 @@ def resolver(mock_fatsecret, mock_repo):
 
 
 @pytest.mark.asyncio
+async def test_resolve_returns_none_when_fatsecret_is_unavailable(mock_repo):
+    resolver = IngredientNutritionResolver(fatsecret=None, food_ref_repo=mock_repo)
+
+    result = await resolver.resolve("chicken breast")
+
+    assert result is None
+    mock_repo.upsert_by_normalized_name.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_resolve_chicken_breast_returns_macros(
     resolver, mock_fatsecret, mock_repo
 ):

--- a/tests/unit/domain/services/test_hydration_catalog_service.py
+++ b/tests/unit/domain/services/test_hydration_catalog_service.py
@@ -1,0 +1,27 @@
+from src.domain.services.hydration_catalog_service import (
+    find_by_id,
+    localized_name,
+    localized_name_for_catalog_name,
+)
+
+
+def test_coke_zero_canonical_name_stays_english():
+    drink = find_by_id("coke-zero")
+    assert drink is not None
+    assert drink.name == "Coke Zero"
+
+
+def test_coke_zero_vietnamese_uses_coca_pepsi_zero():
+    drink = find_by_id("coke-zero")
+    assert localized_name(drink, "vi") == "Coca/Pepsi Zero"
+
+
+def test_sparkling_vietnamese_uses_co_ga():
+    drink = find_by_id("sparkling")
+    assert localized_name(drink, "vi") == "Nước có ga"
+
+
+def test_legacy_snapshots_still_localizes():
+    assert localized_name_for_catalog_name("Coke Zero", "vi") == "Coca/Pepsi Zero"
+    assert localized_name_for_catalog_name("Coca/Pepsi Zero", "en") == "Coke Zero"
+    assert localized_name_for_catalog_name("Coke Zero", "en") == "Coke Zero"

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
@@ -172,6 +172,54 @@ async def test_non_english_openfoodfacts_english_name_is_localized_without_persi
 
 
 @pytest.mark.asyncio
+async def test_lookup_barcode_uses_openfoodfacts_when_fatsecret_is_unavailable():
+    repo = _FoodReferenceRepo()
+    fat_secret = None
+    off = AsyncMock()
+    off.get_product.return_value = {
+        "name": "Brown Rice",
+        "barcode": "0036000291452",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+    )
+
+    result = await handler.handle(_query())
+
+    assert result is not None
+    assert result["source"] == "openfoodfacts"
+    assert result["name"] == "Brown Rice"
+
+
+@pytest.mark.asyncio
+async def test_lookup_barcode_rejects_openfoodfacts_result_without_name():
+    repo = _FoodReferenceRepo()
+    off = AsyncMock()
+    off.get_product.return_value = {
+        "name": None,
+        "barcode": "0036000291452",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=None,
+        open_food_facts_service=off,
+    )
+
+    result = await handler.handle(_query())
+
+    assert result is None
+    assert repo.upserts == []
+
+
+@pytest.mark.asyncio
 async def test_cached_barcode_without_source_provenance_stays_canonical():
     repo = _FoodReferenceRepo(
         {

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
@@ -79,6 +79,7 @@ class _NeutralTranslator:
 async def test_lookup_barcode_returns_cached_product_from_async_uow():
     repo = _FoodReferenceRepo(
         {
+            "id": 42,
             "barcode": "123",
             "name": "Rice",
             "protein_100g": 2.7,
@@ -93,6 +94,8 @@ async def test_lookup_barcode_returns_cached_product_from_async_uow():
 
     assert result is not None
     assert result["source"] == "cache"
+    assert result["origin"] == "local"
+    assert result["food_reference_id"] == 42
     fat_secret.get_product.assert_not_awaited()
 
 
@@ -103,6 +106,9 @@ async def test_lookup_barcode_caches_fatsecret_hit_with_async_uow():
     fat_secret.get_product.return_value = {
         "barcode": "123",
         "name": "Rice",
+        "origin": "provider",
+        "source_namespace": "fatsecret",
+        "source_food_id": "50953",
         "protein_100g": 2.7,
         "carbs_100g": 28,
         "fat_100g": 0.3,
@@ -115,6 +121,9 @@ async def test_lookup_barcode_caches_fatsecret_hit_with_async_uow():
     assert result["source"] == "fatsecret"
     assert repo.upserts[0]["barcode"] == "00036000291452"
     assert result["barcode"] == "036000291452"
+    assert result["origin"] == "provider"
+    assert result["source_namespace"] == "fatsecret"
+    assert result["source_food_id"] == "50953"
 
 
 @pytest.mark.asyncio
@@ -220,10 +229,11 @@ async def test_lookup_barcode_rejects_openfoodfacts_result_without_name():
 
 
 @pytest.mark.asyncio
-async def test_cached_barcode_without_source_provenance_stays_canonical():
+async def test_cached_barcode_uses_reference_identity_without_provider_metadata():
     repo = _FoodReferenceRepo(
         {
             "123": {
+                "id": 17,
                 "barcode": "123",
                 "name": "Brown Rice",
                 "protein_100g": 2.7,
@@ -238,6 +248,8 @@ async def test_cached_barcode_without_source_provenance_stays_canonical():
     result = await handler.handle(LookupBarcodeQuery(barcode="123", language="vi"))
 
     assert result["name"] == "Brown Rice"
+    assert result["origin"] == "local"
+    assert result["food_reference_id"] == 17
     translator.translate_texts.assert_not_awaited()
 
 

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
@@ -37,6 +37,7 @@ async def test_non_english_first_scan_keeps_english_cache_for_later_english_read
     # Simulate cache hit from the English canonical upsert.
     repo.cached = {
         "123": {
+            "id": 17,
             "barcode": "123",
             "name": "Brown Rice",
             "protein_100g": 2.7,
@@ -60,6 +61,7 @@ async def test_cached_fatsecret_hit_localizes_for_vietnamese_request():
     repo = _FoodReferenceRepo(
         {
             "123": {
+                "id": 17,
                 "barcode": "123",
                 "name": "Brown Rice",
                 "protein_100g": 2.7,
@@ -83,6 +85,7 @@ async def test_cached_unknown_source_english_name_still_localizes():
     repo = _FoodReferenceRepo(
         {
             "123": {
+                "id": 17,
                 "barcode": "123",
                 "name": "Brown Rice",
                 "protein_100g": 2.7,

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -1,7 +1,8 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+import src.infra.adapters.fat_secret_service as fat_secret_module
 from src.infra.adapters.fat_secret_service import FatSecretService
 
 
@@ -22,6 +23,22 @@ class _Client:
     async def post(self, *args, **kwargs):
         self.post_calls.append((args, kwargs))
         return _Response()
+
+
+@pytest.mark.unit
+def test_fatsecret_provider_is_optional_when_credentials_are_missing(monkeypatch):
+    monkeypatch.setattr(fat_secret_module, "_fat_secret_service", None)
+    monkeypatch.setattr(fat_secret_module, "_fat_secret_service_initialized", False)
+    monkeypatch.setattr(fat_secret_module.settings, "FATSECRET_CLIENT_ID", None)
+    monkeypatch.setattr(fat_secret_module.settings, "FATSECRET_CLIENT_SECRET", None)
+    warning = Mock()
+    monkeypatch.setattr(fat_secret_module.logger, "warning", warning)
+
+    assert fat_secret_module.get_fat_secret_service() is None
+    assert fat_secret_module.get_fat_secret_service() is None
+    warning.assert_called_once_with(
+        "fatsecret credentials not configured; provider will be skipped"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -353,6 +353,10 @@ async def test_fatsecret_barcode_lookup_uses_method_based_endpoint():
     assert barcode_call.kwargs["params"]["method"] == "food.find_id_for_barcode"
     assert detail_call.args[0] == "POST"
     assert detail_params["method"] == "food.get.v5"
+    assert result["name"] == "Whole Grain Cheerios"
+    assert result["origin"] == "provider"
+    assert result["source_namespace"] == "fatsecret"
+    assert result["source_food_id"] == "50953"
     assert result["allowed_units"][0] == {
         "unit": "g",
         "gram_weight": 1.0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Merge current `main` into `delivery` on branch `feature/sync-main-to-delivery-751f`.
- Bring barcode meal-write capability advertising, source identity for meal creation, nameless provider rejection, legacy meal-edit overrides, and hydration poured-volume / drink-name localization from main.
- Resolve barcode lookup conflicts by keeping delivery’s English/leftover localization while adopting main’s `_canonicalize_cached_product` identity and FatSecret null-safety.
- Update delivery barcode localization fixtures to include durable reference ids required by main’s cache canonicalize path.

## Commits from main
- #556 fix(barcode): return source identity for meal creation
- #555 fix(capabilities): advertise barcode meal writes
- #554 fix(barcode): reject nameless provider results
- #553 fix(meal-edit): accept legacy v2 meal overrides
- #552 fix(hydration): prefer poured volume in activities and localize drink names

## Test plan
- [x] Targeted barcode lookup + translation unit tests (19 passed)
- [x] Related merge unit tests (capabilities / meal-edit / hydration / fatsecret — 64 passed)
- [x] CI-aligned unit suite: 2672 passed, coverage 80.15%
- [x] CI green on this PR
- [ ] Smoke barcode lookup + meal create from cache on delivery after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0204d-3a23-765f-8ec6-137c9ba0751f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0204d-3a23-765f-8ec6-137c9ba0751f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

