### PR TITLE
fix(meals): keep localized names after ingredient edits

### DIFF
--- a/src/api/mappers/meal_locale_ensure.py
+++ b/src/api/mappers/meal_locale_ensure.py
@@ -1,0 +1,98 @@
+"""Apply a requested locale onto a meal before building a detail response."""
+
+import logging
+from dataclasses import replace
+
+from src.api.mappers.meal_mapper import MealMapper
+
+logger = logging.getLogger(__name__)
+
+
+def without_requested_meal_translation(meal, language: str):
+    """Keep incomplete locale data from leaking into a response."""
+    translations = getattr(meal, "translations", None)
+    if not translations or language not in translations:
+        return meal
+    remaining = {
+        cached_language: translation
+        for cached_language, translation in translations.items()
+        if cached_language != language
+    }
+    return replace(meal, translations=remaining or None)
+
+
+async def ensure_requested_meal_translation(
+    *,
+    meal,
+    language: str,
+    query,
+    event_bus,
+    meal_translation_service,
+):
+    """Materialize a missing locale without serving a partial translation."""
+    if MealMapper.has_persisted_image_display_names(meal):
+        return meal
+    if language == "en":
+        return meal
+
+    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
+    instructions = getattr(meal, "instructions", None)
+    if not meal.dish_name and not food_items and not instructions:
+        return meal
+
+    if MealMapper.has_direct_response_localization(meal, language):
+        return meal
+
+    expected_ingredient_count = sum(
+        1 for item in food_items if getattr(item, "name", None)
+    )
+    expected_instruction_count = sum(
+        1 for step in (instructions or []) if isinstance(step, (dict, str))
+    )
+    cached = (meal.translations or {}).get(language)
+    if cached and cached.is_fully_cached(
+        expected_ingredient_count=expected_ingredient_count,
+        expected_instruction_count=expected_instruction_count,
+    ):
+        return meal
+    if meal_translation_service is None:
+        return without_requested_meal_translation(meal, language)
+
+    try:
+        translation = await meal_translation_service.translate_meal(
+            meal=meal,
+            dish_name=meal.dish_name or "",
+            food_items=food_items,
+            target_language=language,
+            instructions=instructions,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Meal translation on read failed meal=%s lang=%s error_type=%s",
+            meal.meal_id,
+            language,
+            type(exc).__name__,
+        )
+        return without_requested_meal_translation(meal, language)
+
+    if translation is None or not translation.is_fully_cached(
+        expected_ingredient_count=expected_ingredient_count,
+        expected_instruction_count=expected_instruction_count,
+    ):
+        logger.warning(
+            "Meal translation remains incomplete meal=%s lang=%s",
+            meal.meal_id,
+            language,
+        )
+        return without_requested_meal_translation(meal, language)
+
+    try:
+        return await event_bus.send(query)
+    except Exception as exc:
+        logger.warning(
+            "Meal translation reload failed meal=%s lang=%s error_type=%s",
+            meal.meal_id,
+            language,
+            type(exc).__name__,
+        )
+        return without_requested_meal_translation(meal, language)

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -28,6 +28,7 @@ from src.domain.model.nutrition import FoodItem, Macros, Micros, Nutrition
 from src.domain.ports.food_reference_repository_port import (
     FoodReferenceNutritionProjection,
 )
+from src.domain.services.localized_display_name import keep_stored_display_name
 from src.domain.services.meal_calorie_service import (
     effective_food_item_calories,
     effective_meal_calories,
@@ -46,6 +47,19 @@ STATUS_MAPPING = {
     "READY": "ready",
     "FAILED": "failed",
 }
+
+
+def _apply_translated_food_name(food_item, translated_name, language: str | None) -> None:
+    if not translated_name:
+        return
+    if keep_stored_display_name(
+        stored=food_item.name,
+        translated=translated_name,
+        language=language,
+    ):
+        return
+    food_item.name = translated_name
+    food_item.display_name = translated_name
 
 
 class MealMapper:
@@ -280,7 +294,11 @@ class MealMapper:
                 translation_language = requested_language
                 # Apply each translated field independently if it exists
                 # (lenient check - scanned meals may not have instructions)
-                if tr.dish_name:
+                if tr.dish_name and not keep_stored_display_name(
+                    stored=dish_name,
+                    translated=tr.dish_name,
+                    language=requested_language,
+                ):
                     dish_name = tr.dish_name
                 if tr.meal_instruction:
                     instructions = tr.meal_instruction
@@ -301,13 +319,14 @@ class MealMapper:
                         translated_name = translated_names_by_id.get(
                             str(fi.id)
                         ) or legacy_names_by_id.get(str(fi.id))
-                        if translated_name:
-                            fi.name = translated_name
-                            fi.display_name = translated_name
+                        _apply_translated_food_name(
+                            fi, translated_name, requested_language
+                        )
                 elif legacy_names_by_id:
                     for i, fi in enumerate(food_items):
-                        fi.name = tr.meal_ingredients[i]
-                        fi.display_name = tr.meal_ingredients[i]
+                        _apply_translated_food_name(
+                            fi, tr.meal_ingredients[i], requested_language
+                        )
 
         value_insights_response = MealMapper._value_insights_response(value_insights)
 
@@ -342,7 +361,7 @@ class MealMapper:
             ready_at=meal.ready_at,
             error_message=meal.error_message,
             created_at=meal.created_at,
-            updated_at=None,
+            updated_at=getattr(meal, "updated_at", None),
             food_items=food_items,
             image_url=image_url,
             total_calories=total_calories,

--- a/src/api/routes/v1/meals_edit.py
+++ b/src/api/routes/v1/meals_edit.py
@@ -7,11 +7,16 @@ from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, Header, Request
 
-from src.api.base_dependencies import get_ai_model_manager, get_cache_service
+from src.api.base_dependencies import (
+    get_ai_model_manager,
+    get_cache_service,
+    get_meal_translation_service,
+)
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.dependencies.task_manager import get_optional_task_manager
 from src.api.exceptions import ValidationException
+from src.api.mappers.meal_locale_ensure import ensure_requested_meal_translation
 from src.api.mappers.meal_mapper import MealMapper
 from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
@@ -80,6 +85,7 @@ async def update_meal_ingredients(
     x_app_version: str | None = Header(default=None, alias="X-App-Version"),
     x_platform: str | None = Header(default=None, alias="X-Platform"),
     idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    meal_translation_service=Depends(get_meal_translation_service),
 ):
     """
     Update meal ingredients and portions.
@@ -177,11 +183,20 @@ async def update_meal_ingredients(
         },
     )
     result = await event_bus.send(command)
-    meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
+    language = get_request_language(request)
+    query = GetMealByIdQuery(meal_id=meal_id, user_id=user_id)
+    meal = await event_bus.send(query)
+    meal = await ensure_requested_meal_translation(
+        meal=meal,
+        language=language,
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=meal_translation_service,
+    )
     schedule_value_insight_generation(
         task_manager,
         meal,
-        language=get_request_language(request),
+        language=language,
         cache_service=cache_service,
         ai_manager=ai_manager,
         event_bus=event_bus,
@@ -193,7 +208,7 @@ async def update_meal_ingredients(
         result["meal_detail"] = MealMapper.to_detailed_response(
             meal,
             image_url,
-            target_language=get_request_language(request),
+            target_language=language,
         )
     return result
 

--- a/src/api/routes/v1/meals_read.py
+++ b/src/api/routes/v1/meals_read.py
@@ -2,7 +2,6 @@
 
 import logging
 import uuid
-from dataclasses import replace
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -17,6 +16,10 @@ from src.api.base_dependencies import (
 from src.api.dependencies.auth import get_current_user_id
 from src.api.dependencies.event_bus import get_configured_event_bus
 from src.api.dependencies.task_manager import get_optional_task_manager
+from src.api.mappers.meal_locale_ensure import (
+    ensure_requested_meal_translation,
+    without_requested_meal_translation,
+)
 from src.api.mappers.meal_mapper import MealMapper
 from src.api.middleware.accept_language import get_request_language
 from src.api.schemas.progress_schemas import DailyBreakdownResponse, StreakResponse
@@ -46,96 +49,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _without_requested_meal_translation(meal, language: str):
-    """Keep incomplete locale data from leaking into a read response."""
-    translations = getattr(meal, "translations", None)
-    if not translations or language not in translations:
-        return meal
-    remaining = {
-        cached_language: translation
-        for cached_language, translation in translations.items()
-        if cached_language != language
-    }
-    return replace(meal, translations=remaining or None)
-
-
-async def _ensure_requested_meal_translation(
-    *,
-    meal,
-    language: str,
-    query: GetMealByIdQuery,
-    event_bus: EventBus,
-    meal_translation_service,
-):
-    """Materialize a missing locale without serving a partial translation."""
-    if MealMapper.has_persisted_image_display_names(meal):
-        return meal
-    if language == "en":
-        return meal
-
-    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
-    instructions = getattr(meal, "instructions", None)
-    if not meal.dish_name and not food_items and not instructions:
-        return meal
-
-    if MealMapper.has_direct_response_localization(meal, language):
-        return meal
-
-    expected_ingredient_count = sum(
-        1 for item in food_items if getattr(item, "name", None)
-    )
-    expected_instruction_count = sum(
-        1 for step in (instructions or []) if isinstance(step, (dict, str))
-    )
-    cached = (meal.translations or {}).get(language)
-    if cached and cached.is_fully_cached(
-        expected_ingredient_count=expected_ingredient_count,
-        expected_instruction_count=expected_instruction_count,
-    ):
-        return meal
-    if meal_translation_service is None:
-        return _without_requested_meal_translation(meal, language)
-
-    try:
-        translation = await meal_translation_service.translate_meal(
-            meal=meal,
-            dish_name=meal.dish_name or "",
-            food_items=food_items,
-            target_language=language,
-            instructions=instructions,
-        )
-    except Exception as exc:
-        logger.warning(
-            "Meal translation on read failed meal=%s lang=%s error_type=%s",
-            meal.meal_id,
-            language,
-            type(exc).__name__,
-        )
-        return _without_requested_meal_translation(meal, language)
-
-    if translation is None or not translation.is_fully_cached(
-        expected_ingredient_count=expected_ingredient_count,
-        expected_instruction_count=expected_instruction_count,
-    ):
-        logger.warning(
-            "Meal translation remains incomplete meal=%s lang=%s",
-            meal.meal_id,
-            language,
-        )
-        return _without_requested_meal_translation(meal, language)
-
-    # The service returns a non-persisted object for partial provider results.
-    # Reload so the mapper can only use a complete, durable translation row.
-    try:
-        return await event_bus.send(query)
-    except Exception as exc:
-        logger.warning(
-            "Meal translation reload failed meal=%s lang=%s error_type=%s",
-            meal.meal_id,
-            language,
-            type(exc).__name__,
-        )
-        return _without_requested_meal_translation(meal, language)
+_without_requested_meal_translation = without_requested_meal_translation
+_ensure_requested_meal_translation = ensure_requested_meal_translation
 
 
 async def _source_nutrition_by_food_reference(meal, food_reference_repository):
@@ -251,7 +166,7 @@ async def get_meal(
         image_url = meal.image.url or image_store.get_url(meal.image.image_id)
 
     language = get_request_language(request)
-    meal = await _ensure_requested_meal_translation(
+    meal = await ensure_requested_meal_translation(
         meal=meal,
         language=language,
         query=query,

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -704,8 +704,12 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
 
             realigned_ingredients = []
             realigned_food_items = []
+            missing_translation = False
             for item in updated_food_items:
-                translated_name = translated_names_by_id.get(str(item.id), item.name)
+                translated_name = translated_names_by_id.get(str(item.id))
+                if not translated_name:
+                    missing_translation = True
+                    break
                 realigned_ingredients.append(translated_name)
                 realigned_food_items.append(
                     FoodItemTranslation(
@@ -713,6 +717,8 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                         name=translated_name,
                     )
                 )
+            if missing_translation:
+                continue
 
             translation.meal_ingredients = realigned_ingredients
             translation.food_items = realigned_food_items

--- a/src/domain/services/localized_display_name.py
+++ b/src/domain/services/localized_display_name.py
@@ -1,0 +1,39 @@
+"""Locale presentation helpers for meal and ingredient display names."""
+
+from src.domain.constants.languages import normalize_language
+
+
+def is_ascii_latin_label(name: str | None) -> bool:
+    """Return whether a label is unaccented Latin catalog text."""
+    stripped = (name or "").strip()
+    if not stripped:
+        return False
+    return stripped.isascii() and any(character.isalpha() for character in stripped)
+
+
+def already_in_target_language(name: str | None, language: str | None) -> bool:
+    """Return whether a stored label is already localized for the locale."""
+    target = normalize_language(language)
+    if target == "en":
+        return False
+    stripped = (name or "").strip()
+    return bool(stripped) and not is_ascii_latin_label(stripped)
+
+
+def keep_stored_display_name(
+    *,
+    stored: str | None,
+    translated: str | None,
+    language: str | None,
+) -> bool:
+    """Keep a localized stored name instead of leftover English catalog text."""
+    target = normalize_language(language)
+    if target == "en":
+        return False
+    stored_name = (stored or "").strip()
+    translated_name = (translated or "").strip()
+    if not stored_name or not translated_name or stored_name == translated_name:
+        return False
+    return is_ascii_latin_label(translated_name) and not is_ascii_latin_label(
+        stored_name
+    )

--- a/src/domain/services/meal_analysis/meal_translation_service.py
+++ b/src/domain/services/meal_analysis/meal_translation_service.py
@@ -53,7 +53,8 @@ class MealTranslationService:
             instructions: Optional list of instruction dicts or strings.
 
         Returns:
-            Saved MealTranslation or None on skip / failure.
+            Saved MealTranslation, including an identity row when names are
+            already in the request locale, or None on failure.
         """
         if target_language == "en":
             return None
@@ -103,7 +104,16 @@ class MealTranslationService:
                     target_language,
                     meal.meal_id,
                 )
-                return None
+                saved = await self._save(
+                    _identity_meal_translation(
+                        meal_id=meal.meal_id,
+                        language=target_language,
+                        dish_name=dish_name,
+                        named_food_items=named_food_items,
+                        normalised_steps=normalised_steps,
+                    )
+                )
+                return saved
 
             result, translated = await _translate_preserving_localized_names(
                 self._text_service,
@@ -188,6 +198,39 @@ class MealTranslationService:
         if inspect.iscoroutinefunction(method):
             return await cast(Any, method)(translation)
         return await asyncio.to_thread(cast(Any, method), translation)
+
+
+def _identity_meal_translation(
+    *,
+    meal_id: str,
+    language: str,
+    dish_name: str,
+    named_food_items: list[FoodItem],
+    normalised_steps: list[dict],
+) -> MealTranslation:
+    """Persist stored localized names as the request-locale row."""
+    return MealTranslation(
+        meal_id=meal_id,
+        language=language,
+        dish_name=dish_name,
+        food_items=[
+            FoodItemTranslation(food_item_id=str(item.id), name=item.name)
+            for item in named_food_items
+        ],
+        meal_instruction=(
+            [
+                {
+                    "instruction": step.get("instruction", ""),
+                    "duration_minutes": step.get("duration_minutes"),
+                }
+                for step in normalised_steps
+            ]
+            if normalised_steps
+            else None
+        ),
+        meal_ingredients=[item.name for item in named_food_items],
+        translated_at=utc_now(),
+    )
 
 
 async def _translate_texts(

--- a/src/domain/services/meal_analysis/meal_translation_service.py
+++ b/src/domain/services/meal_analysis/meal_translation_service.py
@@ -11,6 +11,10 @@ from src.domain.model.translation_result import TranslationOutcome, TranslationR
 from src.domain.ports.meal_translation_repository_port import (
     MealTranslationRepositoryPort,
 )
+from src.domain.services.localized_display_name import (
+    already_in_target_language,
+    keep_stored_display_name,
+)
 from src.domain.services.translation.text_translation_service import (
     TextTranslationService,
 )
@@ -89,13 +93,23 @@ class MealTranslationService:
             # Build a single flat list so we use one provider call.
             # Layout: [dish_name, *ingredient_names, *instruction_texts]
             strings_to_translate = [dish_name] + ingredient_names + instruction_texts
+            if all(
+                already_in_target_language(text, target_language)
+                for text in strings_to_translate
+                if str(text).strip()
+            ):
+                logger.info(
+                    "Meal translation skipped; names already in %s meal=%s",
+                    target_language,
+                    meal.meal_id,
+                )
+                return None
 
-            result = await _translate_texts(
-                self._text_service, strings_to_translate, target_language
+            result, translated = await _translate_preserving_localized_names(
+                self._text_service,
+                strings_to_translate,
+                target_language,
             )
-            translated = result.to_list()
-            if result.outcome is not TranslationOutcome.TRANSLATED:
-                translated.extend(strings_to_translate[len(translated) :])
 
             # --- Unpack results ---
             translated_dish_name = translated[0]
@@ -181,3 +195,48 @@ async def _translate_texts(
 ) -> TranslationResult:
     """Translate an ordered batch from the canonical English source."""
     return await service.translate_texts(texts, "en", target_language)
+
+
+async def _translate_preserving_localized_names(
+    service: TextTranslationService,
+    texts: list[str],
+    target_language: str,
+) -> tuple[TranslationResult, list[str]]:
+    """Translate leftover English labels only. Keep already-localized names."""
+    translate_indexes = [
+        index
+        for index, text in enumerate(texts)
+        if not already_in_target_language(text, target_language)
+    ]
+    if not translate_indexes:
+        passthrough = TranslationResult.passthrough(
+            tuple(texts),
+            source_language="en",
+            target_language=target_language,
+        )
+        return passthrough, list(texts)
+
+    result = await _translate_texts(
+        service,
+        [texts[index] for index in translate_indexes],
+        target_language,
+    )
+    translated_batch = result.to_list()
+    if result.outcome is not TranslationOutcome.TRANSLATED:
+        translated_batch.extend(
+            [texts[index] for index in translate_indexes[len(translated_batch) :]]
+        )
+
+    merged = list(texts)
+    for offset, index in enumerate(translate_indexes):
+        translated_name = (
+            translated_batch[offset] if offset < len(translated_batch) else texts[index]
+        )
+        if keep_stored_display_name(
+            stored=texts[index],
+            translated=translated_name,
+            language=target_language,
+        ):
+            translated_name = texts[index]
+        merged[index] = translated_name
+    return result, merged

--- a/tests/unit/api/test_app_smoke_routes.py
+++ b/tests/unit/api/test_app_smoke_routes.py
@@ -571,6 +571,101 @@ def test_meals_edit_ingredients_v2_includes_meal_detail(client: TestClient):
     assert edit_command.override_intent == "user_entered"
 
 
+def test_meals_edit_ingredients_v2_meal_detail_keeps_requested_locale(
+    client: TestClient,
+):
+    """PUT meal_detail must use Accept-Language the same way GET does."""
+    import json
+    from datetime import datetime
+    from uuid import uuid4
+
+    from src.api.dependencies.event_bus import get_configured_event_bus
+    from src.app.commands.meal import EditMealCommand
+    from src.domain.model.meal import FoodItemTranslation, Meal, MealStatus, MealTranslation
+    from src.domain.model.nutrition import FoodItem, Macros, Nutrition
+
+    meal_id = str(uuid4())
+    food_id = str(uuid4())
+    meal = Meal(
+        meal_id=meal_id,
+        user_id=str(uuid4()),
+        status=MealStatus.READY,
+        created_at=datetime(2026, 8, 22, 12, 0),
+        ready_at=datetime(2026, 8, 22, 12, 0),
+        image=None,
+        dish_name="Broken rice with grilled pork chop",
+        source="scanner",
+        raw_gpt_json=json.dumps(
+            {
+                "dish_name": "Broken rice with grilled pork chop",
+                "foods": [{"name": "Broken Rice"}],
+            }
+        ),
+        nutrition=Nutrition(
+            macros=Macros(protein=35, carbs=45, fat=20),
+            food_items=[
+                FoodItem(
+                    id=food_id,
+                    name="Broken Rice",
+                    quantity=200,
+                    unit="g",
+                    macros=Macros(protein=8, carbs=45, fat=1),
+                )
+            ],
+        ),
+        translations={
+            "vi": MealTranslation(
+                meal_id=meal_id,
+                language="vi",
+                dish_name="Cơm tấm sườn, bì, chả",
+                meal_ingredients=["Cơm tấm"],
+                food_items=[
+                    FoodItemTranslation(food_item_id=food_id, name="Cơm tấm"),
+                ],
+            )
+        },
+    )
+
+    sent = []
+
+    class _EditBus:
+        async def send(self, msg):
+            sent.append(msg)
+            if isinstance(msg, EditMealCommand):
+                return {"success": True}
+            return meal
+
+    client.app.dependency_overrides[get_configured_event_bus] = lambda: _EditBus()
+
+    r = client.put(
+        f"/v1/meals/{meal_id}/ingredients",
+        json={
+            "food_item_changes": [],
+            "nutrition_contract_version": 2,
+            "nutrition_override": {
+                "calories": 500,
+                "protein": 20,
+                "carbs": 30,
+                "fat": 15,
+            },
+        },
+        headers={
+            "Accept-Language": "vi",
+            "X-Nutrition-Contract-Version": "2",
+            "X-App-Version": "1.0.0",
+            "X-Platform": "ios",
+            "Idempotency-Key": "smoke-edit-v2-locale",
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()["meal_detail"]
+    assert body["dish_name"] == "Cơm tấm sườn, bì, chả"
+    assert body["food_items"][0]["name"] == "Cơm tấm"
+    assert body["food_items"][0]["canonical_name"] == "Broken Rice"
+    assert body["translation_language"] == "vi"
+
+
 def test_meals_streak_smoke(client: TestClient):
     """Smoke coverage for GET /v1/meals/streak."""
     from src.api.dependencies.event_bus import get_configured_event_bus

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -476,6 +476,73 @@ class TestMealMapper:
         ]
         assert result.translation_language == "vi"
 
+    def test_to_detailed_response_does_not_apply_leftover_english_vi_translation(
+        self,
+    ):
+        """Parse-text names are already Vietnamese; inverted vi rows must not paint."""
+        food_items = [
+            FoodItem(
+                id="item-1",
+                name="Cơm tấm",
+                quantity=1,
+                unit="dĩa",
+                macros=Macros(protein=12, carbs=70, fat=4),
+            ),
+            FoodItem(
+                id="item-2",
+                name="Bì heo",
+                quantity=1,
+                unit="phần",
+                macros=Macros(protein=6, carbs=2, fat=8),
+            ),
+        ]
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/com-tam.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            source="prompt",
+            dish_name="Cơm tấm với sườn, bì, chả",
+            ready_at=datetime(2026, 8, 22, 13, 50),
+            created_at=datetime(2026, 8, 22, 13, 50),
+            nutrition=Nutrition(
+                macros=Macros(protein=18, carbs=72, fat=12),
+                food_items=food_items,
+            ),
+            translations={
+                "vi": MealTranslation(
+                    meal_id="meal-1",
+                    language="vi",
+                    dish_name="Cơm tấm với sườn, bì, chả",
+                    meal_ingredients=["Broken rice", "Shredded pork skin"],
+                    food_items=[
+                        FoodItemTranslation(
+                            food_item_id="item-1",
+                            name="Broken rice",
+                        ),
+                        FoodItemTranslation(
+                            food_item_id="item-2",
+                            name="Shredded pork skin",
+                        ),
+                    ],
+                )
+            },
+        )
+
+        result = MealMapper.to_detailed_response(meal, target_language="vi")
+
+        assert result.dish_name == "Cơm tấm với sườn, bì, chả"
+        assert [item.name for item in result.food_items] == ["Cơm tấm", "Bì heo"]
+        assert [item.canonical_name for item in result.food_items] == [
+            "Cơm tấm",
+            "Bì heo",
+        ]
+
     def test_to_detailed_response_falls_back_per_item_to_safe_legacy_translation(
         self,
     ):

--- a/tests/unit/api/test_meals_read_translation.py
+++ b/tests/unit/api/test_meals_read_translation.py
@@ -236,3 +236,68 @@ async def test_ensure_requested_translation_does_not_serve_incomplete_cache():
     assert result.translations is None
     assert result.dish_name == meal.dish_name
     translation_service.translate_meal.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_requested_translation_reloads_identity_locale_row():
+    food_id = str(uuid4())
+    now = datetime.utcnow()
+    meal = Meal(
+        meal_id=str(uuid4()),
+        user_id=str(uuid4()),
+        status=MealStatus.READY,
+        created_at=now,
+        ready_at=now,
+        image=MealImage(image_id=str(uuid4()), format="jpeg", size_bytes=1),
+        dish_name="Cơm tấm",
+        nutrition=Nutrition(
+            macros=Macros(protein=12, carbs=70, fat=4),
+            food_items=[
+                FoodItem(
+                    id=food_id,
+                    name="Bì heo",
+                    quantity=1,
+                    unit="phần",
+                    macros=Macros(protein=6, carbs=2, fat=8),
+                )
+            ],
+        ),
+        translations={
+            "vi": MealTranslation(
+                meal_id="unused",
+                language="vi",
+                dish_name="Broken rice",
+                food_items=[],
+                meal_ingredients=[""],
+                meal_instruction=None,
+            )
+        },
+    )
+    identity = MealTranslation(
+        meal_id=meal.meal_id,
+        language="vi",
+        dish_name="Cơm tấm",
+        food_items=[
+            FoodItemTranslation(food_item_id=food_id, name="Bì heo"),
+        ],
+        meal_ingredients=["Bì heo"],
+        meal_instruction=None,
+    )
+    reloaded = replace(meal, translations={"vi": identity})
+    event_bus = _EventBus(reloaded)
+    translation_service = type("TranslationService", (), {})()
+    translation_service.translate_meal = AsyncMock(return_value=identity)
+    query = GetMealByIdQuery(meal_id=meal.meal_id, user_id=meal.user_id)
+
+    result = await meals_read._ensure_requested_meal_translation(
+        meal=meal,
+        language="vi",
+        query=query,
+        event_bus=event_bus,
+        meal_translation_service=translation_service,
+    )
+
+    assert result is reloaded
+    assert result.translations["vi"].dish_name == "Cơm tấm"
+    translation_service.translate_meal.assert_awaited_once()
+    assert event_bus.queries == [query]

--- a/tests/unit/domain/services/test_meal_translation_service.py
+++ b/tests/unit/domain/services/test_meal_translation_service.py
@@ -155,9 +155,13 @@ async def test_translate_meal_skips_when_names_already_in_target_language(
         target_language="vi",
     )
 
-    assert result is None
+    assert result is not None
+    assert result.dish_name == "Cơm tấm với sườn, bì, chả"
+    assert result.meal_ingredients == ["Cơm tấm", "Bì heo"]
+    assert result.food_items[0].name == "Cơm tấm"
+    assert result.food_items[1].name == "Bì heo"
     text_translation_service.translate_texts.assert_not_called()
-    repo.save.assert_not_called()
+    repo.save.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/services/test_meal_translation_service.py
+++ b/tests/unit/domain/services/test_meal_translation_service.py
@@ -128,6 +128,39 @@ async def test_translate_meal_uses_cache_when_fully_cached(
 
 
 @pytest.mark.asyncio
+async def test_translate_meal_skips_when_names_already_in_target_language(
+    service, meal, text_translation_service, repo
+):
+    food_items = [
+        FoodItem(
+            id=str(uuid4()),
+            name="Cơm tấm",
+            quantity=1,
+            unit="dĩa",
+            macros=Macros(protein=12, carbs=70, fat=4),
+        ),
+        FoodItem(
+            id=str(uuid4()),
+            name="Bì heo",
+            quantity=1,
+            unit="phần",
+            macros=Macros(protein=6, carbs=2, fat=8),
+        ),
+    ]
+
+    result = await service.translate_meal(
+        meal,
+        dish_name="Cơm tấm với sườn, bì, chả",
+        food_items=food_items,
+        target_language="vi",
+    )
+
+    assert result is None
+    text_translation_service.translate_texts.assert_not_called()
+    repo.save.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_translate_meal_calls_provider_and_saves(
     service, meal, food_items, text_translation_service, repo
 ):

--- a/tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
+++ b/tests/unit/handlers/command_handlers/test_meal_edit_command_handlers.py
@@ -16,6 +16,7 @@ from src.app.handlers.command_handlers.edit_meal_command_handler import (
     EditMealCommandHandler,
 )
 from src.domain.model.meal import MealTranslation
+from src.domain.model.nutrition import FoodItem, Macros
 from src.infra.database.models import MealORM
 
 
@@ -333,6 +334,40 @@ class TestEditMealCommandHandler:
         assert len(translation.food_items) == len(updated_items)
         assert translation.food_items[0].food_item_id == str(original_items[1].id)
         assert translation.food_items[0].name == translated_names[1]
+
+    def test_realign_does_not_fill_missing_names_with_english_identity(
+        self, sample_meal_with_nutrition
+    ):
+        meal = sample_meal_with_nutrition
+        original_items = meal.nutrition.food_items
+        translated_names = [
+            f"vi ingredient {index}" for index, _ in enumerate(original_items)
+        ]
+        meal.translations = {
+            "vi": MealTranslation(
+                meal_id=meal.meal_id,
+                language="vi",
+                dish_name="Bữa ăn",
+                food_items=[],
+                meal_ingredients=list(translated_names),
+            )
+        }
+        added_item = FoodItem(
+            id="added-avocado",
+            name="Avocado",
+            quantity=50.0,
+            unit="g",
+            macros=Macros(protein=1.0, carbs=4.0, fat=7.0),
+        )
+        handler = EditMealCommandHandler(uow=None)
+
+        handler._realign_translations_after_food_item_changes(
+            meal, [*original_items, added_item]
+        )
+
+        translation = meal.translations["vi"]
+        assert translation.meal_ingredients == translated_names
+        assert "Avocado" not in translation.meal_ingredients
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- PUT `/meals/{id}` `meal_detail` now runs the same locale-ensure path as GET, so nutrition saves keep the request language instead of returning leftover English catalog names.
- Skip `en → vi` translation when stored meal/item names are already Vietnamese (parse-text meals). Inverted translation rows were persisting English as the official `vi` row.
- Mapper no longer paints leftover-English translation labels over localized stored names. Scan meals with English stored names and Vietnamese translations still translate as before.
- Realign aborts instead of filling missing translations with English `item.name`.

Companion mobile PR: https://github.com/Nutree-AI-Vietnam/nutree_ai/pull/700

## Test plan
- [ ] Parse-text Vietnamese meal: update nutrition → list and reopen stay Vietnamese (`Cơm tấm`, `Bì heo`), not `Broken rice` / `Shredded pork skin`
- [ ] Scan meal with English stored names: update nutrition → Vietnamese translations still show (`Ức gà`), not English catalog names
- [ ] Explicit ingredient rename still persists after save
- [ ] Unit: `test_meal_mapper.py`, `test_meal_translation_service.py`, `test_meal_edit_command_handlers.py`, PUT locale smoke in `test_app_smoke_routes.py`