### PR TITLE
fix(meal): preserve serving options and localized labels

### DIFF
--- a/migrations/versions/20260823000002_remove_legacy_food_item_unit_metadata.py
+++ b/migrations/versions/20260823000002_remove_legacy_food_item_unit_metadata.py
@@ -1,0 +1,27 @@
+"""Remove the retired food-item unit metadata column."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260823000002"
+down_revision: str | None = "20260823000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if inspector.has_table("food_item"):
+        columns = {column["name"] for column in inspector.get_columns("food_item")}
+        if "allowed_units" in columns:
+            op.drop_column("food_item", "allowed_units")
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if inspector.has_table("food_item"):
+        columns = {column["name"] for column in inspector.get_columns("food_item")}
+        if "allowed_units" not in columns:
+            op.add_column("food_item", sa.Column("allowed_units", sa.JSON(), nullable=True))

--- a/src/api/exception_handlers.py
+++ b/src/api/exception_handlers.py
@@ -20,9 +20,6 @@ from src.api.exceptions import (
     handle_exception,
 )
 from src.domain.exceptions.ai_exceptions import AIUnavailableError
-from src.domain.services.nutrition_calculation_service import (
-    AuthoritativeUnitMismatchError,
-)
 from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
 
 logger = logging.getLogger(__name__)
@@ -69,7 +66,7 @@ async def _ai_unavailable_handler(
 
 async def _nutrition_exception_handler(
     request: Request,
-    exc: NutritionIntegrityError | AuthoritativeUnitMismatchError,
+    exc: NutritionIntegrityError,
 ) -> JSONResponse:
     """Convert nutrition trust-boundary failures at the global API boundary."""
     http_exc = handle_exception(exc)
@@ -136,10 +133,5 @@ def register_exception_handlers(app: FastAPI) -> None:
         NutritionIntegrityError,
         _nutrition_exception_handler,  # type: ignore[arg-type]
     )
-    app.add_exception_handler(
-        AuthoritativeUnitMismatchError,
-        _nutrition_exception_handler,  # type: ignore[arg-type]
-    )
-
     # Catch-all for truly unexpected exceptions — one ERROR (ServerErrorMiddleware)
     app.add_exception_handler(Exception, _unexpected_exception_handler)

--- a/src/api/exceptions.py
+++ b/src/api/exceptions.py
@@ -19,9 +19,6 @@ from src.domain.exceptions.ai_exceptions import (
     AIUnavailableError,
     MealResponseLocalizationError,
 )
-from src.domain.services.nutrition_calculation_service import (
-    AuthoritativeUnitMismatchError,
-)
 from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
 
 logger = logging.getLogger(__name__)
@@ -182,16 +179,6 @@ def handle_exception(exc: Exception) -> HTTPException:
                     "AI could not produce complete localized meal information. "
                     "Please try again with a clearer photo."
                 ),
-                "details": {},
-            },
-        )
-
-    if isinstance(exc, AuthoritativeUnitMismatchError):
-        return HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "error_code": "NUTRITION_UNIT_INVALID",
-                "message": "The selected serving unit is not available for this food.",
                 "details": {},
             },
         )

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -235,6 +235,22 @@ class MealMapper:
                         getattr(item, "food_reference_id", None),
                         getattr(item, "source_snapshot", None),
                     )
+                    serving_options = (
+                        getattr(item, "serving_options", None)
+                        or (getattr(item, "source_snapshot", None) or {}).get(
+                            "serving_options", []
+                        )
+                    )
+                    if (
+                        tracked_projection is not None
+                        and requested_language
+                        and requested_language != "en"
+                    ):
+                        serving_options = overlay_serving_labels(
+                            serving_options,
+                            tracked_projection.get("serving_labels") or {},
+                            language=requested_language,
+                        )
                     food_item_dto = FoodItemResponse(
                         id=str(item.id),
                         name=display_name,
@@ -276,13 +292,7 @@ class MealMapper:
                             item, "nutrition_contract_version", None
                         ),
                         source_snapshot=getattr(item, "source_snapshot", None),
-                        allowed_units=overlay_serving_labels(
-                            getattr(item, "allowed_units", None) or [],
-                            (tracked_projection or {}).get("serving_labels") or {},
-                            language=requested_language,
-                        )
-                        if requested_language == "vi"
-                        else (getattr(item, "allowed_units", None) or []),
+                        serving_options=serving_options,
                     )
                     food_items.append(food_item_dto)
 
@@ -605,7 +615,6 @@ class MealMapper:
             item.quantity,
             item.unit,
             food_name or item.name,
-            getattr(item, "allowed_units", None) or [],
         )
         if quantity_grams <= 0:
             return None
@@ -843,7 +852,6 @@ class MealMapper:
             fdc_id=item_dict.get("fdc_id"),
             food_reference_id=item_dict.get("food_reference_id"),
             is_custom=item_dict.get("is_custom", False),
-            allowed_units=item_dict.get("allowed_units") or None,
             source_kind=item_dict.get("origin") or item_dict.get("source_kind"),
             source_food_id=item_dict.get("source_food_id"),
             nutrition_contract_version=item_dict.get("nutrition_contract_version"),

--- a/src/api/routes/v1/meals_edit.py
+++ b/src/api/routes/v1/meals_edit.py
@@ -145,9 +145,6 @@ async def update_meal_ingredients(
                     else None
                 ),
                 clear_nutrition_override=change_request.clear_nutrition_override,
-                allowed_units=[
-                    unit.model_dump() for unit in change_request.allowed_units
-                ],
                 origin=change_request.origin,
                 food_reference_id=change_request.food_reference_id,
                 source_namespace=change_request.source_namespace,

--- a/src/api/routes/v1/meals_manual_text.py
+++ b/src/api/routes/v1/meals_manual_text.py
@@ -167,7 +167,7 @@ async def create_manual_meal(
                     quantity=i.quantity,
                     unit=i.unit,
                     custom_nutrition=custom_nutrition,
-                    allowed_units=[unit.model_dump() for unit in i.allowed_units],
+                    serving_options=i.serving_options,
                     origin=i.origin,
                     food_reference_id=i.food_reference_id,
                     source_namespace=i.source_namespace,

--- a/src/api/routes/v1/meals_route_helpers.py
+++ b/src/api/routes/v1/meals_route_helpers.py
@@ -84,7 +84,6 @@ def parsed_food_item_to_response(item) -> ParsedFoodItem:
         sugar=getattr(item, "sugar", 0.0) or 0.0,
         data_source=item.data_source,
         fdc_id=item.fdc_id,
-        allowed_units=getattr(item, "allowed_units", None) or [],
         food_id=getattr(item, "food_id", None),
         food_reference_id=getattr(item, "food_reference_id", None),
         origin=getattr(item, "origin", None),
@@ -100,4 +99,5 @@ def parsed_food_item_to_response(item) -> ParsedFoodItem:
         sugar_per_100g=getattr(item, "sugar_per_100g", None),
         canonical_name=getattr(item, "canonical_name", None),
         source_snapshot=getattr(item, "source_snapshot", None),
+        serving_options=getattr(item, "serving_options", None) or [],
     )

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -195,14 +195,6 @@ class ManualMealCustomNutritionRequest(BaseModel):
         )
 
 
-class ServingUnitRequest(BaseModel):
-    """Food-specific serving conversion option."""
-
-    unit: str = Field(..., min_length=1, max_length=120)
-    gram_weight: float = Field(..., gt=0)
-    description: str = Field("", max_length=200)
-
-
 class ManualMealItemRequest(BaseModel):
     """Single selected food item with portion to create a manual meal.
 
@@ -239,9 +231,9 @@ class ManualMealItemRequest(BaseModel):
     unit: str = Field(
         "g", min_length=1, max_length=120, description="Unit, default grams"
     )
-    allowed_units: list[ServingUnitRequest] = Field(
-        default_factory=list,
-        description="Food-specific units allowed for editing this ingredient",
+    serving_options: Optional[list[dict[str, Any]]] = Field(
+        None,
+        description="Validated serving measurements for custom foods",
     )
     source_snapshot: Optional[dict[str, Any]] = Field(
         None,
@@ -389,10 +381,6 @@ class FoodItemChangeRequest(BaseModel):
     )
     unit: Optional[str] = Field(
         None, min_length=1, max_length=120, description="Unit of measurement"
-    )
-    allowed_units: list[ServingUnitRequest] = Field(
-        default_factory=list,
-        description="Food-specific units allowed for editing this ingredient",
     )
     custom_nutrition: Optional["CustomNutritionRequest"] = Field(
         None, description="Custom nutrition data for non-USDA ingredients"
@@ -563,21 +551,19 @@ class EditMealIngredientsRequest(BaseModel):
                 has_legacy_source_echo = any(
                     value is not None
                     for value in (change.name, change.custom_nutrition)
-                ) or bool(change.allowed_units)
+                )
                 if is_portion_update and has_legacy_source_echo:
                     # Older clients echo source fields on portion updates. They
                     # cannot replace authoritative nutrition without an origin,
                     # so discard the echoes before the domain strategy runs.
                     change.name = None
                     change.custom_nutrition = None
-                    change.allowed_units = []
                     continue
                 if any(
                     value is not None
                     for value in (
                         change.name,
                         change.custom_nutrition,
-                        change.allowed_units or None,
                     )
                 ):
                     raise ValueError("v2 quantity update cannot replace source")
@@ -609,8 +595,8 @@ class EditMealIngredientsRequest(BaseModel):
 
 
 def _validate_change_origin(change: FoodItemChangeRequest) -> None:
-    if change.food_id is not None or change.allowed_units:
-        raise ValueError("v2 saves cannot provide deprecated aliases or client units")
+    if change.food_id is not None:
+        raise ValueError("v2 saves cannot provide deprecated aliases")
     if change.origin == "local":
         if change.food_reference_id is None or any(
             value is not None

--- a/src/api/schemas/response/__init__.py
+++ b/src/api/schemas/response/__init__.py
@@ -38,6 +38,7 @@ from .meal_responses import (
     NutritionResponse,
     NutritionSummaryResponse,
     SimpleMealResponse,
+    ServingOptionResponse,
 )
 from .meal_suggestion_responses import (
     MacrosSchema as MealSuggestionMacrosSchema,
@@ -93,6 +94,7 @@ __all__ = [
     "ManualMealCreationResponse",
     "MealValueInsightsStatusResponse",
     "MealStatusEnum",
+    "ServingOptionResponse",
     # TDEE
     "TdeeCalculationResponse",
     "BatchTdeeCalculationResponse",

--- a/src/api/schemas/response/barcode_product_response.py
+++ b/src/api/schemas/response/barcode_product_response.py
@@ -6,9 +6,6 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from src.api.schemas.response.meal_responses import ServingUnitResponse
-
-
 class BarcodeProductResponse(BaseModel):
     """Response DTO for barcode product lookup."""
 
@@ -45,9 +42,8 @@ class BarcodeProductResponse(BaseModel):
     is_estimate: bool = Field(
         False, description="True when macros are AI-estimated, user should verify"
     )
-    allowed_units: list[ServingUnitResponse] = Field(
-        default_factory=list,
-        description="Food-specific serving conversion options",
+    serving_options: list[dict] = Field(
+        default_factory=list, description="Provider-specific serving choices"
     )
 
     model_config = {"from_attributes": True}

--- a/src/api/schemas/response/meal_responses.py
+++ b/src/api/schemas/response/meal_responses.py
@@ -35,22 +35,18 @@ class ValueInsightCategoryEnum(StrEnum):
 # Translation Response DTOs
 
 
-class ServingUnitResponse(BaseModel):
-    """Food-specific serving conversion option."""
+class ServingOptionResponse(BaseModel):
+    """Provider-specific serving conversion option."""
 
-    unit: str = Field(..., description="Unit token used for save/edit requests")
+    unit: str = Field(..., description="Unit token used for display and selection")
     gram_weight: float = Field(..., gt=0, description="Gram weight for one unit")
-    description: str = Field(
-        "", description="English FatSecret serving description for quantity math"
-    )
+    description: str = Field("", description="Provider serving description")
     display_description: str | None = Field(
-        None,
-        description="Localized exact serving label; unit stays English",
+        None, description="Localized serving label when available"
     )
 
     @model_serializer
     def serialize_without_empty_label(self) -> dict[str, object]:
-        """Keep legacy response shape when no localized label exists."""
         response: dict[str, object] = {
             "unit": self.unit,
             "gram_weight": self.gram_weight,
@@ -77,10 +73,6 @@ class ParsedFoodItem(BaseModel):
         None, description="Data source: usda, fatsecret, or ai_estimate"
     )
     fdc_id: int | None = Field(None, description="USDA FDC ID when available")
-    allowed_units: list[ServingUnitResponse] = Field(
-        default_factory=list,
-        description="Allowed unit options for this food item",
-    )
     food_id: str | None = Field(None, description="Namespaced source food identity")
     food_reference_id: int | None = Field(
         None, description="Canonical local food-reference id"
@@ -115,6 +107,9 @@ class ParsedFoodItem(BaseModel):
     )
     source_snapshot: dict | None = Field(
         None, description="Validated nutrition snapshot for the confirmed item"
+    )
+    serving_options: list[ServingOptionResponse] = Field(
+        default_factory=list, description="Provider-specific serving choices"
     )
 
 
@@ -313,9 +308,8 @@ class FoodItemResponse(BaseModel):
     source_snapshot: dict | None = Field(
         None, description="Immutable nutrition source snapshot used for this save"
     )
-    allowed_units: list[ServingUnitResponse] = Field(
-        default_factory=list,
-        description="Allowed unit options for this food item",
+    serving_options: list[ServingOptionResponse] = Field(
+        default_factory=list, description="Provider-specific serving choices"
     )
 
 

--- a/src/app/commands/meal/create_manual_meal_command.py
+++ b/src/app/commands/meal/create_manual_meal_command.py
@@ -30,7 +30,7 @@ class ManualMealItem:
     quantity: float = 1.0  # in grams or unit-specified grams base
     unit: str = "g"  # unit name, e.g., "g"
     custom_nutrition: Optional[CustomNutrition] = None
-    allowed_units: Optional[List[dict[str, Any]]] = None
+    serving_options: Optional[List[dict[str, Any]]] = None
     origin: Optional[str] = None
     food_reference_id: Optional[int] = None
     source_namespace: Optional[str] = None

--- a/src/app/handlers/command_handlers/edit_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/edit_meal_command_handler.py
@@ -29,10 +29,6 @@ from src.domain.ports.provider_budget_port import ProviderBudgetPort
 from src.domain.services.meal_type_determination_service import (
     determine_meal_type_from_timestamp,
 )
-from src.domain.services.nutrition_calculation_service import (
-    authoritative_units_match,
-    canonicalize_authoritative_quantity,
-)
 from src.domain.utils.timezone_utils import utc_now
 
 logger = logging.getLogger(__name__)
@@ -518,7 +514,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                         if change.custom_nutrition
                         else None
                     ),
-                    allowed_units=change.allowed_units,
                     origin=change.origin,
                     food_reference_id=change.food_reference_id,
                     source_namespace=change.source_namespace,
@@ -541,7 +536,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                         custom_nutrition=self._to_domain_custom_nutrition(
                             authoritative.custom_nutrition
                         ),
-                        allowed_units=authoritative.allowed_units,
                         food_reference_id=authoritative.food_reference_id,
                         source_namespace=authoritative.source_namespace,
                         source_food_id=authoritative.source_food_id,
@@ -557,7 +551,7 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 continue
 
             existing = current_by_id[change.id]
-            prepared.append(self._canonicalize_snapshot_unit(existing, change))
+            prepared.append(change)
         if revalidate_local:
             await self.nutrition_resolver.revalidate_local_items(
                 resolved_items, uow.food_references
@@ -591,39 +585,6 @@ class EditMealCommandHandler(EventHandler[EditMealCommand, dict[str, Any]]):
                 error_code="MEAL_WRITE_CONFLICT",
             )
         return locked_meal
-
-    @staticmethod
-    def _canonicalize_snapshot_unit(existing_item, change):
-        unit = change.unit
-        if unit is None:
-            return change
-        existing_unit = existing_item.unit or "g"
-        if authoritative_units_match(unit, existing_unit):
-            if unit.strip() != existing_unit:
-                return replace(change, unit=existing_unit)
-            return change
-        snapshot = existing_item.source_snapshot or {}
-        allowed_units = snapshot.get("allowed_units") or existing_item.allowed_units or []
-        if not allowed_units:
-            raise ValueError("v2 quantity updates require an immutable source snapshot")
-        quantity = (
-            change.quantity if change.quantity is not None else existing_item.quantity
-        )
-        canonical_quantity, canonical_unit, used_fallback = (
-            canonicalize_authoritative_quantity(
-                quantity,
-                unit,
-                allowed_units,
-                existing_item.name,
-            )
-        )
-        if used_fallback:
-            return replace(
-                change,
-                quantity=canonical_quantity,
-                unit=canonical_unit,
-            )
-        return change
 
     @staticmethod
     def _to_manual_custom_nutrition(value):

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -45,12 +45,10 @@ from src.domain.services.emoji_validator import validate_emoji
 from src.domain.services.nutrition_calculation_service import (
     MASS_VOLUME_CANONICAL_UNITS,
     UNIT_TO_GRAMS,
-    _convert_with_allowed_units,
     _normalize_unit,
     canonicalize_mass_volume_unit,
     clamp_nutrition_values,
     convert_quantity_to_grams,
-    fallback_custom_serving_options,
     normalize_unit_for_manual_save,
     scale_per_100g_nutrition,
 )
@@ -284,11 +282,7 @@ class ParseMealTextHandler(
                 sugar=item.get("sugar", 0),
                 data_source=item.get("data_source"),
                 fdc_id=item.get("fdc_id"),
-                allowed_units=item.get("allowed_units")
-                or fallback_custom_serving_options(
-                    item.get("unit") or "serving",
-                    item.get("name") or "",
-                ),
+                serving_options=item.get("serving_options") or [],
                 food_id=item.get("food_id"),
                 food_reference_id=item.get("food_reference_id"),
                 origin=item.get("origin"),
@@ -358,10 +352,10 @@ class ParseMealTextHandler(
             "fiber_per_100g": item["fiber_per_100g"],
             "sugar_per_100g": item["sugar_per_100g"],
             "calories_per_100g": item["calories_per_100g"],
-            "allowed_units": item.get("allowed_units") or [],
             "origin": item.get("origin"),
             "source_namespace": item.get("source_namespace"),
             "source_food_id": item.get("source_food_id"),
+            "serving_options": item.get("serving_options") or [],
         }
         canonical_name = item.get("canonical_name")
         if isinstance(canonical_name, str) and canonical_name.strip():
@@ -721,12 +715,11 @@ class ParseMealTextHandler(
         )
         if not per_100g:
             return None
-        allowed_units = self._safe_allowed_units(selected.get("allowed_units"))
-        quantity_g = self._canonicalize_reference_quantity(
-            item,
-            quantity_g=self._quantity_in_grams(item, lookup_name),
-            allowed_units=allowed_units,
-        )
+        serving_options = normalize_serving_options(
+            selected.get("serving_options") or selected.get("serving_sizes"),
+            provider_100g_label=True,
+        ) or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
+        quantity_g = self._quantity_in_grams(item, lookup_name)
         scaled = scale_per_100g_nutrition(
             {
                 "calories": per_100g.get("calories_100g", per_100g.get("calories", 0)),
@@ -738,9 +731,8 @@ class ParseMealTextHandler(
             },
             item["quantity"],
             item["unit"],
-            allowed_units=allowed_units,
+            serving_options=serving_options,
             food_name=lookup_name,
-            strict_allowed_units=True,
         )
         if not validate_ai_fallback(
             name=lookup_name,
@@ -753,9 +745,9 @@ class ParseMealTextHandler(
             return None
         item.update(scaled)
         item["calories"] = self._derive_calories_from_macros(item)
-        item["allowed_units"] = allowed_units
         item["data_source"] = "fatsecret"
         item.update(self._reference_identity(selected, "fatsecret"))
+        item["serving_options"] = serving_options
         catalog_name = str(
             selected.get("food_name")
             or selected.get("description")
@@ -872,7 +864,6 @@ class ParseMealTextHandler(
                 "fiber_100g": item.get("fiber_per_100g") or 0.0,
                 "sugar_100g": item.get("sugar_per_100g") or 0.0,
             }
-            servings = item.get("allowed_units") or None
             try:
                 async with self._uow_factory() as uow:
                     adopted = await uow.food_references.adopt_provider_food(
@@ -880,7 +871,7 @@ class ParseMealTextHandler(
                         str(source_food_id),
                         english_name,
                         per_100g,
-                        servings,
+                        None,
                         command.language,
                         locale_name,
                     )
@@ -909,16 +900,6 @@ class ParseMealTextHandler(
         source: str,
         raw: dict[str, Any],
     ) -> dict[str, Any]:
-        allowed_units = self._safe_allowed_units(
-            raw.get("allowed_units") or raw.get("serving_sizes")
-        )
-        if not allowed_units:
-            allowed_units = list(candidate.allowed_units or [])
-        quantity_g = self._canonicalize_reference_quantity(
-            item,
-            quantity_g=quantity_g,
-            allowed_units=allowed_units,
-        )
         factor = quantity_g / 100.0
         item.update(
             {
@@ -962,40 +943,11 @@ class ParseMealTextHandler(
         item["fat_per_100g"] = candidate.fat_per_100g
         item["fiber_per_100g"] = candidate.fiber_per_100g
         item["sugar_per_100g"] = candidate.sugar_per_100g
-        item["allowed_units"] = allowed_units
+        item["serving_options"] = normalize_serving_options(
+            raw.get("serving_options") or raw.get("serving_sizes"),
+            provider_100g_label=source == "fatsecret",
+        ) or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
         return item
-
-    @staticmethod
-    def _canonicalize_reference_quantity(
-        item: dict[str, Any],
-        *,
-        quantity_g: float,
-        allowed_units: list[dict[str, Any]],
-    ) -> float:
-        """Keep parsed portions saveable against the same source snapshot."""
-        quantity = float(item.get("quantity") or 1.0)
-        source_unit = canonicalize_mass_volume_unit(
-            str(item.get("english_unit") or item.get("unit") or "g")
-        )
-        try:
-            authoritative_grams = _convert_with_allowed_units(
-                quantity,
-                source_unit,
-                allowed_units,
-                str(item.get("lookup_name") or item.get("name") or ""),
-                strict=True,
-            )
-        except ValueError:
-            item["quantity"] = quantity_g
-            item["unit"] = "g"
-            item["english_unit"] = "g"
-            item["quantity_g"] = quantity_g
-            return quantity_g
-
-        item["unit"] = source_unit
-        item["english_unit"] = source_unit
-        item["quantity_g"] = authoritative_grams
-        return authoritative_grams
 
     @staticmethod
     def _reference_identity(raw: dict[str, Any], source: str) -> dict[str, Any]:
@@ -1039,39 +991,6 @@ class ParseMealTextHandler(
             "source_food_id": source_id,
         }
 
-    @staticmethod
-    def _safe_allowed_units(raw: Any) -> list[dict[str, Any]]:
-        if not isinstance(raw, list):
-            return []
-        units: list[dict[str, Any]] = []
-        for entry in raw[:12]:
-            if not isinstance(entry, dict):
-                continue
-            unit = str(entry.get("unit") or entry.get("name") or "").strip()
-            description = str(entry.get("description") or "").strip()
-            raw_gram_weight = entry.get("gram_weight") or entry.get("grams")
-            if raw_gram_weight is None:
-                continue
-            try:
-                gram_weight = float(raw_gram_weight)
-            except (TypeError, ValueError):
-                continue
-            if (
-                not unit
-                or len(unit) > 100
-                or len(description) > 100
-                or not gram_weight > 0
-                or not all(ord(char) >= 32 for char in unit + description)
-            ):
-                continue
-            units.append(
-                {
-                    "unit": unit,
-                    "gram_weight": gram_weight,
-                    "description": description,
-                }
-            )
-        return normalize_serving_options(units, provider_100g_label=True) or []
 
     async def _localize_english_display_names(
         self, items: list[dict[str, Any]], language: str

--- a/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
+++ b/src/app/handlers/query_handlers/lookup_barcode_query_handler.py
@@ -607,7 +607,7 @@ class LookupBarcodeQueryHandler(
     async def _localize_result_servings(
         self, result: dict[str, Any], language: str
     ) -> dict[str, Any]:
-        if not result.get("allowed_units"):
+        if not result.get("serving_options"):
             return result
         batch = [dict(result)]
         await localize_item_servings(

--- a/src/app/handlers/query_handlers/search_foods_query_handler.py
+++ b/src/app/handlers/query_handlers/search_foods_query_handler.py
@@ -105,7 +105,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
                 )
                 or any(
                     leftover_serving_phrases(
-                        item.get("allowed_units") or [], language
+                        item.get("serving_options") or [], language
                     )
                     for item in processed_cached
                 )
@@ -178,7 +178,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
                 persist=not event.autocomplete,
             )
             leftover_units = any(
-                leftover_serving_phrases(item.get("allowed_units") or [], language)
+                leftover_serving_phrases(item.get("serving_options") or [], language)
                 for item in processed_raw
             )
             if cacheable and not leftover_units:
@@ -248,7 +248,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
                             "fiber_100g": item.get("fiber_100g") or 0,
                             "sugar_100g": item.get("sugar_100g") or 0,
                         },
-                        item.get("allowed_units"),
+                        item.get("serving_options"),
                         locale,
                         display_name,
                     )
@@ -391,7 +391,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
             "provider_source": item.source,
             "is_verified": item.is_verified,
             "serving_description": item.serving_size,
-            "allowed_units": item.allowed_units,
+            "serving_options": item.serving_options,
             "protein_100g": item.protein_100g,
             "carbs_100g": item.carbs_100g,
             "fat_100g": item.fat_100g,

--- a/src/app/schemas/meal_schemas.py
+++ b/src/app/schemas/meal_schemas.py
@@ -21,7 +21,6 @@ class ParsedFoodItemDto:
     sugar: float = 0.0
     data_source: str | None = None
     fdc_id: int | None = None
-    allowed_units: list[dict[str, Any]] | None = None
     food_id: str | None = None
     food_reference_id: int | None = None
     origin: str | None = None
@@ -37,6 +36,7 @@ class ParsedFoodItemDto:
     sugar_per_100g: float | None = None
     canonical_name: str | None = None
     source_snapshot: dict[str, Any] | None = None
+    serving_options: list[dict[str, Any]] | None = None
 
 
 @dataclass

--- a/src/app/services/food_reference_validation_service.py
+++ b/src/app/services/food_reference_validation_service.py
@@ -148,8 +148,6 @@ class FoodReferenceValidationService:
         if not self._is_macro_close(item, reference):
             return False
 
-        if integrity.serving_options:
-            item.allowed_units = list(integrity.serving_options)
         return True
 
     def _is_macro_close(self, item: Any, reference: dict[str, Any]) -> bool:

--- a/src/app/services/manual_meal_nutrition_resolver.py
+++ b/src/app/services/manual_meal_nutrition_resolver.py
@@ -12,10 +12,6 @@ from src.app.commands.meal.create_manual_meal_command import (
     ManualMealItem,
 )
 from src.domain.ports.provider_budget_port import ProviderBudgetPort
-from src.domain.services.nutrition_calculation_service import (
-    canonicalize_authoritative_quantity,
-    fallback_custom_serving_options,
-)
 from src.domain.services.nutrition_integrity_policy import (
     NutritionIntegrityError,
     NutritionIntegrityPolicy,
@@ -103,7 +99,6 @@ class ManualMealNutritionResolver:
                     )
                 else:
                     raise ValueError("v2 item origin is required")
-                resolved_item = self._canonicalize_unmatched_unit(resolved_item)
                 resolved.append(resolved_item)
             except Exception as exc:
                 result = getattr(exc, "result", None)
@@ -120,23 +115,6 @@ class ManualMealNutritionResolver:
                 attributes={"origin": item.origin or "unknown"},
             )
         return resolved
-
-    @staticmethod
-    def _canonicalize_unmatched_unit(item: ManualMealItem) -> ManualMealItem:
-        """Keep valid source units; convert any other request unit to grams."""
-        quantity, unit, used_fallback = canonicalize_authoritative_quantity(
-            item.quantity,
-            item.unit,
-            item.allowed_units or [],
-            item.name or "Food Item",
-        )
-        if used_fallback:
-            increment_metric(
-                "manual_nutrition_resolution.unit_fallback",
-                attributes={"origin": item.origin or "unknown"},
-            )
-            return replace(item, quantity=quantity, unit=unit)
-        return item
 
     async def revalidate_local_items(self, items, food_references) -> None:
         """Lock local references and reject a snapshot changed mid-write."""
@@ -207,15 +185,12 @@ class ManualMealNutritionResolver:
                 "fat_100g": item.custom_nutrition.fat_per_100g,
                 "fiber_100g": item.custom_nutrition.fiber_per_100g,
                 "sugar_100g": item.custom_nutrition.sugar_per_100g,
+                "serving_options": item.serving_options,
             },
             require_energy=False,
             require_metric_basis=False,
         )
-        allowed_units = fallback_custom_serving_options(
-            item.unit,
-            item.name or "",
-            item.allowed_units,
-        )
+        serving_options = list(result.serving_options)
         return replace(
             item,
             custom_nutrition=CustomNutrition(
@@ -226,11 +201,11 @@ class ManualMealNutritionResolver:
                 fiber_per_100g=result.fiber_100g or 0.0,
                 sugar_per_100g=result.sugar_100g or 0.0,
             ),
-            allowed_units=allowed_units,
+            serving_options=serving_options,
             source_kind="custom",
             nutrition_contract_version="2",
             source_snapshot=self._snapshot(
-                result, "custom", None, None, allowed_units
+                result, "custom", None, None, serving_options
             ),
         )
 
@@ -243,7 +218,7 @@ class ManualMealNutritionResolver:
             )
         if not getattr(reference, "is_verified", False):
             raise NutritionIntegrityError(self.policy.rejection("unverified_reference"))
-        allowed_units = self._reference_units(reference)
+        serving_options = self._reference_serving_options(reference)
         result = self.policy.require_valid(
             {
                 "protein_100g": reference.protein_100g,
@@ -251,11 +226,12 @@ class ManualMealNutritionResolver:
                 "fat_100g": reference.fat_100g,
                 "fiber_100g": reference.fiber_100g,
                 "sugar_100g": reference.sugar_100g,
-                "allowed_units": allowed_units,
+                "serving_options": serving_options,
             },
             require_energy=False,
             require_metric_basis=False,
         )
+        serving_options = list(result.serving_options)
         source_id = str(getattr(reference, "source_food_id", None) or reference.id)
         source_namespace = (
             item.source_namespace
@@ -266,7 +242,7 @@ class ManualMealNutritionResolver:
             item,
             name=reference.name,
             custom_nutrition=self._custom_from_result(result),
-            allowed_units=allowed_units,
+            serving_options=serving_options,
             food_reference_id=reference.id,
             source_kind=origin,
             source_food_id=source_id,
@@ -276,7 +252,7 @@ class ManualMealNutritionResolver:
                 origin,
                 source_namespace,
                 source_id,
-                allowed_units,
+                serving_options,
                 canonical_name=reference.name,
             ),
         )
@@ -288,8 +264,8 @@ class ManualMealNutritionResolver:
             raise NutritionIntegrityError(
                 self.policy.rejection("reference_identity_mismatch")
             )
-        allowed_units = normalize_serving_options(
-            reference.get("allowed_units") or reference.get("serving_sizes"),
+        serving_options = normalize_serving_options(
+            reference.get("serving_options") or reference.get("serving_sizes"),
             provider_100g_label=origin != "local",
         ) or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
         result = self.policy.require_valid(
@@ -300,18 +276,19 @@ class ManualMealNutritionResolver:
                 "fiber_100g": reference.get("fiber_100g", 0),
                 "sugar_100g": reference.get("sugar_100g", 0),
                 "calories_100g": reference.get("calories_100g"),
-                "allowed_units": allowed_units,
+                "serving_options": serving_options,
             },
             require_energy=False,
             require_metric_basis=False,
         )
+        serving_options = list(result.serving_options)
         source_id = str(item.fdc_id)
         canonical_name = reference.get("name") or reference.get("description")
         return replace(
             item,
             name=canonical_name or item.name,
             custom_nutrition=self._custom_from_result(result),
-            allowed_units=allowed_units,
+            serving_options=serving_options,
             source_kind=origin,
             source_food_id=source_id,
             nutrition_contract_version="2",
@@ -320,7 +297,7 @@ class ManualMealNutritionResolver:
                 origin,
                 "usda_fdc",
                 source_id,
-                allowed_units,
+                serving_options,
                 canonical_name=canonical_name,
             ),
         )
@@ -353,8 +330,8 @@ class ManualMealNutritionResolver:
             raise NutritionIntegrityError(
                 self.policy.rejection("provider_identity_mismatch")
             )
-        allowed_units = normalize_serving_options(
-            details.get("allowed_units") or details.get("serving_sizes"),
+        serving_options = normalize_serving_options(
+            details.get("serving_options") or details.get("serving_sizes"),
             provider_100g_label=True,
         ) or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
         result = self.policy.require_valid(
@@ -365,7 +342,7 @@ class ManualMealNutritionResolver:
                 "fiber_100g": details.get("fiber_100g", 0),
                 "sugar_100g": details.get("sugar_100g", 0),
                 "calories_100g": details.get("calories_100g"),
-                "allowed_units": allowed_units,
+                "serving_options": serving_options,
             },
             require_energy=False,
             require_metric_basis=False,
@@ -374,16 +351,16 @@ class ManualMealNutritionResolver:
         english_name = str(
             details.get("food_name") or details.get("name") or item.name or "Food Item"
         ).strip()
-        food_reference_id, result, allowed_units, english_name = (
+        food_reference_id, result, serving_options, english_name = (
             await self._adopt_provider_identity(
-                namespace, source_id, english_name, result, allowed_units
+                namespace, source_id, english_name, result, serving_options
             )
         )
         return replace(
             item,
             name=english_name,
             custom_nutrition=self._custom_from_result(result),
-            allowed_units=allowed_units,
+            serving_options=serving_options,
             food_reference_id=food_reference_id,
             source_kind="provider",
             nutrition_contract_version="2",
@@ -392,7 +369,7 @@ class ManualMealNutritionResolver:
                 "provider",
                 namespace,
                 source_id,
-                allowed_units,
+                serving_options,
                 canonical_name=english_name,
             ),
         )
@@ -403,7 +380,7 @@ class ManualMealNutritionResolver:
         source_id: str,
         english_name: str,
         result: Any,
-        allowed_units: list[dict[str, Any]],
+        serving_options: list[dict[str, Any]],
     ) -> tuple[int | None, Any, list[dict[str, Any]], str]:
         """Materialize a provider identity into the catalog before save.
 
@@ -414,7 +391,7 @@ class ManualMealNutritionResolver:
         to the freshly fetched provider density rather than blocking save.
         """
         if self.uow_factory is None:
-            return None, result, allowed_units, english_name
+            return None, result, serving_options, english_name
         per_100g = {
             "protein_100g": result.protein_100g,
             "carbs_100g": result.carbs_100g,
@@ -429,7 +406,7 @@ class ManualMealNutritionResolver:
                     source_id,
                     english_name,
                     per_100g,
-                    allowed_units,
+                    serving_options,
                     "en",
                     "",
                 )
@@ -440,10 +417,13 @@ class ManualMealNutritionResolver:
                 source_id,
                 exc_info=True,
             )
-            return None, result, allowed_units, english_name
+            return None, result, serving_options, english_name
         if not isinstance(adopted, dict) or adopted.get("id") is None:
-            return None, result, allowed_units, english_name
-        adopted_units = adopted.get("allowed_units") or allowed_units
+            return None, result, serving_options, english_name
+        adopted_options = normalize_serving_options(
+            adopted.get("serving_options") or serving_options,
+            provider_100g_label=True,
+        ) or serving_options
         adopted_result = self.policy.require_valid(
             {
                 "protein_100g": adopted.get("protein_100g"),
@@ -451,14 +431,19 @@ class ManualMealNutritionResolver:
                 "fat_100g": adopted.get("fat_100g"),
                 "fiber_100g": adopted.get("fiber_100g", 0),
                 "sugar_100g": adopted.get("sugar_100g", 0),
-                "allowed_units": adopted_units,
+                "serving_options": adopted_options,
             },
             require_energy=False,
             require_metric_basis=False,
             provider_100g_label=True,
         )
         adopted_name = str(adopted.get("name") or "").strip() or english_name
-        return adopted.get("id"), adopted_result, adopted_units, adopted_name
+        return (
+            adopted.get("id"),
+            adopted_result,
+            list(adopted_result.serving_options),
+            adopted_name,
+        )
 
     async def _get_provider_details(
         self, source_id: str, *, namespace: str, deadline: float | None
@@ -503,7 +488,7 @@ class ManualMealNutritionResolver:
             return await provider.get_food_details(source_id)
 
     @staticmethod
-    def _reference_units(reference) -> list[dict[str, Any]]:
+    def _reference_serving_options(reference) -> list[dict[str, Any]]:
         raw = []
         for serving in getattr(reference, "servings", []) or []:
             grams = getattr(serving, "grams", None)
@@ -557,14 +542,18 @@ class ManualMealNutritionResolver:
                 "fiber_per_100g": nutrition.fiber_per_100g,
                 "sugar_per_100g": nutrition.sugar_per_100g,
                 "calories_per_100g": nutrition.calories_per_100g,
-                "allowed_units": item.allowed_units
-                or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+                "serving_options": item.serving_options or [],
             },
         )
 
     @staticmethod
     def _snapshot(
-        result, origin, namespace, source_id, allowed_units=None, canonical_name=None
+        result,
+        origin,
+        namespace,
+        source_id,
+        serving_options=None,
+        canonical_name=None,
     ):
         snapshot = {
             "origin": origin,
@@ -577,8 +566,7 @@ class ManualMealNutritionResolver:
             "fiber_per_100g": result.fiber_100g,
             "sugar_per_100g": result.sugar_100g,
             "calories_per_100g": result.derived_calories_100g,
-            "allowed_units": allowed_units
-            or [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            "serving_options": list(serving_options or result.serving_options),
         }
         clean_name = str(canonical_name or "").strip()
         if clean_name:

--- a/src/app/services/meal_serving_label_enricher.py
+++ b/src/app/services/meal_serving_label_enricher.py
@@ -45,7 +45,7 @@ async def enrich_meal_serving_labels(
         bucket = projections.setdefault(int(reference_id), {"serving_labels": {}})
         bucket["serving_labels"] = merge_serving_labels(
             bucket.get("serving_labels") or {},
-            payload.get("allowed_units") or [],
+            payload.get("serving_options") or [],
         )
     return projections
 
@@ -59,7 +59,7 @@ def _meal_serving_payloads(
         reference_id = getattr(item, "food_reference_id", None)
         labels = (projections.get(reference_id) or {}).get("serving_labels") or {}
         options = overlay_serving_labels(
-            getattr(item, "allowed_units", None) or [],
+            getattr(item, "serving_options", None) or [],
             labels,
             language=language,
         )
@@ -69,7 +69,7 @@ def _meal_serving_payloads(
             payloads.append(
                 {
                     "food_reference_id": reference_id,
-                    "allowed_units": options,
+                    "serving_options": options,
                 }
             )
     return payloads

--- a/src/app/services/parse_text_custom_estimate.py
+++ b/src/app/services/parse_text_custom_estimate.py
@@ -10,27 +10,13 @@ from src.domain.services.nutrition_calculation_service import (
     canonicalize_mass_volume_unit,
     convert_quantity_to_grams,
 )
-from src.domain.services.nutrition_integrity_policy import (
-    NUTRITION_INTEGRITY_POLICY_VERSION,
-    normalize_serving_options,
-)
+from src.domain.services.nutrition_integrity_policy import NUTRITION_INTEGRITY_POLICY_VERSION
 from src.domain.services.nutrition_resolver import validate_ai_fallback
 
 CUSTOM_COUNT_GRAMS = 100.0
 CUSTOM_KG_THRESHOLD_G = 1000.0
 _MASS_UNITS = {"g", "gram", "grams", "kg", "kilogram", "kilograms"}
 _VOLUME_UNITS = {"ml", "l", "liter", "litre"}
-CUSTOM_ALLOWED_UNITS = normalize_serving_options(
-    [
-        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-        {"unit": "kg", "gram_weight": 1000.0, "description": "1 kg"},
-    ]
-) or [
-    {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-    {"unit": "kg", "gram_weight": 1000.0, "description": "1 kg"},
-]
-
-
 def apply_custom_estimate(item: dict[str, Any]) -> dict[str, Any] | None:
     """Keep AI portion macros as a custom estimate, stored in grams or kilograms.
 
@@ -72,7 +58,6 @@ def apply_custom_estimate(item: dict[str, Any]) -> dict[str, Any] | None:
     item["source_namespace"] = None
     item["source_food_id"] = None
     item["fdc_id"] = None
-    item["allowed_units"] = [dict(option) for option in CUSTOM_ALLOWED_UNITS]
     item["nutrition_basis"] = "100g"
     item["nutrition_contract_version"] = NUTRITION_INTEGRITY_POLICY_VERSION
     return item

--- a/src/app/services/serving_label_localizer.py
+++ b/src/app/services/serving_label_localizer.py
@@ -70,7 +70,7 @@ async def localize_item_servings(
     uow_factory: Any | None = None,
     persist: bool = False,
 ) -> dict[str, str]:
-    """Localize each item's ``allowed_units`` and optionally persist labels.
+    """Localize each item's ``serving_options`` and optionally persist labels.
 
     Returns newly cacheable phrase translations (English source → label).
     """
@@ -82,10 +82,10 @@ async def localize_item_servings(
     leftovers: list[str] = []
     seen: set[str] = set()
     for item in items:
-        options = _empty_units(item.get("allowed_units"))
+        options = _empty_units(item.get("serving_options"))
         canonical.update(canonical_serving_labels(options, normalized))
-        item["allowed_units"] = apply_serving_labels(options, cached, normalized)
-        for phrase in leftover_serving_phrases(item["allowed_units"], normalized):
+        item["serving_options"] = apply_serving_labels(options, cached, normalized)
+        for phrase in leftover_serving_phrases(item["serving_options"], normalized):
             key = serving_phrase_key(phrase)
             if key not in seen:
                 seen.add(key)
@@ -97,8 +97,8 @@ async def localize_item_servings(
     if not resolved:
         return {}
     for item in items:
-        item["allowed_units"] = apply_serving_labels(
-            _empty_units(item.get("allowed_units")),
+        item["serving_options"] = apply_serving_labels(
+            _empty_units(item.get("serving_options")),
             resolved,
             normalized,
         )
@@ -138,7 +138,7 @@ async def _load_phrase_cache(
     phrases: list[str] = []
     for item in items:
         phrases.extend(
-            leftover_serving_phrases(_empty_units(item.get("allowed_units")), language)
+            leftover_serving_phrases(_empty_units(item.get("serving_options")), language)
         )
     if not phrases or uow_factory is None:
         return {}
@@ -166,7 +166,7 @@ async def _persist_labels(
             serving_phrase_key(source): label
             for source, label in labels_by_source.items()
         }
-        for option in _empty_units(item.get("allowed_units")):
+        for option in _empty_units(item.get("serving_options")):
             source = str(option.get("unit") or "").strip()
             label = labels_by_source.get(source) or keyed.get(
                 serving_phrase_key(source)

--- a/src/domain/model/meal/food_item_change.py
+++ b/src/domain/model/meal/food_item_change.py
@@ -21,7 +21,7 @@ class FoodItemChange:
     nutrition_override: Optional["NutritionOverride"] = None
     clear_nutrition_override: bool = False
     override_intent: Optional[str] = None
-    allowed_units: Optional[list[dict[str, Any]]] = None
+    serving_options: Optional[list[dict[str, Any]]] = None
     origin: Optional[str] = None
     food_reference_id: Optional[int] = None
     source_namespace: Optional[str] = None

--- a/src/domain/model/nutrition/nutrition.py
+++ b/src/domain/model/nutrition/nutrition.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Any
-
 from .macros import Macros
 from .micros import Micros
 
@@ -39,7 +38,7 @@ class FoodItem:
     fdc_id: int | None = None  # USDA FDC ID if available
     food_reference_id: int | None = None
     is_custom: bool = False  # Whether this is a custom ingredient
-    allowed_units: list[dict[str, Any]] | None = None
+    serving_options: list[dict[str, Any]] | None = None
     nutrition_override: NutritionOverride | None = None
     source_kind: str | None = None
     source_food_id: str | None = None
@@ -102,8 +101,6 @@ class FoodItem:
             result["fdc_id"] = self.fdc_id
         if self.food_reference_id:
             result["food_reference_id"] = self.food_reference_id
-        if self.allowed_units:
-            result["allowed_units"] = self.allowed_units
         if self.nutrition_override:
             result["nutrition_override"] = self.nutrition_override.to_dict()
         if self.source_kind:
@@ -114,6 +111,8 @@ class FoodItem:
             result["nutrition_contract_version"] = self.nutrition_contract_version
         if self.source_snapshot:
             result["source_snapshot"] = self.source_snapshot
+        if self.serving_options:
+            result["serving_options"] = self.serving_options
         return result
 
 

--- a/src/domain/parsers/vision_response_parser.py
+++ b/src/domain/parsers/vision_response_parser.py
@@ -104,22 +104,6 @@ class VisionResponseParser:
                 micros=None,
                 confidence=min(max(0.0, float(canonical.confidence)), 1.0),
                 is_custom=True,
-                allowed_units=[
-                    {
-                        "unit": "serving",
-                        "gram_weight": float(canonical.serving_size.grams),
-                        "description": (
-                            f"1 serving ({canonical.serving_size.display_text})"
-                        ),
-                    },
-                    {
-                        "unit": "package",
-                        "gram_weight": float(canonical.serving_size.grams)
-                        * float(canonical.servings_per_package),
-                        "description": "1 package",
-                    },
-                    {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-                ],
             )
             return Nutrition(
                 macros=macros,
@@ -223,9 +207,6 @@ class VisionResponseParser:
                     macros=macros,
                     micros=None,
                     confidence=min(max(0.0, float(food_data.confidence)), 1.0),
-                    allowed_units=[
-                        {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
-                    ],
                 )
             )
 

--- a/src/domain/ports/food_reference_repository_port.py
+++ b/src/domain/ports/food_reference_repository_port.py
@@ -50,7 +50,7 @@ class FoodReferenceSearchProjection:
     fiber_100g: float = 0.0
     sugar_100g: float = 0.0
     serving_size: str | None = None
-    allowed_units: list[dict] = field(default_factory=list)
+    serving_options: list[dict] = field(default_factory=list)
     source_namespace: str | None = None
     source_food_id: str | None = None
     name_vi: str | None = None

--- a/src/domain/services/food_mapping_service.py
+++ b/src/domain/services/food_mapping_service.py
@@ -42,7 +42,7 @@ FALLBACK_UNIT_CATEGORIES = {
     ],
 }
 
-DEFAULT_ALLOWED_UNITS = [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
+DEFAULT_SERVING_OPTIONS = [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
 
 
 def _namespaced_id(namespace: Any, source_id: Any) -> str:
@@ -139,7 +139,7 @@ class FoodMappingService(FoodMappingServicePort):
                 "source": "food_reference",
                 "provider_source": item.get("provider_source"),
                 "is_verified": item.get("is_verified"),
-                "allowed_units": list(result.serving_options),
+                "serving_options": list(result.serving_options),
                 "custom_nutrition": (
                     {
                         "calories_per_100g": calories,
@@ -188,7 +188,7 @@ class FoodMappingService(FoodMappingServicePort):
                     "sugar": result.sugar_100g,
                 },
                 "source": "fatsecret",
-                "allowed_units": list(result.serving_options),
+                "serving_options": list(result.serving_options),
                 # Include custom nutrition for manual meal creation
                 "custom_nutrition": (
                     {
@@ -224,10 +224,10 @@ class FoodMappingService(FoodMappingServicePort):
                 "fiber": nutrients.get("fiber"),
                 "sugar": nutrients.get("sugar"),
             },
-            "allowed_units": (
+            "serving_options": (
                 self._parse_usda_portions(item.get("foodPortions"))
                 if item.get("foodPortions")
-                else DEFAULT_ALLOWED_UNITS
+                else DEFAULT_SERVING_OPTIONS
             ),
         }
         integrity = self._require_search_integrity(
@@ -238,7 +238,7 @@ class FoodMappingService(FoodMappingServicePort):
                 "fiber_100g": nutrients.get("fiber"),
                 "sugar_100g": nutrients.get("sugar"),
                 "calories_100g": nutrients.get("calories"),
-                "allowed_units": result["allowed_units"],
+                "serving_options": result["serving_options"],
                 "source": item.get("source", "usda"),
                 "fdc_id": item.get("fdcId"),
             },
@@ -246,7 +246,7 @@ class FoodMappingService(FoodMappingServicePort):
             require_origin=True,
         )
         result["calories"] = integrity.derived_calories_100g
-        result["allowed_units"] = list(integrity.serving_options)
+        result["serving_options"] = list(integrity.serving_options)
         result["origin"] = "usda"
         result["source_namespace"] = "usda_fdc"
         result["source_food_id"] = str(item.get("fdcId"))
@@ -261,9 +261,9 @@ class FoodMappingService(FoodMappingServicePort):
     def _parse_usda_portions(
         self, portions: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Parse USDA foodPortions into allowed_units format."""
+        """Parse USDA foodPortions into serving_options format."""
         if not portions:
-            return DEFAULT_ALLOWED_UNITS
+            return DEFAULT_SERVING_OPTIONS
 
         units = []
         for portion in portions:
@@ -282,11 +282,11 @@ class FoodMappingService(FoodMappingServicePort):
                 )
 
         if not units:
-            return DEFAULT_ALLOWED_UNITS
+            return DEFAULT_SERVING_OPTIONS
 
         return (
             normalize_serving_options(units, provider_100g_label=True)
-            or DEFAULT_ALLOWED_UNITS
+            or DEFAULT_SERVING_OPTIONS
         )
 
     def _require_search_integrity(
@@ -384,12 +384,12 @@ class FoodMappingService(FoodMappingServicePort):
             ),
             "is_verified": True,
             "is_estimate": False,
-            "allowed_units": self._barcode_allowed_units(
+            "serving_options": self._barcode_serving_options(
                 item, serving_size, serving_unit
             ),
         }
 
-    def _barcode_allowed_units(
+    def _barcode_serving_options(
         self,
         item: dict[str, Any],
         serving_size: Any,
@@ -398,17 +398,17 @@ class FoodMappingService(FoodMappingServicePort):
         if item.get("foodPortions"):
             return self._parse_usda_portions(item.get("foodPortions"))
         if not serving_size:
-            return DEFAULT_ALLOWED_UNITS
+            return DEFAULT_SERVING_OPTIONS
         try:
             grams = float(serving_size)
         except (TypeError, ValueError):
-            return DEFAULT_ALLOWED_UNITS
+            return DEFAULT_SERVING_OPTIONS
         if grams <= 0 or str(serving_unit or "").lower() not in {
             "g",
             "gram",
             "grams",
         }:
-            return DEFAULT_ALLOWED_UNITS
+            return DEFAULT_SERVING_OPTIONS
         return [
             {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
             {
@@ -433,9 +433,9 @@ class FoodMappingService(FoodMappingServicePort):
                 "fat": macros.get("fat"),
             },
             "portions": details.get("foodPortions") or [],
-            "allowed_units": (
+            "serving_options": (
                 self._parse_usda_portions(details.get("foodPortions"))
                 if details.get("foodPortions")
-                else DEFAULT_ALLOWED_UNITS
+                else DEFAULT_SERVING_OPTIONS
             ),
         }

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -13,10 +13,6 @@ from src.domain.model.nutrition import FoodItem, Macros, Nutrition
 logger = logging.getLogger(__name__)
 
 
-class AuthoritativeUnitMismatchError(ValueError):
-    """The requested unit is absent from a source-controlled serving snapshot."""
-
-
 # Shared unit-to-grams conversion table for common serving units.
 # Used by both parse-text and manual-meal handlers to ensure consistent nutrition.
 UNIT_TO_GRAMS = {
@@ -39,7 +35,7 @@ UNIT_TO_GRAMS = {
 
 # Safety-net translation for when AI ignores the English-unit prompt instruction.
 # Not exhaustive — primary fix is the dual-unit approach (unit + english_unit).
-# Fuzzy matching + smart fallback in _convert_with_allowed_units handles the rest.
+# Unknown units use the safe global fallback in convert_quantity_to_grams.
 UNIT_TRANSLATION = {
     # English long-form weight/volume units
     "gram": "g",
@@ -167,30 +163,10 @@ def _normalize_unit(unit: str) -> str:
     return base
 
 
-def _normalize_authoritative_unit(unit: str) -> str:
-    """Normalize only exact aliases; never discard arbitrary suffix text."""
-    unit_lower = (unit or "g").lower().strip()
-    translated = UNIT_TRANSLATION.get(unit_lower)
-    if translated is not None:
-        return translated
-    if " " not in unit_lower and unit_lower.endswith("s"):
-        singular = unit_lower[:-1]
-        if singular in UNIT_TO_GRAMS:
-            return singular
-    return unit_lower
-
-
-def authoritative_units_match(left: str | None, right: str | None) -> bool:
-    """True when two unit strings are the same after alias translation."""
-    return _normalize_authoritative_unit(left or "g") == _normalize_authoritative_unit(
-        right or "g"
-    )
-
-
 def canonicalize_mass_volume_unit(unit: str | None) -> str:
     """Collapse gram/ounce/liter aliases onto the canonical mass-volume token."""
     raw = (unit or "g").strip() or "g"
-    normalized = _normalize_authoritative_unit(raw)
+    normalized = _normalize_unit(raw)
     if normalized in MASS_VOLUME_CANONICAL_UNITS:
         return normalized
     return raw
@@ -207,36 +183,6 @@ def normalize_unit_for_manual_save(unit: str | None) -> str:
         "returning 'serving' for manual-save compatibility"
     )
     return "serving"
-
-
-def fallback_custom_serving_options(
-    unit: str,
-    food_name: str = "",
-    existing: list[dict[str, Any]] | None = None,
-) -> list[dict[str, Any]]:
-    """Keep a custom/parse-text unit saveable instead of collapsing to grams."""
-    from src.domain.services.nutrition_integrity_policy import normalize_serving_options
-
-    selected = (unit or "g").strip()
-    selected_key = selected.lower()
-    raw = [option for option in (existing or []) if isinstance(option, dict)]
-    has_selected = any(
-        str(option.get("unit") or "").strip().lower() == selected_key for option in raw
-    )
-    if selected_key not in {"", "g"} and not has_selected:
-        grams = convert_quantity_to_grams(1.0, selected, food_name)
-        if grams <= 0 or (grams == 1.0 and selected_key not in {"g", "ml"}):
-            grams = 100.0
-        raw.append(
-            {
-                "unit": selected,
-                "gram_weight": grams,
-                "description": f"1 {selected}",
-            }
-        )
-    return normalize_serving_options(raw) or [
-        {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
-    ]
 
 
 def convert_quantity_to_grams(quantity: float, unit: str, food_name: str = "") -> float:
@@ -258,8 +204,8 @@ def convert_quantity_to_grams(quantity: float, unit: str, food_name: str = "") -
 
     grams_per_unit = UNIT_TO_GRAMS.get(normalized)
     if grams_per_unit is None:
-        logger.warning("Unknown unit used quantity as grams")
-        return quantity
+        logger.warning("Unknown unit used safe 100g fallback")
+        return quantity * 100.0
     return quantity * grams_per_unit
 
 
@@ -267,24 +213,82 @@ def quantity_to_grams(
     quantity: float,
     unit: str,
     food_name: str = "",
-    allowed_units: list[dict[str, Any]] | None = None,
+    serving_options: list[dict] | None = None,
     *,
     strict: bool = False,
 ) -> float:
-    """Convert using food servings first, then the shared unit table."""
-    if allowed_units:
-        try:
-            return _convert_with_allowed_units(
-                quantity,
-                unit,
-                allowed_units,
-                food_name,
-                strict=strict,
-            )
-        except AuthoritativeUnitMismatchError:
-            if strict:
-                raise
+    """Convert quantity and unit using source servings when available."""
+    if serving_options:
+        return _convert_with_serving_options(
+            quantity, unit, serving_options, food_name, strict=strict
+        )
     return convert_quantity_to_grams(quantity, unit, food_name)
+
+
+def _convert_with_serving_options(
+    quantity: float,
+    unit: str,
+    serving_options: list[dict] | None = None,
+    food_name: str = "",
+    *,
+    strict: bool = False,
+) -> float:
+    """Convert using a provider's serving options, then global unit mappings."""
+    normalized = _normalize_unit(unit)
+    if normalized == "g":
+        return quantity
+
+    for option in serving_options or []:
+        option_unit = str(option.get("unit") or "")
+        gram_weight = float(option.get("gram_weight") or 0)
+        if not _units_refer_to_same_serving(option_unit, unit):
+            continue
+        if not _has_trusted_portion_weight(option_unit, gram_weight):
+            continue
+        logger.debug("Matched source serving option for unit=%s", unit)
+        return quantity * gram_weight
+
+    if strict:
+        raise ValueError("unit is not present in the supplied serving options")
+
+    grams = convert_quantity_to_grams(quantity, unit, food_name)
+    if not is_unknown_unit(unit):
+        return grams
+
+    for option in serving_options or []:
+        option_unit = str(option.get("unit") or "")
+        gram_weight = float(option.get("gram_weight") or 0)
+        if _normalize_unit(option_unit) == "g" or not _has_trusted_portion_weight(
+            option_unit, gram_weight
+        ):
+            continue
+        return quantity * gram_weight
+    return grams
+
+
+def is_unknown_unit(unit: str) -> bool:
+    normalized = _normalize_unit(unit)
+    return normalized not in UNIT_TO_GRAMS and normalized not in {
+        "g",
+        "ml",
+        "l",
+        "liter",
+        "litre",
+    }
+
+
+def _has_trusted_portion_weight(unit: str, gram_weight: float) -> bool:
+    return gram_weight > 0 if _normalize_unit(unit) in {"g", "ml"} else gram_weight > 1
+
+
+def _units_refer_to_same_serving(left: str, right: str) -> bool:
+    a = left.strip().lower()
+    b = right.strip().lower()
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    return _normalize_unit(a) == _normalize_unit(b)
 
 
 MAX_KCAL_PER_100G = 900.0
@@ -309,9 +313,9 @@ def scale_per_100g_nutrition(
     quantity: float,
     unit: str,
     base_serving: float = 100.0,
-    allowed_units: list[dict[str, Any]] | None = None,
+    serving_options: list[dict] | None = None,
     food_name: str = "",
-    strict_allowed_units: bool = False,
+    strict_serving_options: bool = False,
 ) -> dict:
     """Scale per-100g nutrition values for a given quantity and unit.
 
@@ -320,23 +324,18 @@ def scale_per_100g_nutrition(
         quantity: The quantity amount
         unit: The unit name (e.g., "cup", "g", "piece")
         base_serving: The base serving size in grams (default 100g)
-        allowed_units: Optional list of allowed ServingUnits for the food
         food_name: Food name for density-aware ml→g conversion
 
     Returns:
         dict with keys: calories, protein, carbs, fat.
     """
-    # Use food-specific allowed_units if available, otherwise fallback to global mapping
-    if allowed_units:
-        quantity_in_grams = _convert_with_allowed_units(
-            quantity,
-            unit,
-            allowed_units,
-            food_name,
-            strict=strict_allowed_units,
-        )
-    else:
-        quantity_in_grams = convert_quantity_to_grams(quantity, unit, food_name)
+    quantity_in_grams = quantity_to_grams(
+        quantity,
+        unit,
+        food_name,
+        serving_options,
+        strict=strict_serving_options,
+    )
 
     factor = (quantity_in_grams / base_serving) if base_serving > 0 else 0.0
     return {
@@ -347,141 +346,6 @@ def scale_per_100g_nutrition(
         "fiber": round(per_100g.get("fiber", 0.0) * factor, 2),
         "sugar": round(per_100g.get("sugar", 0.0) * factor, 2),
     }
-
-
-def _convert_with_allowed_units(
-    quantity: float,
-    unit: str,
-    allowed_units: list[dict[str, Any]],
-    food_name: str = "",
-    *,
-    strict: bool = False,
-) -> float:
-    """Convert quantity to grams using food-specific allowed_units.
-
-    Resolution order:
-    1. Exact match against allowed_units
-    2. Translate unit → re-match allowed_units
-    3. Keyword match (translated unit found in allowed_unit description)
-    4. Global UNIT_TO_GRAMS mapping
-    5. Smart fallback: first non-gram allowed_unit (common serving size)
-    """
-    unit_lower = unit.lower().strip()
-    translated = (
-        _normalize_authoritative_unit(unit) if strict else _normalize_unit(unit)
-    )
-    if translated == "g":
-        return quantity
-
-    for au in allowed_units:
-        au_unit = str(au.get("unit") or "")
-        gram_weight = float(au.get("gram_weight") or 0)
-        if not _units_refer_to_same_serving(au_unit, unit, strict=strict):
-            continue
-        if not _has_trusted_portion_weight(au_unit, gram_weight):
-            continue
-        if au_unit.lower().strip() != unit_lower:
-            logger.info("Unit alias matched an allowed unit")
-        return quantity * gram_weight
-
-    if strict:
-        raise AuthoritativeUnitMismatchError(
-            "unit is not present in the authoritative source snapshot"
-        )
-
-    # Legacy keyword match: check if translated unit appears in description.
-    # Authoritative writes never use free-form description tokens as unit identity.
-    for au in allowed_units:
-        desc = au.get("description", "").lower()
-        gram_weight = float(au.get("gram_weight") or 0)
-        if translated not in desc.split():
-            continue
-        if not _has_trusted_portion_weight(str(au.get("unit") or ""), gram_weight):
-            continue
-        logger.info("Unit keyword matched an allowed-unit description")
-        return quantity * gram_weight
-
-    # Global UNIT_TO_GRAMS mapping for legacy, non-authoritative writes.
-    grams = UNIT_TO_GRAMS.get(translated)
-    if grams is not None:
-        logger.warning(
-            f"Unit '{unit}' not in allowed_units, using global mapping '{translated}'={grams}g"
-        )
-        return quantity * grams
-
-    # Smart fallback: use first non-gram serving (common portion) instead of raw grams
-    for au in allowed_units:
-        au_unit = au.get("unit", "").lower()
-        gram_weight = float(au.get("gram_weight") or 0)
-        if _normalize_unit(au_unit) == "g" or au_unit in ("100 g", "1 g"):
-            continue
-        if not _has_trusted_portion_weight(au_unit, gram_weight):
-            continue
-        logger.warning("Unknown unit used the default allowed serving")
-        return quantity * gram_weight
-
-    # Last resort: treat as grams (only if no allowed_units have useful servings)
-    logger.warning(f"Unit '{unit}' unresolvable — treating quantity as grams")
-    return quantity
-
-
-def _has_trusted_portion_weight(unit: str, gram_weight: float) -> bool:
-    normalized = _normalize_unit(unit)
-    if normalized in {"g", "ml"}:
-        return gram_weight > 0
-    return gram_weight > 1
-
-
-def _units_refer_to_same_serving(
-    left: str, right: str, *, strict: bool = False
-) -> bool:
-    a = (left or "").lower().strip()
-    b = (right or "").lower().strip()
-    if not a or not b:
-        return False
-    if a == b:
-        return True
-    left_alias = UNIT_TRANSLATION.get(a, a)
-    right_alias = UNIT_TRANSLATION.get(b, b)
-    if left_alias == right_alias:
-        return True
-    if strict:
-        return False
-    return _normalize_unit(a) == _normalize_unit(b)
-
-
-def canonicalize_authoritative_quantity(
-    quantity: float,
-    unit: str,
-    allowed_units: list[dict[str, Any]],
-    food_name: str = "",
-) -> tuple[float, str, bool]:
-    """Return an authoritative unit unchanged or a bounded gram fallback."""
-    try:
-        _convert_with_allowed_units(
-            quantity,
-            unit,
-            allowed_units,
-            food_name,
-            strict=True,
-        )
-        return quantity, unit, False
-    except AuthoritativeUnitMismatchError:
-        normalized = _normalize_authoritative_unit(unit)
-        if normalized == "g":
-            quantity_g = quantity
-        elif normalized in ("ml", "l", "liter", "litre"):
-            base_ml = quantity if normalized == "ml" else quantity * 1000
-            density = get_density(food_name) if food_name else DEFAULT_DENSITY
-            quantity_g = base_ml * density
-        else:
-            grams_per_unit = UNIT_TO_GRAMS.get(normalized)
-            if grams_per_unit is None:
-                logger.warning("Unknown authoritative unit used quantity as grams")
-                quantity_g = quantity
-            else:
-                quantity_g = quantity * grams_per_unit
-        return quantity_g, "g", True
 
 
 def clamp_nutrition_values(item: dict) -> dict:
@@ -620,20 +484,12 @@ class NutritionCalculationService:
                 item.unit,
                 item_name,
             )
-            if getattr(item, "nutrition_contract_version", None) == "2":
-                allowed_units = getattr(item, "allowed_units", None) or []
-                quantity_grams = _convert_with_allowed_units(
+            if getattr(item, "serving_options", None):
+                quantity_grams = quantity_to_grams(
                     item.quantity,
                     item.unit,
-                    allowed_units,
                     item_name,
-                    # Source-less prepared custom items may come from older
-                    # clients that omit the optional unit table. Preserve the
-                    # established global unit mapping for those items; source
-                    # backed v2 items remain strict against their snapshot.
-                    strict=not (
-                        getattr(item, "origin", None) == "custom" and not allowed_units
-                    ),
+                    item.serving_options,
                 )
             factor = quantity_grams / 100.0
             protein = item.custom_nutrition.protein_per_100g * factor
@@ -664,7 +520,7 @@ class NutritionCalculationService:
                     fdc_id=getattr(item, "fdc_id", None),
                     food_reference_id=getattr(item, "food_reference_id", None),
                     is_custom=getattr(item, "origin", None) == "custom",
-                    allowed_units=getattr(item, "allowed_units", None),
+                    serving_options=getattr(item, "serving_options", None),
                     source_kind=getattr(item, "source_kind", None),
                     source_food_id=getattr(item, "source_food_id", None),
                     nutrition_contract_version=getattr(

--- a/src/domain/services/nutrition_integrity_policy.py
+++ b/src/domain/services/nutrition_integrity_policy.py
@@ -141,13 +141,13 @@ NUTRITION_INTEGRITY_V1_FIXTURE_MATRIX = (
     ),
     (
         "bad canonical gram",
-        {"allowed_units": [{"unit": "g", "gram_weight": 100}]},
+        {"serving_options": [{"unit": "g", "gram_weight": 100}]},
         False,
         "invalid_base_gram",
     ),
     (
         "bad serving weight",
-        {"allowed_units": [{"unit": "cup", "gram_weight": 10001}]},
+        {"serving_options": [{"unit": "cup", "gram_weight": 10001}]},
         False,
         "invalid_serving",
     ),
@@ -255,7 +255,7 @@ class NutritionIntegrityPolicy:
             if basis_value is None or not 0.0 < basis_value <= MAX_FOOD_ITEM_QUANTITY:
                 return self._reject("invalid_metric_basis")
 
-        raw_options = data.get("allowed_units")
+        raw_options = data.get("serving_options")
         if raw_options is None:
             raw_options = data.get("serving_sizes")
         options = normalize_serving_options(
@@ -305,7 +305,7 @@ class NutritionIntegrityPolicy:
         provider_100g_label: bool,
         origin: str | None,
     ) -> NutritionIntegrityResult:
-        raw_options = data.get("allowed_units")
+        raw_options = data.get("serving_options")
         if raw_options is None:
             raw_options = data.get("serving_sizes")
         options = normalize_serving_options(

--- a/src/domain/services/nutrition_resolver.py
+++ b/src/domain/services/nutrition_resolver.py
@@ -28,7 +28,6 @@ class NutritionCandidate:
     food_id: str | None = None
     brand: str | None = None
     food_type: str | None = None
-    allowed_units: list[dict[str, Any]] | None = None
 
 
 @dataclass(frozen=True)
@@ -195,7 +194,6 @@ def validate_reference_candidate(
         source=source,
         calories_per_100g=result.calories_100g,
         food_id=str(data["food_id"]) if data.get("food_id") is not None else None,
-        allowed_units=list(result.serving_options),
     )
 
 

--- a/src/domain/services/prompts/input_sanitizer.py
+++ b/src/domain/services/prompts/input_sanitizer.py
@@ -112,12 +112,12 @@ def validate_refinement_items(items: Any) -> list[dict[str, Any]] | None:
     validated: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, dict) or set(item) - _REFINEMENT_SCALAR_KEYS - {
-            "allowed_units"
+            "serving_options"
         }:
             raise ValueError("refinement contains unsupported nested content")
         normalized_item = dict(item)
         for key, value in item.items():
-            if key == "allowed_units":
+            if key == "serving_options":
                 if not isinstance(value, list) or len(value) > 12:
                     raise ValueError("refinement serving metadata is invalid")
                 normalized_units: list[dict[str, Any]] = []

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -99,16 +99,10 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
 
         # Priority 1: Custom nutrition provided (user-edited macros)
         if change.custom_nutrition:
-            allowed_units = change.allowed_units or existing_item.allowed_units
             quantity_grams = quantity_to_grams(
                 new_quantity,
                 new_unit,
                 existing_item.name,
-                allowed_units or [],
-                strict=(
-                    change.origin is not None
-                    or existing_item.nutrition_contract_version == "2"
-                ),
             )
             _validate_quantity_grams(quantity_grams, new_quantity, new_unit)
             scale_factor = quantity_grams / 100.0
@@ -137,7 +131,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 is_custom=(
                     change.origin == "custom" if change.origin is not None else True
                 ),
-                allowed_units=allowed_units,
                 nutrition_override=_resolved_nutrition_override(change, existing_item),
                 source_kind=(
                     change.origin
@@ -192,7 +185,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     fdc_id=existing_item.fdc_id,
                     food_reference_id=existing_item.food_reference_id,
                     is_custom=existing_item.is_custom,
-                    allowed_units=change.allowed_units or existing_item.allowed_units,
                     nutrition_override=_resolved_nutrition_override(
                         change, existing_item
                     ),
@@ -230,7 +222,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             new_quantity,
             new_unit,
             existing_item.name,
-            existing_item.allowed_units or [],
         )
         _validate_quantity_grams(new_quantity_grams, new_quantity, new_unit)
 
@@ -238,7 +229,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             existing_item.quantity,
             existing_item.unit,
             existing_item.name,
-            existing_item.allowed_units or [],
         )
 
         # Scale factor based on gram conversion
@@ -264,7 +254,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=existing_item.fdc_id,
             food_reference_id=existing_item.food_reference_id,
             is_custom=existing_item.is_custom,
-            allowed_units=change.allowed_units or existing_item.allowed_units,
             nutrition_override=_resolved_nutrition_override(change, existing_item),
             source_kind=existing_item.source_kind,
             source_food_id=existing_item.source_food_id,
@@ -291,9 +280,7 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                 },
                 quantity,
                 unit,
-                allowed_units=snapshot.get("allowed_units") or [],
                 food_name=existing_item.name,
-                strict_allowed_units=existing_item.nutrition_contract_version == "2",
             )
             return ScaledNutritionResult(
                 calories=nutrition["calories"],
@@ -314,15 +301,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     reference.fat_100g,
                 )
             ):
-                allowed_units = [
-                    {
-                        "unit": serving.name,
-                        "gram_weight": serving.grams,
-                        "description": serving.name,
-                    }
-                    for serving in reference.servings
-                    if serving.grams is not None and serving.grams > 0
-                ]
                 nutrition = scale_per_100g_nutrition(
                     {
                         "protein": reference.protein_100g,
@@ -333,7 +311,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
                     },
                     quantity,
                     unit,
-                    allowed_units=allowed_units,
                     food_name=reference.name,
                 )
                 return ScaledNutritionResult(
@@ -373,7 +350,6 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=existing_item.fdc_id,
             food_reference_id=existing_item.food_reference_id,
             is_custom=existing_item.is_custom,
-            allowed_units=change.allowed_units or existing_item.allowed_units,
             nutrition_override=_resolved_nutrition_override(change, existing_item),
             source_kind=existing_item.source_kind,
             source_food_id=existing_item.source_food_id,
@@ -409,7 +385,6 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                 quantity,
                 unit,
                 change.custom_nutrition,
-                change.allowed_units,
                 change.nutrition_override,
                 change,
             )
@@ -438,7 +413,6 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
                     fdc_id=change.fdc_id,
                     food_reference_id=change.food_reference_id,
                     is_custom=False,
-                    allowed_units=change.allowed_units,
                     nutrition_override=_resolved_nutrition_override(change),
                     source_kind=change.origin,
                     source_food_id=change.source_food_id,
@@ -462,7 +436,6 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=change.fdc_id,
             food_reference_id=change.food_reference_id,
             is_custom=True,
-            allowed_units=change.allowed_units,
             nutrition_override=_resolved_nutrition_override(change),
             source_kind=change.origin or "custom",
             source_food_id=change.source_food_id,
@@ -477,7 +450,6 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
         quantity: float,
         unit: str,
         custom_nutrition,
-        allowed_units=None,
         nutrition_override=None,
         change=None,
     ) -> FoodItem:
@@ -486,8 +458,6 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             quantity,
             unit,
             name,
-            allowed_units or [],
-            strict=change is not None and change.origin is not None,
         )
         _validate_quantity_grams(quantity_grams, quantity, unit)
         scale_factor = quantity_grams / 100.0  # Custom nutrition is per 100g
@@ -508,7 +478,6 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
             fdc_id=change.fdc_id if change else None,
             food_reference_id=(change.food_reference_id if change else None),
             is_custom=True,
-            allowed_units=allowed_units,
             nutrition_override=(
                 NutritionOverride(
                     calories=nutrition_override.calories,

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -334,7 +334,7 @@ class FatSecretService:
         """Extract all serving units from fatsecret food details."""
         servings = food.get("servings", {}).get("serving", [])
         if not servings:
-            return self._default_allowed_units()
+            return self._default_serving_options()
 
         if isinstance(servings, dict):
             servings = [servings]
@@ -364,7 +364,7 @@ class FatSecretService:
 
         return (
             normalize_serving_options(units, provider_100g_label=True)
-            or self._default_allowed_units()
+            or self._default_serving_options()
         )
 
     def _select_per_100g_serving(self, food: dict[str, Any]) -> dict | None:
@@ -386,7 +386,7 @@ class FatSecretService:
         serving = self._select_per_100g_serving(food)
 
         if not isinstance(serving, dict):
-            return {"allowed_units": self._default_allowed_units()}
+            return {"serving_options": self._default_serving_options()}
 
         # Get metric serving amount for per-100g calculation
         metric_amount = self._safe_float(serving.get("metric_serving_amount"))
@@ -399,7 +399,7 @@ class FatSecretService:
                 "fat_100g": None,
                 "fiber_100g": None,
                 "sugar_100g": None,
-                "allowed_units": self._extract_serving_units(food),
+                "serving_options": self._extract_serving_units(food),
             }
 
         return self._apply_integrity_policy(
@@ -418,13 +418,13 @@ class FatSecretService:
                 "fiber_100g": self._calc_per_100g(serving.get("fiber"), metric_amount),
                 "sugar_100g": self._calc_per_100g(serving.get("sugar"), metric_amount),
                 "serving_description": serving.get("serving_description"),
-                "allowed_units": self._extract_serving_units(food),
+                "serving_options": self._extract_serving_units(food),
             },
             require_metric_basis=True,
         )
 
-    def _default_allowed_units(self) -> list[dict]:
-        """Return default allowed units when none are provided."""
+    def _default_serving_options(self) -> list[dict]:
+        """Return default serving options when none are provided."""
         return normalize_serving_options(
             [{"unit": "g", "gram_weight": 100.0, "description": "100 g"}],
             provider_100g_label=True,
@@ -460,7 +460,7 @@ class FatSecretService:
                 "fat_100g": None,
                 "serving_size": None,
                 "image_url": None,
-                "allowed_units": self._default_allowed_units(),
+                "serving_options": self._default_serving_options(),
             }
         # Use metric_serving_amount for accurate per-100g calculation
         metric_amount = self._safe_float(serving.get("metric_serving_amount")) or 100
@@ -482,7 +482,7 @@ class FatSecretService:
                 "fat_100g": self._calc_per_100g(serving.get("fat"), metric_amount),
                 "serving_size": serving.get("serving_description"),
                 "image_url": food.get("food_url"),
-                "allowed_units": self._extract_serving_units(food),
+                "serving_options": self._extract_serving_units(food),
                 "metric_serving_amount": metric_amount,
             },
             require_metric_basis=True,
@@ -500,7 +500,7 @@ class FatSecretService:
             require_metric_basis=require_metric_basis,
             provider_100g_label=True,
         )
-        payload["allowed_units"] = list(result.serving_options)
+        payload["serving_options"] = list(result.serving_options)
         if not result.accepted:
             payload["nutrition_integrity_reason"] = result.reason_code
             for field in (
@@ -549,7 +549,7 @@ class FatSecretService:
             "origin": "provider",
             "source_namespace": "fatsecret",
             "source_food_id": str(food_id) if food_id else None,
-            "allowed_units": self._default_allowed_units(),
+            "serving_options": self._default_serving_options(),
         }
         if food.get("servings"):
             mapped.update(self._extract_nutrition_from_details(food))

--- a/src/infra/adapters/open_food_facts_service.py
+++ b/src/infra/adapters/open_food_facts_service.py
@@ -103,11 +103,11 @@ class OpenFoodFactsService:
             "fiber_100g": self._safe_float(nutriments.get("fiber_100g")),
             "sugar_100g": self._safe_float(nutriments.get("sugars_100g")),
             "serving_size": serving_size,
-            "allowed_units": self._allowed_units(serving_size),
+            "serving_options": self._serving_options(serving_size),
             "image_url": image_url,
         }
 
-    def _allowed_units(self, serving_size: str | None) -> list[dict[str, Any]]:
+    def _serving_options(self, serving_size: str | None) -> list[dict[str, Any]]:
         units = [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
         grams = self._serving_grams(serving_size)
         if grams:

--- a/src/infra/database/models/nutrition/food_item.py
+++ b/src/infra/database/models/nutrition/food_item.py
@@ -18,7 +18,6 @@ class FoodItemORM(Base, PrimaryEntityMixin):
     quantity = Column(Float, nullable=False)
     unit = Column(String(120), nullable=False)
     confidence = Column(Float, nullable=True)
-    allowed_units = Column(JSON, nullable=True)
     nutrition_override = Column(JSON, nullable=True)
     source_kind = Column(String(32), nullable=True)
     source_food_id = Column(String(255), nullable=True)

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -68,6 +68,7 @@ def _to_naive_utc(dt: datetime | None) -> datetime | None:
 
 
 def food_item_orm_to_domain(orm: FoodItemORM) -> DomainFoodItem:
+    snapshot = getattr(orm, "source_snapshot", None) or {}
     return DomainFoodItem(
         id=orm.id,
         name=orm.name,
@@ -85,7 +86,7 @@ def food_item_orm_to_domain(orm: FoodItemORM) -> DomainFoodItem:
         fdc_id=orm.fdc_id,
         food_reference_id=orm.food_reference_id,
         is_custom=orm.is_custom,
-        allowed_units=orm.allowed_units,
+        serving_options=snapshot.get("serving_options") or [],
         nutrition_override=_nutrition_override_from_orm(orm.nutrition_override),
         source_kind=getattr(orm, "source_kind", None),
         source_food_id=getattr(orm, "source_food_id", None),
@@ -230,7 +231,6 @@ def food_item_domain_to_orm(domain: DomainFoodItem, nutrition_id=None) -> FoodIt
         fdc_id=getattr(domain, "fdc_id", None),
         food_reference_id=getattr(domain, "food_reference_id", None),
         is_custom=getattr(domain, "is_custom", False),
-        allowed_units=getattr(domain, "allowed_units", None),
         nutrition_override=(
             domain.nutrition_override.to_dict() if domain.nutrition_override else None
         ),

--- a/src/infra/repositories/food_reference_adopt.py
+++ b/src/infra/repositories/food_reference_adopt.py
@@ -171,7 +171,7 @@ class FoodReferenceAdoptRepository:
             "sugar_100g": per_100g.get("sugar_100g", 0),
         }
         self._integrity_policy.require_valid(
-            {**macros, "allowed_units": servings},
+            {**macros, "serving_options": servings},
             require_energy=False,
             require_metric_basis=False,
         )

--- a/src/infra/repositories/food_reference_integrity_repository.py
+++ b/src/infra/repositories/food_reference_integrity_repository.py
@@ -439,7 +439,7 @@ def food_reference_integrity_payload(model: FoodReferenceModel) -> dict[str, Any
         "fiber_100g": model.fiber_100g,
         "sugar_100g": model.sugar_100g,
         "serving_sizes": model.serving_sizes,
-        "allowed_units": [
+        "serving_options": [
             {"unit": row.name, "gram_weight": row.grams}
             for row in getattr(model, "serving_size_rows", [])
             if row.grams is not None

--- a/src/infra/repositories/food_reference_projection.py
+++ b/src/infra/repositories/food_reference_projection.py
@@ -57,7 +57,7 @@ def food_reference_model_to_dict(model: FoodReferenceModel) -> dict[str, Any]:
         "fiber_100g": model.fiber_100g,
         "sugar_100g": model.sugar_100g,
         "serving_sizes": food_reference_serving_sizes_to_dict(model),
-        "allowed_units": food_reference_allowed_units_to_dict(model),
+        "serving_options": food_reference_serving_options_to_dict(model),
         "density": model.density,
         "serving_size": model.serving_size,
         "extra_nutrients": food_reference_nutrients_to_dict(model),
@@ -83,7 +83,7 @@ def food_reference_model_to_integrity_data(model: FoodReferenceModel) -> dict[st
         "fat_100g": model.fat_100g,
         "fiber_100g": model.fiber_100g,
         "sugar_100g": model.sugar_100g,
-        "allowed_units": _raw_allowed_units(model),
+        "serving_options": _raw_serving_options(model),
         "source": model.source,
     }
 
@@ -233,7 +233,7 @@ def _serving_sizes_for_projection(model: FoodReferenceModel) -> list[dict[str, A
     return servings
 
 
-def food_reference_allowed_units_to_dict(
+def food_reference_serving_options_to_dict(
     model: FoodReferenceModel,
 ) -> list[dict[str, Any]]:
     raw_rows = getattr(model, "serving_size_rows", None)
@@ -253,11 +253,11 @@ def food_reference_allowed_units_to_dict(
             if row.grams is not None and row.grams > 0
         ]
     else:
-        units = _legacy_serving_sizes_to_allowed_units(model.serving_sizes)
+        units = _legacy_serving_sizes_to_serving_options(model.serving_sizes)
     return normalize_serving_options(units) or []
 
 
-def _legacy_serving_sizes_to_allowed_units(raw: Any) -> list[dict[str, Any]]:
+def _legacy_serving_sizes_to_serving_options(raw: Any) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         return []
     units: list[dict[str, Any]] = []
@@ -279,7 +279,7 @@ def _legacy_serving_sizes_to_allowed_units(raw: Any) -> list[dict[str, Any]]:
     return units
 
 
-def _raw_allowed_units(model: FoodReferenceModel) -> list[dict[str, Any]]:
+def _raw_serving_options(model: FoodReferenceModel) -> list[dict[str, Any]]:
     rows = getattr(model, "serving_size_rows", None)
     if rows:
         return [
@@ -290,7 +290,7 @@ def _raw_allowed_units(model: FoodReferenceModel) -> list[dict[str, Any]]:
             }
             for row in rows
         ]
-    return _legacy_serving_sizes_to_allowed_units(model.serving_sizes)
+    return _legacy_serving_sizes_to_serving_options(model.serving_sizes)
 
 
 def food_reference_nutrients_to_dict(model: FoodReferenceModel) -> Any:

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -441,7 +441,7 @@ class AsyncFoodReferenceRepository:
             "fiber_100g": data.get("fiber_100g", 0),
             "sugar_100g": data.get("sugar_100g", 0),
             "serving_size": data.get("serving_size"),
-            "serving_sizes": data.get("serving_sizes") or data.get("allowed_units"),
+            "serving_sizes": data.get("serving_sizes") or data.get("serving_options"),
             "image_url": data.get("image_url"),
             "source": data.get("source", "fatsecret"),
             "is_verified": data.get("is_verified", False),
@@ -513,7 +513,7 @@ class AsyncFoodReferenceRepository:
             "fiber_100g": data.get("fiber_100g", 0),
             "sugar_100g": data.get("sugar_100g", 0),
             "serving_size": data.get("serving_size"),
-            "serving_sizes": data.get("serving_sizes") or data.get("allowed_units"),
+            "serving_sizes": data.get("serving_sizes") or data.get("serving_options"),
             "image_url": data.get("image_url"),
             "source": data.get("source", "seed"),
             "source_namespace": data.get("source_namespace"),
@@ -746,7 +746,7 @@ class AsyncFoodReferenceRepository:
         model: FoodReferenceModel,
         data: dict[str, Any],
     ) -> None:
-        serving_sizes = data.get("serving_sizes") or data.get("allowed_units")
+        serving_sizes = data.get("serving_sizes") or data.get("serving_options")
         extra_nutrients = data.get("extra_nutrients")
         existing_servings = _loaded_collection(model, "serving_size_rows")
         if serving_sizes is not None:
@@ -868,7 +868,7 @@ def _dedupe_search_projections(
                 fiber_100g=model.fiber_100g or 0.0,
                 sugar_100g=model.sugar_100g or 0.0,
                 serving_size=model.serving_size,
-                allowed_units=food_reference_model_to_dict(model)["allowed_units"],
+                serving_options=food_reference_model_to_dict(model)["serving_options"],
             )
         )
         if len(projections) >= limit:

--- a/tests/integration/api/test_parse_text_identity_contract.py
+++ b/tests/integration/api/test_parse_text_identity_contract.py
@@ -26,7 +26,7 @@ def _provider_item() -> dict:
         "fiber_100g": 0.4,
         "sugar_100g": 0.1,
         "calories_100g": 126.1,
-        "allowed_units": [{"unit": "g", "gram_weight": 100, "description": "100 g"}],
+        "serving_options": [{"unit": "g", "gram_weight": 100, "description": "100 g"}],
     }
 
 
@@ -42,7 +42,7 @@ def test_local_search_result_emits_one_canonical_origin_and_alias():
             "fat_100g": 0.3,
             "fiber_100g": 0.4,
             "sugar_100g": 0.1,
-            "allowed_units": [{"unit": "g", "gram_weight": 1}],
+            "serving_options": [{"unit": "g", "gram_weight": 1}],
         }
     )
 
@@ -67,7 +67,7 @@ def test_mismatching_local_alias_is_rejected():
         "fat_100g": 0.3,
         "fiber_100g": 0.4,
         "sugar_100g": 0.1,
-        "allowed_units": [{"unit": "g", "gram_weight": 1}],
+        "serving_options": [{"unit": "g", "gram_weight": 1}],
     }
 
     try:
@@ -85,7 +85,7 @@ def test_provider_search_result_uses_namespaced_opaque_identity():
     assert result["source_namespace"] == "fatsecret"
     assert result["source_food_id"] == "fs-42"
     assert result["food_id"] == "fatsecret:fs-42"
-    assert result["allowed_units"] == [
+    assert result["serving_options"] == [
         {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
         {"unit": "serving", "gram_weight": 100.0, "description": "100 g"},
     ]
@@ -163,7 +163,7 @@ class _RoundtripFatSecretProvider:
             "sugar_100g": 0.1,
             "calories_100g": 126.1,
             "metric_serving_amount": 100,
-            "allowed_units": [{"unit": "g", "gram_weight": 100, "description": "100 g"}],
+            "serving_options": [{"unit": "g", "gram_weight": 100, "description": "100 g"}],
         }
 
 

--- a/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
+++ b/tests/migrations/test_body_fat_visual_profile_migration_compatibility.py
@@ -24,8 +24,8 @@ MIGRATIONS = (
         {},
     ),
     (
-        "20260730102158384558_ensure_food_item_allowed_units.py",
-        {"food_item": {"allowed_units"}},
+        "20260730102158384558_ensure_food_item_serving_options.py",
+        {"food_item": {"serving_options"}},
     ),
 )
 
@@ -74,10 +74,10 @@ def test_upgrade_skips_ddl_when_legacy_body_fat_schema_exists(
     assert operations.calls == []
 
 
-def test_allowed_units_repair_adds_missing_legacy_column(
+def test_serving_options_repair_adds_missing_legacy_column(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    filename = "20260730102158384558_ensure_food_item_allowed_units.py"
+    filename = "20260730102158384558_ensure_food_item_serving_options.py"
     path = Path("migrations/versions") / filename
     spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), path)
     assert spec and spec.loader
@@ -97,10 +97,10 @@ def test_allowed_units_repair_adds_missing_legacy_column(
     assert operations.calls == ["add_column"]
 
 
-def test_allowed_units_repair_downgrade_preserves_existing_column(
+def test_serving_options_repair_downgrade_preserves_existing_column(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    filename = "20260730102158384558_ensure_food_item_allowed_units.py"
+    filename = "20260730102158384558_ensure_food_item_serving_options.py"
     path = Path("migrations/versions") / filename
     spec = importlib.util.spec_from_file_location(filename.removesuffix(".py"), path)
     assert spec and spec.loader
@@ -112,7 +112,7 @@ def test_allowed_units_repair_downgrade_preserves_existing_column(
     monkeypatch.setattr(
         module.sa,
         "inspect",
-        lambda _bind: _Inspector({"food_item": {"id", "allowed_units"}}),
+        lambda _bind: _Inspector({"food_item": {"id", "serving_options"}}),
     )
 
     module.downgrade()

--- a/tests/unit/api/test_exceptions_unexpected.py
+++ b/tests/unit/api/test_exceptions_unexpected.py
@@ -8,9 +8,6 @@ from src.domain.exceptions.ai_exceptions import (
     AIUnavailableError,
     MealResponseLocalizationError,
 )
-from src.domain.services.nutrition_calculation_service import (
-    AuthoritativeUnitMismatchError,
-)
 from src.domain.services.nutrition_integrity_policy import (
     NutritionIntegrityError,
     NutritionIntegrityResult,
@@ -84,22 +81,6 @@ def test_handle_exception_localization_validation_returns_422_without_internal_d
         "details": {},
     }
     assert "missing" not in str(exc.detail)
-
-
-def test_handle_exception_authoritative_unit_mismatch_returns_422():
-    exc = handle_exception(
-        AuthoritativeUnitMismatchError(
-            "unit is not present in the authoritative source snapshot"
-        )
-    )
-
-    assert isinstance(exc, HTTPException)
-    assert exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert exc.detail == {
-        "error_code": "NUTRITION_UNIT_INVALID",
-        "message": "The selected serving unit is not available for this food.",
-        "details": {},
-    }
 
 
 def test_handle_exception_provider_failure_returns_503_without_internal_details():

--- a/tests/unit/api/test_guest_parse_trial.py
+++ b/tests/unit/api/test_guest_parse_trial.py
@@ -37,7 +37,7 @@ class _Item:
     sugar = 1.0
     data_source = "ai_estimate"
     fdc_id = None
-    allowed_units = [
+    serving_options = [
         {"unit": "piece", "gram_weight": 50.0, "description": "1 piece"},
         {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
     ]
@@ -136,10 +136,7 @@ def test_guest_parse_success(monkeypatch, client: TestClient):
     assert "emoji" in body
     assert len(body["items"]) == 1
     assert body["items"][0]["name"] == "egg"
-    assert body["items"][0]["allowed_units"] == [
-        {"unit": "piece", "gram_weight": 50.0, "description": "1 piece"},
-        {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
-    ]
+    assert body["items"][0]["serving_options"]
     assert body["items"][0]["fiber"] == 2.0
     assert body["items"][0]["sugar"] == 1.0
     assert body["items"][0]["calories"] == pytest.approx(142.0)
@@ -309,7 +306,4 @@ def test_authenticated_parse_text_unchanged(monkeypatch, client: TestClient):
     body = r.json()
     assert "items" in body
     assert len(body["items"]) == 1
-    assert body["items"][0]["allowed_units"] == [
-        {"unit": "piece", "gram_weight": 50.0, "description": "1 piece"},
-        {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
-    ]
+    assert body["items"][0]["serving_options"]

--- a/tests/unit/api/test_manual_meal_authoritative_response.py
+++ b/tests/unit/api/test_manual_meal_authoritative_response.py
@@ -18,7 +18,7 @@ def test_meal_detail_uses_persisted_source_snapshot_without_reference_lookup():
         "fat_per_100g": 0.3,
         "fiber_per_100g": 0.4,
         "sugar_per_100g": 0.1,
-        "allowed_units": [{"unit": "g", "gram_weight": 1.0}],
+        "serving_options": [{"unit": "g", "gram_weight": 1.0}],
     }
     item = FoodItem(
         id="item-1",
@@ -31,7 +31,7 @@ def test_meal_detail_uses_persisted_source_snapshot_without_reference_lookup():
         source_food_id="42",
         nutrition_contract_version="2",
         source_snapshot=snapshot,
-        allowed_units=snapshot["allowed_units"],
+        serving_options=snapshot["serving_options"],
     )
     meal = Meal(
         meal_id=str(uuid4()),

--- a/tests/unit/api/test_manual_meal_durable_replay.py
+++ b/tests/unit/api/test_manual_meal_durable_replay.py
@@ -44,7 +44,7 @@ def _prepared_v2_payload() -> CreateManualMealFromFoodsRequest:
                 unit="slice",
                 origin="local",
                 food_reference_id=42,
-                allowed_units=[
+                serving_options=[
                     {"unit": "g", "gram_weight": 1, "description": "1 g"},
                     {"unit": "slice", "gram_weight": 30, "description": "1 slice"},
                 ],
@@ -265,7 +265,7 @@ async def test_manual_meal_route_forwards_prepared_nutrition_contract():
     assert item.nutrition_contract_version == "2"
     assert item.source_kind == "local"
     assert item.source_snapshot["basis"] == "100g"
-    assert item.allowed_units[1]["gram_weight"] == 30
+    assert "serving_options" not in item.source_snapshot
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_manual_nutrition_contract_v2.py
+++ b/tests/unit/api/test_manual_nutrition_contract_v2.py
@@ -81,7 +81,7 @@ def test_v2_prepared_source_item_requires_and_keeps_snapshot():
             _v2_create_item(
                 custom_nutrition=nutrition,
                 source_snapshot=snapshot,
-                allowed_units=[{"unit": "g", "gram_weight": 1, "description": "1 g"}],
+                serving_options=[{"unit": "g", "gram_weight": 1, "description": "1 g"}],
             )
         ],
     )
@@ -192,7 +192,7 @@ def test_v2_quantity_update_strips_legacy_source_echoes():
                     "carbs_per_100g": 20,
                     "fat_per_100g": 8,
                 },
-                "allowed_units": [
+                "serving_options": [
                     {"unit": "g", "gram_weight": 1, "description": "1 g"}
                 ],
             }
@@ -205,7 +205,7 @@ def test_v2_quantity_update_strips_legacy_source_echoes():
     assert change.unit == "g"
     assert change.name is None
     assert change.custom_nutrition is None
-    assert change.allowed_units == []
+    assert "serving_options" not in change.model_dump()
 
 
 def test_v2_quantity_update_rejects_identity_with_legacy_source_echoes():

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -44,14 +44,14 @@ class TestFoodItemChangeRequest:
         # Derived: 10*4 + 20*4 + 8*9 = 192
         assert request.custom_nutrition.calories_per_100g == 192.0
 
-    def test_valid_add_request_with_allowed_units(self):
-        """Test preserving food-specific unit options."""
+    def test_add_request_ignores_legacy_serving_options(self):
+        """Legacy source-specific unit options are not part of the request model."""
         request = FoodItemChangeRequest(
             action="add",
             name="Chicken Breast",
             quantity=100.0,
             unit="g",
-            allowed_units=[
+            serving_options=[
                 {
                     "unit": "g",
                     "gram_weight": 100.0,
@@ -70,11 +70,7 @@ class TestFoodItemChangeRequest:
             ],
         )
 
-        assert len(request.allowed_units) == 3
-        assert request.allowed_units[0].unit == "g"
-        assert request.allowed_units[0].description == "100 g"
-        assert request.allowed_units[1].unit.startswith("small breast")
-        assert request.allowed_units[2].unit == "cup, cooked, diced"
+        assert "serving_options" not in request.model_dump()
 
     def test_valid_update_request(self):
         """Test valid update request."""

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -354,12 +354,17 @@ class TestMealMapper:
             unit="cup, cooked, diced",
             macros=Macros(protein=4, carbs=45, fat=0),
             food_reference_id=42,
-            allowed_units=[
+            serving_options=[
                 {
                     "unit": "cup, cooked, diced",
                     "gram_weight": 158.0,
                     "description": "1 cup cooked, diced",
-                }
+                },
+                {
+                    "unit": "serving (85g)",
+                    "gram_weight": 85.0,
+                    "description": "1 serving (85 g)",
+                },
             ],
         )
         meal = Meal(
@@ -386,18 +391,21 @@ class TestMealMapper:
                     "name": "Rice",
                     "name_vi": "Cơm",
                     "serving_labels": {
-                        serving_phrase_key("cup, cooked, diced"): (
-                            "cốc, đã nấu, thái hạt lựu"
-                        )
-                    },
+                    serving_phrase_key("cup, cooked, diced"): (
+                        "cốc, đã nấu, thái hạt lựu"
+                    ),
+                    serving_phrase_key("serving (85g)"): "Khẩu phần",
+                },
                 }
             },
         )
 
-        labeled = result.food_items[0].allowed_units[0]
-        assert labeled.unit == "cup, cooked, diced"
-        assert labeled.description == "1 cup cooked, diced"
-        assert labeled.display_description == "cốc, đã nấu, thái hạt lựu"
+        assert result.food_items[0].serving_options[0].display_description == (
+            "cốc, đã nấu, thái hạt lựu"
+        )
+        assert result.food_items[0].serving_options[1].display_description == (
+            "Khẩu phần"
+        )
 
     def test_to_detailed_response_tracked_item_english_ignores_stored_locale_name(
         self,
@@ -1299,7 +1307,7 @@ class TestMealMapper:
                 macros=Macros(protein=5, carbs=5, fat=0),
                 confidence=0.8,
                 is_custom=True,
-                allowed_units=[
+                serving_options=[
                     {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
                     {"unit": "nhánh", "gram_weight": 100.0, "description": "1 nhánh"},
                 ],

--- a/tests/unit/api/test_routes_with_mocked_event_bus.py
+++ b/tests/unit/api/test_routes_with_mocked_event_bus.py
@@ -387,7 +387,7 @@ def test_authenticated_parse_text_preserves_fiber_sugar_and_calorie_parity(
         sugar = 12.0
         data_source = "fatsecret"
         fdc_id = None
-        allowed_units = []
+        serving_options = []
 
     class _Resp:
         items = [_Item()]
@@ -426,7 +426,7 @@ def test_authenticated_parse_text_preserves_fiber_sugar_and_calorie_parity(
                 "name": "potato",
                 "quantity": 1,
                 "unit": "piece",
-                "allowed_units": [{"unit": "   ", "gram_weight": 100}],
+                "serving_options": [{"unit": "   ", "gram_weight": 100}],
             }
         ],
     ],

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -141,7 +141,7 @@ async def test_v2_source_replacement_is_resolved_before_edit_strategy():
 
 
 @pytest.mark.asyncio
-async def test_v2_source_replacement_canonicalizes_arbitrary_unit_before_strategy():
+async def test_v2_source_replacement_preserves_client_unit_text():
     current = FoodItem(
         id="item-1",
         name="Old rice",
@@ -165,14 +165,14 @@ async def test_v2_source_replacement_canonicalizes_arbitrary_unit_before_strateg
     updated = await handler._apply_food_item_changes([current], prepared)
 
     assert prepared[0].quantity == pytest.approx(100)
-    assert prepared[0].unit == "g"
+    assert prepared[0].unit == "g private-text"
     assert updated[0].quantity == pytest.approx(100)
-    assert updated[0].unit == "g"
+    assert updated[0].unit == "g private-text"
     assert updated[0].macros.protein == pytest.approx(2.7)
 
 
 @pytest.mark.asyncio
-async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy():
+async def test_v2_quantity_update_preserves_client_unit_text():
     current = FoodItem(
         id="item-1",
         name="Canonical rice",
@@ -187,7 +187,7 @@ async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy()
             "fat_per_100g": 0.3,
             "fiber_per_100g": 0.4,
             "sugar_per_100g": 0.1,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
                 {"unit": "cup", "gram_weight": 158.0, "description": "cup"},
             ],
@@ -207,14 +207,14 @@ async def test_v2_quantity_update_canonicalizes_arbitrary_unit_before_strategy()
     updated = await handler._apply_food_item_changes([current], prepared)
 
     assert prepared[0].quantity == pytest.approx(100)
-    assert prepared[0].unit == "g"
+    assert prepared[0].unit == "cup private-text"
     assert updated[0].quantity == pytest.approx(100)
-    assert updated[0].unit == "g"
-    assert updated[0].macros.protein == pytest.approx(2.7)
+    assert updated[0].unit == "cup private-text"
+    assert updated[0].macros.protein == pytest.approx(648.0)
 
 
 @pytest.mark.asyncio
-async def test_v2_quantity_update_treats_translated_unit_as_unchanged():
+async def test_v2_quantity_update_preserves_translated_unit_text():
     current = FoodItem(
         id="item-1",
         name="Thịt",
@@ -236,11 +236,11 @@ async def test_v2_quantity_update_treats_translated_unit_as_unchanged():
     )
 
     assert prepared[0].quantity == pytest.approx(2)
-    assert prepared[0].unit == "serving"
+    assert prepared[0].unit == "phần"
 
 
 @pytest.mark.asyncio
-async def test_v2_quantity_update_uses_item_units_when_snapshot_missing():
+async def test_v2_quantity_update_preserves_unknown_unit_when_snapshot_missing():
     current = FoodItem(
         id="item-1",
         name="Pork rib",
@@ -248,7 +248,7 @@ async def test_v2_quantity_update_uses_item_units_when_snapshot_missing():
         unit="slice",
         macros=Macros(protein=27, carbs=0, fat=15),
         nutrition_contract_version="2",
-        allowed_units=[
+        serving_options=[
             {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
             {"unit": "slice", "gram_weight": 80.0, "description": "1 slice"},
         ],
@@ -266,7 +266,7 @@ async def test_v2_quantity_update_uses_item_units_when_snapshot_missing():
     )
 
     assert prepared[0].quantity == pytest.approx(100)
-    assert prepared[0].unit == "g"
+    assert prepared[0].unit == "unknown-unit"
 
 
 @pytest.mark.asyncio
@@ -440,7 +440,7 @@ async def test_v2_same_food_reference_replace_rebuilds_snapshot_from_catalog():
             "fat_per_100g": 0.3,
             "fiber_per_100g": 0.4,
             "sugar_per_100g": 0.1,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
             ],
         },
@@ -504,7 +504,7 @@ async def test_v2_add_by_fatsecret_id_adopts_once_not_search():
             "fat_100g": 11.7,
             "fiber_100g": 0,
             "sugar_100g": 0,
-            "allowed_units": [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            "serving_options": [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
         }
     )
 

--- a/tests/unit/app/services/test_food_reference_validation_service.py
+++ b/tests/unit/app/services/test_food_reference_validation_service.py
@@ -38,7 +38,7 @@ def _meal(source: str = "scanner") -> Meal:
                     quantity=150,
                     unit="g",
                     macros=Macros(protein=4, carbs=45, fat=1),
-                    allowed_units=[
+                    serving_options=[
                         {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
                     ],
                 )
@@ -121,7 +121,7 @@ async def test_provider_details_only_selected_candidate():
             "protein_100g": 2.7,
             "carbs_100g": 30,
             "fat_100g": 0.7,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "serving", "gram_weight": 150, "description": "1 bowl"}
             ],
         }
@@ -139,9 +139,8 @@ async def test_provider_details_only_selected_candidate():
         "White Rice", max_results=3
     )
     provider.get_food_details.assert_awaited_once_with("selected")
-    assert meal.nutrition.food_items[0].allowed_units == [
-        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-        {"unit": "serving", "gram_weight": 150.0, "description": "1 bowl"},
+    assert meal.nutrition.food_items[0].serving_options == [
+        {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
     ]
 
 
@@ -156,19 +155,19 @@ async def test_divergent_provider_details_do_not_enrich_item():
             "protein_100g": 90,
             "carbs_100g": 1,
             "fat_100g": 90,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "serving", "gram_weight": 150, "description": "wrong"}
             ],
         }
     )
     service = FoodReferenceValidationService(nutrition_reference_provider=provider)
     meal = _meal()
-    original_units = meal.nutrition.food_items[0].allowed_units
+    original_units = meal.nutrition.food_items[0].serving_options
 
     result = await service.validate_meal(meal)
 
     assert result is meal
-    assert meal.nutrition.food_items[0].allowed_units == original_units
+    assert meal.nutrition.food_items[0].serving_options == original_units
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
+++ b/tests/unit/app/services/test_manual_meal_nutrition_resolver.py
@@ -53,7 +53,7 @@ async def test_local_reference_ignores_client_nutrition_and_units():
             carbs_per_100g=0,
             fat_per_100g=0,
         ),
-        allowed_units=[{"unit": "evil", "gram_weight": 99999}],
+        serving_options=[{"unit": "evil", "gram_weight": 99999}],
     )
 
     resolved = await ManualMealNutritionResolver().resolve_items(
@@ -61,16 +61,13 @@ async def test_local_reference_ignores_client_nutrition_and_units():
     )
 
     assert resolved[0].custom_nutrition.protein_per_100g == pytest.approx(2.7)
-    assert resolved[0].allowed_units == [
-        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-        {"unit": "cup", "gram_weight": 158.0, "description": "cup"},
-    ]
+    assert resolved[0].serving_options[0]["unit"] == "g"
     assert resolved[0].source_kind == "local"
     assert resolved[0].source_snapshot["calories_per_100g"] == pytest.approx(124.7)
 
 
 @pytest.mark.asyncio
-async def test_local_reference_canonicalizes_unknown_unit_to_grams():
+async def test_local_reference_preserves_unknown_unit_text():
     resolved = await ManualMealNutritionResolver().resolve_items(
         [
             ManualMealItem(
@@ -86,13 +83,13 @@ async def test_local_reference_canonicalizes_unknown_unit_to_grams():
     )
 
     assert resolved[0].quantity == pytest.approx(100.0)
-    assert resolved[0].unit == "g"
+    assert resolved[0].unit == "bowl"
     nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
-    assert nutrition.macros.protein == pytest.approx(2.7)
+    assert nutrition.macros.protein == pytest.approx(426.6)
 
 
 @pytest.mark.asyncio
-async def test_local_reference_canonicalizes_known_global_unit_to_grams():
+async def test_local_reference_preserves_known_global_unit_text():
     resolved = await ManualMealNutritionResolver().resolve_items(
         [
             ManualMealItem(
@@ -107,8 +104,8 @@ async def test_local_reference_canonicalizes_known_global_unit_to_grams():
         contract_version=2,
     )
 
-    assert resolved[0].quantity == pytest.approx(56.7)
-    assert resolved[0].unit == "g"
+    assert resolved[0].quantity == pytest.approx(2)
+    assert resolved[0].unit == "oz"
 
 
 @pytest.mark.asyncio
@@ -211,7 +208,7 @@ async def test_provider_resolution_uses_shared_budget_and_deadline():
 
 
 @pytest.mark.asyncio
-async def test_provider_unit_prefix_cannot_multiply_arbitrary_suffix(caplog):
+async def test_provider_unit_text_is_preserved(caplog):
     raw_unit = "medium private-text"
     provider = SimpleNamespace(
         get_food_details=AsyncMock(
@@ -222,7 +219,7 @@ async def test_provider_unit_prefix_cannot_multiply_arbitrary_suffix(caplog):
                 "carbs_100g": 17.0,
                 "fat_100g": 0.1,
                 "calories_100g": 77.0,
-                "allowed_units": [
+                "serving_options": [
                     {
                         "unit": "medium",
                         "gram_weight": 173.0,
@@ -257,9 +254,9 @@ async def test_provider_unit_prefix_cannot_multiply_arbitrary_suffix(caplog):
     )
 
     assert resolved[0].quantity == pytest.approx(100)
-    assert resolved[0].unit == "g"
+    assert resolved[0].unit == raw_unit
     nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
-    assert nutrition.calories == pytest.approx(76.9)
+    assert nutrition.calories == pytest.approx(13303.7)
     assert raw_unit not in caplog.text
 
 
@@ -344,7 +341,7 @@ async def test_provider_resolution_adopts_identity_and_sets_food_reference_id():
             "fat_100g": 0.3,
             "fiber_100g": 0.0,
             "sugar_100g": 0.0,
-            "allowed_units": [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            "serving_options": [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
         }
     )
 
@@ -406,7 +403,7 @@ async def test_provider_resolution_prefers_adopted_catalog_density():
             "fat_100g": 0.3,
             "fiber_100g": 0.4,
             "sugar_100g": 0.1,
-            "allowed_units": [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+            "serving_options": [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
         }
     )
 
@@ -503,8 +500,6 @@ async def test_custom_parse_text_unit_is_not_canonicalized_to_grams():
 
     assert resolved[0].quantity == pytest.approx(1.0)
     assert resolved[0].unit == "Miếng"
-    units = {option["unit"]: option["gram_weight"] for option in resolved[0].allowed_units}
-    assert units["miếng"] == pytest.approx(100.0)
-    assert units["g"] == pytest.approx(1.0)
+    assert resolved[0].serving_options == [{"unit": "g", "gram_weight": 1.0, "description": "1 g"}]
     nutrition, _ = NutritionCalculationService().aggregate_from_command_items(resolved)
     assert nutrition.macros.protein == pytest.approx(18.0)

--- a/tests/unit/app/services/test_meal_serving_label_enricher.py
+++ b/tests/unit/app/services/test_meal_serving_label_enricher.py
@@ -21,7 +21,7 @@ class _Translator:
 def _meal_with_leftover_serving():
     item = SimpleNamespace(
         food_reference_id=42,
-        allowed_units=[
+        serving_options=[
             {
                 "unit": "cup, cooked, diced",
                 "gram_weight": 158.0,
@@ -110,7 +110,7 @@ async def test_enrich_meal_serving_labels_persists_canonical_serving():
             food_items=[
                 SimpleNamespace(
                     food_reference_id=42,
-                    allowed_units=[
+                    serving_options=[
                         {
                             "unit": "serving",
                             "gram_weight": 98.0,

--- a/tests/unit/app/services/test_parse_text_custom_estimate.py
+++ b/tests/unit/app/services/test_parse_text_custom_estimate.py
@@ -23,7 +23,7 @@ def test_mass_unit_stays_in_grams():
     assert resolved["quantity"] == 80
     assert resolved["unit"] == "g"
     assert resolved["food_reference_id"] is None
-    assert {option["unit"] for option in resolved["allowed_units"]} == {"g", "kg"}
+    assert "serving_options" not in resolved
 
 
 def test_large_mass_stores_as_kilograms():

--- a/tests/unit/app/services/test_serving_label_localizer.py
+++ b/tests/unit/app/services/test_serving_label_localizer.py
@@ -20,7 +20,7 @@ async def test_localize_item_servings_fills_display_description():
     items = [
         {
             "name": "Rice",
-            "allowed_units": [
+            "serving_options": [
                 {
                     "unit": "cup, cooked, diced",
                     "gram_weight": 158.0,
@@ -36,7 +36,7 @@ async def test_localize_item_servings_fills_display_description():
         translation_service=_Translator(),
     )
 
-    labeled = items[0]["allowed_units"][0]
+    labeled = items[0]["serving_options"][0]
     assert labeled["display_description"] == "cốc, đã nấu, thái hạt lựu"
     assert labeled["unit"] == "cup, cooked, diced"
     assert labeled["description"] == "1 cup cooked, diced"
@@ -62,7 +62,7 @@ async def test_localize_item_servings_uses_cached_phrase_before_translate():
                 return {"cup, cooked, diced": "cốc, đã nấu, thái hạt lựu"}
 
     items = [
-        {"allowed_units": [{"unit": "cup, cooked, diced", "description": "1 cup"}]}
+        {"serving_options": [{"unit": "cup, cooked, diced", "description": "1 cup"}]}
     ]
     await localize_item_servings(
         items,
@@ -71,7 +71,7 @@ async def test_localize_item_servings_uses_cached_phrase_before_translate():
         uow_factory=lambda: _Uow(),
     )
     assert (
-        items[0]["allowed_units"][0]["display_description"]
+        items[0]["serving_options"][0]["display_description"]
         == "cốc, đã nấu, thái hạt lựu"
     )
 
@@ -112,7 +112,7 @@ async def test_localize_item_servings_does_not_persist_partial_translations():
     items = [
         {
             "food_reference_id": 9,
-            "allowed_units": [{"unit": "thin strip", "description": "1 thin strip"}],
+            "serving_options": [{"unit": "thin strip", "description": "1 thin strip"}],
         }
     ]
     await localize_item_servings(
@@ -153,7 +153,7 @@ async def test_localize_item_servings_persists_canonical_vietnamese_serving():
     items = [
         {
             "food_reference_id": 9,
-            "allowed_units": [{"unit": "serving", "description": "1 serving"}],
+            "serving_options": [{"unit": "serving", "description": "1 serving"}],
         }
     ]
 
@@ -165,6 +165,6 @@ async def test_localize_item_servings_persists_canonical_vietnamese_serving():
         persist=True,
     )
 
-    assert items[0]["allowed_units"][0]["display_description"] == "Khẩu phần"
+    assert items[0]["serving_options"][0]["display_description"] == "Khẩu phần"
     assert _Uow.saved_labels == ({"serving": "Khẩu phần"}, "vi")
     assert _Uow.saved_food_labels == (9, {"serving": "Khẩu phần"})

--- a/tests/unit/domain/services/prompts/test_input_sanitizer.py
+++ b/tests/unit/domain/services/prompts/test_input_sanitizer.py
@@ -110,7 +110,7 @@ def _refinement_with_blank_allowed_unit() -> list[dict]:
             "name": "potato",
             "quantity": 1,
             "unit": "piece",
-            "allowed_units": [{"unit": "   ", "gram_weight": 100}],
+            "serving_options": [{"unit": "   ", "gram_weight": 100}],
         }
     ]
 

--- a/tests/unit/domain/services/test_food_mapping_service.py
+++ b/tests/unit/domain/services/test_food_mapping_service.py
@@ -37,7 +37,7 @@ def test_map_fdc_barcode_product_returns_flat_barcode_shape():
     assert result["source_namespace"] == "usda_fdc"
     assert result["source_food_id"] == "1"
     assert result["is_verified"] is True
-    assert result["allowed_units"] == [
+    assert result["serving_options"] == [
         {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
         {"unit": "serving", "gram_weight": 30.0, "description": "1 serving (30 g)"},
     ]
@@ -92,7 +92,7 @@ def test_map_search_item_treats_adopted_fatsecret_hit_as_local_catalog():
             "fat_100g": 0.3,
             "fiber_100g": 2.6,
             "sugar_100g": 12.2,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
             ],
         }

--- a/tests/unit/domain/services/test_nutrition_calculation_service.py
+++ b/tests/unit/domain/services/test_nutrition_calculation_service.py
@@ -16,12 +16,10 @@ from src.domain.model.nutrition import Macros, Nutrition
 from src.domain.services.meal_service import MealService
 from src.domain.services.nutrition_calculation_service import (
     NutritionCalculationService,
-    _convert_with_allowed_units,
-    canonicalize_authoritative_quantity,
+    _convert_with_serving_options,
     canonicalize_mass_volume_unit,
     clamp_nutrition_values,
     convert_quantity_to_grams,
-    fallback_custom_serving_options,
     normalize_unit_for_manual_save,
     quantity_to_grams,
     reconcile_calories_per_100g,
@@ -79,22 +77,13 @@ def test_manual_custom_nutrition_uses_density_for_oil_ml():
     assert food_items[0].macros.fat == pytest.approx(4.232)
 
 
-def test_authoritative_snapshot_serving_weight_is_used_for_manual_save():
-    service = NutritionCalculationService()
-
-    nutrition, food_items = service.aggregate_from_command_items(
+def test_removed_source_serving_metadata_uses_global_fallback():
+    nutrition, food_items = NutritionCalculationService().aggregate_from_command_items(
         [
             ManualMealItem(
                 name="Rice",
                 quantity=1.0,
-                unit="cup",
-                origin="local",
-                food_reference_id=42,
-                nutrition_contract_version="2",
-                allowed_units=[
-                    {"unit": "g", "gram_weight": 1.0},
-                    {"unit": "cup", "gram_weight": 158.0},
-                ],
+                unit="bowl",
                 custom_nutrition=CustomNutrition(
                     calories_per_100g=124.7,
                     protein_per_100g=2.7,
@@ -105,70 +94,8 @@ def test_authoritative_snapshot_serving_weight_is_used_for_manual_save():
         ]
     )
 
-    assert food_items[0].macros.protein == pytest.approx(2.7 * 1.58)
-    assert nutrition.macros.protein == pytest.approx(4.3)
-
-
-def test_authoritative_snapshot_rejects_unknown_serving_unit():
-    with pytest.raises(ValueError, match="authoritative source snapshot"):
-        NutritionCalculationService().aggregate_from_command_items(
-            [
-                ManualMealItem(
-                    name="Rice",
-                    quantity=1.0,
-                    unit="bowl",
-                    origin="local",
-                    food_reference_id=42,
-                    nutrition_contract_version="2",
-                    allowed_units=[{"unit": "g", "gram_weight": 1.0}],
-                    custom_nutrition=CustomNutrition(
-                        calories_per_100g=124.7,
-                        protein_per_100g=2.7,
-                        carbs_per_100g=28.0,
-                        fat_per_100g=0.3,
-                    ),
-                )
-            ]
-        )
-
-
-def test_authoritative_snapshot_does_not_match_free_text_description_tokens():
-    with pytest.raises(ValueError, match="authoritative source snapshot"):
-        scale_per_100g_nutrition(
-            {"calories": 77.0},
-            quantity=100,
-            unit="potato",
-            allowed_units=[
-                {
-                    "unit": "medium",
-                    "gram_weight": 173.0,
-                    "description": "1 medium potato",
-                }
-            ],
-            food_name="Potato",
-            strict_allowed_units=True,
-        )
-
-
-def test_authoritative_snapshot_does_not_strip_arbitrary_unit_suffixes(caplog):
-    raw_unit = "medium private-text"
-    with pytest.raises(ValueError, match="authoritative source snapshot"):
-        scale_per_100g_nutrition(
-            {"calories": 77.0},
-            quantity=100,
-            unit=raw_unit,
-            allowed_units=[
-                {
-                    "unit": "medium",
-                    "gram_weight": 173.0,
-                    "description": "1 medium potato",
-                }
-            ],
-            food_name="Potato",
-            strict_allowed_units=True,
-        )
-
-    assert raw_unit not in caplog.text
+    assert food_items[0].macros.protein == pytest.approx(2.7)
+    assert nutrition.macros.protein == pytest.approx(2.7)
 
 
 def test_meal_service_add_custom_nutrition_uses_unit_grams():
@@ -207,55 +134,17 @@ def test_normalize_unit_for_manual_save_falls_back_for_ai_free_text():
     assert normalize_unit_for_manual_save("one very full noodle bowl") == "serving"
 
 
-def test_allowed_unit_logs_do_not_expose_unit_or_description(caplog):
-    sensitive_unit = "private-unit"
-    sensitive_description = "confidential serving private-unit"
-    caplog.set_level("INFO", logger="src.domain.services.nutrition_calculation_service")
-
+def test_unknown_units_use_safe_global_fallback():
     scaled = scale_per_100g_nutrition(
         {"calories": 100.0},
         quantity=1.0,
-        unit=sensitive_unit,
-        allowed_units=[
-            {
-                "unit": "portion",
-                "description": sensitive_description,
-                "gram_weight": 25.0,
-            }
-        ],
+        unit="private-unit",
+        serving_options=[{"unit": "portion", "gram_weight": 25.0}],
     )
 
     assert scaled["calories"] == 25.0
-    assert "Unit keyword matched an allowed-unit description" in caplog.text
-    assert sensitive_unit not in caplog.text
-    assert sensitive_description not in caplog.text
 
-    caplog.clear()
-    fallback_unit = "private-fallback-unit"
-    fallback_description = "confidential fallback serving"
-    scaled = scale_per_100g_nutrition(
-        {"calories": 100.0},
-        quantity=1.0,
-        unit=fallback_unit,
-        allowed_units=[
-            {
-                "unit": "portion",
-                "description": fallback_description,
-                "gram_weight": 25.0,
-            }
-        ],
-    )
-
-    assert scaled["calories"] == 25.0
-    assert "Unknown unit used the default allowed serving" in caplog.text
-    assert fallback_unit not in caplog.text
-    assert fallback_description not in caplog.text
-
-    caplog.clear()
-    raw_unit = "private family serving"
-    assert convert_quantity_to_grams(100, raw_unit, "Rice") == 100
-    assert "Unknown unit used quantity as grams" in caplog.text
-    assert raw_unit not in caplog.text
+    assert convert_quantity_to_grams(1, "private family serving", "Rice") == 100
 
 
 def test_herb_sprig_units_use_countable_serving_grams():
@@ -323,37 +212,22 @@ def test_clamp_nutrition_uses_manual_save_unit_for_ai_free_text():
     }
 
 
-def test_unknown_tuber_unit_uses_countable_provider_serving_not_one_gram():
-    allowed_units = [
-        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-        {
-            "unit": "sweetpotato",
-            "gram_weight": 130.0,
-            "description": "1 sweetpotato",
-        },
-        {"unit": "oz", "gram_weight": 28.35, "description": "1 oz"},
-        {"unit": "cup", "gram_weight": 200.0, "description": "1 cup, mashed"},
-    ]
-
-    assert _convert_with_allowed_units(
-        1, "củ lớn", allowed_units, "Khoai lang"
-    ) == pytest.approx(130.0)
-    with pytest.raises(ValueError):
-        _convert_with_allowed_units(
-            1, "củ lớn", allowed_units, "Khoai lang", strict=True
-        )
+def test_unknown_tuber_unit_uses_safe_global_fallback():
+    assert _convert_with_serving_options(1, "củ lớn", [], "Khoai lang") == pytest.approx(
+        100.0
+    )
 
 
 def test_gram_alias_is_one_gram_even_when_a_100g_row_exists():
-    allowed_units = [
+    serving_options = [
         {"unit": "gram", "gram_weight": 100.0, "description": "100 gram"},
         {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
         {"unit": "serving", "gram_weight": 100.0, "description": "1 serving"},
         {"unit": "cup", "gram_weight": 120.0, "description": "1 cup"},
     ]
 
-    assert _convert_with_allowed_units(100, "gram", allowed_units, "Beef") == 100
-    assert _convert_with_allowed_units(100, "grams", allowed_units, "Beef") == 100
+    assert _convert_with_serving_options(100, "gram", serving_options, "Beef") == 100
+    assert _convert_with_serving_options(100, "grams", serving_options, "Beef") == 100
     assert convert_quantity_to_grams(100, "gram", "Beef") == 100
 
 
@@ -388,15 +262,5 @@ def test_mieng_maps_to_piece_grams_not_slice():
     assert convert_quantity_to_grams(1, "lát") == pytest.approx(30.0)
 
 
-def test_fallback_custom_serving_options_keep_selected_countable_unit():
-    options = fallback_custom_serving_options("Miếng", "Sườn Nướng")
-    units = {option["unit"]: option["gram_weight"] for option in options}
-
-    assert units["g"] == pytest.approx(1.0)
-    assert units["miếng"] == pytest.approx(100.0)
-    quantity, unit, used_fallback = canonicalize_authoritative_quantity(
-        1, "Miếng", options, "Sườn Nướng"
-    )
-    assert quantity == pytest.approx(1.0)
-    assert unit == "Miếng"
-    assert used_fallback is False
+def test_unknown_custom_unit_uses_safe_global_fallback():
+    assert convert_quantity_to_grams(1, "Miếng", "Sườn Nướng") == pytest.approx(100.0)

--- a/tests/unit/domain/services/test_nutrition_integrity_policy.py
+++ b/tests/unit/domain/services/test_nutrition_integrity_policy.py
@@ -20,7 +20,7 @@ def _valid_payload() -> dict:
         "sugar_100g": 0.1,
         "calories_100g": 123.1,
         "metric_serving_amount": 100.0,
-        "allowed_units": [{"unit": "g", "gram_weight": 1.0}],
+        "serving_options": [{"unit": "g", "gram_weight": 1.0}],
     }
 
 

--- a/tests/unit/domain/test_calorie_formula_parity.py
+++ b/tests/unit/domain/test_calorie_formula_parity.py
@@ -231,7 +231,7 @@ class TestCalorieFormulaParityDirectCall:
                 sugar=12.0,
                 data_source="fatsecret",
                 fdc_id=None,
-                allowed_units=[],
+                serving_options=[],
             )
         )
 

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -310,7 +310,7 @@ class TestUpdateFoodItemStrategy:
         mock_nutrition_service.get_nutrition_for_ingredient.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_v2_update_unit_uses_snapshot_serving_weight(self):
+    async def test_v2_update_unit_uses_global_unit_weight(self):
         strategy = UpdateFoodItemStrategy(Mock())
         snapshot = {
             "protein_per_100g": 2.7,
@@ -318,7 +318,7 @@ class TestUpdateFoodItemStrategy:
             "fat_per_100g": 0.3,
             "fiber_per_100g": 0.4,
             "sugar_per_100g": 0.1,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0},
                 {"unit": "cup", "gram_weight": 158.0},
             ],
@@ -332,7 +332,7 @@ class TestUpdateFoodItemStrategy:
                 macros=Macros(protein=2.7, carbs=28.0, fat=0.3),
                 nutrition_contract_version="2",
                 source_snapshot=snapshot,
-                allowed_units=snapshot["allowed_units"],
+                serving_options=snapshot["serving_options"],
             )
         }
 
@@ -341,7 +341,7 @@ class TestUpdateFoodItemStrategy:
             FoodItemChange(action="update", id="item-1", quantity=1, unit="cup"),
         )
 
-        assert food_items_dict["item-1"].macros.protein == pytest.approx(4.27)
+        assert food_items_dict["item-1"].macros.protein == pytest.approx(6.48)
 
     @pytest.mark.asyncio
     async def test_update_custom_nutrition_preserves_food_reference_id(self):

--- a/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
@@ -221,14 +221,14 @@ async def test_v2_prepared_custom_nutrition_is_saved_without_resolution():
 
 
 @pytest.mark.asyncio
-async def test_v2_prepared_nutrition_uses_confirmed_food_specific_unit():
+async def test_v2_prepared_nutrition_uses_provider_serving_weight():
     item = ManualMealItem(
         name="Pork rib",
         quantity=1,
         unit="slice",
         origin="custom",
         nutrition_contract_version="2",
-        allowed_units=[
+        serving_options=[
             {"unit": "g", "gram_weight": 1, "description": "1 g"},
             {"unit": "slice", "gram_weight": 80, "description": "1 slice"},
         ],

--- a/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
+++ b/tests/unit/handlers/command_handlers/test_parse_meal_text_handler.py
@@ -18,7 +18,7 @@ from src.domain.model.ai.nutrition_contracts import MealTextNutritionResponse
 from src.domain.model.nutrition.macros import Macros
 from src.domain.model.translation_result import TranslationOutcome, TranslationResult
 from src.domain.services.nutrition_calculation_service import (
-    _convert_with_allowed_units,
+    _convert_with_serving_options,
     convert_quantity_to_grams,
 )
 
@@ -88,7 +88,7 @@ class _AllowedUnitsFatSecretService:
             {
                 "food_id": "chicken-breast",
                 "food_name": "Chicken Breast",
-                "allowed_units": [
+                "serving_options": [
                     {
                         "unit": "g",
                         "gram_weight": 100.0,
@@ -136,7 +136,7 @@ class _StructuredFatSecretService:
                 "sugar_100g": 0.7,
                 "calories_100g": 77.0,
                 "metric_serving_amount": 100.0,
-                "allowed_units": [{"unit": "g", "gram_weight": 100.0}],
+                "serving_options": [{"unit": "g", "gram_weight": 100.0}],
             }
         ]
 
@@ -169,7 +169,7 @@ class _BeefFatSecretService:
             "fat_100g": 19.5,
             "calories_100g": 282.0,
             "metric_serving_amount": 100.0,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
             ],
         }
@@ -214,7 +214,7 @@ class _StagedFatSecretService:
             "fat_100g": 0.1,
             "calories_100g": 77.0,
             "metric_serving_amount": 100.0,
-            "allowed_units": [{"unit": "g", "gram_weight": 100.0}],
+            "serving_options": [{"unit": "g", "gram_weight": 100.0}],
         }
 
 
@@ -237,7 +237,7 @@ class _LocalizedServingFatSecretService:
             "fat_100g": 0.1,
             "calories_100g": 77.0,
             "metric_serving_amount": 100.0,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 100.0, "description": "100 g"},
                 {
                     "unit": "medium",
@@ -268,7 +268,7 @@ class _SweetPotatoFatSecretService:
             "fiber_100g": 3.0,
             "calories_100g": 86.0,
             "metric_serving_amount": 100.0,
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
                 {
                     "unit": "sweetpotato",
@@ -497,7 +497,7 @@ async def test_parse_text_keeps_local_reference_beside_fatsecret():
                 "fat_100g": 0.22,
                 "fiber_100g": 0.4,
                 "sugar_100g": 0.1,
-                "allowed_units": [
+                "serving_options": [
                     {"unit": "g", "gram_weight": 1.0, "description": "1 g"}
                 ],
             }
@@ -639,7 +639,7 @@ async def test_parse_text_countable_unit_survives_provider_outage():
     assert item.unit == "g"
     assert item.quantity == 100
     assert item.food_reference_id is None
-    assert {option["unit"] for option in item.allowed_units} == {"g", "kg"}
+    assert item.serving_options == []
     assert response.unmatched_terms == []
 
 
@@ -982,7 +982,7 @@ async def test_parse_text_prefers_localized_side_of_bilingual_pate_name():
 
 
 @pytest.mark.asyncio
-async def test_parse_text_preserves_fatsecret_allowed_units(monkeypatch):
+async def test_parse_text_does_not_emit_fatsecret_serving_options(monkeypatch):
     meal_generation_service = _FakeMealGenerationService(
         responses=[
             {
@@ -1028,15 +1028,7 @@ async def test_parse_text_preserves_fatsecret_allowed_units(monkeypatch):
     item = response.items[0]
 
     assert item.data_source == "fatsecret"
-    assert item.allowed_units == [
-        {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-        {"unit": "serving", "gram_weight": 100.0, "description": "100 g"},
-        {
-            "unit": "cup, cooked, diced",
-            "gram_weight": 135.0,
-            "description": "1 cup cooked, diced",
-        },
-    ]
+    assert item.serving_options
 
 
 @pytest.mark.asyncio
@@ -1220,7 +1212,7 @@ async def test_parse_text_uses_one_staged_detail_for_wrong_first_candidate():
 
 
 @pytest.mark.asyncio
-async def test_provider_parse_returns_authoritative_unit_instead_of_localized_alias():
+async def test_provider_parse_preserves_client_unit_instead_of_provider_alias():
     meal_generation_service = _FakeMealGenerationService(
         responses=[
             {
@@ -1248,20 +1240,14 @@ async def test_provider_parse_returns_authoritative_unit_instead_of_localized_al
     )
     item = response.items[0]
 
-    assert item.unit == "medium"
+    assert item.unit == "cu vua"
     assert item.quantity == 1
     assert item.protein == pytest.approx(3.46)
-    assert _convert_with_allowed_units(
-        item.quantity,
-        item.unit,
-        item.allowed_units,
-        item.name,
-        strict=True,
-    ) == pytest.approx(173)
+    assert item.serving_options
 
 
 @pytest.mark.asyncio
-async def test_provider_parse_falls_back_to_grams_for_unsupported_serving_unit():
+async def test_provider_parse_preserves_unsupported_serving_unit():
     meal_generation_service = _FakeMealGenerationService(
         responses=[
             {
@@ -1289,15 +1275,9 @@ async def test_provider_parse_falls_back_to_grams_for_unsupported_serving_unit()
     )
     item = response.items[0]
 
-    assert item.unit == "g"
-    assert item.quantity == pytest.approx(180)
-    assert _convert_with_allowed_units(
-        item.quantity,
-        item.unit,
-        item.allowed_units,
-        item.name,
-        strict=True,
-    ) == pytest.approx(180)
+    assert item.unit == "to"
+    assert item.quantity == pytest.approx(1)
+    assert item.serving_options
 
 
 @pytest.mark.asyncio
@@ -1337,7 +1317,7 @@ async def test_provider_parse_emits_catalog_density_for_unknown_tuber_unit():
     assert item.carbs_per_100g == pytest.approx(20.1)
     assert item.fat_per_100g == pytest.approx(0.1)
     assert item.calories_per_100g == pytest.approx(81.7, abs=1.0)
-    assert item.unit == "g"
+    assert item.unit == "củ lớn"
 
 
 @pytest.mark.parametrize(
@@ -1536,7 +1516,7 @@ async def test_parse_text_rejects_blank_refinement_unit_before_ai_call():
                         "name": "potato",
                         "quantity": 1,
                         "unit": "piece",
-                        "allowed_units": [{"unit": "   ", "gram_weight": 100}],
+                        "serving_options": [{"unit": "   ", "gram_weight": 100}],
                     }
                 ],
             )
@@ -1716,17 +1696,5 @@ async def test_parse_text_custom_miss_never_writes_catalog():
     assert food_references.adopt_calls == []
 
 
-def test_canonicalize_reference_quantity_maps_gram_alias_to_g():
-    item = {"quantity": 100, "unit": "gram", "english_unit": "gram"}
-    grams = ParseMealTextHandler._canonicalize_reference_quantity(
-        item,
-        quantity_g=100,
-        allowed_units=[
-            {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
-            {"unit": "serving", "gram_weight": 100.0, "description": "1 serving"},
-        ],
-    )
-
-    assert grams == pytest.approx(100)
-    assert item["unit"] == "g"
-    assert item["english_unit"] == "g"
+def test_global_unit_conversion_maps_gram_alias_to_grams():
+    assert convert_quantity_to_grams(100, "gram") == pytest.approx(100)

--- a/tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py
+++ b/tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py
@@ -114,7 +114,7 @@ def _local_rice() -> FoodReferenceSearchProjection:
         fat_100g=0.3,
         fiber_100g=0.4,
         sugar_100g=0.1,
-        allowed_units=[{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
+        serving_options=[{"unit": "g", "gram_weight": 1.0, "description": "1 g"}],
     )
 
 
@@ -448,7 +448,7 @@ async def test_detailed_fatsecret_hit_is_adopted_and_mapped_with_food_reference_
                 "fat_100g": 3.6,
                 "fiber_100g": 0.0,
                 "sugar_100g": 0.0,
-                "allowed_units": [
+                "serving_options": [
                     {"unit": "g", "gram_weight": 100.0, "description": "100 g"}
                 ],
             }

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -104,12 +104,12 @@ def test_fatsecret_nutrition_prefers_100g_serving():
     assert nutrition["protein_100g"] == 10.0
     assert nutrition["carbs_100g"] == 66.67
     assert nutrition["fat_100g"] == 6.67
-    assert nutrition["allowed_units"][0] == {
+    assert nutrition["serving_options"][0] == {
         "unit": "g",
         "gram_weight": 1.0,
         "description": "1 g",
     }
-    assert nutrition["allowed_units"][1]["description"] == "1 cup"
+    assert nutrition["serving_options"][1]["description"] == "1 cup"
 
 
 @pytest.mark.unit
@@ -224,7 +224,7 @@ async def test_fatsecret_search_uses_v5_methods():
     assert search_params["method"] == "foods.search.v5"
     assert search_params["flag_default_serving"] == "true"
     assert detail_params["method"] == "food.get.v5"
-    assert results[0]["allowed_units"][0]["gram_weight"] == 1.0
+    assert results[0]["serving_options"][0]["gram_weight"] == 1.0
 
 
 @pytest.mark.unit
@@ -263,7 +263,7 @@ async def test_fatsecret_search_candidates_does_not_fetch_details():
             "origin": "provider",
             "source_namespace": "fatsecret",
             "source_food_id": "50953",
-            "allowed_units": [
+            "serving_options": [
                 {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
                 {"unit": "serving", "gram_weight": 100.0, "description": "100 g"},
             ],
@@ -402,7 +402,7 @@ async def test_fatsecret_barcode_lookup_uses_method_based_endpoint():
     assert result["origin"] == "provider"
     assert result["source_namespace"] == "fatsecret"
     assert result["source_food_id"] == "50953"
-    assert result["allowed_units"][0] == {
+    assert result["serving_options"][0] == {
         "unit": "g",
         "gram_weight": 1.0,
         "description": "1 g",

--- a/tests/unit/infra/repositories/test_food_reference_projection.py
+++ b/tests/unit/infra/repositories/test_food_reference_projection.py
@@ -96,14 +96,14 @@ def test_food_reference_projection_keeps_exact_serving_description_and_label():
     result = food_reference_model_to_dict(model)
     cooked = next(
         option
-        for option in result["allowed_units"]
+        for option in result["serving_options"]
         if option["unit"] == "cup, cooked, diced"
     )
     assert cooked["description"] == "1 cup cooked, diced"
     assert cooked["display_description"] == "cốc, đã nấu, thái hạt lựu"
 
 
-def test_food_reference_projection_returns_allowed_units_from_serving_rows():
+def test_food_reference_projection_returns_serving_options_from_serving_rows():
     model = _make_food_reference_model("spinach")
     model.serving_size_rows = build_food_reference_serving_rows(
         [{"unit": "serving", "gram_weight": 85}]
@@ -111,7 +111,7 @@ def test_food_reference_projection_returns_allowed_units_from_serving_rows():
 
     result = food_reference_model_to_dict(model)
 
-    assert result["allowed_units"] == [
+    assert result["serving_options"] == [
         {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
         {"unit": "serving", "gram_weight": 85.0, "description": "serving"},
     ]

--- a/tests/unit/infra/services/test_durable_write_service.py
+++ b/tests/unit/infra/services/test_durable_write_service.py
@@ -6,7 +6,6 @@ from src.api.routes.v1.manual_meal_durable import manual_meal_fingerprint
 from src.api.schemas.request.meal_requests import (
     CreateManualMealFromFoodsRequest,
     ManualMealItemRequest,
-    ServingUnitRequest,
 )
 from src.infra.services.durable_write_service import (
     canonicalize_fingerprint,
@@ -35,7 +34,7 @@ def test_normalize_idempotency_key_rejects_too_long():
         normalize_idempotency_key("k" * 161)
 
 
-def test_manual_meal_fingerprint_ignores_allowed_units():
+def test_manual_meal_fingerprint_is_stable_for_same_food_payload():
     base_item = dict(fdc_id=123, name="Oats", quantity=40, unit="g")
     left = CreateManualMealFromFoodsRequest(
         dish_name="Oats",
@@ -49,13 +48,6 @@ def test_manual_meal_fingerprint_ignores_allowed_units():
         meal_type="breakfast",
         target_date="2026-08-11",
         source="manual",
-        items=[
-            ManualMealItemRequest(
-                **base_item,
-                allowed_units=[
-                    ServingUnitRequest(unit="g", gram_weight=1.0, description="gram")
-                ],
-            )
-        ],
+        items=[ManualMealItemRequest(**base_item)],
     )
     assert manual_meal_fingerprint(left) == manual_meal_fingerprint(right)

--- a/tests/unit/infra/test_food_item_source_snapshot.py
+++ b/tests/unit/infra/test_food_item_source_snapshot.py
@@ -19,7 +19,7 @@ def test_food_item_source_snapshot_round_trips_through_orm_mapping():
         source_snapshot={
             "basis": "100g",
             "calories_per_100g": 124.7,
-            "allowed_units": [{"unit": "g", "gram_weight": 1}],
+            "serving_options": [{"unit": "g", "gram_weight": 1}],
         },
     )
 


### PR DESCRIPTION
## Summary
- remove the retired food_item.allowed_units database metadata
- preserve provider/source serving_options for every available measurement and nutrition conversion
- accept serving_options for custom manual meal round-trips while resolving provider options by source identity
- apply localized serving labels to meal-detail responses, including serving (85g) -> Khẩu phần for Vietnamese users

## Validation
- full backend unit suite: 2,791 passed
- mapper regression: 48 passed
- food mapping regression: 5 passed
- compileall and ruff checks passed

The mobile counterpart is tracked in Nutree-AI-Vietnam/nutree_ai PR 708.