### PR TITLE
fix(nutrition): default provider RPM so catalog saves are not 503

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,9 +78,9 @@ REDIS_USERNAME=
 REDIS_PASSWORD=
 REDIS_SSL=false
 REDIS_MAX_CONNECTIONS=10
-# Required for provider-origin authoritative manual-meal saves. Set this to the
-# approved shared FatSecret requests-per-minute budget for the deployment.
-NUTRITION_PROVIDER_GLOBAL_RPM=
+# Shared FatSecret requests-per-minute budget for catalog-food meal saves.
+# Defaults to 60 if omitted or empty.
+NUTRITION_PROVIDER_GLOBAL_RPM=60
 
 # ---------------------------------------------------------------------------
 # Firebase (required for authentication)

--- a/docs/external-services.md
+++ b/docs/external-services.md
@@ -32,10 +32,11 @@ settings, wiring from adapters, and live health from OpenAPI `/docs`.
 **Redis rule:** optional caches are never the source of truth for nutrition,
 notification delivery, FCM token ownership, or write-path correctness. Cache
 admission policy: `docs/decisions/260608-2223-selective-cache-admission-policy.md`.
-Provider-origin v2 manual saves additionally require Redis and an explicit
-`NUTRITION_PROVIDER_GLOBAL_RPM` deployment setting. `CACHE_ENABLED=false` may
-disable optional cache reads, but it must not disable this shared write-path
-budget.
+Provider-origin v2 manual saves use Redis and `NUTRITION_PROVIDER_GLOBAL_RPM`
+(default **60** if unset or empty). `ENVIRONMENT=development` may use a
+process-local budget if Redis is down so local catalog-food saves work.
+`CACHE_ENABLED=false` may disable optional cache reads, but it must not
+disable this shared write-path budget.
 
 **Privacy rule:** never log prompts, food payloads, raw AI output, base64
 images, emails, auth tokens, full barcodes, or secrets. Prefer operation name,

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -220,7 +220,7 @@ from src.domain.ports.food_reference_repository_port import (
     FoodReferenceSearchProjection,
 )
 from src.domain.services.nutrition_integrity_policy import NutritionIntegrityPolicy
-from src.infra.cache.provider_budget import RedisProviderBudget
+from src.infra.cache.provider_budget import MemoryProviderBudget, RedisProviderBudget
 from src.infra.config.settings import settings
 from src.infra.database.uow_async import AsyncUnitOfWork
 from src.infra.event_bus import EventBus, PyMediatorEventBus
@@ -233,13 +233,26 @@ _configured_event_bus: EventBus | None = None
 
 
 def _build_provider_budget(cache_service):
-    """Build the required shared provider budget from the initialized Redis client."""
-    if cache_service is None or settings.NUTRITION_PROVIDER_GLOBAL_RPM is None:
+    """Build the shared provider budget. Production fail-closes without Redis."""
+    if settings.NUTRITION_PROVIDER_GLOBAL_RPM is None:
+        logger.error(
+            "NUTRITION_PROVIDER_GLOBAL_RPM is unset; provider-origin meal saves "
+            "will return NUTRITION_PROVIDER_UNAVAILABLE"
+        )
         return None
     redis_client = getattr(cache_service, "redis", None)
-    if redis_client is None:
-        return None
-    return RedisProviderBudget(redis_client)
+    if redis_client is not None:
+        return RedisProviderBudget(redis_client)
+    if settings.ENVIRONMENT.lower() == "development":
+        logger.warning(
+            "Redis cache unavailable; using process-local provider budget in development"
+        )
+        return MemoryProviderBudget()
+    logger.error(
+        "Redis cache unavailable; provider-origin meal saves will return "
+        "NUTRITION_PROVIDER_UNAVAILABLE"
+    )
+    return None
 
 
 async def _search_local_food_references(

--- a/src/infra/cache/provider_budget.py
+++ b/src/infra/cache/provider_budget.py
@@ -1,9 +1,29 @@
-"""Redis-backed shared provider budget."""
+"""Shared provider request budgets."""
 
+import asyncio
 import time
 
 from src.domain.ports.provider_budget_port import ProviderBudgetPort
 from src.infra.cache.redis_client import RedisClient
+
+
+class MemoryProviderBudget:
+    """Process-local rolling window. Used only when Redis is unavailable in development."""
+
+    def __init__(self, window_seconds: int = 60):
+        self.window_seconds = window_seconds
+        self._counts: dict[tuple[str, int], int] = {}
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, namespace: str, limit: int) -> bool:
+        if limit < 1:
+            return False
+        window = int(time.time() // self.window_seconds)
+        key = (namespace, window)
+        async with self._lock:
+            count = self._counts.get(key, 0) + 1
+            self._counts[key] = count
+        return count <= limit
 
 
 class RedisProviderBudget(ProviderBudgetPort):

--- a/src/infra/config/settings.py
+++ b/src/infra/config/settings.py
@@ -116,10 +116,10 @@ class Settings(BaseSettings):
     FATSECRET_CLIENT_SECRET: str | None = Field(
         default=None, description="fatsecret OAuth 2.0 client secret"
     )
-    NUTRITION_PROVIDER_GLOBAL_RPM: int | None = Field(
-        default=None,
+    NUTRITION_PROVIDER_GLOBAL_RPM: int = Field(
+        default=60,
         ge=1,
-        description="Required shared per-minute budget for authoritative provider saves",
+        description="Shared per-minute FatSecret budget for provider-origin meal saves.",
     )
     BRAVE_SEARCH_API_KEY: str | None = Field(
         default=None, description="Brave Search API key (free tier: 2K/mo)"
@@ -343,6 +343,13 @@ class Settings(BaseSettings):
         default={"USD": 25000, "EUR": 27000, "default": 25000},
         description="Fixed exchange rates to VND for wallet conversion",
     )
+
+    @field_validator("NUTRITION_PROVIDER_GLOBAL_RPM", mode="before")
+    @classmethod
+    def default_provider_rpm(cls, value: Any) -> Any:
+        if value is None or value == "":
+            return 60
+        return value
 
     @field_validator("REFERRAL_COMMISSIONS", "EXCHANGE_RATES_TO_VND", mode="before")
     @classmethod

--- a/tests/unit/api/test_event_bus_dependency_singletons.py
+++ b/tests/unit/api/test_event_bus_dependency_singletons.py
@@ -3,6 +3,10 @@ import importlib
 import pytest
 
 
+class _CacheStub:
+    redis = object()
+
+
 def test_provider_budget_does_not_depend_on_optional_cache_flag(monkeypatch):
     mod = importlib.import_module("src.api.dependencies.event_bus")
 
@@ -20,6 +24,16 @@ def test_provider_budget_does_not_depend_on_optional_cache_flag(monkeypatch):
     budget = mod._build_provider_budget(_Cache())
 
     assert isinstance(budget, _Budget)
+
+
+def test_development_uses_memory_budget_when_redis_cache_missing(monkeypatch):
+    mod = importlib.import_module("src.api.dependencies.event_bus")
+    monkeypatch.setattr(mod.settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(mod.settings, "NUTRITION_PROVIDER_GLOBAL_RPM", 10)
+
+    budget = mod._build_provider_budget(None)
+
+    assert isinstance(budget, mod.MemoryProviderBudget)
 
 
 def test_get_food_search_event_bus_is_singleton(monkeypatch):
@@ -100,7 +114,7 @@ def test_get_configured_event_bus_is_singleton(monkeypatch):
     monkeypatch.setattr(deps, "get_food_data_service", lambda: object())
     monkeypatch.setattr(deps, "get_food_mapping_service", lambda: object())
     monkeypatch.setattr(deps, "get_fat_secret_service_instance", lambda: object())
-    monkeypatch.setattr(deps, "get_cache_service", lambda: object())
+    monkeypatch.setattr(deps, "get_cache_service", lambda: _CacheStub())
     monkeypatch.setattr(deps, "get_suggestion_orchestration_service", lambda: object())
     monkeypatch.setattr(deps, "get_meal_translation_service", lambda: object())
 
@@ -217,7 +231,7 @@ def test_configured_event_bus_wires_meal_analyze_validation(monkeypatch):
     monkeypatch.setattr(deps, "get_food_data_service", lambda: object())
     monkeypatch.setattr(deps, "get_food_mapping_service", lambda: object())
     monkeypatch.setattr(deps, "get_fat_secret_service_instance", lambda: object())
-    monkeypatch.setattr(deps, "get_cache_service", lambda: object())
+    monkeypatch.setattr(deps, "get_cache_service", lambda: _CacheStub())
     monkeypatch.setattr(deps, "get_suggestion_orchestration_service", lambda: object())
     monkeypatch.setattr(deps, "get_meal_translation_service", lambda: object())
     monkeypatch.setattr(deps, "get_text_translation_service", lambda: object())
@@ -351,7 +365,7 @@ async def test_configured_event_bus_can_send_movement_catalog_query(monkeypatch)
     monkeypatch.setattr(deps, "get_food_data_service", lambda: object())
     monkeypatch.setattr(deps, "get_food_mapping_service", lambda: object())
     monkeypatch.setattr(deps, "get_fat_secret_service_instance", lambda: object())
-    monkeypatch.setattr(deps, "get_cache_service", lambda: object())
+    monkeypatch.setattr(deps, "get_cache_service", lambda: _CacheStub())
     monkeypatch.setattr(deps, "get_suggestion_orchestration_service", lambda: object())
     monkeypatch.setattr(deps, "get_meal_translation_service", lambda: object())
 

--- a/tests/unit/infra/config/test_provider_rpm_settings.py
+++ b/tests/unit/infra/config/test_provider_rpm_settings.py
@@ -1,0 +1,11 @@
+from src.infra.config.settings import Settings
+
+
+def test_provider_rpm_defaults_when_unset():
+    settings = Settings(_env_file=None)
+    assert settings.NUTRITION_PROVIDER_GLOBAL_RPM == 60
+
+
+def test_provider_rpm_defaults_when_empty_string():
+    settings = Settings(NUTRITION_PROVIDER_GLOBAL_RPM="", _env_file=None)
+    assert settings.NUTRITION_PROVIDER_GLOBAL_RPM == 60

--- a/tests/unit/infra/test_provider_budget.py
+++ b/tests/unit/infra/test_provider_budget.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.infra.cache.provider_budget import RedisProviderBudget
+from src.infra.cache.provider_budget import MemoryProviderBudget, RedisProviderBudget
 
 
 @pytest.mark.asyncio
@@ -29,3 +29,12 @@ async def test_redis_provider_budget_fails_closed_on_unavailable_or_exhausted_bu
 
     redis.incr_with_expiry.return_value = 11
     assert await budget.acquire("fatsecret", 10) is False
+
+
+@pytest.mark.asyncio
+async def test_memory_provider_budget_accepts_calls_inside_limit():
+    budget = MemoryProviderBudget(window_seconds=60)
+
+    assert await budget.acquire("fatsecret", 2) is True
+    assert await budget.acquire("fatsecret", 2) is True
+    assert await budget.acquire("fatsecret", 2) is False


### PR DESCRIPTION
## Summary
- `NUTRITION_PROVIDER_GLOBAL_RPM` now defaults to **60** when unset or empty, so catalog-food / provider-origin meal saves no longer fail closed with `provider_budget_unavailable`.
- Production still requires Redis for the shared budget. `ENVIRONMENT=development` falls back to a process-local `MemoryProviderBudget` when Redis is down.
- Delivery's `getattr(cache_service, "redis", None)` guard is kept.

## Test plan
- [ ] Restart the backend with empty `NUTRITION_PROVIDER_GLOBAL_RPM` and save a catalog food; expect 200, not 503.
- [ ] Local/dev without Redis: catalog save still works.
- [ ] Production-like env without Redis: still fail closed.


Made with [Cursor](https://cursor.com)