### PR TITLE
feat(parse-text): keep catalog misses as custom g/kg rows

### DIFF
--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -111,7 +111,7 @@ class ParseMealTextResponse(BaseModel):
     emoji: str | None = Field(None, description="AI-assigned dish emoji")
     unmatched_terms: list[str] = Field(
         default_factory=list,
-        description="Original phrases dropped: not found in the catalog or FatSecret",
+        description="Unused. Kept empty for older clients; misses become custom rows.",
     )
 
 

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -28,6 +28,7 @@ from src.app.services.food_display_name import (
 )
 from src.app.services.food_name_localizer import translate_food_texts
 from src.app.services.parse_text_composition import composition_retry_feedback
+from src.app.services.parse_text_custom_estimate import apply_custom_estimate
 from src.domain.exceptions.ai_exceptions import AIOutputValidationError
 from src.domain.model.ai.nutrition_contracts import (
     LocalizedFoodNameBatch,
@@ -176,7 +177,6 @@ class ParseMealTextHandler(
         budget = _ParseTextRequestBudget()
         semantic_feedback: list[str] = []
         enhanced_items: list[dict[str, Any]] = []
-        unmatched_terms: list[str] = []
         validated_payload: dict[str, Any] | None = None
         for semantic_attempt in range(2):
             retry_prompt = sanitized_text
@@ -209,7 +209,6 @@ class ParseMealTextHandler(
             )
             try:
                 enhanced_items = []
-                unmatched_terms = []
                 for item in parsed_items:
                     resolved = await self._cascade_lookup(
                         item,
@@ -221,9 +220,6 @@ class ParseMealTextHandler(
                         ),
                     )
                     if resolved is None:
-                        original = str(item.get("name") or item.get("lookup_name") or "")
-                        if original:
-                            unmatched_terms.append(original)
                         continue
                     enhanced_items.append(resolved)
                 break
@@ -309,7 +305,7 @@ class ParseMealTextHandler(
             total_carbs=total_carbs,
             total_fat=total_fat,
             emoji=emoji,
-            unmatched_terms=unmatched_terms,
+            unmatched_terms=[],
         )
 
     def _attach_per_100g_snapshot(self, item: dict[str, Any]) -> None:
@@ -590,7 +586,7 @@ class ParseMealTextHandler(
         budget: _ParseTextRequestBudget,
         local_reference: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        """Resolve local reference, then FatSecret; drop when neither has a match."""
+        """Resolve local catalog, then FatSecret; otherwise keep a custom g/kg estimate."""
         name = str(item.get("name") or "")
         lookup_name = str(item.get("lookup_name") or self._extract_english_name(name))
         preparation = str(item.get("preparation") or "unknown")
@@ -624,9 +620,7 @@ class ParseMealTextHandler(
             if legacy is not None:
                 return legacy
 
-        # Neither the catalog nor FatSecret can back this phrase with a
-        # durable identity: drop it rather than trust AI-only macros.
-        return None
+        return apply_custom_estimate(item)
 
     async def _resolve_staged_provider(
         self,

--- a/src/app/services/parse_text_custom_estimate.py
+++ b/src/app/services/parse_text_custom_estimate.py
@@ -32,7 +32,12 @@ CUSTOM_ALLOWED_UNITS = normalize_serving_options(
 
 
 def apply_custom_estimate(item: dict[str, Any]) -> dict[str, Any] | None:
-    """Keep AI portion macros as a custom estimate, stored in grams or kilograms."""
+    """Keep AI portion macros as a custom estimate, stored in grams or kilograms.
+
+    Countable misses bind those portion totals to 100 g × count. There is no
+    trusted original gram weight, so macros are not rescaled from cup/slice
+    heuristics. Density validation still drops impossible rows.
+    """
     quantity_g = custom_estimate_quantity_g(item)
     if quantity_g is None:
         return None

--- a/src/app/services/parse_text_custom_estimate.py
+++ b/src/app/services/parse_text_custom_estimate.py
@@ -1,0 +1,104 @@
+"""Build a g/kg-only custom row when parse-text has no catalog or FatSecret hit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.domain.services.nutrition_calculation_service import (
+    MASS_VOLUME_CANONICAL_UNITS,
+    _normalize_unit,
+    canonicalize_mass_volume_unit,
+    convert_quantity_to_grams,
+)
+from src.domain.services.nutrition_integrity_policy import (
+    NUTRITION_INTEGRITY_POLICY_VERSION,
+    normalize_serving_options,
+)
+from src.domain.services.nutrition_resolver import validate_ai_fallback
+
+CUSTOM_COUNT_GRAMS = 100.0
+CUSTOM_KG_THRESHOLD_G = 1000.0
+_MASS_UNITS = {"g", "gram", "grams", "kg", "kilogram", "kilograms"}
+_VOLUME_UNITS = {"ml", "l", "liter", "litre"}
+CUSTOM_ALLOWED_UNITS = normalize_serving_options(
+    [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+        {"unit": "kg", "gram_weight": 1000.0, "description": "1 kg"},
+    ]
+) or [
+    {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+    {"unit": "kg", "gram_weight": 1000.0, "description": "1 kg"},
+]
+
+
+def apply_custom_estimate(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Keep AI portion macros as a custom estimate, stored in grams or kilograms."""
+    quantity_g = custom_estimate_quantity_g(item)
+    if quantity_g is None:
+        return None
+    protein = float(item.get("protein") or 0.0)
+    carbs = float(item.get("carbs") or 0.0)
+    fat = float(item.get("fat") or 0.0)
+    fiber = float(item.get("fiber") or 0.0)
+    lookup_name = str(item.get("lookup_name") or item.get("name") or "")
+    if not validate_ai_fallback(
+        name=lookup_name,
+        protein=protein,
+        carbs=carbs,
+        fat=fat,
+        fiber=fiber,
+        quantity_g=quantity_g,
+    ):
+        return None
+
+    if quantity_g >= CUSTOM_KG_THRESHOLD_G:
+        item["quantity"] = round(quantity_g / CUSTOM_KG_THRESHOLD_G, 4)
+        item["unit"] = "kg"
+        item["english_unit"] = "kg"
+    else:
+        item["quantity"] = round(quantity_g, 2)
+        item["unit"] = "g"
+        item["english_unit"] = "g"
+    item["quantity_g"] = quantity_g
+    item["origin"] = "custom"
+    item["data_source"] = "custom"
+    item["food_id"] = None
+    item["food_reference_id"] = None
+    item["source_namespace"] = None
+    item["source_food_id"] = None
+    item["fdc_id"] = None
+    item["allowed_units"] = [dict(option) for option in CUSTOM_ALLOWED_UNITS]
+    item["nutrition_basis"] = "100g"
+    item["nutrition_contract_version"] = NUTRITION_INTEGRITY_POLICY_VERSION
+    return item
+
+
+def custom_estimate_quantity_g(item: dict[str, Any]) -> float | None:
+    """Prefer stated grams; otherwise convert mass/volume or use a 100g count."""
+    raw_quantity_g = item.get("quantity_g")
+    if raw_quantity_g is not None:
+        quantity_g = float(raw_quantity_g)
+        return quantity_g if quantity_g > 0 else None
+    quantity = float(item.get("quantity") or 0.0)
+    if quantity <= 0:
+        return None
+    unit = _unit_for_custom_quantity(item)
+    unit_norm = _normalize_unit(unit)
+    food_name = str(item.get("lookup_name") or item.get("name") or "")
+    if unit_norm in _MASS_UNITS or unit_norm in _VOLUME_UNITS:
+        converted = convert_quantity_to_grams(quantity, unit, food_name)
+        return converted if converted > 0 else None
+    return quantity * CUSTOM_COUNT_GRAMS
+
+
+def _unit_for_custom_quantity(item: dict[str, Any]) -> str:
+    local = str(item.get("unit") or "").strip()
+    english = str(item.get("english_unit") or "").strip()
+    if local:
+        canonical = canonicalize_mass_volume_unit(local)
+        if canonical in MASS_VOLUME_CANONICAL_UNITS:
+            return canonical
+        local_norm = _normalize_unit(local)
+        if local_norm in _MASS_UNITS or local_norm in _VOLUME_UNITS:
+            return local
+    return english or local or "serving"

--- a/tests/fixtures/parse_text_nutrition_golden_cases.json
+++ b/tests/fixtures/parse_text_nutrition_golden_cases.json
@@ -71,8 +71,9 @@
     "language": "en",
     "expected_lookup_name": "oats",
     "expected_quantity_g": 40,
-    "expected_drop": true,
-    "expected_unmatched_terms": ["Oats"],
+    "expected_source": "custom",
+    "expected_calorie_range": [130, 160],
+    "expected_candidate_id": null,
     "ai_payload": {"items": [{"name": "Oats", "lookup_name": "oats", "quantity": 40, "quantity_g": 40, "unit": "g", "macros": {"protein_g": 5, "carbs_g": 24, "fat_g": 3}}]},
     "provider_candidates": [],
     "provider_details": {}
@@ -83,12 +84,22 @@
     "language": "en",
     "expected_lookup_name": "potato",
     "expected_quantity_g": 100,
-    "expected_drop": true,
-    "expected_unmatched_terms": ["Potato"],
-    "expected_candidate_id": "potato-incomplete",
+    "expected_source": "custom",
+    "expected_calorie_range": [70, 90],
+    "expected_candidate_id": null,
     "ai_payload": {"items": [{"name": "Potato", "lookup_name": "potato", "quantity": 100, "quantity_g": 100, "unit": "g", "macros": {"protein_g": 2, "carbs_g": 17, "fat_g": 0.1}}]},
     "provider_candidates": [{"food_id": "potato-incomplete", "food_name": "Potato", "food_type": "Generic"}],
     "provider_details": {"potato-incomplete": {"food_id": "potato-incomplete", "food_name": "Potato", "protein_100g": 2, "carbs_100g": 17, "calories_100g": 77, "metric_serving_amount": 100}}
+  },
+  {
+    "case_id": "en-potato-impossible-density",
+    "text": "100g potato",
+    "language": "en",
+    "expected_drop": true,
+    "expected_unmatched_terms": [],
+    "ai_payload": {"items": [{"name": "Potato", "lookup_name": "potato", "quantity": 100, "quantity_g": 100, "unit": "g", "macros": {"protein_g": 0, "carbs_g": 0, "fat_g": 98.9}}]},
+    "provider_candidates": [],
+    "provider_details": {}
   },
   {
     "case_id": "vi-rice-fried-180g",

--- a/tests/unit/app/services/test_parse_text_custom_estimate.py
+++ b/tests/unit/app/services/test_parse_text_custom_estimate.py
@@ -60,6 +60,9 @@ def test_countable_unit_uses_hundred_gram_serving():
     assert resolved is not None
     assert resolved["unit"] == "g"
     assert resolved["quantity"] == 100
+    assert resolved["protein"] == 18
+    assert resolved["carbs"] == 4
+    assert resolved["fat"] == 11
 
 
 def test_impossible_density_is_rejected():

--- a/tests/unit/app/services/test_parse_text_custom_estimate.py
+++ b/tests/unit/app/services/test_parse_text_custom_estimate.py
@@ -1,0 +1,76 @@
+from src.app.services.parse_text_custom_estimate import (
+    apply_custom_estimate,
+    custom_estimate_quantity_g,
+)
+
+
+def test_mass_unit_stays_in_grams():
+    item = {
+        "name": "Secret sauce",
+        "quantity": 80,
+        "unit": "g",
+        "protein": 1,
+        "carbs": 8,
+        "fat": 4,
+        "fiber": 0,
+    }
+
+    resolved = apply_custom_estimate(item)
+
+    assert resolved is not None
+    assert resolved["origin"] == "custom"
+    assert resolved["data_source"] == "custom"
+    assert resolved["quantity"] == 80
+    assert resolved["unit"] == "g"
+    assert resolved["food_reference_id"] is None
+    assert {option["unit"] for option in resolved["allowed_units"]} == {"g", "kg"}
+
+
+def test_large_mass_stores_as_kilograms():
+    item = {
+        "name": "Rice",
+        "quantity": 1.5,
+        "unit": "kg",
+        "protein": 12,
+        "carbs": 120,
+        "fat": 2,
+    }
+
+    resolved = apply_custom_estimate(item)
+
+    assert resolved is not None
+    assert resolved["unit"] == "kg"
+    assert resolved["quantity"] == 1.5
+    assert resolved["quantity_g"] == 1500
+
+
+def test_countable_unit_uses_hundred_gram_serving():
+    item = {
+        "name": "Sườn Nướng",
+        "quantity": 1,
+        "unit": "miếng",
+        "english_unit": "slice",
+        "protein": 18,
+        "carbs": 4,
+        "fat": 11,
+    }
+
+    assert custom_estimate_quantity_g(item) == 100
+    resolved = apply_custom_estimate(item)
+    assert resolved is not None
+    assert resolved["unit"] == "g"
+    assert resolved["quantity"] == 100
+
+
+def test_impossible_density_is_rejected():
+    item = {
+        "name": "Potato",
+        "quantity": 100,
+        "quantity_g": 100,
+        "unit": "g",
+        "protein": 0,
+        "carbs": 0,
+        "fat": 98.9,
+    }
+
+    assert apply_custom_estimate(item) is None

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -603,7 +603,7 @@ async def test_parse_text_unit_stays_compatible_with_prompt_manual_save():
 
 @pytest.mark.asyncio
 async def test_parse_text_countable_unit_survives_provider_outage():
-    """A countable-unit food that misses both the catalog and FatSecret drops."""
+    """A countable miss becomes a custom 100g row instead of being dropped."""
     meal_generation_service = _FakeMealGenerationService(
         responses=[
             {
@@ -633,8 +633,14 @@ async def test_parse_text_countable_unit_survives_provider_outage():
         ParseMealTextCommand(text="1 miếng sườn nướng", user_id="user-1", language="vi")
     )
 
-    assert response.items == []
-    assert response.unmatched_terms == ["Sườn Nướng"]
+    item = response.items[0]
+    assert item.origin == "custom"
+    assert item.data_source == "custom"
+    assert item.unit == "g"
+    assert item.quantity == 100
+    assert item.food_reference_id is None
+    assert {option["unit"] for option in item.allowed_units} == {"g", "kg"}
+    assert response.unmatched_terms == []
 
 
 @pytest.mark.asyncio
@@ -1365,8 +1371,11 @@ async def test_parse_text_does_not_claim_fatsecret_for_invalid_structured_nutrit
         ParseMealTextCommand(text="100g potato", user_id="user-1", language="en")
     )
 
-    assert response.items == []
-    assert response.unmatched_terms == ["Potato"]
+    item = response.items[0]
+    assert item.origin == "custom"
+    assert item.data_source == "custom"
+    assert item.unit == "g"
+    assert response.unmatched_terms == []
 
 
 @pytest.mark.asyncio
@@ -1392,8 +1401,11 @@ async def test_parse_text_does_not_claim_provider_without_durable_identity():
         ParseMealTextCommand(text="100g rice", user_id="user-1", language="en")
     )
 
-    assert response.items == []
-    assert response.unmatched_terms == ["Rice"]
+    item = response.items[0]
+    assert item.origin == "custom"
+    assert item.data_source == "custom"
+    assert item.unit == "g"
+    assert response.unmatched_terms == []
 
 
 @pytest.mark.asyncio
@@ -1457,7 +1469,7 @@ async def test_parse_text_rejects_dense_fallback_when_ai_omits_quantity_g():
     )
 
     assert response.items == []
-    assert response.unmatched_terms == ["Potato"]
+    assert response.unmatched_terms == []
     assert len(meal_generation_service.calls) == 1
 
 
@@ -1596,13 +1608,17 @@ async def test_parse_text_rejects_fatsecret_using_backend_derived_calories(
         ParseMealTextCommand(text="100g potato", user_id="user-1", language="en")
     )
 
-    assert response.items == []
-    assert response.unmatched_terms == ["Pho bowl"]
+    item = response.items[0]
+    assert item.origin == "custom"
+    assert item.data_source == "custom"
+    assert item.unit == "g"
+    assert item.quantity == 100
+    assert response.unmatched_terms == []
 
 
 @pytest.mark.asyncio
-async def test_parse_text_all_items_unmatched_returns_empty_items_with_terms():
-    """When every item misses the catalog and FatSecret, drop all and report terms."""
+async def test_parse_text_all_items_unmatched_become_custom_rows():
+    """When every item misses the catalog and FatSecret, keep them as custom g/kg rows."""
     meal_generation_service = _FakeMealGenerationService(
         responses=[
             {
@@ -1624,8 +1640,10 @@ async def test_parse_text_all_items_unmatched_returns_empty_items_with_terms():
         )
     )
 
-    assert response.items == []
-    assert response.unmatched_terms == ["Sườn Nướng", "Chả lụa"]
+    assert [item.name for item in response.items] == ["Sườn Nướng", "Chả lụa"]
+    assert {item.origin for item in response.items} == {"custom"}
+    assert {item.unit for item in response.items} == {"g"}
+    assert response.unmatched_terms == []
 
 
 @pytest.mark.asyncio
@@ -1675,6 +1693,26 @@ async def test_parse_text_guest_never_adopts_fatsecret_hit():
     )
 
     assert response.items[0].data_source == "fatsecret"
+    assert food_references.adopt_calls == []
+
+
+@pytest.mark.asyncio
+async def test_parse_text_custom_miss_never_writes_catalog():
+    meal_generation_service = _FakeMealGenerationService(
+        responses=[{"items": [_parse_item(name="Secret sauce")]}]
+    )
+    food_references = _FakeFoodReferenceAdoptRepository()
+    handler = ParseMealTextHandler(
+        meal_generation_service=meal_generation_service,
+        fat_secret_service=_FakeFatSecretService(),
+        uow_factory=_FakeUowFactory(food_references),
+    )
+
+    response = await handler.handle(
+        ParseMealTextCommand(text="secret sauce", user_id="user-1", language="en")
+    )
+
+    assert response.items[0].origin == "custom"
     assert food_references.adopt_calls == []
 
 

--- a/tests/unit/scripts/test_evaluate_parse_text_nutrition.py
+++ b/tests/unit/scripts/test_evaluate_parse_text_nutrition.py
@@ -19,10 +19,11 @@ def _module():
 
 
 def test_golden_corpus_is_synthetic_and_versioned():
-    cases = _module().load_corpus()
-    assert len(cases) >= 10
-    assert all("@" not in case.case_id for case in cases)
+    cases, drop_cases = _module().load_corpus()
+    assert len(cases) + len(drop_cases) >= 10
+    assert all("@" not in case.case_id for case in (*cases, *drop_cases))
     assert any(case.case_id == "vi-potato-raw-100g" for case in cases)
+    assert any(case.expected_source == "custom" for case in cases)
 
 
 def test_live_mode_fails_closed_for_unset_or_non_staging_environment(monkeypatch):
@@ -72,7 +73,7 @@ def test_explicit_repository_report_path_must_be_ignored():
 @pytest.mark.asyncio
 async def test_live_runner_stops_at_hard_case_deadline(monkeypatch):
     module = _module()
-    case = module.load_corpus()[0]
+    case = module.load_corpus()[0][0]
 
     async def slow_case(*_args, **_kwargs):
         await asyncio.sleep(0.05)
@@ -86,7 +87,7 @@ async def test_live_runner_stops_at_hard_case_deadline(monkeypatch):
 
 def test_live_runner_reserves_worst_case_provider_capacity():
     module = _module()
-    case = module.load_corpus()[0]
+    case = module.load_corpus()[0][0]
     case.ai_payload["items"] = [{}] * 20
 
     assert module._case_item_count(case) == module.MAX_HANDLER_ITEMS


### PR DESCRIPTION
## Summary
- When catalog and FatSecret both miss, parse-text now keeps the AI portion as a custom `g`/`kg` row (`origin: custom`) instead of dropping it into `unmatched_terms`.
- Countable/unknown units become `100g × count`. Mass ≥ 1000g stores as kg. Impossible density still drops silently.
- `unmatched_terms` stays on the JSON contract but is always empty so older clients keep working.

## Test plan
- [ ] Parse a food that is not in the catalog or FatSecret and confirm a custom g/kg item is returned
- [ ] Parse a countable miss (e.g. `1 miếng sườn nướng`) and confirm quantity is 100g
- [ ] Parse an impossible-density miss and confirm the item is omitted with empty `unmatched_terms`
- [ ] Confirm catalog/FatSecret hits are unchanged
- [ ] Confirm parse still does not write `food_reference` for custom rows


Made with [Cursor](https://cursor.com)