### PR TITLE
fix(docker): make startup migrations configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ ENVIRONMENT=development
 ENABLE_DEV_AUTH_BYPASS=1
 FAIL_ON_MIGRATION_ERROR=false
 FAIL_ON_CACHE_ERROR=false
+# Non-production startup migration toggle; production uses the pre-deploy command.
 AUTO_MIGRATE=true
 MIGRATION_TIMEOUT=60
 MIGRATION_RETRY_ATTEMPTS=3

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ uvicorn src.api.main:app --reload
 
 Production uses `python migrations/run.py` as the pre-deploy command. The
 production container then starts through `docker-entrypoint.sh` without
-re-running migrations; non-production containers run migrations at startup.
+re-running migrations; non-production containers run migrations at startup
+unless `AUTO_MIGRATE=false` (also accepts `0`, `no`, or `off`).
 
 - **Swagger Docs**: http://localhost:8000/docs
 - **Tests**: `pytest tests/unit --cov=src --cov-fail-under=65` for the default CI-aligned suite. Broad unscoped `pytest` currently hits two duplicate-package import collisions, so prefer targeted paths.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,16 +8,35 @@ log() {
     echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1"
 }
 
-# Run database migrations (skip production only — uses pre-deploy)
-if [ "${ENV:-}" = "production" ]; then
+# Run database migrations unless disabled or handled by the production pre-deploy.
+if [ "${ENV:-}" = "production" ] || [ "${ENVIRONMENT:-}" = "production" ]; then
     log "⏭️ Skipping migrations (pre-deploy handles this)"
 else
-    log "📦 Running database migrations..."
-    if python migrations/run.py; then
-        log "✅ Migrations completed successfully"
+    AUTO_MIGRATE="${AUTO_MIGRATE:-true}"
+    AUTO_MIGRATE_NORMALIZED="$(printf '%s' "$AUTO_MIGRATE" | tr '[:upper:]' '[:lower:]')"
+    case "$AUTO_MIGRATE_NORMALIZED" in
+        1|true|yes|on)
+            RUN_MIGRATIONS=true
+            ;;
+        0|false|no|off)
+            RUN_MIGRATIONS=false
+            ;;
+        *)
+            log "❌ AUTO_MIGRATE must be one of: true, false, 1, 0, yes, no, on, off"
+            exit 1
+            ;;
+    esac
+
+    if [ "$RUN_MIGRATIONS" = true ]; then
+        log "📦 Running database migrations..."
+        if python migrations/run.py; then
+            log "✅ Migrations completed successfully"
+        else
+            log "❌ Migrations failed!"
+            exit 1
+        fi
     else
-        log "❌ Migrations failed!"
-        exit 1
+        log "⏭️ Skipping migrations (AUTO_MIGRATE=${AUTO_MIGRATE})"
     fi
 fi
 

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -22,13 +22,15 @@ def _run_entrypoint(
     *,
     auto_migrate: str | None = None,
     production_variable: str | None = None,
+    migration_exit_code: int = 0,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     command_log = tmp_path / "commands.log"
     _write_executable(
         bin_dir / "python",
-        'printf "python %s\\n" "$*" >> "$ENTRYPOINT_TEST_LOG"\n',
+        'printf "python %s\\n" "$*" >> "$ENTRYPOINT_TEST_LOG"\n'
+        'exit "$MIGRATION_EXIT_CODE"\n',
     )
     _write_executable(
         bin_dir / "uvicorn",
@@ -40,6 +42,7 @@ def _run_entrypoint(
         {
             "PATH": f"{bin_dir}:{os.defpath}",
             "ENTRYPOINT_TEST_LOG": str(command_log),
+            "MIGRATION_EXIT_CODE": str(migration_exit_code),
             "PORT": "8000",
             "UVICORN_WORKERS": "1",
         }
@@ -78,6 +81,13 @@ def test_enabled_values_run_migrations(tmp_path: Path, value: str) -> None:
     assert any(command.startswith("uvicorn ") for command in commands)
 
 
+def test_unset_toggle_runs_migrations_by_default(tmp_path: Path) -> None:
+    result, commands = _run_entrypoint(tmp_path)
+
+    assert result.returncode == 0
+    assert any(command == "python migrations/run.py" for command in commands)
+
+
 @pytest.mark.parametrize("value", ["false", "0", "NO", "off"])
 def test_disabled_values_skip_migrations(tmp_path: Path, value: str) -> None:
     result, commands = _run_entrypoint(tmp_path, auto_migrate=value)
@@ -110,3 +120,15 @@ def test_invalid_non_production_toggle_fails_before_startup(
     assert result.returncode == 1
     assert "AUTO_MIGRATE must be one of" in result.stdout
     assert commands == []
+
+
+def test_migration_failure_stops_application_startup(tmp_path: Path) -> None:
+    result, commands = _run_entrypoint(
+        tmp_path,
+        auto_migrate="true",
+        migration_exit_code=7,
+    )
+
+    assert result.returncode == 1
+    assert "Migrations failed!" in result.stdout
+    assert commands == ["python migrations/run.py"]

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+ENTRYPOINT = REPOSITORY_ROOT / "docker-entrypoint.sh"
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(f"#!/bin/sh\n{contents}", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _run_entrypoint(
+    tmp_path: Path,
+    *,
+    auto_migrate: str | None = None,
+    production_variable: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    command_log = tmp_path / "commands.log"
+    _write_executable(
+        bin_dir / "python",
+        'printf "python %s\\n" "$*" >> "$ENTRYPOINT_TEST_LOG"\n',
+    )
+    _write_executable(
+        bin_dir / "uvicorn",
+        'printf "uvicorn %s\\n" "$*" >> "$ENTRYPOINT_TEST_LOG"\n',
+    )
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{bin_dir}:{os.defpath}",
+            "ENTRYPOINT_TEST_LOG": str(command_log),
+            "PORT": "8000",
+            "UVICORN_WORKERS": "1",
+        }
+    )
+    environment.pop("ENV", None)
+    environment.pop("ENVIRONMENT", None)
+    if auto_migrate is None:
+        environment.pop("AUTO_MIGRATE", None)
+    else:
+        environment["AUTO_MIGRATE"] = auto_migrate
+    if production_variable is not None:
+        environment[production_variable] = "production"
+
+    result = subprocess.run(
+        ["bash", str(ENTRYPOINT)],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    commands = (
+        command_log.read_text(encoding="utf-8").splitlines()
+        if command_log.exists()
+        else []
+    )
+    return result, commands
+
+
+@pytest.mark.parametrize("value", ["true", "1", "YES", "on"])
+def test_enabled_values_run_migrations(tmp_path: Path, value: str) -> None:
+    result, commands = _run_entrypoint(tmp_path, auto_migrate=value)
+
+    assert result.returncode == 0
+    assert any(command == "python migrations/run.py" for command in commands)
+    assert any(command.startswith("uvicorn ") for command in commands)
+
+
+@pytest.mark.parametrize("value", ["false", "0", "NO", "off"])
+def test_disabled_values_skip_migrations(tmp_path: Path, value: str) -> None:
+    result, commands = _run_entrypoint(tmp_path, auto_migrate=value)
+
+    assert result.returncode == 0
+    assert not any(command.startswith("python ") for command in commands)
+    assert any(command.startswith("uvicorn ") for command in commands)
+
+
+@pytest.mark.parametrize("production_variable", ["ENV", "ENVIRONMENT"])
+def test_production_skips_before_validating_toggle(
+    tmp_path: Path, production_variable: str
+) -> None:
+    result, commands = _run_entrypoint(
+        tmp_path,
+        auto_migrate="not-a-boolean",
+        production_variable=production_variable,
+    )
+
+    assert result.returncode == 0
+    assert "pre-deploy handles this" in result.stdout
+    assert not any(command.startswith("python ") for command in commands)
+
+
+def test_invalid_non_production_toggle_fails_before_startup(
+    tmp_path: Path,
+) -> None:
+    result, commands = _run_entrypoint(tmp_path, auto_migrate="not-a-boolean")
+
+    assert result.returncode == 1
+    assert "AUTO_MIGRATE must be one of" in result.stdout
+    assert commands == []


### PR DESCRIPTION
## Summary\n\n- Wire the existing AUTO_MIGRATE setting into docker-entrypoint.sh.\n- Keep production startup migrations disabled because the pre-deploy command owns them.\n- Add boolean validation, documentation, and entrypoint decision-matrix coverage.\n\n## Validation\n\n- pytest tests/unit — 2772 passed, 44 warnings\n- pytest --confcutdir=tests/unit -q tests/unit/test_docker_entrypoint.py — 13 passed\n- bash -n docker-entrypoint.sh\n- git diff --check\n\nTarget: delivery