### PR TITLE
fix(weekly-budget): keep leftover split above the daily safety floor

### DIFF
--- a/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
+++ b/src/app/handlers/query_handlers/get_weekly_budget_query_handler.py
@@ -213,21 +213,20 @@ class GetWeeklyBudgetQueryHandler(EventHandler[GetWeeklyBudgetQuery, dict[str, A
                         tomorrow_adjusted, policy
                     )
 
-                    # Budget cap: preview can't exceed actual remaining after today
                     actual_remaining_after_today = (
                         weekly_budget.target_calories
                         - consumed_including_today["calories"]
                     )
-                    if tomorrow_remaining > 0 and actual_remaining_after_today > 0:
-                        max_tomorrow = actual_remaining_after_today / tomorrow_remaining
-                        if tomorrow_adjusted.calories > max_tomorrow:
-                            tomorrow_adjusted = self._apply_target_policy(
-                                replace(
-                                    tomorrow_adjusted,
-                                    calories=round(max_tomorrow, 1),
-                                ),
-                                policy,
-                            )
+                    tomorrow_adjusted = WeeklyBudgetService.apply_leftover_budget_cap(
+                        tomorrow_adjusted,
+                        remaining_before_today=actual_remaining_after_today,
+                        remaining_days=tomorrow_remaining,
+                        standard_daily_calories=base_daily_cal,
+                        bmr=bmr,
+                    )
+                    tomorrow_adjusted = self._apply_target_policy(
+                        tomorrow_adjusted, policy
+                    )
 
                     deviation = abs(tomorrow_adjusted.calories - base_daily_cal) / max(
                         base_daily_cal, 1

--- a/src/domain/services/weekly_budget_service.py
+++ b/src/domain/services/weekly_budget_service.py
@@ -404,18 +404,13 @@ class WeeklyBudgetService:
         remaining_before_today = (
             weekly_budget.target_calories - consumed_before_today["calories"]
         )
-        if remaining_days > 0 and remaining_before_today > 0:
-            max_daily = remaining_before_today / remaining_days
-            if adjusted.calories > max_daily:
-                scale = max_daily / adjusted.calories
-                adjusted = AdjustedDailyTargets(
-                    calories=round(max_daily, 1),
-                    carbs=round(adjusted.carbs * scale, 1),
-                    fat=round(adjusted.fat * scale, 1),
-                    protein=adjusted.protein,
-                    bmr_floor_active=adjusted.bmr_floor_active,
-                    remaining_days=adjusted.remaining_days,
-                )
+        adjusted = calc.apply_leftover_budget_cap(
+            adjusted,
+            remaining_before_today=remaining_before_today,
+            remaining_days=remaining_days,
+            standard_daily_calories=base_daily_cal,
+            bmr=bmr,
+        )
 
         return EffectiveAdjustedResult(
             adjusted=adjusted,
@@ -633,6 +628,55 @@ class WeeklyBudgetService:
             protein=rounded_protein,
             bmr_floor_active=bmr_floor_active,
             remaining_days=remaining_days,
+        )
+
+    @staticmethod
+    def calorie_safety_floor(standard_daily_calories: float, bmr: float) -> float:
+        """Lowest allowed adjusted day: deficit cap or BMR floor, whichever is higher."""
+        bmr_floor = max(
+            bmr, standard_daily_calories * WeeklyBudgetConstants.BMR_FLOOR_RATIO
+        )
+        deficit_floor = standard_daily_calories * (
+            1 - WeeklyBudgetConstants.MAX_DAILY_DEFICIT_RATIO
+        )
+        return max(bmr_floor, deficit_floor)
+
+    @staticmethod
+    def apply_leftover_budget_cap(
+        adjusted: AdjustedDailyTargets,
+        *,
+        remaining_before_today: float,
+        remaining_days: int,
+        standard_daily_calories: float,
+        bmr: float,
+    ) -> AdjustedDailyTargets:
+        """Split leftover weekly calories, but never below the safety floor.
+
+        Leftover / remaining days can still lower a day that is above the
+        floor. It must not undo the deficit cap or BMR floor.
+        """
+        if remaining_days <= 0 or remaining_before_today <= 0:
+            return adjusted
+
+        leftover_daily = remaining_before_today / remaining_days
+        if adjusted.calories <= leftover_daily:
+            return adjusted
+
+        floor = WeeklyBudgetService.calorie_safety_floor(
+            standard_daily_calories, bmr
+        )
+        capped = max(leftover_daily, floor)
+        if capped >= adjusted.calories:
+            return adjusted
+
+        scale = capped / adjusted.calories
+        return AdjustedDailyTargets(
+            calories=round(capped, 1),
+            carbs=round(adjusted.carbs * scale, 1),
+            fat=round(adjusted.fat * scale, 1),
+            protein=adjusted.protein,
+            bmr_floor_active=adjusted.bmr_floor_active,
+            remaining_days=adjusted.remaining_days,
         )
 
     @staticmethod

--- a/tests/unit/domain/services/test_weekly_budget_async.py
+++ b/tests/unit/domain/services/test_weekly_budget_async.py
@@ -693,8 +693,11 @@ class TestGetEffectiveAdjustedDailyAsync:
             cheat_dates=[],
         )
 
-        # Budget cap: both are capped at actual_remaining / remaining_days (8000/5=1600)
-        assert result_with_cheat.adjusted.calories == result_no_cheat.adjusted.calories
+        leftover_split = (14000 - 6000) / 5
+        floor = WeeklyBudgetService.calorie_safety_floor(_BASE_CAL, _BMR)
+        assert leftover_split < floor
+        assert result_with_cheat.adjusted.calories == pytest.approx(floor, abs=1)
+        assert result_no_cheat.adjusted.calories == pytest.approx(floor, abs=1)
         # Macros may differ due to different redistribution paths
         assert result_with_cheat.adjusted.carbs != result_no_cheat.adjusted.carbs
 
@@ -859,3 +862,42 @@ class TestGetEffectiveAdjustedDailyAsync:
 
         assert result.consumed_before_today["calories"] == 995
         assert result.adjusted.calories == pytest.approx((14000 - 995) / 6, abs=2)
+
+    @pytest.mark.asyncio
+    async def test_overeating_leftover_split_holds_safety_floor(self):
+        """Monday 8,000 must not smash Tuesday to leftover/days (1,000)."""
+        week_start = date(2026, 3, 23)
+        tuesday = date(2026, 3, 24)
+        meals = [
+            FakeMeal(
+                status=MealStatus.READY,
+                nutrition=FakeNutrition(
+                    calories=8000,
+                    macros=FakeNutritionMacros(protein=200, carbs=900, fat=400),
+                ),
+                created_at=datetime(2026, 3, 23, 12, 0, tzinfo=UTC),
+            ),
+        ]
+        daily_counts = {date(2026, 3, 23): 1}
+        budget = _make_budget(week_start)
+        uow = FakeUoWAsync(meals=meals, daily_counts=daily_counts)
+
+        result = await WeeklyBudgetService.get_effective_adjusted_daily_async(
+            uow=uow,
+            user_id="user-1",
+            week_start=week_start,
+            target_date=tuesday,
+            weekly_budget=budget,
+            base_daily_cal=_BASE_CAL,
+            base_daily_protein=_BASE_P,
+            base_daily_carbs=_BASE_C,
+            base_daily_fat=_BASE_F,
+            bmr=_BMR,
+            cheat_dates=[],
+        )
+
+        leftover_split = (14000 - 8000) / 6
+        floor = WeeklyBudgetService.calorie_safety_floor(_BASE_CAL, _BMR)
+        assert leftover_split < floor
+        assert result.adjusted.calories == pytest.approx(floor, abs=1)
+        assert result.adjusted.protein == _BASE_P

--- a/tests/unit/domain/services/test_weekly_budget_service.py
+++ b/tests/unit/domain/services/test_weekly_budget_service.py
@@ -15,7 +15,10 @@ import pytest
 
 from src.domain.constants import WeeklyBudgetConstants
 from src.domain.model.weekly import WeeklyMacroBudget
-from src.domain.services.weekly_budget_service import WeeklyBudgetService
+from src.domain.services.weekly_budget_service import (
+    AdjustedDailyTargets,
+    WeeklyBudgetService,
+)
 
 
 class TestWeeklyBudgetService:
@@ -484,3 +487,74 @@ class TestWeeklyMacroBudgetDomain:
         )
 
         assert budget.consumption_percentage == 50.0
+
+
+class TestLeftoverBudgetCap:
+    """Leftover weekly split must not undo the deficit/BMR floor."""
+
+    def test_calorie_safety_floor_uses_deficit_cap_when_higher_than_bmr(self):
+        floor = WeeklyBudgetService.calorie_safety_floor(2000, bmr=1500)
+        assert floor == 1800
+
+    def test_calorie_safety_floor_uses_bmr_when_higher_than_deficit_cap(self):
+        floor = WeeklyBudgetService.calorie_safety_floor(2000, bmr=1900)
+        assert floor == 1900
+
+    def test_large_overeating_does_not_drop_below_floor(self):
+        """8,000 Monday leaves 6,000 / 6 days = 1,000 leftover; floor holds 1,800."""
+        adjusted = AdjustedDailyTargets(
+            calories=1800,
+            carbs=171.4,
+            fat=57.1,
+            protein=150,
+            bmr_floor_active=False,
+            remaining_days=6,
+        )
+        result = WeeklyBudgetService.apply_leftover_budget_cap(
+            adjusted,
+            remaining_before_today=6000,
+            remaining_days=6,
+            standard_daily_calories=2000,
+            bmr=1600,
+        )
+        assert result.calories == 1800
+        assert result.protein == 150
+
+    def test_leftover_split_still_lowers_a_day_above_the_floor(self):
+        """11,400 leftover / 6 days = 1,900, which is still above the 1,800 floor."""
+        adjusted = AdjustedDailyTargets(
+            calories=2000,
+            carbs=200,
+            fat=67,
+            protein=150,
+            bmr_floor_active=False,
+            remaining_days=6,
+        )
+        result = WeeklyBudgetService.apply_leftover_budget_cap(
+            adjusted,
+            remaining_before_today=11400,
+            remaining_days=6,
+            standard_daily_calories=2000,
+            bmr=1600,
+        )
+        assert result.calories == pytest.approx(1900, abs=1)
+        assert result.protein == 150
+        assert result.carbs < 200
+
+    def test_empty_leftover_skips_cap(self):
+        adjusted = AdjustedDailyTargets(
+            calories=1800,
+            carbs=171.4,
+            fat=57.1,
+            protein=150,
+            bmr_floor_active=False,
+            remaining_days=3,
+        )
+        result = WeeklyBudgetService.apply_leftover_budget_cap(
+            adjusted,
+            remaining_before_today=0,
+            remaining_days=3,
+            standard_daily_calories=2000,
+            bmr=1600,
+        )
+        assert result.calories == 1800


### PR DESCRIPTION
## Summary
- Leftover weekly calories / remaining days can still lower a later day, but not below the existing safety floor (`max(90% of goal, BMR, 85% of goal)`).
- An 8,000 kcal Monday no longer smashes Tuesday to 1,000; it stays at the ~1,800 floor. Tomorrow preview uses the same cap.
- Cheat-day behavior is unchanged.

## Test plan
- [x] `pytest tests/unit/domain/services/test_weekly_budget_service.py tests/unit/domain/services/test_weekly_budget_async.py --no-cov`
- [ ] After overeating mid-week, home adjusted target should not drop more than 10% below the goal daily (or below BMR if that is higher)
- [ ] Mild overeating that still leaves leftover/days above the floor should still lower the next day


Made with [Cursor](https://cursor.com)