### PR TITLE
fix(movement): return log and delete before Redis cache SCAN

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -427,9 +427,11 @@ def get_configured_event_bus() -> EventBus:
     )
     from src.infra.database.uow_async import AsyncUnitOfWork
 
-    # Synchronous invalidation service — handlers await this before returning,
-    # eliminating the fire-and-forget race condition.
-    cache_invalidation_service = CacheInvalidationService(cache_service)
+    # Meal/hydration handlers still await invalidation. Movement handlers
+    # schedule it on the task manager so log/delete can return after persist.
+    cache_invalidation_service = CacheInvalidationService(
+        cache_service, task_manager=task_manager
+    )
     provider_budget = _build_provider_budget(cache_service)
     nutrition_integrity_policy = NutritionIntegrityPolicy()
 

--- a/src/app/handlers/command_handlers/delete_movement_entry_command_handler.py
+++ b/src/app/handlers/command_handlers/delete_movement_entry_command_handler.py
@@ -40,6 +40,8 @@ class DeleteMovementEntryCommandHandler(EventHandler[DeleteMovementEntryCommand,
                 )
 
         if self.cache_invalidation:
-            await self.cache_invalidation.after_movement_write(cmd.user_id, log_date)
+            await self.cache_invalidation.schedule_after_movement_write(
+                cmd.user_id, log_date
+            )
 
         return {}

--- a/src/app/handlers/command_handlers/log_movement_command_handler.py
+++ b/src/app/handlers/command_handlers/log_movement_command_handler.py
@@ -109,6 +109,8 @@ class LogMovementCommandHandler(EventHandler[LogMovementCommand, dict]):
             saved = await uow.movement_entries.add(entry)
 
         if self.cache_invalidation:
-            await self.cache_invalidation.after_movement_write(cmd.user_id, log_date)
+            await self.cache_invalidation.schedule_after_movement_write(
+                cmd.user_id, log_date
+            )
 
         return _movement_response(saved)

--- a/src/app/handlers/command_handlers/update_movement_entry_command_handler.py
+++ b/src/app/handlers/command_handlers/update_movement_entry_command_handler.py
@@ -58,6 +58,8 @@ class UpdateMovementEntryCommandHandler(
             )
 
         if self.cache_invalidation:
-            await self.cache_invalidation.after_movement_write(cmd.user_id, log_date)
+            await self.cache_invalidation.schedule_after_movement_write(
+                cmd.user_id, log_date
+            )
 
         return _movement_response(updated)

--- a/src/app/services/cache_invalidation_service.py
+++ b/src/app/services/cache_invalidation_service.py
@@ -1,14 +1,18 @@
-"""Centralized, synchronous cache invalidation for all mutations.
+"""Centralized cache invalidation for all mutations.
 
-Synchronous invalidation guarantees Redis is cleared before the response
-returns to the client, eliminating the race condition where a Flutter GET
-immediately after a POST would hit a stale Redis key.
+Meal/hydration writes still await invalidation before the HTTP response so a
+follow-up GET cannot hit a stale Redis key.
+
+Movement writes persist first, then schedule invalidation on the process
+task manager. The Flutter client already projects SQLite locally and must
+not wait on Redis SCAN of `nutrition_bulk:*` / weekly-budget patterns.
 """
 
 import logging
 import time
+from collections.abc import Coroutine
 from datetime import date, timedelta
-from typing import Optional
+from typing import Any
 
 from src.domain.cache.cache_keys import CacheKeys
 from src.domain.ports.cache_port import CachePort
@@ -21,10 +25,15 @@ def _get_week_start(d: date) -> date:
 
 
 class CacheInvalidationService:
-    """Synchronous cache invalidation called by command handlers before returning."""
+    """Cache invalidation called by command handlers after a successful write."""
 
-    def __init__(self, cache: Optional[CachePort]):
+    def __init__(
+        self,
+        cache: CachePort | None,
+        task_manager: Any | None = None,
+    ):
         self._cache = cache
+        self._task_manager = task_manager
 
     async def _invalidate_key(self, key: str) -> None:
         if not self._cache:
@@ -94,6 +103,7 @@ class CacheInvalidationService:
 
     async def after_movement_write(self, user_id: str, log_date: date) -> None:
         """Invalidate all caches affected by a movement log/edit/delete."""
+        _t0 = time.perf_counter()
         week_start = _get_week_start(log_date)
         current_week_start = _get_week_start(date.today())
 
@@ -112,6 +122,29 @@ class CacheInvalidationService:
         if week_start != current_week_start:
             await self._invalidate_weekly_budget(user_id, current_week_start)
             await self._invalidate_key(CacheKeys.daily_breakdown(user_id, current_week_start)[0])
+
+        logger.info(
+            "cache_invalidation movement timing: user=%s total_ms=%.1f",
+            user_id,
+            (time.perf_counter() - _t0) * 1000,
+        )
+
+    async def schedule_after_movement_write(self, user_id: str, log_date: date) -> None:
+        """Run movement cache invalidation after the HTTP response when possible.
+
+        Without a task manager (unit tests, scripts) this awaits in-process so
+        callers still observe the same cache effects.
+        """
+        await self._schedule(
+            f"cache:after_movement_write:{user_id}:{log_date.isoformat()}",
+            self.after_movement_write(user_id, log_date),
+        )
+
+    async def _schedule(self, name: str, coro: Coroutine[Any, Any, Any]) -> None:
+        if self._task_manager is not None:
+            self._task_manager.spawn(name, coro)
+            return
+        await coro
 
     async def after_hydration_write(self, user_id: str, log_date: date) -> None:
         """Invalidate all caches affected by a hydration log/delete.

--- a/src/infra/cache/redis_client.py
+++ b/src/infra/cache/redis_client.py
@@ -167,13 +167,29 @@ class RedisClient:
         return await self._with_client("DELETE", operation, False, key)
 
     async def delete_pattern(self, pattern: str) -> int:
-        """Delete keys matching a pattern using non-blocking SCAN."""
+        """Delete keys matching a pattern using non-blocking SCAN.
+
+        Keys are deleted in batches to avoid one Redis round-trip per match.
+        `nutrition_bulk:*` invalidation otherwise dominates movement writes.
+        """
 
         async def operation(client: redis.Redis) -> int:
             deleted = 0
+            batch: list[str] = []
+
+            async def flush() -> None:
+                nonlocal deleted
+                if not batch:
+                    return
+                await client.delete(*batch)
+                deleted += len(batch)
+                batch.clear()
+
             async for key in client.scan_iter(match=pattern):
-                await client.delete(key)
-                deleted += 1
+                batch.append(key)
+                if len(batch) >= 100:
+                    await flush()
+            await flush()
             if deleted:
                 logger.debug("Deleted %d keys matching %s", deleted, pattern)
             return deleted

--- a/tests/unit/app/services/test_cache_invalidation_service.py
+++ b/tests/unit/app/services/test_cache_invalidation_service.py
@@ -278,3 +278,35 @@ async def test_service_noop_when_cache_is_none():
     await svc.after_movement_write("u", date(2026, 6, 2))
     await svc.after_hydration_write("u", date(2026, 6, 2))
     await svc.after_custom_macros_update("u")
+
+
+class _FakeTaskManager:
+    def __init__(self):
+        self.spawned: list[tuple[str, object]] = []
+
+    def spawn(self, name, coro):
+        self.spawned.append((name, coro))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_schedule_after_movement_write_awaits_without_task_manager(cache_mock):
+    svc = CacheInvalidationService(cache_mock)
+    await svc.schedule_after_movement_write("user2", date(2026, 6, 2))
+    cache_mock.invalidate_pattern.assert_any_call("user:user2:activities:2026-06-02:*")
+
+
+@pytest.mark.asyncio
+async def test_schedule_after_movement_write_spawns_when_task_manager_present(cache_mock):
+    tasks = _FakeTaskManager()
+    svc = CacheInvalidationService(cache_mock, task_manager=tasks)
+
+    await svc.schedule_after_movement_write("user2", date(2026, 6, 2))
+
+    assert cache_mock.invalidate_pattern.call_count == 0
+    assert cache_mock.invalidate.call_count == 0
+    assert len(tasks.spawned) == 1
+    assert tasks.spawned[0][0].startswith("cache:after_movement_write:user2:")
+
+    await tasks.spawned[0][1]
+    cache_mock.invalidate_pattern.assert_any_call("user:user2:activities:2026-06-02:*")

--- a/tests/unit/handlers/command_handlers/test_movement_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_movement_command_handlers.py
@@ -445,6 +445,84 @@ async def test_update_movement_handler_updates_and_invalidates_caches():
     assert _weekly_budget_key() in cache.invalidated
 
 
+class _FakeTaskManager:
+    def __init__(self):
+        self.spawned = []
+
+    def spawn(self, name, coro):
+        self.spawned.append((name, coro))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_log_movement_returns_before_scheduled_cache_invalidation():
+    uow = _FakeUow()
+    cache = _FakeCache()
+    tasks = _FakeTaskManager()
+    handler = LogMovementCommandHandler(
+        uow=uow,
+        cache_invalidation=CacheInvalidationService(cache, task_manager=tasks),
+    )
+
+    result = await handler.handle(
+        LogMovementCommand(
+            user_id="user-1",
+            activity_id="badminton",
+            activity_name="Badminton",
+            duration_min=45,
+            kcal_burned=200.5,
+            intensity="moderate",
+            include_in_balance=True,
+            target_date=date(2026, 5, 30),
+            header_timezone="Asia/Ho_Chi_Minh",
+        )
+    )
+
+    assert result["id"] == uow.movement_entries.added[0].id
+    assert uow.committed is True
+    assert cache.invalidated == []
+    assert cache.patterns == []
+    assert len(tasks.spawned) == 1
+
+    await tasks.spawned[0][1]
+    assert "user:user-1:macros:2026-05-30" in cache.invalidated
+    assert "user:user-1:activities:2026-05-30:*" in cache.patterns
+
+
+@pytest.mark.asyncio
+async def test_delete_movement_returns_before_scheduled_cache_invalidation():
+    uow = _FakeUow(timezone="Asia/Ho_Chi_Minh")
+    cache = _FakeCache()
+    tasks = _FakeTaskManager()
+    uow.movement_entries.entry = log_movement_command_handler.MovementEntry(
+        id="mvmt_123",
+        user_id="user-1",
+        activity_id="badminton",
+        activity_name="Badminton",
+        duration_min=45,
+        kcal_burned=200.5,
+        intensity="moderate",
+        include_in_balance=True,
+        logged_at=datetime(2026, 5, 30, 18, 0, tzinfo=timezone.utc),
+    )
+    handler = DeleteMovementEntryCommandHandler(
+        uow=uow,
+        cache_invalidation=CacheInvalidationService(cache, task_manager=tasks),
+    )
+
+    result = await handler.handle(
+        DeleteMovementEntryCommand(user_id="user-1", entry_id="mvmt_123")
+    )
+
+    assert result == {}
+    assert uow.committed is True
+    assert cache.invalidated == []
+    assert len(tasks.spawned) == 1
+
+    await tasks.spawned[0][1]
+    assert "user:user-1:macros:2026-05-31" in cache.invalidated
+
+
 def test_validate_log_movement_rejects_kcal_above_absolute_max():
     with pytest.raises(ValidationException) as exc:
         _validate_log_movement(

--- a/tests/unit/infra/test_redis_client_timeout.py
+++ b/tests/unit/infra/test_redis_client_timeout.py
@@ -102,7 +102,11 @@ async def test_delete_pattern_uses_scan_not_keys():
 
     mock_client = AsyncMock()
     mock_client.scan_iter = fake_scan_iter
-    mock_client.delete = AsyncMock(side_effect=lambda k: deleted_keys.append(k))
+
+    async def fake_delete(*keys):
+        deleted_keys.extend(keys)
+
+    mock_client.delete = AsyncMock(side_effect=fake_delete)
     client.client = mock_client
 
     count = await client.delete_pattern("user:abc:macros:*")
@@ -110,4 +114,5 @@ async def test_delete_pattern_uses_scan_not_keys():
     assert count == 2
     assert "user:abc:macros:2026-01-01" in deleted_keys
     assert "user:abc:macros:2026-01-02" in deleted_keys
+    mock_client.delete.assert_awaited_once()
     assert mock_client.keys.call_count == 0  # must NOT use blocking KEYS


### PR DESCRIPTION
## Summary
- Pairs with app [nutree_ai#697](https://github.com/Nutree-AI-Vietnam/nutree_ai/pull/697) (same movement log/delete issue; separate repo so it cannot live in this PR).
- Movement log/update/delete persist first, then schedule Redis invalidation on the background task manager instead of blocking the HTTP response.
- Batch `SCAN` deletes so `nutrition_bulk:*` / weekly-budget pattern clears are one Redis round-trip per 100 keys, not per key.

## Why
POST `/v1/movement/log` and DELETE `/v1/movement/{id}` were returning in ~4s after the row was already written because handlers awaited Redis `SCAN` of bulk nutrition and weekly-budget keys. The client already projects the movement locally, so that wait is not required on the request path.

## Test plan
- [ ] `uv run pytest tests/unit/handlers/command_handlers/test_movement_command_handlers.py tests/unit/app/services/test_cache_invalidation_service.py tests/unit/infra/test_redis_client_timeout.py`
- [ ] Log a movement in the app and confirm `POST /v1/movement/log` returns 201 without waiting on cache invalidation (invalidation log should appear after the response)
- [ ] Delete a movement and confirm `DELETE` returns 204 similarly
- [ ] After a few seconds, home / weekly budget / nutrition bulk still reflect the write (stale Redis keys are cleared in the background)