### PR TITLE
Fix barcode identity lookups

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -207,8 +207,14 @@ handler/schema when implementing; the bullets below are the durable WHY.
 - Search order: optional Redis cache → local `food_reference` → provider fill.
   Local results first; optional cache failures are misses.
 - Barcode accepts valid GTIN check digits; malformed → 400 before external
-  calls; valid miss → 404. Estimate sources stay `is_estimate=true` and are not
-  written to the global catalog.
+  calls; valid miss → 404. Verified hits return a durable logging identity:
+  cached/provider results use the local `food_reference_id` when the verified
+  row is written, while FatSecret can fall back to its provider identity when
+  caching is unavailable. If OpenFoodFacts or USDA cannot materialize a local
+  identity, the endpoint fails with a retryable 503 rather than returning an
+  unsaveable verified result. Estimate sources stay `is_estimate=true`, are not
+  written to the global catalog, and are not eligible for canonical meal
+  creation.
 
 ### Onboarding TDEE preview
 

--- a/docs/archive/progress/project-changelog.md
+++ b/docs/archive/progress/project-changelog.md
@@ -3,6 +3,15 @@
 **Status:** Stateful release notes — archived; not evergreen product authority  
 **Evergreen route:** see `docs/codebase-summary.md` and root `README.md`
 
+## 2026-08-21
+
+### Fixed
+
+- Barcode lookup now returns the durable local `food_reference_id` created by a
+  verified provider cache write, preventing first-time OpenFoodFacts and USDA
+  barcode logs from falling through the canonical nutrition identity guard. It
+  now fails closed with a retryable 503 when that identity cannot be materialized.
+
 ## 2026-08-18
 
 ### Fixed

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Any
 
+from src.api.exceptions import ExternalServiceException
 from src.app.events.base import EventHandler, handles
 from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 from src.app.services.food_name_localizer import (
@@ -149,7 +150,12 @@ class LookupBarcodeQueryHandler(
             result = self._trusted_provider_result(
                 fat_secret_result, query.barcode, scanned_barcode, "fatsecret"
             )
-            await self._cache_result(result, cache_barcode=query.barcode)
+            cached_reference = await self._cache_result(
+                result, cache_barcode=query.barcode
+            )
+            result = self._resolve_verified_identity(
+                result, cached_reference, provider_source="fatsecret"
+            )
             log_hit("fatsecret", result)
             return await self._maybe_translate(
                 result, query.language, source_language="en"
@@ -179,7 +185,12 @@ class LookupBarcodeQueryHandler(
             result = self._trusted_provider_result(
                 off_result, query.barcode, scanned_barcode, "openfoodfacts"
             )
-            await self._cache_result(result, cache_barcode=query.barcode)
+            cached_reference = await self._cache_result(
+                result, cache_barcode=query.barcode
+            )
+            result = self._resolve_verified_identity(
+                result, cached_reference, provider_source="openfoodfacts"
+            )
             log_hit("openfoodfacts", result)
             return await self._maybe_translate(
                 result, query.language, source_language=source_language
@@ -202,7 +213,12 @@ class LookupBarcodeQueryHandler(
             and self._has_nutrition(fdc_result)
             and self._has_name(fdc_result)
         ):
-            await self._cache_result(fdc_result, cache_barcode=query.barcode)
+            cached_reference = await self._cache_result(
+                fdc_result, cache_barcode=query.barcode
+            )
+            fdc_result = self._resolve_verified_identity(
+                fdc_result, cached_reference, provider_source="usda_fdc"
+            )
             log_hit("usda_fdc", fdc_result)
             return await self._maybe_translate(
                 fdc_result, query.language, source_language="en"
@@ -316,6 +332,70 @@ class LookupBarcodeQueryHandler(
             cached["origin"] = "provider"
             return cached
         return None
+
+    @staticmethod
+    def _attach_cached_identity(
+        result: dict[str, Any], cached_reference: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        """Prefer the durable local identity created by a verified cache write."""
+        if cached_reference is None:
+            return result
+        canonical = LookupBarcodeQueryHandler._canonicalize_cached_product(
+            cached_reference
+        )
+        if canonical is None or canonical.get("food_reference_id") is None:
+            return result
+        enriched = dict(canonical)
+        for field in (
+            "barcode",
+            "source",
+            "provider_source",
+            "is_estimate",
+            "calories_100g",
+            "calories_per_100g",
+            "nutrition_basis",
+            "nutrition_contract_version",
+        ):
+            if field in result:
+                enriched[field] = result[field]
+        enriched.update(
+            {
+                "food_reference_id": canonical["food_reference_id"],
+                "origin": "local",
+                "source_namespace": "food_reference",
+                "source_food_id": canonical["source_food_id"],
+            }
+        )
+        return enriched
+
+    @classmethod
+    def _resolve_verified_identity(
+        cls,
+        result: dict[str, Any],
+        cached_reference: dict[str, Any] | None,
+        *,
+        provider_source: str,
+    ) -> dict[str, Any]:
+        """Return an identity the meal-creation contract can resolve."""
+        enriched = cls._attach_cached_identity(result, cached_reference)
+        if enriched.get("food_reference_id") is not None:
+            return enriched
+
+        # FatSecret has a provider-backed resolver in the meal path. OFF and
+        # USDA identities must be materialized locally before they are shown as
+        # verified barcode results, otherwise the client cannot create a meal.
+        if (
+            provider_source == "fatsecret"
+            and enriched.get("origin") == "provider"
+            and enriched.get("source_namespace")
+            and enriched.get("source_food_id")
+        ):
+            return enriched
+
+        raise ExternalServiceException(
+            "Barcode nutrition identity is temporarily unavailable. Please retry.",
+            error_code="BARCODE_SOURCE_IDENTITY_UNAVAILABLE",
+        )
 
     async def _first_barcode_hit(self, aliases, fetch):
         for alias in aliases:
@@ -520,29 +600,41 @@ class LookupBarcodeQueryHandler(
 
     async def _cache_result(
         self, result: dict[str, Any], cache_barcode: str | None = None
-    ) -> None:
-        """Cache verified API result to food_reference table."""
+    ) -> dict[str, Any] | None:
+        """Cache a verified result and return its durable reference row."""
         if not result.get("name"):
             logger.warning(
                 "Skipping barcode cache: name is required",
             )
-            return
+            return None
         payload = dict(result)
         if cache_barcode:
             payload["barcode"] = cache_barcode
         payload.pop("cache_barcode", None)
+        lookup_barcode = payload.get("barcode")
         try:
             if self.async_uow_factory is not None:
                 async with self.async_uow_factory() as uow:
                     await uow.food_references.upsert(payload)
-                return
+                    if lookup_barcode:
+                        return await uow.food_references.get_by_barcode(lookup_barcode)
+                return None
             if self.repo is None:
-                return
+                return None
             upserted = self.repo.upsert(payload)
             if hasattr(upserted, "__await__"):
                 await upserted
+            if lookup_barcode:
+                get_by_barcode = getattr(self.repo, "get_by_barcode", None)
+                if get_by_barcode is not None:
+                    cached = get_by_barcode(lookup_barcode)
+                    if hasattr(cached, "__await__"):
+                        return await cached
+                    return cached
+            return None
         except Exception as exc:
             logger.warning(
                 "Failed to cache barcode result error=%s",
                 type(exc).__name__,
             )
+            return None

--- a/src/domain/services/food_mapping_service.py
+++ b/src/domain/services/food_mapping_service.py
@@ -358,6 +358,10 @@ class FoodMappingService(FoodMappingServicePort):
             "fdc_id": item.get("fdcId"),
             "source": "usda_fdc",
             "provider_source": "usda_fdc",
+            "source_namespace": "usda_fdc",
+            "source_food_id": (
+                str(item["fdcId"]) if item.get("fdcId") is not None else None
+            ),
             "is_verified": True,
             "is_estimate": False,
             "allowed_units": self._barcode_allowed_units(

--- a/src/infra/adapters/open_food_facts_service.py
+++ b/src/infra/adapters/open_food_facts_service.py
@@ -3,8 +3,8 @@ OpenFoodFacts API HTTP client.
 Provides product lookup by barcode for packaged foods.
 """
 
-from typing import Dict, Any, Optional
 import re
+from typing import Any
 
 import httpx
 
@@ -17,7 +17,7 @@ class OpenFoodFactsService:
     # Barcode validation pattern (8-14 digits)
     BARCODE_PATTERN = re.compile(r"^\d{8,14}$")
 
-    def __init__(self, client: Optional[httpx.AsyncClient] = None):
+    def __init__(self, client: httpx.AsyncClient | None = None):
         self._client = client
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -32,7 +32,7 @@ class OpenFoodFactsService:
             await self._client.aclose()
             self._client = None
 
-    async def get_product(self, barcode: str) -> Optional[Dict[str, Any]]:
+    async def get_product(self, barcode: str) -> dict[str, Any] | None:
         """
         Fetch product by barcode from OpenFoodFacts.
 
@@ -67,7 +67,7 @@ class OpenFoodFactsService:
         except httpx.HTTPError:
             return None
 
-    def _map_product(self, product: Dict[str, Any]) -> Dict[str, Any]:
+    def _map_product(self, product: dict[str, Any]) -> dict[str, Any]:
         """Map OpenFoodFacts response to clean dict."""
         nutriments = product.get("nutriments", {})
 
@@ -87,12 +87,15 @@ class OpenFoodFactsService:
         )
 
         english_name = product.get("product_name_en")
+        source_food_id = str(product.get("code") or "").strip() or None
         return {
             "name": english_name or product.get("product_name"),
             # product_name may be localized; only mark explicit English data.
             "source_language": "en" if english_name else None,
             "brand": product.get("brands"),
             "barcode": product.get("code"),
+            "source_namespace": "openfoodfacts",
+            "source_food_id": source_food_id,
             "calories_100g": self._safe_float(nutriments.get("energy-kcal_100g")),
             "protein_100g": self._safe_float(nutriments.get("proteins_100g")),
             "carbs_100g": self._safe_float(nutriments.get("carbohydrates_100g")),
@@ -104,7 +107,7 @@ class OpenFoodFactsService:
             "image_url": image_url,
         }
 
-    def _allowed_units(self, serving_size: Optional[str]) -> list[dict[str, Any]]:
+    def _allowed_units(self, serving_size: str | None) -> list[dict[str, Any]]:
         units = [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
         grams = self._serving_grams(serving_size)
         if grams:
@@ -117,7 +120,7 @@ class OpenFoodFactsService:
             )
         return units
 
-    def _serving_grams(self, serving_size: Optional[str]) -> Optional[float]:
+    def _serving_grams(self, serving_size: str | None) -> float | None:
         if not serving_size:
             return None
         match = re.search(
@@ -129,7 +132,7 @@ class OpenFoodFactsService:
             return None
         return self._safe_float(match.group(1).replace(",", "."))
 
-    def _safe_float(self, value: Any) -> Optional[float]:
+    def _safe_float(self, value: Any) -> float | None:
         """Safely convert value to float."""
         if value is None:
             return None
@@ -140,7 +143,7 @@ class OpenFoodFactsService:
 
 
 # Singleton instance
-_open_food_facts_service: Optional[OpenFoodFactsService] = None
+_open_food_facts_service: OpenFoodFactsService | None = None
 
 
 def get_open_food_facts_service() -> OpenFoodFactsService:

--- a/tests/unit/api/test_foods_auth_and_rate_limits.py
+++ b/tests/unit/api/test_foods_auth_and_rate_limits.py
@@ -4,6 +4,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.dependencies.auth import get_current_user_id
+from src.api.exception_handlers import register_exception_handlers
+from src.api.exceptions import ExternalServiceException
 from src.api.routes.v1 import feature_flags, foods
 from src.api.schemas.response.barcode_product_response import BarcodeProductResponse
 
@@ -62,3 +64,25 @@ def test_barcode_response_preserves_provider_identity():
     assert payload["origin"] == "provider"
     assert payload["source_namespace"] == "fatsecret"
     assert payload["source_food_id"] == "50953"
+
+
+def test_barcode_identity_failure_is_retryable_503(monkeypatch):
+    app = _app(authenticated=True)
+    register_exception_handlers(app)
+
+    class _EventBus:
+        async def send(self, _query):
+            raise ExternalServiceException(
+                "Barcode nutrition identity is temporarily unavailable. Please retry.",
+                error_code="BARCODE_SOURCE_IDENTITY_UNAVAILABLE",
+            )
+
+    monkeypatch.setattr(foods, "get_food_search_event_bus", lambda: _EventBus())
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/v1/foods/barcode/036000291452")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error_code"] == (
+        "BARCODE_SOURCE_IDENTITY_UNAVAILABLE"
+    )

--- a/tests/unit/domain/services/test_food_mapping_service.py
+++ b/tests/unit/domain/services/test_food_mapping_service.py
@@ -34,6 +34,8 @@ def test_map_fdc_barcode_product_returns_flat_barcode_shape():
     assert result["fiber_100g"] == 6
     assert result["sugar_100g"] == 18
     assert result["source"] == "usda_fdc"
+    assert result["source_namespace"] == "usda_fdc"
+    assert result["source_food_id"] == "1"
     assert result["is_verified"] is True
     assert result["allowed_units"] == [
         {"unit": "g", "gram_weight": 1.0, "description": "1 g"},

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_async.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from src.api.exceptions import ExternalServiceException
 from src.app.handlers.query_handlers.lookup_barcode_query_handler import (
     LookupBarcodeQueryHandler,
 )
@@ -11,8 +12,9 @@ from src.infra.adapters.open_food_facts_service import OpenFoodFactsService
 
 
 class _FoodReferenceRepo:
-    def __init__(self, cached=None):
+    def __init__(self, cached=None, cached_after_upsert=None):
         self.cached = cached
+        self.cached_after_upsert = cached_after_upsert
         self.lookups = []
         self.upserts = []
 
@@ -24,6 +26,8 @@ class _FoodReferenceRepo:
 
     async def upsert(self, data):
         self.upserts.append(data)
+        if self.cached_after_upsert is not None:
+            self.cached = self.cached_after_upsert
 
 
 class _Uow:
@@ -101,7 +105,20 @@ async def test_lookup_barcode_returns_cached_product_from_async_uow():
 
 @pytest.mark.asyncio
 async def test_lookup_barcode_caches_fatsecret_hit_with_async_uow():
-    repo = _FoodReferenceRepo()
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 72,
+            "barcode": "00036000291452",
+            "name": "Rice",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+            "is_verified": True,
+            "source": "fatsecret",
+            "source_namespace": "fatsecret",
+            "source_food_id": "50953",
+        }
+    )
     fat_secret = AsyncMock()
     fat_secret.get_product.return_value = {
         "barcode": "123",
@@ -121,6 +138,33 @@ async def test_lookup_barcode_caches_fatsecret_hit_with_async_uow():
     assert result["source"] == "fatsecret"
     assert repo.upserts[0]["barcode"] == "00036000291452"
     assert result["barcode"] == "036000291452"
+    assert result["origin"] == "local"
+    assert result["food_reference_id"] == 72
+    assert result["source_namespace"] == "food_reference"
+    assert result["source_food_id"] == "72"
+    assert repo.upserts[0]["origin"] == "provider"
+    assert repo.upserts[0]["source_namespace"] == "fatsecret"
+    assert repo.upserts[0]["source_food_id"] == "50953"
+
+
+@pytest.mark.asyncio
+async def test_fatsecret_provider_identity_survives_cache_unavailability():
+    repo = _FoodReferenceRepo()
+    fat_secret = AsyncMock()
+    fat_secret.get_product.return_value = {
+        "barcode": "123",
+        "name": "Rice",
+        "origin": "provider",
+        "source_namespace": "fatsecret",
+        "source_food_id": "50953",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(repo, fat_secret_service=fat_secret)
+
+    result = await handler.handle(LookupBarcodeQuery(barcode="123", language="en"))
+
     assert result["origin"] == "provider"
     assert result["source_namespace"] == "fatsecret"
     assert result["source_food_id"] == "50953"
@@ -128,7 +172,16 @@ async def test_lookup_barcode_caches_fatsecret_hit_with_async_uow():
 
 @pytest.mark.asyncio
 async def test_non_english_barcode_fetches_and_stores_english_then_localizes_response():
-    repo = _FoodReferenceRepo()
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 75,
+            "barcode": "123",
+            "name": "Brown Rice",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+        }
+    )
     fat_secret = AsyncMock()
     fat_secret.get_product.return_value = {
         "barcode": "123",
@@ -152,7 +205,16 @@ async def test_non_english_barcode_fetches_and_stores_english_then_localizes_res
 
 @pytest.mark.asyncio
 async def test_non_english_openfoodfacts_english_name_is_localized_without_persisting_metadata():
-    repo = _FoodReferenceRepo()
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 76,
+            "barcode": "123",
+            "name": "Brown Rice",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+        }
+    )
     fat_secret = AsyncMock()
     fat_secret.get_product.return_value = None
     off = AsyncMock()
@@ -160,6 +222,7 @@ async def test_non_english_openfoodfacts_english_name_is_localized_without_persi
         {
             "product_name": "Riz brun",
             "product_name_en": "Brown Rice",
+            "code": "123",
             "nutriments": {
                 "proteins_100g": 2.7,
                 "carbohydrates_100g": 28,
@@ -178,11 +241,24 @@ async def test_non_english_openfoodfacts_english_name_is_localized_without_persi
 
     assert result["name"] == "Cơm gạo lứt"
     assert "source_language" not in repo.upserts[0]
+    assert repo.upserts[0]["source_namespace"] == "openfoodfacts"
+    assert repo.upserts[0]["source_food_id"] == "123"
 
 
 @pytest.mark.asyncio
 async def test_lookup_barcode_uses_openfoodfacts_when_fatsecret_is_unavailable():
-    repo = _FoodReferenceRepo()
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 73,
+            "barcode": "00036000291452",
+            "name": "Brown Rice",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+            "is_verified": True,
+            "source": "openfoodfacts",
+        }
+    )
     fat_secret = None
     off = AsyncMock()
     off.get_product.return_value = {
@@ -203,6 +279,70 @@ async def test_lookup_barcode_uses_openfoodfacts_when_fatsecret_is_unavailable()
     assert result is not None
     assert result["source"] == "openfoodfacts"
     assert result["name"] == "Brown Rice"
+    assert result["origin"] == "local"
+    assert result["food_reference_id"] == 73
+    assert result["source_namespace"] == "food_reference"
+    assert result["source_food_id"] == "73"
+
+
+@pytest.mark.asyncio
+async def test_lookup_barcode_returns_persisted_projection_after_provider_upsert():
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 77,
+            "barcode": "00036000291452",
+            "name": "Canonical Brown Rice",
+            "protein_100g": 3.1,
+            "carbs_100g": 27,
+            "fat_100g": 0.4,
+            "source": "openfoodfacts",
+            "is_verified": True,
+        }
+    )
+    off = AsyncMock()
+    off.get_product.return_value = {
+        "name": "Provider Brown Rice",
+        "barcode": "0036000291452",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=None,
+        open_food_facts_service=off,
+    )
+
+    result = await handler.handle(_query())
+
+    assert result["name"] == "Canonical Brown Rice"
+    assert result["protein_100g"] == 3.1
+    assert result["barcode"] == "036000291452"
+    assert result["food_reference_id"] == 77
+
+
+@pytest.mark.asyncio
+async def test_lookup_barcode_fails_closed_when_openfoodfacts_identity_cannot_be_cached():
+    repo = _FoodReferenceRepo()
+    fat_secret = None
+    off = AsyncMock()
+    off.get_product.return_value = {
+        "name": "Brown Rice",
+        "barcode": "0036000291452",
+        "protein_100g": 2.7,
+        "carbs_100g": 28,
+        "fat_100g": 0.3,
+    }
+    handler = _handler(
+        repo,
+        fat_secret_service=fat_secret,
+        open_food_facts_service=off,
+    )
+
+    with pytest.raises(ExternalServiceException) as exc_info:
+        await handler.handle(_query())
+
+    assert exc_info.value.error_code == "BARCODE_SOURCE_IDENTITY_UNAVAILABLE"
 
 
 @pytest.mark.asyncio
@@ -332,7 +472,18 @@ async def test_lookup_barcode_skips_untrusted_brave_cache_row():
 
 @pytest.mark.asyncio
 async def test_lookup_barcode_uses_fdc_exact_hit_caches_verified_and_localizes():
-    repo = _FoodReferenceRepo()
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 74,
+            "barcode": "00036000291452",
+            "name": "Test Cereal",
+            "protein_100g": 8,
+            "carbs_100g": 72,
+            "fat_100g": 2.5,
+            "is_verified": True,
+            "source": "usda_fdc",
+        }
+    )
     fat_secret = AsyncMock()
     fat_secret.get_product.return_value = None
     off = AsyncMock()
@@ -381,6 +532,10 @@ async def test_lookup_barcode_uses_fdc_exact_hit_caches_verified_and_localizes()
     assert result["source"] == "usda_fdc"
     assert result["barcode"] == "036000291452"
     assert result["name"] == "Cơm gạo lứt"
+    assert result["origin"] == "local"
+    assert result["food_reference_id"] == 74
+    assert result["source_namespace"] == "food_reference"
+    assert result["source_food_id"] == "74"
     assert repo.upserts[0]["barcode"] == "00036000291452"
     assert repo.upserts[0]["is_verified"] is True
 

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_logging.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_query_handler_logging.py
@@ -58,6 +58,9 @@ async def test_hit_log_uses_controlled_provider_source(caplog):
     fat_secret.get_product.return_value = {
         "barcode": raw_barcode,
         "name": "Rice",
+        "origin": "provider",
+        "source_namespace": "fatsecret",
+        "source_food_id": "50953",
         "protein_100g": 2.7,
         "carbs_100g": 28,
         "fat_100g": 0.3,

--- a/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
+++ b/tests/unit/handlers/query_handlers/test_lookup_barcode_translation.py
@@ -15,7 +15,18 @@ from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 @pytest.mark.asyncio
 async def test_non_english_first_scan_keeps_english_cache_for_later_english_read():
     """Vietnamese first-writer must not poison the global barcode cache."""
-    repo = _FoodReferenceRepo()
+    repo = _FoodReferenceRepo(
+        cached_after_upsert={
+            "id": 17,
+            "barcode": "123",
+            "name": "Brown Rice",
+            "protein_100g": 2.7,
+            "carbs_100g": 28,
+            "fat_100g": 0.3,
+            "source": "fatsecret",
+            "is_verified": True,
+        }
+    )
     fat_secret = AsyncMock()
     fat_secret.get_product.return_value = {
         "barcode": "123",

--- a/tests/unit/infra/repositories/test_food_reference_repository_async.py
+++ b/tests/unit/infra/repositories/test_food_reference_repository_async.py
@@ -71,6 +71,8 @@ def _food_row(
     row.nutrient_rows = []
     row.extra_nutrients = None
     row.source = "seed"
+    row.source_namespace = None
+    row.source_food_id = None
     row.is_verified = verified
     row.image_url = None
     row.name_normalized = name_normalized
@@ -394,7 +396,7 @@ async def test_upsert_by_barcode_uses_on_conflict_and_flushes_children():
 async def test_upsert_by_barcode_persists_verified_flag():
     row = _food_row()
     row.barcode = "00036000291452"
-    session = _AsyncSession([_Result(), _Result(rows=[row])])
+    session = _AsyncSession([_Result(), _Result(), _Result(), _Result(rows=[row])])
     repo = AsyncFoodReferenceRepository(session)
     statement = MagicMock()
     statement.values.return_value = statement
@@ -412,13 +414,20 @@ async def test_upsert_by_barcode_persists_verified_flag():
                 "carbs_100g": 72,
                 "fat_100g": 2.5,
                 "source": "usda_fdc",
+                "source_namespace": "usda_fdc",
+                "source_food_id": "12345",
                 "is_verified": True,
             }
         )
 
     values = statement.values.call_args.kwargs
     assert values["is_verified"] is True
+    assert values["source_namespace"] == "usda_fdc"
+    assert values["source_food_id"] == "12345"
     statement.on_conflict_do_update.assert_called_once()
+    update_fields = statement.on_conflict_do_update.call_args.kwargs["set_"]
+    assert update_fields["source_namespace"] == "usda_fdc"
+    assert update_fields["source_food_id"] == "12345"
     assert "where" not in statement.on_conflict_do_update.call_args.kwargs
 
 


### PR DESCRIPTION
Summary:
- Return canonical food identity for verified barcode lookups.
- Keep the backend as the source of truth for barcode translation and mapping.

Test plan:
- 2,676 unit tests passed
- 80.32% coverage
- Ruff, format, compileall, and git diff --check passed
- No live provider/database/device validation