### PR TITLE
fix(localization): persist Vietnamese serving labels

### DIFF
--- a/migrations/versions/20260823000001_add_serving_label_translations.py
+++ b/migrations/versions/20260823000001_add_serving_label_translations.py
@@ -1,0 +1,46 @@
+"""Persist FatSecret serving text and Vietnamese serving labels.
+
+Revision ID: 20260823000001
+Revises: 20260820000002
+Create Date: 2026-08-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260823000001"
+down_revision: str | None = "20260820000002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "food_reference_serving_sizes",
+        sa.Column("description", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "food_reference_serving_sizes",
+        sa.Column("name_vi", sa.String(length=100), nullable=True),
+    )
+    op.create_table(
+        "serving_phrase_translation",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("source_key", sa.String(length=120), nullable=False),
+        sa.Column("language", sa.String(length=8), nullable=False),
+        sa.Column("translated_text", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_key",
+            "language",
+            name="uq_serving_phrase_translation_source_language",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("serving_phrase_translation")
+    op.drop_column("food_reference_serving_sizes", "name_vi")
+    op.drop_column("food_reference_serving_sizes", "description")

--- a/src/api/base_dependencies.py
+++ b/src/api/base_dependencies.py
@@ -572,6 +572,15 @@ def get_text_translation_service():
     return _text_translation_service
 
 
+def get_serving_label_dependencies():
+    """Compose serving-label enrichment dependencies for read routes."""
+    from src.app.services.meal_serving_label_enricher import (
+        enrich_meal_serving_labels,
+    )
+
+    return enrich_meal_serving_labels, get_text_translation_service(), AsyncUnitOfWork
+
+
 def get_ai_model_manager():
     """Get provider-agnostic AI manager singleton."""
     from src.infra.services.ai.ai_model_manager import AIModelManager

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -18,6 +18,7 @@ from src.api.schemas.response import (
     SimpleMealResponse,
 )
 from src.api.schemas.response.daily_nutrition_response import DailyNutritionResponse
+from src.app.services.serving_label import overlay_serving_labels
 from src.domain.constants.languages import normalize_language
 from src.domain.model.meal import Meal
 from src.domain.model.meal.meal_response_localization import (
@@ -62,7 +63,9 @@ def _snapshot_canonical_name(item) -> str | None:
     return None
 
 
-def _apply_translated_food_name(food_item, translated_name, language: str | None) -> None:
+def _apply_translated_food_name(
+    food_item, translated_name, language: str | None
+) -> None:
     if not translated_name:
         return
     if keep_stored_display_name(
@@ -194,13 +197,10 @@ class MealMapper:
                             tracked_projection, requested_language
                         )
                     else:
-                        canonical_name = (
-                            _snapshot_canonical_name(item)
-                            or (
-                                canonical_food_names[index]
-                                if index < len(canonical_food_names)
-                                else item.name
-                            )
+                        canonical_name = _snapshot_canonical_name(item) or (
+                            canonical_food_names[index]
+                            if index < len(canonical_food_names)
+                            else item.name
                         )
                         display_name = item.name
                     item_calories = effective_food_item_calories(
@@ -276,7 +276,13 @@ class MealMapper:
                             item, "nutrition_contract_version", None
                         ),
                         source_snapshot=getattr(item, "source_snapshot", None),
-                        allowed_units=getattr(item, "allowed_units", None) or [],
+                        allowed_units=overlay_serving_labels(
+                            getattr(item, "allowed_units", None) or [],
+                            (tracked_projection or {}).get("serving_labels") or {},
+                            language=requested_language,
+                        )
+                        if requested_language == "vi"
+                        else (getattr(item, "allowed_units", None) or []),
                     )
                     food_items.append(food_item_dto)
 

--- a/src/api/routes/v1/meal_scan_by_url.py
+++ b/src/api/routes/v1/meal_scan_by_url.py
@@ -173,7 +173,7 @@ async def _scan_by_url(
             source="api",
         )
     display_projections = await load_food_reference_display_projections(
-        meal, food_reference_repository
+        meal, food_reference_repository, language=language
     )
     return MealMapper.to_detailed_response(
         meal,

--- a/src/api/routes/v1/meal_suggestions.py
+++ b/src/api/routes/v1/meal_suggestions.py
@@ -301,7 +301,7 @@ async def save_meal_suggestion(
 
     meal = await event_bus.send(GetMealByIdQuery(meal_id=meal_id, user_id=user_id))
     display_projections = await load_food_reference_display_projections(
-        meal, food_reference_repository
+        meal, food_reference_repository, language=language
     )
 
     return SaveMealSuggestionResponse(

--- a/src/api/routes/v1/meals_analyze.py
+++ b/src/api/routes/v1/meals_analyze.py
@@ -135,7 +135,7 @@ async def _analyze_uploaded_image(
     )
 
     display_projections = await load_food_reference_display_projections(
-        meal, food_reference_repository
+        meal, food_reference_repository, language=language
     )
     return MealMapper.to_detailed_response(
         meal,

--- a/src/api/routes/v1/meals_edit.py
+++ b/src/api/routes/v1/meals_edit.py
@@ -211,7 +211,7 @@ async def update_meal_ingredients(
         result = dict(result)
         image_url = getattr(getattr(meal, "image", None), "url", None)
         display_projections = await load_food_reference_display_projections(
-            meal, food_reference_repository
+            meal, food_reference_repository, language=language
         )
         result["meal_detail"] = MealMapper.to_detailed_response(
             meal,

--- a/src/api/routes/v1/meals_manual_text.py
+++ b/src/api/routes/v1/meals_manual_text.py
@@ -234,7 +234,9 @@ async def create_manual_meal(
                 image_url=getattr(getattr(meal, "image", None), "url", None),
                 target_language=get_request_language(request),
                 display_name_by_food_reference=await load_food_reference_display_projections(
-                    meal, food_reference_repository
+                    meal,
+                    food_reference_repository,
+                    language=get_request_language(request),
                 ),
             ),
         )

--- a/src/api/routes/v1/meals_read.py
+++ b/src/api/routes/v1/meals_read.py
@@ -201,7 +201,7 @@ async def get_meal(
         meal, food_reference_repository
     )
     display_projections = await load_food_reference_display_projections(
-        meal, food_reference_repository
+        meal, food_reference_repository, language=language
     )
     return MealMapper.to_detailed_response(
         meal,

--- a/src/api/routes/v1/meals_route_helpers.py
+++ b/src/api/routes/v1/meals_route_helpers.py
@@ -9,7 +9,10 @@ from src.domain.model.nutrition.macros import Macros as MacrosModel
 
 
 async def load_food_reference_display_projections(
-    meal, food_reference_repository
+    meal,
+    food_reference_repository,
+    *,
+    language: str | None = None,
 ) -> dict[int, dict[str, Any]]:
     """Load id-keyed catalog display names for every tracked line on a meal.
 
@@ -25,8 +28,28 @@ async def load_food_reference_display_projections(
     }
     if not food_reference_ids:
         return {}
-    return await food_reference_repository.get_display_projections(
-        list(food_reference_ids)
+    projections = await food_reference_repository.get_display_projections(
+        list(food_reference_ids),
+        language=language,
+    )
+    if not language or language == "en":
+        return projections
+    return await _enrich_serving_labels(meal, projections, language)
+
+
+async def _enrich_serving_labels(meal, projections, language: str):
+    from src.api.base_dependencies import get_text_translation_service
+    from src.app.services.meal_serving_label_enricher import (
+        enrich_meal_serving_labels,
+    )
+    from src.infra.database.uow_async import AsyncUnitOfWork
+
+    return await enrich_meal_serving_labels(
+        meal,
+        projections,
+        language=language,
+        translation_service=get_text_translation_service(),
+        uow_factory=AsyncUnitOfWork,
     )
 
 

--- a/src/api/routes/v1/meals_route_helpers.py
+++ b/src/api/routes/v1/meals_route_helpers.py
@@ -38,18 +38,18 @@ async def load_food_reference_display_projections(
 
 
 async def _enrich_serving_labels(meal, projections, language: str):
-    from src.api.base_dependencies import get_text_translation_service
-    from src.app.services.meal_serving_label_enricher import (
-        enrich_meal_serving_labels,
+    from src.api.base_dependencies import get_serving_label_dependencies
+
+    enrich_meal_serving_labels, translation_service, uow_factory = (
+        get_serving_label_dependencies()
     )
-    from src.infra.database.uow_async import AsyncUnitOfWork
 
     return await enrich_meal_serving_labels(
         meal,
         projections,
         language=language,
-        translation_service=get_text_translation_service(),
-        uow_factory=AsyncUnitOfWork,
+        translation_service=translation_service,
+        uow_factory=uow_factory,
     )
 
 

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -5,7 +5,7 @@ Meal-related response DTOs.
 from datetime import UTC, datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
 
 
 def _serialize_datetime_utc(v: datetime) -> str:
@@ -47,6 +47,18 @@ class ServingUnitResponse(BaseModel):
         None,
         description="Localized exact serving label; unit stays English",
     )
+
+    @model_serializer
+    def serialize_without_empty_label(self) -> dict[str, object]:
+        """Keep legacy response shape when no localized label exists."""
+        response: dict[str, object] = {
+            "unit": self.unit,
+            "gram_weight": self.gram_weight,
+            "description": self.description,
+        }
+        if self.display_description is not None:
+            response["display_description"] = self.display_description
+        return response
 
 
 class ParsedFoodItem(BaseModel):

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -40,7 +40,13 @@ class ServingUnitResponse(BaseModel):
 
     unit: str = Field(..., description="Unit token used for save/edit requests")
     gram_weight: float = Field(..., gt=0, description="Gram weight for one unit")
-    description: str = Field("", description="User-facing serving description")
+    description: str = Field(
+        "", description="English FatSecret serving description for quantity math"
+    )
+    display_description: str | None = Field(
+        None,
+        description="Localized exact serving label; unit stays English",
+    )
 
 
 class ParsedFoodItem(BaseModel):

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -27,6 +27,7 @@ from src.app.services.food_display_name import (
     needs_display_localization,
 )
 from src.app.services.food_name_localizer import translate_food_texts
+from src.app.services.serving_label_localizer import localize_item_servings
 from src.app.services.parse_text_composition import composition_retry_feedback
 from src.app.services.parse_text_custom_estimate import apply_custom_estimate
 from src.domain.exceptions.ai_exceptions import AIOutputValidationError
@@ -261,6 +262,14 @@ class ParseMealTextHandler(
             )
 
         await self._adopt_fatsecret_items(enhanced_items, command)
+        if command.language and command.language != "en":
+            await localize_item_servings(
+                enhanced_items,
+                language=command.language,
+                translation_service=self._translation_service,
+                uow_factory=self._uow_factory,
+                persist=True,
+            )
 
         # Build response items
         items = [

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -15,6 +15,7 @@ from src.app.services.food_name_localizer import (
     translate_food_texts,
     translated_values,
 )
+from src.app.services.serving_label_localizer import localize_item_servings
 from src.domain.model.translation_result import TranslationOutcome
 from src.domain.services.barcode.barcode_logging import redact_barcode
 from src.domain.services.barcode.barcode_nutrition_validator import (
@@ -579,30 +580,44 @@ class LookupBarcodeQueryHandler(
     ) -> dict[str, Any]:
         """Translate known-English or leftover-English names for presentation."""
         name = result.get("name")
-        if language == "en" or not self.translation_service or not name:
+        if language == "en":
             return result
+        if not name:
+            return await self._localize_result_servings(result, language)
 
         # Proven English sources always localize. Unknown provenance only
         # localizes when the display name still looks like leftover English,
         # so printed non-English product names are not mangled.
-        if source_language != "en" and not (
+        localized = dict(result)
+        if source_language == "en" or (
             source_language is None and needs_display_localization(str(name), language)
         ):
-            return result
+            translated = await translate_food_texts(
+                [str(name)],
+                target_language=language,
+                translation_service=self.translation_service,
+            )
+            if translated.outcome in {
+                TranslationOutcome.TRANSLATED,
+                TranslationOutcome.PARTIAL,
+            }:
+                localized["name"] = translated_values([str(name)], translated)[0]
+        return await self._localize_result_servings(localized, language)
 
-        translated = await translate_food_texts(
-            [str(name)],
-            target_language=language,
+    async def _localize_result_servings(
+        self, result: dict[str, Any], language: str
+    ) -> dict[str, Any]:
+        if not result.get("allowed_units"):
+            return result
+        batch = [dict(result)]
+        await localize_item_servings(
+            batch,
+            language=language,
             translation_service=self.translation_service,
+            uow_factory=self.async_uow_factory,
+            persist=True,
         )
-        if translated.outcome in {
-            TranslationOutcome.TRANSLATED,
-            TranslationOutcome.PARTIAL,
-        }:
-            localized = dict(result)
-            localized["name"] = translated_values([str(name)], translated)[0]
-            return localized
-        return result
+        return batch[0]
 
     async def _get_cached_product(
         self, aliases: tuple[str, ...]

--- a/src/app/handlers/query_handlers/search_foods_query_handler.py
+++ b/src/app/handlers/query_handlers/search_foods_query_handler.py
@@ -12,6 +12,8 @@ from src.app.queries.food.search_foods_query import SearchFoodsQuery
 from src.app.services.food_display_name import leftover_display_names
 from src.app.services.food_name_localizer import translate_food_texts
 from src.app.services.search_result_localizer import localize_search_result_names
+from src.app.services.serving_label import leftover_serving_phrases
+from src.app.services.serving_label_localizer import localize_item_servings
 from src.domain.model.translation_result import TranslationOutcome
 from src.domain.ports.food_mapping_service_port import FoodMappingServicePort
 from src.domain.ports.food_reference_repository_port import (
@@ -88,17 +90,25 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
         if cached is not None:
             processed_cached = self._process_search_results(cached)
             processed_cached = processed_cached[: event.limit]
-            leftover_cached = language != "en" and leftover_display_names(
-                [
-                    {
-                        **item,
-                        "name": str(
-                            item.get("description") or item.get("name") or ""
-                        ),
-                    }
+            leftover_cached = language != "en" and (
+                leftover_display_names(
+                    [
+                        {
+                            **item,
+                            "name": str(
+                                item.get("description") or item.get("name") or ""
+                            ),
+                        }
+                        for item in processed_cached
+                    ],
+                    language,
+                )
+                or any(
+                    leftover_serving_phrases(
+                        item.get("allowed_units") or [], language
+                    )
                     for item in processed_cached
-                ],
-                language,
+                )
             )
             if not leftover_cached:
                 for item in processed_cached:
@@ -154,14 +164,25 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
                     logger.warning("fatsecret search failed", exc_info=True)
 
         if is_non_english and processed_raw:
-            processed_raw = await self._localize_results(
+            processed_raw, cacheable = await self._localize_results(
                 processed_raw,
                 language=language,
-                cache_key=cache_key,
-                cache_context=cache_context,
             )
             if not event.autocomplete:
                 await self._adopt_provider_hits(processed_raw, locale=language)
+            await localize_item_servings(
+                processed_raw,
+                language=language,
+                translation_service=self.translation_service,
+                uow_factory=self.uow_factory,
+                persist=not event.autocomplete,
+            )
+            leftover_units = any(
+                leftover_serving_phrases(item.get("allowed_units") or [], language)
+                for item in processed_raw
+            )
+            if cacheable and not leftover_units:
+                await self._cache_search(cache_key, processed_raw, cache_context)
 
         mapped = self._map_search_items(processed_raw)
         self._record_search_metrics(
@@ -288,17 +309,13 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
         results: list[dict[str, Any]],
         *,
         language: str,
-        cache_key: str,
-        cache_context: Mapping[str, int | str] | None,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         localized, cacheable = await localize_search_result_names(
             results,
             language=language,
             translation_service=self.translation_service,
         )
-        if cacheable:
-            await self._cache_search(cache_key, localized, cache_context)
-        return localized
+        return localized, cacheable
 
     async def _cache_search(
         self,

--- a/src/app/services/meal_serving_label_enricher.py
+++ b/src/app/services/meal_serving_label_enricher.py
@@ -1,0 +1,75 @@
+"""Fill leftover FatSecret serving labels on meal-detail projections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.app.services.serving_label import (
+    canonical_serving_labels,
+    leftover_serving_phrases,
+    merge_serving_labels,
+    overlay_serving_labels,
+)
+from src.app.services.serving_label_localizer import localize_item_servings
+from src.domain.constants.languages import normalize_language
+
+__all__ = ["enrich_meal_serving_labels"]
+
+
+async def enrich_meal_serving_labels(
+    meal: Any,
+    projections: dict[int, dict[str, Any]],
+    *,
+    language: str,
+    translation_service: Any | None,
+    uow_factory: Any | None,
+) -> dict[int, dict[str, Any]]:
+    """Translate leftover serving phrases and merge them into projections."""
+    normalized = normalize_language(language)
+    if not projections or normalized == "en":
+        return projections
+    items = _meal_serving_payloads(meal, projections, normalized)
+    if not items:
+        return projections
+    await localize_item_servings(
+        items,
+        language=normalized,
+        translation_service=translation_service,
+        uow_factory=uow_factory,
+        persist=True,
+    )
+    for payload in items:
+        reference_id = payload.get("food_reference_id")
+        if reference_id is None:
+            continue
+        bucket = projections.setdefault(int(reference_id), {"serving_labels": {}})
+        bucket["serving_labels"] = merge_serving_labels(
+            bucket.get("serving_labels") or {},
+            payload.get("allowed_units") or [],
+        )
+    return projections
+
+
+def _meal_serving_payloads(
+    meal: Any, projections: dict[int, dict[str, Any]], language: str
+) -> list[dict[str, Any]]:
+    food_items = getattr(getattr(meal, "nutrition", None), "food_items", None) or []
+    payloads: list[dict[str, Any]] = []
+    for item in food_items:
+        reference_id = getattr(item, "food_reference_id", None)
+        labels = (projections.get(reference_id) or {}).get("serving_labels") or {}
+        options = overlay_serving_labels(
+            getattr(item, "allowed_units", None) or [],
+            labels,
+            language=language,
+        )
+        if canonical_serving_labels(options, language) or leftover_serving_phrases(
+            options, language
+        ):
+            payloads.append(
+                {
+                    "food_reference_id": reference_id,
+                    "allowed_units": options,
+                }
+            )
+    return payloads

--- a/src/app/services/serving_label.py
+++ b/src/app/services/serving_label.py
@@ -1,0 +1,196 @@
+"""Presentation-only serving labels. English unit tokens stay the identity."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from src.app.services.food_display_name import (
+    fold_latin_display_name,
+    is_ascii_display_name,
+    needs_display_localization,
+)
+from src.domain.services.nutrition_calculation_service import (
+    MASS_VOLUME_CANONICAL_UNITS,
+)
+
+DISPLAY_DESCRIPTION_KEY = "display_description"
+
+# Keep common units predictable instead of relying on a translation provider
+# for vocabulary the product already owns. Provider phrases remain translated
+# as complete phrases; mobile decides whether a list needs their compact form.
+_VI_CANONICAL_SERVING_LABELS = {
+    "serving": "Khẩu phần",
+    "piece": "Cái",
+    "slice": "Lát",
+    "cup": "Cốc",
+    "tablespoon": "Muỗng canh",
+    "tbsp": "Muỗng canh",
+    "teaspoon": "Muỗng cà phê",
+    "tsp": "Muỗng cà phê",
+    "large": "Lớn",
+    "medium": "Vừa",
+    "small": "Nhỏ",
+}
+_VI_SERVING_WORDS = {
+    "thin": "mỏng",
+    "thick": "dày",
+    "large": "lớn",
+    "medium": "vừa",
+    "small": "nhỏ",
+    "slice": "lát",
+    "slices": "lát",
+    "piece": "cái",
+    "pieces": "cái",
+    "serving": "khẩu phần",
+    "servings": "khẩu phần",
+    "cup": "cốc",
+    "cups": "cốc",
+    "tablespoon": "muỗng canh",
+    "tbsp": "muỗng canh",
+    "teaspoon": "muỗng cà phê",
+    "tsp": "muỗng cà phê",
+}
+_VI_SERVING_ADJECTIVES = {"mỏng", "dày", "lớn", "vừa", "nhỏ"}
+
+
+def serving_phrase_key(text: str) -> str:
+    """Stable lookup key for an exact FatSecret serving phrase."""
+    return " ".join(fold_latin_display_name(text).lower().split())[:120]
+
+
+def serving_display_source(option: Mapping[str, Any]) -> str:
+    """English phrase to translate: full unit token, not a shortened noun."""
+    return str(option.get("unit") or option.get("name") or "").strip()
+
+
+def canonical_serving_labels(
+    options: Iterable[Mapping[str, Any]], language: str
+) -> dict[str, str]:
+    """Return product-owned localized labels for exact common unit tokens."""
+    if language != "vi":
+        return {}
+    labels: dict[str, str] = {}
+    for option in options:
+        source = serving_display_source(option)
+        key = serving_phrase_key(source)
+        if not source:
+            continue
+        if key in _VI_CANONICAL_SERVING_LABELS:
+            labels[key] = _VI_CANONICAL_SERVING_LABELS[key]
+            continue
+        compact = re.sub(r"\s*\([^)]*\)", "", source).split(",", 1)[0].strip()
+        words = compact.lower().split()
+        translated = [_VI_SERVING_WORDS.get(word, "") for word in words]
+        if words and all(translated):
+            ordered = [
+                value for value in translated if value not in _VI_SERVING_ADJECTIVES
+            ] + [value for value in translated if value in _VI_SERVING_ADJECTIVES]
+            labels[key] = " ".join(ordered).capitalize()
+    return labels
+
+
+def needs_serving_label(text: str, language: str) -> bool:
+    """True when a serving phrase is still English for a non-English user."""
+    if not language or language == "en":
+        return False
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if serving_phrase_key(stripped) in MASS_VOLUME_CANONICAL_UNITS:
+        return False
+    return needs_display_localization(stripped, language) or is_ascii_display_name(
+        stripped
+    )
+
+
+def leftover_serving_phrases(
+    options: Iterable[Mapping[str, Any]], language: str
+) -> list[str]:
+    """Unique English unit phrases that still lack a localized label."""
+    leftovers: list[str] = []
+    seen: set[str] = set()
+    for option in options:
+        display = str(option.get(DISPLAY_DESCRIPTION_KEY) or "").strip()
+        if display and not needs_serving_label(display, language):
+            continue
+        source = serving_display_source(option)
+        if not needs_serving_label(source, language):
+            continue
+        key = serving_phrase_key(source)
+        if key and key not in seen:
+            seen.add(key)
+            leftovers.append(source)
+    return leftovers
+
+
+def apply_serving_labels(
+    options: list[dict[str, Any]],
+    labels_by_key: Mapping[str, str],
+    language: str,
+) -> list[dict[str, Any]]:
+    """Copy localized labels onto options without rewriting unit or description."""
+    keyed = {
+        serving_phrase_key(source): label
+        for source, label in labels_by_key.items()
+        if label
+    }
+    keyed.update(
+        {str(source): label for source, label in labels_by_key.items() if label}
+    )
+    # Canonical labels deliberately override stale phrase-cache translations.
+    keyed.update(canonical_serving_labels(options, language))
+    updated: list[dict[str, Any]] = []
+    for option in options:
+        copied = dict(option)
+        source = serving_display_source(copied)
+        label = (
+            keyed.get(serving_phrase_key(source), "") or keyed.get(source, "")
+        ).strip()
+        if label and not needs_serving_label(label, language):
+            copied[DISPLAY_DESCRIPTION_KEY] = label[:100]
+        updated.append(copied)
+    return updated
+
+
+def merge_serving_labels(
+    labels: Mapping[str, str],
+    options: Iterable[Mapping[str, Any]],
+) -> dict[str, str]:
+    """Copy ``display_description`` values onto phrase keys."""
+    merged = dict(labels)
+    for option in options:
+        source = serving_display_source(option)
+        display = str(option.get(DISPLAY_DESCRIPTION_KEY) or "").strip()
+        if source and display:
+            merged[serving_phrase_key(source)] = display[:100]
+    return merged
+
+
+def overlay_serving_labels(
+    options: list[Any],
+    labels_by_unit: Mapping[str, str],
+    *,
+    language: str = "",
+) -> list[dict[str, Any]]:
+    """Apply catalog ``name_vi`` labels keyed by English unit."""
+    canonical = canonical_serving_labels(
+        [option for option in options if isinstance(option, Mapping)], language
+    )
+    updated: list[dict[str, Any]] = []
+    for option in options:
+        copied = dict(option) if isinstance(option, Mapping) else {}
+        if not copied:
+            continue
+        unit_key = serving_phrase_key(serving_display_source(copied))
+        label = (
+            canonical.get(unit_key) or str(labels_by_unit.get(unit_key) or "").strip()
+        )
+        if label and (
+            unit_key in canonical
+            or not str(copied.get(DISPLAY_DESCRIPTION_KEY) or "").strip()
+        ):
+            copied[DISPLAY_DESCRIPTION_KEY] = label[:100]
+        updated.append(copied)
+    return updated

--- a/src/app/services/serving_label.py
+++ b/src/app/services/serving_label.py
@@ -80,7 +80,10 @@ def canonical_serving_labels(
         if key in _VI_CANONICAL_SERVING_LABELS:
             labels[key] = _VI_CANONICAL_SERVING_LABELS[key]
             continue
-        compact = re.sub(r"\s*\([^)]*\)", "", source).split(",", 1)[0].strip()
+        # Parenthetical provider measurements are detail-only. Comma-qualified
+        # phrases such as ``cup, cooked, diced`` carry semantic qualifiers and
+        # must remain intact for the phrase translator/cache.
+        compact = re.sub(r"\s*\([^)]*\)", "", source).strip()
         words = compact.lower().split()
         translated = [_VI_SERVING_WORDS.get(word, "") for word in words]
         if words and all(translated):

--- a/src/app/services/serving_label.py
+++ b/src/app/services/serving_label.py
@@ -7,13 +7,13 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from src.app.services.food_display_name import (
-    fold_latin_display_name,
     is_ascii_display_name,
     needs_display_localization,
 )
 from src.domain.services.nutrition_calculation_service import (
     MASS_VOLUME_CANONICAL_UNITS,
 )
+from src.domain.services.serving_phrase import serving_phrase_key
 
 DISPLAY_DESCRIPTION_KEY = "display_description"
 
@@ -53,11 +53,6 @@ _VI_SERVING_WORDS = {
     "tsp": "muỗng cà phê",
 }
 _VI_SERVING_ADJECTIVES = {"mỏng", "dày", "lớn", "vừa", "nhỏ"}
-
-
-def serving_phrase_key(text: str) -> str:
-    """Stable lookup key for an exact FatSecret serving phrase."""
-    return " ".join(fold_latin_display_name(text).lower().split())[:120]
 
 
 def serving_display_source(option: Mapping[str, Any]) -> str:

--- a/src/app/services/serving_label_localizer.py
+++ b/src/app/services/serving_label_localizer.py
@@ -1,0 +1,184 @@
+"""Localize FatSecret serving phrases: database first, translator last."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from src.app.services.food_name_localizer import (
+    translate_food_texts,
+    translated_values,
+    translation_is_cacheable,
+)
+from src.app.services.serving_label import (
+    apply_serving_labels,
+    canonical_serving_labels,
+    leftover_serving_phrases,
+    needs_serving_label,
+    serving_phrase_key,
+)
+from src.domain.constants.languages import normalize_language
+
+__all__ = ["localize_item_servings", "localize_serving_options"]
+
+
+def _empty_units(options: Any) -> list[dict[str, Any]]:
+    if not isinstance(options, list):
+        return []
+    return [dict(option) for option in options if isinstance(option, Mapping)]
+
+
+async def localize_serving_options(
+    options: list[Any],
+    *,
+    language: str,
+    translation_service: Any | None,
+    cached_labels: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return options with ``display_description`` filled when possible."""
+    copied = _empty_units(options)
+    normalized = normalize_language(language)
+    if not copied or normalized == "en":
+        return copied
+    labeled = apply_serving_labels(copied, cached_labels or {}, normalized)
+    leftovers = leftover_serving_phrases(labeled, normalized)
+    if not leftovers or translation_service is None:
+        return labeled
+    result = await translate_food_texts(
+        leftovers,
+        target_language=normalized,
+        translation_service=translation_service,
+    )
+    fresh = {
+        serving_phrase_key(source): str(translated).strip()
+        for source, translated in zip(
+            leftovers, translated_values(leftovers, result), strict=False
+        )
+        if str(translated).strip()
+        and not needs_serving_label(str(translated), normalized)
+    }
+    if not fresh:
+        return labeled
+    return apply_serving_labels(labeled, fresh, normalized)
+
+
+async def localize_item_servings(
+    items: list[dict[str, Any]],
+    *,
+    language: str,
+    translation_service: Any | None,
+    uow_factory: Any | None = None,
+    persist: bool = False,
+) -> dict[str, str]:
+    """Localize each item's ``allowed_units`` and optionally persist labels.
+
+    Returns newly cacheable phrase translations (English source → label).
+    """
+    normalized = normalize_language(language)
+    if not items or normalized == "en":
+        return {}
+    cached = await _load_phrase_cache(items, normalized, uow_factory)
+    canonical: dict[str, str] = {}
+    leftovers: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        options = _empty_units(item.get("allowed_units"))
+        canonical.update(canonical_serving_labels(options, normalized))
+        item["allowed_units"] = apply_serving_labels(options, cached, normalized)
+        for phrase in leftover_serving_phrases(item["allowed_units"], normalized):
+            key = serving_phrase_key(phrase)
+            if key not in seen:
+                seen.add(key)
+                leftovers.append(phrase)
+    fresh, cacheable = await _translate_leftovers(
+        leftovers, normalized, translation_service
+    )
+    resolved = {**canonical, **fresh}
+    if not resolved:
+        return {}
+    for item in items:
+        item["allowed_units"] = apply_serving_labels(
+            _empty_units(item.get("allowed_units")),
+            resolved,
+            normalized,
+        )
+    if persist and uow_factory is not None and (canonical or cacheable):
+        await _persist_labels(items, resolved, normalized, uow_factory)
+    return resolved
+
+
+async def _translate_leftovers(
+    leftovers: list[str],
+    language: str,
+    translation_service: Any | None,
+) -> tuple[dict[str, str], bool]:
+    if not leftovers or translation_service is None:
+        return {}, False
+    result = await translate_food_texts(
+        leftovers,
+        target_language=language,
+        translation_service=translation_service,
+    )
+    labels = {
+        source: str(translated).strip()
+        for source, translated in zip(
+            leftovers, translated_values(leftovers, result), strict=False
+        )
+        if str(translated).strip()
+        and not needs_serving_label(str(translated), language)
+    }
+    return labels, bool(labels) and translation_is_cacheable(result)
+
+
+async def _load_phrase_cache(
+    items: list[dict[str, Any]],
+    language: str,
+    uow_factory: Any | None,
+) -> dict[str, str]:
+    phrases: list[str] = []
+    for item in items:
+        phrases.extend(
+            leftover_serving_phrases(_empty_units(item.get("allowed_units")), language)
+        )
+    if not phrases or uow_factory is None:
+        return {}
+    try:
+        async with uow_factory() as uow:
+            return await uow.food_references.get_serving_phrase_translations(
+                phrases, language
+            )
+    except Exception:
+        return {}
+
+
+async def _persist_labels(
+    items: list[dict[str, Any]],
+    labels_by_source: dict[str, str],
+    language: str,
+    uow_factory: Any,
+) -> None:
+    by_reference: dict[int, dict[str, str]] = {}
+    for item in items:
+        reference_id = item.get("food_reference_id")
+        if reference_id is None:
+            continue
+        keyed = {
+            serving_phrase_key(source): label
+            for source, label in labels_by_source.items()
+        }
+        for option in _empty_units(item.get("allowed_units")):
+            source = str(option.get("unit") or "").strip()
+            label = labels_by_source.get(source) or keyed.get(
+                serving_phrase_key(source)
+            )
+            if label:
+                by_reference.setdefault(int(reference_id), {})[source] = label
+    try:
+        async with uow_factory() as uow:
+            await uow.food_references.upsert_serving_phrase_translations(
+                labels_by_source, language
+            )
+            for reference_id, labels in by_reference.items():
+                await uow.food_references.apply_serving_name_vi(reference_id, labels)
+    except Exception:
+        return

--- a/src/domain/ports/food_reference_repository_port.py
+++ b/src/domain/ports/food_reference_repository_port.py
@@ -127,5 +127,27 @@ class FoodReferenceRepositoryPort(Protocol):
     async def get_display_projections(
         self,
         food_reference_ids: list[int],
+        language: str | None = None,
     ) -> dict[int, dict[str, Any]]:
         """Return id-keyed display names for already-linked meal lines."""
+
+    async def get_serving_phrase_translations(
+        self,
+        phrases: list[str],
+        language: str,
+    ) -> dict[str, str]:
+        """Return cached exact serving-phrase translations."""
+
+    async def upsert_serving_phrase_translations(
+        self,
+        labels_by_source: dict[str, str],
+        language: str,
+    ) -> None:
+        """Persist exact serving-phrase translations for reuse."""
+
+    async def apply_serving_name_vi(
+        self,
+        food_reference_id: int,
+        labels_by_unit: dict[str, str],
+    ) -> None:
+        """Write Vietnamese serving labels onto matching catalog rows."""

--- a/src/domain/services/nutrition_integrity_policy.py
+++ b/src/domain/services/nutrition_integrity_policy.py
@@ -370,6 +370,11 @@ def normalize_serving_options(
             "gram_weight": float(gram_weight),
             "description": description[:100] or unit_key,
         }
+        display = str(
+            raw.get("display_description") or raw.get("name_vi") or ""
+        ).strip()
+        if display:
+            candidate["display_description"] = display[:100]
         if not any(
             item["unit"] == candidate["unit"]
             and isinstance(item["gram_weight"], (int, float))

--- a/src/domain/services/serving_phrase.py
+++ b/src/domain/services/serving_phrase.py
@@ -1,0 +1,15 @@
+"""Pure helpers for stable serving-phrase identities."""
+
+from __future__ import annotations
+
+import unicodedata
+
+
+def serving_phrase_key(text: str) -> str:
+    """Return a stable lookup key for an external serving phrase."""
+    normalized = unicodedata.normalize("NFKD", str(text or ""))
+    folded = "".join(char for char in normalized if not unicodedata.combining(char))
+    return " ".join(folded.casefold().split())[:120]
+
+
+__all__ = ["serving_phrase_key"]

--- a/src/infra/database/models/__init__.py
+++ b/src/infra/database/models/__init__.py
@@ -30,6 +30,7 @@ from .feature_flag import FeatureFlag
 from .food_reference_model import FoodReferenceModel
 from .food_reference_nutrient import FoodReferenceNutrientModel
 from .food_reference_serving_size import FoodReferenceServingSizeModel
+from .serving_phrase_translation import ServingPhraseTranslationModel
 from .hydration_entry import HydrationEntryORM
 from .meal.food_item_translation_model import FoodItemTranslationORM
 
@@ -158,6 +159,7 @@ __all__ = [
     "FoodReferenceModel",
     "FoodReferenceNutrientModel",
     "FoodReferenceServingSizeModel",
+    "ServingPhraseTranslationModel",
     "FoodReferenceIntegrityControlModel",
     "FoodReferenceIntegrityEventModel",
     "BarcodeProductModel",  # backward-compatible alias

--- a/src/infra/database/models/food_reference_serving_size.py
+++ b/src/infra/database/models/food_reference_serving_size.py
@@ -18,6 +18,8 @@ class FoodReferenceServingSizeModel(Base):
         nullable=False,
     )
     name = Column(String(100), nullable=False)
+    description = Column(String(100), nullable=True)
+    name_vi = Column(String(100), nullable=True)
     grams = Column(Float, nullable=True)
     milliliters = Column(Float, nullable=True)
     is_default = Column(Boolean, nullable=False, default=False)

--- a/src/infra/database/models/serving_phrase_translation.py
+++ b/src/infra/database/models/serving_phrase_translation.py
@@ -1,0 +1,24 @@
+"""Cached exact translations of FatSecret serving phrases."""
+
+from sqlalchemy import Column, Integer, String, UniqueConstraint
+
+from src.infra.database.base import Base
+
+
+class ServingPhraseTranslationModel(Base):
+    """Reuse one FatSecret phrase translation across foods."""
+
+    __tablename__ = "serving_phrase_translation"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    source_key = Column(String(120), nullable=False)
+    language = Column(String(8), nullable=False)
+    translated_text = Column(String(100), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "source_key",
+            "language",
+            name="uq_serving_phrase_translation_source_language",
+        ),
+    )

--- a/src/infra/repositories/food_reference_adopt.py
+++ b/src/infra/repositories/food_reference_adopt.py
@@ -181,10 +181,14 @@ class FoodReferenceAdoptRepository:
             setattr(model, field, value)
         existing_servings = _loaded_collection(model, "serving_size_rows")
         if servings:
+            incoming = _preserve_serving_locale(
+                existing_servings,
+                build_food_reference_serving_rows(servings),
+            )
             _replace_relationship_collection(
                 model,
                 "serving_size_rows",
-                build_food_reference_serving_rows(servings),
+                incoming,
             )
         elif existing_servings is not None and not existing_servings:
             _replace_relationship_collection(
@@ -211,6 +215,32 @@ class FoodReferenceAdoptRepository:
         )
         result = await self._session.execute(stmt.options(*_ADOPT_LOAD_OPTIONS))
         return result.scalars().first()
+
+
+def _preserve_serving_locale(
+    existing: list[Any] | None,
+    incoming: list[Any],
+) -> list[Any]:
+    """Keep ``name_vi`` when the English FatSecret phrase did not change."""
+    if not existing:
+        return incoming
+    by_key = {
+        (
+            str(row.name or "").casefold(),
+            str(getattr(row, "description", None) or "").casefold(),
+        ): row
+        for row in existing
+    }
+    for row in incoming:
+        old = by_key.get(
+            (
+                str(row.name or "").casefold(),
+                str(getattr(row, "description", None) or "").casefold(),
+            )
+        )
+        if old is not None and getattr(old, "name_vi", None) and not row.name_vi:
+            row.name_vi = old.name_vi
+    return incoming
 
 
 __all__ = ["FoodReferenceAdoptRepository", "sanitize_locale_name"]

--- a/src/infra/repositories/food_reference_locale.py
+++ b/src/infra/repositories/food_reference_locale.py
@@ -15,13 +15,18 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.app.services.serving_label import serving_phrase_key
 from src.infra.database.models.food_reference_model import FoodReferenceModel
+from src.infra.database.models.food_reference_serving_size import (
+    FoodReferenceServingSizeModel,
+)
 from src.infra.repositories.food_reference_integrity_repository import (
     FoodReferenceIntegrityRepository,
 )
 from src.infra.repositories.food_reference_projection import (
     food_reference_model_to_dict,
 )
+from src.infra.repositories.serving_phrase_repository import ServingPhraseRepository
 
 _DISPLAY_LOAD_OPTIONS = (
     selectinload(FoodReferenceModel.serving_size_rows),
@@ -35,6 +40,7 @@ class FoodReferenceLocaleRepository:
     def __init__(self, session: AsyncSession):
         self._session = session
         self._integrity_repository = FoodReferenceIntegrityRepository(session)
+        self._phrase_repository = ServingPhraseRepository(session)
 
     async def find_by_locale_names(
         self, language: str, names: list[str]
@@ -73,7 +79,7 @@ class FoodReferenceLocaleRepository:
         return matched
 
     async def get_display_projections(
-        self, food_reference_ids: list[int]
+        self, food_reference_ids: list[int], language: str | None = None
     ) -> dict[int, dict[str, Any]]:
         """Id-keyed English name + ``name_vi`` for linked meal lines.
 
@@ -90,13 +96,70 @@ class FoodReferenceLocaleRepository:
                 FoodReferenceModel.name_vi,
             ).where(FoodReferenceModel.id.in_(ids))
         )
-        return {
+        projections = {
             row.id: {
                 "name": row.name,
                 "name_vi": row.name_vi,
+                "serving_labels": {},
             }
             for row in result.all()
         }
+        serving_rows = await self._session.execute(
+            select(
+                FoodReferenceServingSizeModel.food_reference_id,
+                FoodReferenceServingSizeModel.name,
+                FoodReferenceServingSizeModel.name_vi,
+            ).where(FoodReferenceServingSizeModel.food_reference_id.in_(ids))
+        )
+        missing_phrases: list[str] = []
+        pending: list[tuple[int, str]] = []
+        for food_reference_id, name, name_vi in serving_rows.all():
+            if name_vi:
+                projections[food_reference_id]["serving_labels"][
+                    serving_phrase_key(name)
+                ] = name_vi
+                continue
+            missing_phrases.append(name)
+            pending.append((food_reference_id, name))
+        phrase_language = language or "vi"
+        cached = {}
+        if missing_phrases and phrase_language != "en":
+            cached = await self._phrase_repository.get_translations(
+                missing_phrases, phrase_language
+            )
+        for food_reference_id, name in pending:
+            label = cached.get(serving_phrase_key(name))
+            if label:
+                projections[food_reference_id]["serving_labels"][
+                    serving_phrase_key(name)
+                ] = label
+        return projections
+
+    async def get_serving_phrase_translations(
+        self, phrases: list[str], language: str
+    ) -> dict[str, str]:
+        return await self._phrase_repository.get_translations(phrases, language)
+
+    async def upsert_serving_phrase_translations(
+        self, labels_by_source: dict[str, str], language: str
+    ) -> None:
+        await self._phrase_repository.upsert_translations(labels_by_source, language)
+
+    async def apply_serving_name_vi(
+        self, food_reference_id: int, labels_by_unit: dict[str, str]
+    ) -> None:
+        if not labels_by_unit:
+            return
+        keyed = {serving_phrase_key(unit): label for unit, label in labels_by_unit.items()}
+        result = await self._session.execute(
+            select(FoodReferenceServingSizeModel).where(
+                FoodReferenceServingSizeModel.food_reference_id == food_reference_id
+            )
+        )
+        for row in result.scalars().all():
+            label = keyed.get(serving_phrase_key(row.name))
+            if label:
+                row.name_vi = label[:100]
 
 
 __all__ = ["FoodReferenceLocaleRepository"]

--- a/src/infra/repositories/food_reference_locale.py
+++ b/src/infra/repositories/food_reference_locale.py
@@ -15,7 +15,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from src.app.services.serving_label import serving_phrase_key
+from src.domain.services.serving_phrase import serving_phrase_key
 from src.infra.database.models.food_reference_model import FoodReferenceModel
 from src.infra.database.models.food_reference_serving_size import (
     FoodReferenceServingSizeModel,

--- a/src/infra/repositories/food_reference_projection.py
+++ b/src/infra/repositories/food_reference_projection.py
@@ -132,9 +132,17 @@ def build_food_reference_serving_rows(
         ).strip()
         if not name:
             continue
+        description = str(
+            item.get("description") or item.get("serving_description") or ""
+        ).strip()
+        name_vi = str(
+            item.get("name_vi") or item.get("display_description") or ""
+        ).strip()
         rows.append(
             FoodReferenceServingSizeModel(
                 name=name[:100],
+                description=description[:100] or None,
+                name_vi=name_vi[:100] or None,
                 grams=as_optional_float(item.get("grams") or item.get("gram_weight")),
                 milliliters=as_optional_float(
                     item.get("milliliters") or item.get("ml")
@@ -176,6 +184,8 @@ def food_reference_serving_sizes_to_dict(model: FoodReferenceModel) -> Any:
     return [
         {
             "name": row.name,
+            "description": row.description,
+            "name_vi": row.name_vi,
             "grams": row.grams,
             "milliliters": row.milliliters,
             "is_default": row.is_default,
@@ -232,7 +242,12 @@ def food_reference_allowed_units_to_dict(
             {
                 "unit": row.name,
                 "gram_weight": row.grams,
-                "description": row.name,
+                "description": row.description or row.name,
+                **(
+                    {"display_description": row.name_vi}
+                    if row.name_vi
+                    else {}
+                ),
             }
             for row in raw_rows
             if row.grams is not None and row.grams > 0
@@ -271,7 +286,7 @@ def _raw_allowed_units(model: FoodReferenceModel) -> list[dict[str, Any]]:
             {
                 "unit": row.name,
                 "gram_weight": row.grams,
-                "description": row.name,
+                "description": row.description or row.name,
             }
             for row in rows
         ]

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -372,9 +372,32 @@ class AsyncFoodReferenceRepository:
         return await self._locale_repository.find_by_locale_names(language, names)
 
     async def get_display_projections(
-        self, food_reference_ids: list[int]
+        self, food_reference_ids: list[int], language: str | None = None
     ) -> dict[int, dict[str, Any]]:
-        return await self._locale_repository.get_display_projections(food_reference_ids)
+        return await self._locale_repository.get_display_projections(
+            food_reference_ids, language
+        )
+
+    async def get_serving_phrase_translations(
+        self, phrases: list[str], language: str
+    ) -> dict[str, str]:
+        return await self._locale_repository.get_serving_phrase_translations(
+            phrases, language
+        )
+
+    async def upsert_serving_phrase_translations(
+        self, labels_by_source: dict[str, str], language: str
+    ) -> None:
+        await self._locale_repository.upsert_serving_phrase_translations(
+            labels_by_source, language
+        )
+
+    async def apply_serving_name_vi(
+        self, food_reference_id: int, labels_by_unit: dict[str, str]
+    ) -> None:
+        await self._locale_repository.apply_serving_name_vi(
+            food_reference_id, labels_by_unit
+        )
 
     async def upsert(self, data: dict[str, Any]) -> None:
         """Insert or update a food reference by barcode without owning commit."""

--- a/src/infra/repositories/food_reference_uow_adapter.py
+++ b/src/infra/repositories/food_reference_uow_adapter.py
@@ -118,9 +118,33 @@ class AsyncFoodReferenceUowAdapter:
             return await uow.food_references.find_by_locale_names(language, names)
 
     async def get_display_projections(
-        self, food_reference_ids: list[int]
+        self, food_reference_ids: list[int], language: str | None = None
     ) -> dict[int, dict[str, Any]]:
         async with self._uow_factory() as uow:
             return await uow.food_references.get_display_projections(
-                food_reference_ids
+                food_reference_ids, language
+            )
+
+    async def get_serving_phrase_translations(
+        self, phrases: list[str], language: str
+    ) -> dict[str, str]:
+        async with self._uow_factory() as uow:
+            return await uow.food_references.get_serving_phrase_translations(
+                phrases, language
+            )
+
+    async def upsert_serving_phrase_translations(
+        self, labels_by_source: dict[str, str], language: str
+    ) -> None:
+        async with self._uow_factory() as uow:
+            await uow.food_references.upsert_serving_phrase_translations(
+                labels_by_source, language
+            )
+
+    async def apply_serving_name_vi(
+        self, food_reference_id: int, labels_by_unit: dict[str, str]
+    ) -> None:
+        async with self._uow_factory() as uow:
+            await uow.food_references.apply_serving_name_vi(
+                food_reference_id, labels_by_unit
             )

--- a/src/infra/repositories/serving_phrase_repository.py
+++ b/src/infra/repositories/serving_phrase_repository.py
@@ -1,0 +1,59 @@
+"""Lookup and upsert exact FatSecret serving-phrase translations."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.app.services.serving_label import serving_phrase_key
+from src.infra.database.models.serving_phrase_translation import (
+    ServingPhraseTranslationModel,
+)
+
+
+class ServingPhraseRepository:
+    """Shared phrase cache keyed by folded English text + language."""
+
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def get_translations(
+        self, phrases: list[str], language: str
+    ) -> dict[str, str]:
+        keys = [serving_phrase_key(phrase) for phrase in phrases if phrase.strip()]
+        if not keys or not language or language == "en":
+            return {}
+        result = await self._session.execute(
+            select(
+                ServingPhraseTranslationModel.source_key,
+                ServingPhraseTranslationModel.translated_text,
+            ).where(
+                ServingPhraseTranslationModel.language == language,
+                ServingPhraseTranslationModel.source_key.in_(keys),
+            )
+        )
+        return {row.source_key: row.translated_text for row in result.all()}
+
+    async def upsert_translations(
+        self, labels_by_source: dict[str, str], language: str
+    ) -> None:
+        if not labels_by_source or not language or language == "en":
+            return
+        rows = [
+            {
+                "source_key": serving_phrase_key(source),
+                "language": language,
+                "translated_text": translated[:100],
+            }
+            for source, translated in labels_by_source.items()
+            if serving_phrase_key(source) and translated.strip()
+        ]
+        if not rows:
+            return
+        stmt = insert(ServingPhraseTranslationModel).values(rows)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_serving_phrase_translation_source_language",
+            set_={"translated_text": stmt.excluded.translated_text},
+        )
+        await self._session.execute(stmt)

--- a/src/infra/repositories/serving_phrase_repository.py
+++ b/src/infra/repositories/serving_phrase_repository.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.app.services.serving_label import serving_phrase_key
+from src.domain.services.serving_phrase import serving_phrase_key
 from src.infra.database.models.serving_phrase_translation import (
     ServingPhraseTranslationModel,
 )

--- a/tests/migrations/test_serving_label_translation_migration.py
+++ b/tests/migrations/test_serving_label_translation_migration.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+MIGRATION = Path(
+    "migrations/versions/20260823000001_add_serving_label_translations.py"
+)
+
+
+def test_serving_label_translation_migration_is_additive():
+    text = MIGRATION.read_text()
+
+    assert 'revision: str = "20260823000001"' in text
+    assert 'down_revision: str | None = "20260820000002"' in text
+    assert 'sa.Column("description", sa.String(length=100), nullable=True)' in text
+    assert 'sa.Column("name_vi", sa.String(length=100), nullable=True)' in text
+    assert '"serving_phrase_translation"' in text

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -344,6 +344,61 @@ class TestMealMapper:
         assert result.food_items[0].display_name == "Gà nướng"
         assert result.food_items[0].canonical_name == "Grilled chicken"
 
+    def test_to_detailed_response_overlays_serving_labels_for_vi(self):
+        from src.app.services.serving_label import serving_phrase_key
+
+        item = FoodItem(
+            id="item-1",
+            name="Rice",
+            quantity=1,
+            unit="cup, cooked, diced",
+            macros=Macros(protein=4, carbs=45, fat=0),
+            food_reference_id=42,
+            allowed_units=[
+                {
+                    "unit": "cup, cooked, diced",
+                    "gram_weight": 158.0,
+                    "description": "1 cup cooked, diced",
+                }
+            ],
+        )
+        meal = Meal(
+            meal_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+            status=MealStatus.READY,
+            image=MealImage(
+                url="https://example.com/rice.jpg",
+                image_id=str(uuid.uuid4()),
+                format="jpeg",
+                size_bytes=1024,
+            ),
+            dish_name="Rice",
+            created_at=datetime(2026, 8, 22),
+            ready_at=datetime(2026, 8, 22),
+            nutrition=Nutrition(macros=item.macros, food_items=[item]),
+        )
+
+        result = MealMapper.to_detailed_response(
+            meal,
+            target_language="vi",
+            display_name_by_food_reference={
+                42: {
+                    "name": "Rice",
+                    "name_vi": "Cơm",
+                    "serving_labels": {
+                        serving_phrase_key("cup, cooked, diced"): (
+                            "cốc, đã nấu, thái hạt lựu"
+                        )
+                    },
+                }
+            },
+        )
+
+        labeled = result.food_items[0].allowed_units[0]
+        assert labeled.unit == "cup, cooked, diced"
+        assert labeled.description == "1 cup cooked, diced"
+        assert labeled.display_description == "cốc, đã nấu, thái hạt lựu"
+
     def test_to_detailed_response_tracked_item_english_ignores_stored_locale_name(
         self,
     ):

--- a/tests/unit/app/services/test_meal_serving_label_enricher.py
+++ b/tests/unit/app/services/test_meal_serving_label_enricher.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.app.services.meal_serving_label_enricher import enrich_meal_serving_labels
+from src.app.services.serving_label import serving_phrase_key
+from src.domain.model.translation_result import TranslationOutcome, TranslationResult
+
+
+class _Translator:
+    async def translate_texts(self, texts, source_language, target_language):
+        mapping = {"cup, cooked, diced": "cốc, đã nấu, thái hạt lựu"}
+        return TranslationResult(
+            tuple(mapping.get(text, text) for text in texts),
+            TranslationOutcome.TRANSLATED,
+            source_language,
+            target_language,
+        )
+
+
+def _meal_with_leftover_serving():
+    item = SimpleNamespace(
+        food_reference_id=42,
+        allowed_units=[
+            {
+                "unit": "cup, cooked, diced",
+                "gram_weight": 158.0,
+                "description": "1 cup cooked, diced",
+            }
+        ],
+    )
+    return SimpleNamespace(nutrition=SimpleNamespace(food_items=[item]))
+
+
+@pytest.mark.asyncio
+async def test_enrich_meal_serving_labels_translates_leftovers():
+    meal = _meal_with_leftover_serving()
+    projections = {42: {"name": "Rice", "name_vi": "Cơm", "serving_labels": {}}}
+
+    result = await enrich_meal_serving_labels(
+        meal,
+        projections,
+        language="vi",
+        translation_service=_Translator(),
+        uow_factory=None,
+    )
+
+    assert (
+        result[42]["serving_labels"][serving_phrase_key("cup, cooked, diced")]
+        == "cốc, đã nấu, thái hạt lựu"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrich_meal_serving_labels_skips_when_catalog_already_has_label():
+    class _Boom:
+        async def translate_texts(self, *args, **kwargs):
+            raise AssertionError("translator should not run")
+
+    meal = _meal_with_leftover_serving()
+    projections = {
+        42: {
+            "name": "Rice",
+            "serving_labels": {
+                serving_phrase_key("cup, cooked, diced"): "cốc, đã nấu, thái hạt lựu"
+            },
+        }
+    }
+
+    result = await enrich_meal_serving_labels(
+        meal,
+        projections,
+        language="vi",
+        translation_service=_Boom(),
+        uow_factory=None,
+    )
+
+    assert (
+        result[42]["serving_labels"][serving_phrase_key("cup, cooked, diced")]
+        == "cốc, đã nấu, thái hạt lựu"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrich_meal_serving_labels_persists_canonical_serving():
+    class _Uow:
+        saved_food_labels = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        class food_references:
+            @staticmethod
+            async def get_serving_phrase_translations(*_args, **_kwargs):
+                return {}
+
+            @staticmethod
+            async def upsert_serving_phrase_translations(*_args, **_kwargs):
+                return None
+
+            @staticmethod
+            async def apply_serving_name_vi(food_reference_id, labels):
+                _Uow.saved_food_labels = (food_reference_id, labels)
+
+    meal = SimpleNamespace(
+        nutrition=SimpleNamespace(
+            food_items=[
+                SimpleNamespace(
+                    food_reference_id=42,
+                    allowed_units=[
+                        {
+                            "unit": "serving",
+                            "gram_weight": 98.0,
+                            "description": "1 serving",
+                        }
+                    ],
+                )
+            ]
+        )
+    )
+
+    result = await enrich_meal_serving_labels(
+        meal,
+        {42: {"serving_labels": {}}},
+        language="vi",
+        translation_service=None,
+        uow_factory=lambda: _Uow(),
+    )
+
+    assert result[42]["serving_labels"][serving_phrase_key("serving")] == "Khẩu phần"
+    assert _Uow.saved_food_labels == (42, {"serving": "Khẩu phần"})

--- a/tests/unit/app/services/test_serving_label.py
+++ b/tests/unit/app/services/test_serving_label.py
@@ -1,0 +1,97 @@
+from src.app.services.serving_label import (
+    apply_serving_labels,
+    leftover_serving_phrases,
+    needs_serving_label,
+    overlay_serving_labels,
+    serving_phrase_key,
+)
+
+
+def test_metric_units_do_not_need_labels():
+    assert needs_serving_label("g", "vi") is False
+    assert needs_serving_label("ml", "vi") is False
+
+
+def test_exact_fatsecret_phrase_is_leftover():
+    options = [{"unit": "cup, cooked, diced", "description": "1 cup cooked, diced"}]
+    assert leftover_serving_phrases(options, "vi") == ["cup, cooked, diced"]
+
+
+def test_english_cached_display_description_is_still_leftover():
+    options = [
+        {
+            "unit": 'thin slice (approx 2" x 1-1/2" x 1/8")',
+            "display_description": 'thin slice (approx 2" x 1-1/2" x 1/8")',
+        }
+    ]
+    assert leftover_serving_phrases(options, "vi") == [options[0]["unit"]]
+
+
+def test_apply_serving_labels_does_not_rewrite_unit():
+    options = [
+        {
+            "unit": "cup, cooked, diced",
+            "gram_weight": 158.0,
+            "description": "1 cup cooked, diced",
+        }
+    ]
+    labeled = apply_serving_labels(
+        options,
+        {serving_phrase_key("cup, cooked, diced"): "cốc, đã nấu, thái hạt lựu"},
+        "vi",
+    )
+    assert labeled[0]["unit"] == "cup, cooked, diced"
+    assert labeled[0]["description"] == "1 cup cooked, diced"
+    assert labeled[0]["display_description"] == "cốc, đã nấu, thái hạt lựu"
+
+
+def test_vietnamese_canonical_serving_label_overrides_stale_translation():
+    labeled = apply_serving_labels(
+        [{"unit": "serving", "gram_weight": 98.0, "description": "1 serving"}],
+        {serving_phrase_key("serving"): "Phần ăn"},
+        "vi",
+    )
+
+    assert labeled[0]["unit"] == "serving"
+    assert labeled[0]["description"] == "1 serving"
+    assert labeled[0]["display_description"] == "Khẩu phần"
+
+
+def test_vietnamese_canonical_label_handles_verbose_provider_phrase():
+    labeled = apply_serving_labels(
+        [
+            {
+                "unit": 'thin slice (approx 2" x 1-1/2" x 1/8")',
+                "gram_weight": 12.0,
+                "description": '1 thin slice (approx 2" x 1-1/2" x 1/8")',
+            }
+        ],
+        {},
+        "vi",
+    )
+
+    assert labeled[0]["display_description"] == "Lát mỏng"
+
+
+def test_overlay_serving_labels_uses_catalog_name_vi():
+    options = [{"unit": "slice", "gram_weight": 30.0, "description": "1 slice"}]
+    overlay = overlay_serving_labels(options, {serving_phrase_key("slice"): "lát"})
+    assert overlay[0]["display_description"] == "lát"
+    assert overlay[0]["unit"] == "slice"
+
+
+def test_overlay_replaces_stale_vietnamese_canonical_serving_label():
+    overlay = overlay_serving_labels(
+        [
+            {
+                "unit": "serving",
+                "gram_weight": 98.0,
+                "description": "1 serving",
+                "display_description": "Phần ăn",
+            }
+        ],
+        {serving_phrase_key("serving"): "Phần ăn"},
+        language="vi",
+    )
+
+    assert overlay[0]["display_description"] == "Khẩu phần"

--- a/tests/unit/app/services/test_serving_label_localizer.py
+++ b/tests/unit/app/services/test_serving_label_localizer.py
@@ -1,0 +1,170 @@
+import pytest
+
+from src.app.services.serving_label_localizer import localize_item_servings
+from src.domain.model.translation_result import TranslationOutcome, TranslationResult
+
+
+class _Translator:
+    async def translate_texts(self, texts, source_language, target_language):
+        mapping = {"cup, cooked, diced": "cốc, đã nấu, thái hạt lựu"}
+        return TranslationResult(
+            tuple(mapping.get(text, text) for text in texts),
+            TranslationOutcome.TRANSLATED,
+            source_language,
+            target_language,
+        )
+
+
+@pytest.mark.asyncio
+async def test_localize_item_servings_fills_display_description():
+    items = [
+        {
+            "name": "Rice",
+            "allowed_units": [
+                {
+                    "unit": "cup, cooked, diced",
+                    "gram_weight": 158.0,
+                    "description": "1 cup cooked, diced",
+                }
+            ],
+        }
+    ]
+
+    await localize_item_servings(
+        items,
+        language="vi",
+        translation_service=_Translator(),
+    )
+
+    labeled = items[0]["allowed_units"][0]
+    assert labeled["display_description"] == "cốc, đã nấu, thái hạt lựu"
+    assert labeled["unit"] == "cup, cooked, diced"
+    assert labeled["description"] == "1 cup cooked, diced"
+
+
+@pytest.mark.asyncio
+async def test_localize_item_servings_uses_cached_phrase_before_translate():
+    class _Boom:
+        async def translate_texts(self, *args, **kwargs):
+            raise AssertionError("translator should not run on cache hit")
+
+    class _Uow:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        class food_references:
+            @staticmethod
+            async def get_serving_phrase_translations(phrases, language):
+                assert language == "vi"
+                return {"cup, cooked, diced": "cốc, đã nấu, thái hạt lựu"}
+
+    items = [
+        {"allowed_units": [{"unit": "cup, cooked, diced", "description": "1 cup"}]}
+    ]
+    await localize_item_servings(
+        items,
+        language="vi",
+        translation_service=_Boom(),
+        uow_factory=lambda: _Uow(),
+    )
+    assert (
+        items[0]["allowed_units"][0]["display_description"]
+        == "cốc, đã nấu, thái hạt lựu"
+    )
+
+
+@pytest.mark.asyncio
+async def test_localize_item_servings_does_not_persist_partial_translations():
+    class _Partial:
+        async def translate_texts(self, texts, source_language, target_language):
+            return TranslationResult(
+                tuple("lát" for _text in texts),
+                TranslationOutcome.PARTIAL,
+                source_language,
+                target_language,
+            )
+
+    class _Uow:
+        persisted = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        class food_references:
+            @staticmethod
+            async def get_serving_phrase_translations(phrases, language):
+                return {}
+
+            @staticmethod
+            async def upsert_serving_phrase_translations(*_args, **_kwargs):
+                _Uow.persisted = True
+
+            @staticmethod
+            async def apply_serving_name_vi(*_args, **_kwargs):
+                _Uow.persisted = True
+
+    items = [
+        {
+            "food_reference_id": 9,
+            "allowed_units": [{"unit": "thin strip", "description": "1 thin strip"}],
+        }
+    ]
+    await localize_item_servings(
+        items,
+        language="vi",
+        translation_service=_Partial(),
+        uow_factory=lambda: _Uow(),
+        persist=True,
+    )
+    assert _Uow.persisted is False
+
+
+@pytest.mark.asyncio
+async def test_localize_item_servings_persists_canonical_vietnamese_serving():
+    class _Uow:
+        saved_labels = None
+        saved_food_labels = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        class food_references:
+            @staticmethod
+            async def get_serving_phrase_translations(*_args, **_kwargs):
+                return {}
+
+            @staticmethod
+            async def upsert_serving_phrase_translations(labels, language):
+                _Uow.saved_labels = (labels, language)
+
+            @staticmethod
+            async def apply_serving_name_vi(food_reference_id, labels):
+                _Uow.saved_food_labels = (food_reference_id, labels)
+
+    items = [
+        {
+            "food_reference_id": 9,
+            "allowed_units": [{"unit": "serving", "description": "1 serving"}],
+        }
+    ]
+
+    await localize_item_servings(
+        items,
+        language="vi",
+        translation_service=None,
+        uow_factory=lambda: _Uow(),
+        persist=True,
+    )
+
+    assert items[0]["allowed_units"][0]["display_description"] == "Khẩu phần"
+    assert _Uow.saved_labels == ({"serving": "Khẩu phần"}, "vi")
+    assert _Uow.saved_food_labels == (9, {"serving": "Khẩu phần"})

--- a/tests/unit/infra/repositories/test_food_reference_locale.py
+++ b/tests/unit/infra/repositories/test_food_reference_locale.py
@@ -116,13 +116,40 @@ async def test_get_display_projections_returns_name_and_name_vi():
         SimpleNamespace(id=7, name="Beef", name_vi="Thit bo"),
         SimpleNamespace(id=8, name="Rice", name_vi=None),
     ]
-    session = _Session([_Result(all_rows=rows)])
+    session = _Session(
+        [_Result(all_rows=rows), _Result(all_rows=[])]
+    )
     repo = FoodReferenceLocaleRepository(session)
 
     result = await repo.get_display_projections([7, 8])
 
-    assert result[7] == {"name": "Beef", "name_vi": "Thit bo"}
-    assert result[8] == {"name": "Rice", "name_vi": None}
+    assert result[7] == {
+        "name": "Beef",
+        "name_vi": "Thit bo",
+        "serving_labels": {},
+    }
+    assert result[8] == {"name": "Rice", "name_vi": None, "serving_labels": {}}
+
+
+@pytest.mark.asyncio
+async def test_get_display_projections_includes_serving_name_vi():
+    from src.app.services.serving_label import serving_phrase_key
+
+    rows = [SimpleNamespace(id=7, name="Rice", name_vi="Cơm")]
+    serving_rows = [
+        (7, "cup, cooked, diced", "cốc, đã nấu, thái hạt lựu"),
+    ]
+    session = _Session(
+        [_Result(all_rows=rows), _Result(all_rows=serving_rows)]
+    )
+    repo = FoodReferenceLocaleRepository(session)
+
+    result = await repo.get_display_projections([7], language="vi")
+
+    assert result[7]["serving_labels"][
+        serving_phrase_key("cup, cooked, diced")
+    ] == "cốc, đã nấu, thái hạt lựu"
+    assert serving_phrase_key("g") not in result[7]["serving_labels"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infra/repositories/test_food_reference_projection.py
+++ b/tests/unit/infra/repositories/test_food_reference_projection.py
@@ -80,6 +80,29 @@ def test_food_reference_nutrient_projection_preserves_legacy_object_shape():
     }
 
 
+def test_food_reference_projection_keeps_exact_serving_description_and_label():
+    model = _make_food_reference_model("rice")
+    model.serving_size_rows = build_food_reference_serving_rows(
+        [
+            {
+                "unit": "cup, cooked, diced",
+                "gram_weight": 158,
+                "description": "1 cup cooked, diced",
+                "display_description": "cốc, đã nấu, thái hạt lựu",
+            }
+        ]
+    )
+
+    result = food_reference_model_to_dict(model)
+    cooked = next(
+        option
+        for option in result["allowed_units"]
+        if option["unit"] == "cup, cooked, diced"
+    )
+    assert cooked["description"] == "1 cup cooked, diced"
+    assert cooked["display_description"] == "cốc, đã nấu, thái hạt lựu"
+
+
 def test_food_reference_projection_returns_allowed_units_from_serving_rows():
     model = _make_food_reference_model("spinach")
     model.serving_size_rows = build_food_reference_serving_rows(


### PR DESCRIPTION
## Summary
- Persist localized serving labels and translations for meal/search detail flows.
- Add deterministic Vietnamese fallbacks such as `serving` → `Khẩu phần` and verbose `thin slice` → `Lát mỏng`.
- Reprocess stale English cached labels while preserving stable provider unit identities.
- Add migration, repository support, API mapping, and focused tests.

## Validation
- Ruff checks passed.
- Python compile checks passed.
- Direct canonical-label and persistence checks passed.
- Full targeted pytest collection is currently environment-blocked by the local virtualenv missing the `openai` package during shared fixture setup.

## Merge order
Merge this backend PR before the mobile PR so the API can supply persisted localized labels.