### PR TITLE
fix(meal-edit): persist source snapshots for prepared custom meals

### DIFF
--- a/src/app/handlers/command_handlers/create_manual_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/create_manual_meal_command_handler.py
@@ -168,6 +168,11 @@ class CreateManualMealCommandHandler(EventHandler[CreateManualMealCommand, Any])
             else:
                 resolved_items = list(event.items)
 
+            resolved_items = [
+                ManualMealNutritionResolver.ensure_source_snapshot(item)
+                for item in resolved_items
+            ]
+
             async with self.uow as uow:
                 if items_needing_resolution:
                     await self.nutrition_resolver.revalidate_local_items(

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -30,6 +30,7 @@ from src.domain.services.meal_type_determination_service import (
     determine_meal_type_from_timestamp,
 )
 from src.domain.services.nutrition_calculation_service import (
+    authoritative_units_match,
     canonicalize_authoritative_quantity,
 )
 from src.domain.utils.timezone_utils import utc_now
@@ -593,12 +594,17 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
     @staticmethod
     def _canonicalize_snapshot_unit(existing_item, change):
         unit = change.unit
-        if unit is None or unit.lower().strip() == existing_item.unit.lower().strip():
+        if unit is None:
             return change
-        snapshot = existing_item.source_snapshot
-        if not snapshot:
+        existing_unit = existing_item.unit or "g"
+        if authoritative_units_match(unit, existing_unit):
+            if unit.strip() != existing_unit:
+                return replace(change, unit=existing_unit)
+            return change
+        snapshot = existing_item.source_snapshot or {}
+        allowed_units = snapshot.get("allowed_units") or existing_item.allowed_units or []
+        if not allowed_units:
             raise ValueError("v2 quantity updates require an immutable source snapshot")
-        allowed_units = snapshot.get("allowed_units") or []
         quantity = (
             change.quantity if change.quantity is not None else existing_item.quantity
         )

--- a/src/app/services/manual_meal_nutrition_resolver.py
+++ b/src/app/services/manual_meal_nutrition_resolver.py
@@ -440,6 +440,38 @@ class ManualMealNutritionResolver:
         )
 
     @staticmethod
+    def ensure_source_snapshot(item: ManualMealItem) -> ManualMealItem:
+        """Fill a missing snapshot from already-prepared custom density.
+
+        Prepared custom items skip reference resolution so portion nutrition is
+        not reinterpreted as per-100g. They still need an immutable snapshot
+        or later v2 quantity/unit edits fail closed.
+        """
+        if item.source_snapshot:
+            return item
+        nutrition = item.custom_nutrition
+        if nutrition is None:
+            return item
+        return replace(
+            item,
+            nutrition_contract_version=item.nutrition_contract_version or "2",
+            source_snapshot={
+                "origin": item.origin,
+                "source_namespace": item.source_namespace,
+                "source_food_id": item.source_food_id,
+                "basis": "100g",
+                "protein_per_100g": nutrition.protein_per_100g,
+                "carbs_per_100g": nutrition.carbs_per_100g,
+                "fat_per_100g": nutrition.fat_per_100g,
+                "fiber_per_100g": nutrition.fiber_per_100g,
+                "sugar_per_100g": nutrition.sugar_per_100g,
+                "calories_per_100g": nutrition.calories_per_100g,
+                "allowed_units": item.allowed_units
+                or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            },
+        )
+
+    @staticmethod
     def _snapshot(result, origin, namespace, source_id, allowed_units=None):
         return {
             "origin": origin,

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -180,6 +180,13 @@ def _normalize_authoritative_unit(unit: str) -> str:
     return unit_lower
 
 
+def authoritative_units_match(left: str | None, right: str | None) -> bool:
+    """True when two unit strings are the same after alias translation."""
+    return _normalize_authoritative_unit(left or "g") == _normalize_authoritative_unit(
+        right or "g"
+    )
+
+
 def canonicalize_mass_volume_unit(unit: str | None) -> str:
     """Collapse gram/ounce/liter aliases onto the canonical mass-volume token."""
     raw = (unit or "g").strip() or "g"

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -213,6 +213,62 @@ async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy()
 
 
 @pytest.mark.asyncio
+async def test_v2_quantity_update_treats_translated_unit_as_unchanged():
+    current = FoodItem(
+        id="item-1",
+        name="Thịt",
+        quantity=1,
+        unit="serving",
+        macros=Macros(protein=20, carbs=0, fat=16),
+        nutrition_contract_version="2",
+    )
+    change = FoodItemChange(
+        action="update",
+        id="item-1",
+        quantity=2,
+        unit="phần",
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+
+    assert prepared[0].quantity == pytest.approx(2)
+    assert prepared[0].unit == "serving"
+
+
+@pytest.mark.asyncio
+async def test_v2_quantity_update_uses_item_units_when_snapshot_missing():
+    current = FoodItem(
+        id="item-1",
+        name="Pork rib",
+        quantity=1,
+        unit="slice",
+        macros=Macros(protein=27, carbs=0, fat=15),
+        nutrition_contract_version="2",
+        allowed_units=[
+            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            {"unit": "slice", "gram_weight": 80.0, "description": "1 slice"},
+        ],
+    )
+    change = FoodItemChange(
+        action="update",
+        id="item-1",
+        quantity=100,
+        unit="unknown-unit",
+    )
+    handler = EditMealCommandHandler(uow=None)
+
+    prepared = await handler._prepare_v2_changes(
+        [current], [change], SimpleNamespace(food_references=object())
+    )
+
+    assert prepared[0].quantity == pytest.approx(100)
+    assert prepared[0].unit == "g"
+
+
+@pytest.mark.asyncio
 async def test_v2_item_override_does_not_require_intent_in_handler():
     current = FoodItem(
         id="item-1",

--- a/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
@@ -213,6 +213,10 @@ async def test_v2_prepared_custom_nutrition_is_saved_without_resolution():
     resolver.resolve_items.assert_not_awaited()
     resolver.revalidate_local_items.assert_not_awaited()
     assert uow.meal_write_operations.completed[1] == meal.meal_id
+    saved_item = meal.nutrition.food_items[0]
+    assert saved_item.source_snapshot["basis"] == "100g"
+    assert saved_item.source_snapshot["protein_per_100g"] == 90
+    assert saved_item.source_snapshot["origin"] == "custom"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Prepared custom v2 creates now stamp an immutable source snapshot so later quantity/unit edits do not fail closed.
- Quantity updates treat translated units (`phần` vs `serving`) as unchanged, and can use the item's allowed units when a snapshot is missing.

## Test plan
- [ ] Create a parse-text / custom meal, then change ingredient quantity or unit
- [ ] Confirm PUT `/meals/{id}/ingredients` no longer returns `v2 quantity updates require an immutable source snapshot`
- [ ] `uv run pytest tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py tests/unit/app/handlers/test_edit_meal_v2_authority.py`


Made with [Cursor](https://cursor.com)