### PR TITLE
fix(catalog): skip FatSecret food.get when search already has macros

### DIFF
--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -40,6 +40,13 @@ LANGUAGE_TO_REGION = {
 }
 
 
+def _has_search_macros(food: dict[str, Any]) -> bool:
+    return all(
+        food.get(field) is not None
+        for field in ("protein_100g", "carbs_100g", "fat_100g")
+    )
+
+
 class FatSecretService:
     """HTTP client for fatsecret API with OAuth 2.0."""
 
@@ -226,9 +233,7 @@ class FatSecretService:
             async def _process(food: dict) -> dict:
                 food_id = food.get("food_id")
                 mapped = dict(food)
-
-                # Fetch detailed nutrition if we have a food_id
-                if food_id:
+                if food_id and not _has_search_macros(mapped):
                     try:
                         details = await self.get_food_details(
                             food_id,
@@ -238,7 +243,7 @@ class FatSecretService:
                         if details:
                             mapped.update(details)
                     except Exception:
-                        pass  # Use basic mapped data if details fail
+                        pass
 
                 return mapped
 
@@ -534,16 +539,21 @@ class FatSecretService:
 
     def _map_search_result(self, food: dict[str, Any]) -> dict[str, Any]:
         """Map fatsecret search result to clean dict."""
-        return {
+        food_id = food.get("food_id")
+        mapped: dict[str, Any] = {
             "description": food.get("food_name", ""),
             "brand": food.get("brand_name"),
             "food_description": food.get("food_description", ""),
             "source": "fatsecret",
-            "food_id": food.get(
-                "food_id"
-            ),  # fatsecret's internal ID for getting details
-            "allowed_units": self._default_allowed_units(),  # Will be enriched with details
+            "food_id": food_id,
+            "origin": "provider",
+            "source_namespace": "fatsecret",
+            "source_food_id": str(food_id) if food_id else None,
+            "allowed_units": self._default_allowed_units(),
         }
+        if food.get("servings"):
+            mapped.update(self._extract_nutrition_from_details(food))
+        return mapped
 
     def _safe_float(self, value: Any) -> float | None:
         """Safely convert value to float."""

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -260,6 +260,9 @@ async def test_fatsecret_search_candidates_does_not_fetch_details():
             "food_description": "",
             "source": "fatsecret",
             "food_id": "50953",
+            "origin": "provider",
+            "source_namespace": "fatsecret",
+            "source_food_id": "50953",
             "allowed_units": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
                 {"unit": "serving", "gram_weight": 100.0, "description": "100 g"},
@@ -315,6 +318,48 @@ async def test_fatsecret_get_food_details_fetches_one_selected_candidate():
     assert params["method"] == "food.get.v5"
     assert params["food_id"] == "50953"
     assert result["protein_100g"] == 10.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fatsecret_search_skips_details_when_search_includes_servings():
+    service = FatSecretService("client", "secret")
+    service._api_request = AsyncMock(
+        return_value={
+            "foods_search": {
+                "results": {
+                    "food": [
+                        {
+                            "food_id": "50953",
+                            "food_name": "Whole Grain Cheerios",
+                            "brand_name": "General Mills",
+                            "servings": {
+                                "serving": {
+                                    "measurement_description": "g",
+                                    "metric_serving_amount": "100.000",
+                                    "serving_description": "100 g",
+                                    "calories": "333",
+                                    "protein": "10",
+                                    "carbohydrate": "66.67",
+                                    "fat": "6.67",
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    results = await service.search_foods("cheerios", max_results=1)
+
+    service._api_request.assert_awaited_once()
+    assert (
+        service._api_request.await_args.kwargs["params"]["method"] == "foods.search.v5"
+    )
+    assert results[0]["protein_100g"] == 10.0
+    assert results[0]["carbs_100g"] == pytest.approx(66.67)
+    assert results[0]["fat_100g"] == pytest.approx(6.67)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Map nutrition from FatSecret `foods.search.v5` embedded servings instead of always calling `food.get.v5` per row.
- Keep `food.get` as a fallback when search results have no macros.
- Cuts typed catalog search from ~1+N FatSecret calls down to 1 when servings are present.

## Test plan
- [ ] `uv run pytest tests/unit/infra/adapters/test_fat_secret_service.py`
- [ ] Search for a common food (e.g. chicken) from mobile: results still show calories and P/C/F.
- [ ] Confirm search latency is closer to one FatSecret round trip, not one get per card.


Made with [Cursor](https://cursor.com)