### PR TITLE
feat(foods): popular staples from SQL + serving label backfill

### DIFF
--- a/migrations/versions/20260823000002_backfill_popular_staple_serving_labels.py
+++ b/migrations/versions/20260823000002_backfill_popular_staple_serving_labels.py
@@ -1,0 +1,115 @@
+"""Backfill popular staple Vietnamese names and serving labels.
+
+Revision ID: 20260823000002
+Revises: 20260823000001
+Create Date: 2026-08-23
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "20260823000002"
+down_revision: str | None = "20260823000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# beef=205, pork=294, white rice=348, egg=363, whole milk=440
+_STAPLE_NAME_VI = {
+    348: "Cơm",
+}
+
+_STAPLE_SERVING_NAME_VI = (
+    (205, "serving", "Khẩu phần"),
+    (205, "cup, cooked, shredded", "Cốc, đã nấu chín, xé sợi"),
+    (205, "oz, boneless, cooked", "Oz, không xương, đã nấu"),
+    (205, "serving (85g)", "Khẩu phần"),
+    (205, "cup, cooked, diced", "Cốc, đã nấu, cắt hạt lựu"),
+    (
+        205,
+        "oz, boneless, raw (yield after cooking)",
+        "Oz, không xương, sống (sau khi nấu)",
+    ),
+    (205, "cubic inch, boneless, cooked", "Inch khối, không xương, đã nấu"),
+    (294, "serving", "Khẩu phần"),
+    (294, "cup, cooked, diced", "Cốc, đã nấu, cắt hạt lựu"),
+    (294, "oz, boneless, cooked", "Oz, không xương, đã nấu"),
+    (294, "serving (85g)", "Khẩu phần"),
+    (
+        294,
+        "oz, boneless, raw (yield after cooking)",
+        "Oz, không xương, sống (sau khi nấu)",
+    ),
+    (294, "cubic inch, boneless, cooked", "Inch khối, không xương, đã nấu"),
+    (
+        294,
+        "oz, with bone, cooked (yield after bone removed)",
+        "Oz, có xương, đã nấu (sau khi bỏ xương)",
+    ),
+    (348, "cup, cooked", "Cốc, đã nấu"),
+    (348, "serving", "Khẩu phần"),
+    (348, "serving (105g)", "Khẩu phần"),
+    (348, "cup, dry, yields", "Cốc, khô, cho ra"),
+    (348, "oz, dry, yields", "Oz, khô, cho ra"),
+    (363, "large", "Lớn"),
+    (363, "medium", "Vừa"),
+    (363, "serving", "Khẩu phần"),
+    (363, "small", "Nhỏ"),
+    (363, "extra large", "Cực lớn"),
+    (363, "jumbo", "Khổng lồ"),
+    (440, "cup", "Cốc"),
+    (440, "ml", "Ml"),
+    (440, "serving", "Khẩu phần"),
+    (440, "fl oz", "Oz lỏng"),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for ref_id, name_vi in _STAPLE_NAME_VI.items():
+        conn.execute(
+            text(
+                """
+                UPDATE food_reference
+                SET name_vi = :name_vi
+                WHERE id = :ref_id
+                  AND (name_vi IS NULL OR btrim(name_vi) = '')
+                """
+            ),
+            {"ref_id": ref_id, "name_vi": name_vi},
+        )
+
+    for ref_id, name, name_vi in _STAPLE_SERVING_NAME_VI:
+        conn.execute(
+            text(
+                """
+                UPDATE food_reference_serving_sizes
+                SET name_vi = :name_vi
+                WHERE food_reference_id = :ref_id
+                  AND name = :name
+                  AND (name_vi IS NULL OR btrim(name_vi) = '')
+                """
+            ),
+            {"ref_id": ref_id, "name": name, "name_vi": name_vi},
+        )
+
+    conn.execute(
+        text(
+            """
+            UPDATE food_reference_serving_sizes
+            SET description = '100 ml'
+            WHERE food_reference_id = 440
+              AND name = 'ml'
+              AND (
+                description IS NULL
+                OR lower(description) IN ('ml', '1 ml')
+              )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Data backfill only — leave labels in place.
+    pass

--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -135,6 +135,7 @@ from src.app.handlers.query_handlers import (
     GetDailyMacrosQueryHandler,
     GetDailyMovementQueryHandler,
     GetFoodDetailsQueryHandler,
+    GetPopularStaplesQueryHandler,
     GetJourneyProgressQueryHandler,
     GetMealByIdQueryHandler,
     GetMealsByDateQueryHandler,
@@ -177,6 +178,7 @@ from src.app.handlers.query_handlers.list_logged_catalog_meals_query_handler imp
 from src.app.queries.activity import GetBulkActivitiesQuery, GetDailyActivitiesQuery
 from src.app.queries.cheat_day import GetCheatDaysQuery
 from src.app.queries.food.get_food_details_query import GetFoodDetailsQuery
+from src.app.queries.food.get_popular_staples_query import GetPopularStaplesQuery
 from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 from src.app.queries.food.search_foods_query import SearchFoodsQuery
 from src.app.queries.get_weekly_budget_query import GetWeeklyBudgetQuery
@@ -264,6 +266,13 @@ async def _search_local_food_references(
         return await uow.food_references.search_local(query, region, limit)
 
 
+async def _load_popular_staple_food_references(
+    ref_ids: list[int],
+) -> list[dict]:
+    async with AsyncUnitOfWork() as uow:
+        return await uow.food_references.get_by_ids(ref_ids)
+
+
 async def _food_integrity_cache_context() -> dict[str, int | str]:
     """Read DB-owned cache namespace before any food-search cache access."""
     async with AsyncUnitOfWork() as uow:
@@ -335,6 +344,13 @@ def get_food_search_event_bus() -> EventBus:
             local_search=_search_local_food_references,
             integrity_context=_food_integrity_cache_context,
             uow_factory=AsyncUnitOfWork,
+        ),
+    )
+    event_bus.register_handler(
+        GetPopularStaplesQuery,
+        GetPopularStaplesQueryHandler(
+            food_mapping_service,
+            _load_popular_staple_food_references,
         ),
     )
     event_bus.register_handler(
@@ -590,6 +606,13 @@ def get_configured_event_bus() -> EventBus:
             local_search=_search_local_food_references,
             integrity_context=_food_integrity_cache_context,
             uow_factory=AsyncUnitOfWork,
+        ),
+    )
+    event_bus.register_handler(
+        GetPopularStaplesQuery,
+        GetPopularStaplesQueryHandler(
+            food_mapping_service,
+            _load_popular_staple_food_references,
         ),
     )
     event_bus.register_handler(

--- a/src/api/mappers/meal_mapper.py
+++ b/src/api/mappers/meal_mapper.py
@@ -880,10 +880,13 @@ class MealMapper:
                 },
             )
 
+        target_macros_data = daily_macros_data.get("target_macros") or {}
+        if not isinstance(target_macros_data, dict):
+            target_macros_data = {}
         target_macros = MacrosResponse(
-            protein=daily_macros_data.get("target_macros").get("protein") or 0.0,
-            carbs=daily_macros_data.get("target_macros").get("carbs") or 0.0,
-            fat=daily_macros_data.get("target_macros").get("fat") or 0.0,
+            protein=target_macros_data.get("protein") or 0.0,
+            carbs=target_macros_data.get("carbs") or 0.0,
+            fat=target_macros_data.get("fat") or 0.0,
         )
 
         consumed_macros = MacrosResponse(

--- a/src/api/routes/v1/foods.py
+++ b/src/api/routes/v1/foods.py
@@ -24,6 +24,21 @@ FOOD_SEARCH_LIMIT = "30/minute"
 FOOD_AUTOCOMPLETE_LIMIT = "60/minute"
 FOOD_DETAILS_LIMIT = "30/minute"
 FOOD_BARCODE_LIMIT = "20/minute"
+FOOD_POPULAR_STAPLES_LIMIT = "60/minute"
+
+
+@router.get("/popular-staples")
+@limiter.limit(FOOD_POPULAR_STAPLES_LIMIT)
+async def get_popular_staples(
+    request: Request,
+    _: str = Depends(get_current_user_id),
+):
+    """Curated staple foods from food_reference (no live FatSecret search)."""
+    from src.app.queries.food.get_popular_staples_query import GetPopularStaplesQuery
+
+    event_bus = get_food_search_event_bus()
+    language = get_request_language(request)
+    return await event_bus.send(GetPopularStaplesQuery(language=language))
 
 
 @router.get("/search")

--- a/src/app/handlers/query_handlers/__init__.py
+++ b/src/app/handlers/query_handlers/__init__.py
@@ -17,6 +17,7 @@ from .get_daily_macros_query_handler import GetDailyMacrosQueryHandler
 from .get_daily_movement_query_handler import GetDailyMovementQueryHandler
 from .get_drink_catalog_query_handler import GetDrinkCatalogQueryHandler
 from .get_food_details_query_handler import GetFoodDetailsQueryHandler
+from .get_popular_staples_query_handler import GetPopularStaplesQueryHandler
 from .get_journey_progress_query_handler import GetJourneyProgressQueryHandler
 
 # Meal handlers
@@ -56,6 +57,7 @@ __all__ = [
     "PreviewTdeeQueryHandler",
     # Food
     "SearchFoodsQueryHandler",
+    "GetPopularStaplesQueryHandler",
     "GetFoodDetailsQueryHandler",
     "LookupBarcodeQueryHandler",
     # Meal

--- a/src/app/handlers/query_handlers/get_bulk_activities_query_handler.py
+++ b/src/app/handlers/query_handlers/get_bulk_activities_query_handler.py
@@ -137,22 +137,40 @@ class GetBulkActivitiesQueryHandler(
         }
 
         for meal in meals:
-            if meal.status not in _ACTIVE_STATUSES:
-                continue
-            local_date = meal.created_at.astimezone(tz).date().isoformat()
-            if local_date not in result:
-                result[local_date] = []
-            if meal.meal_type == "hydration":
-                if meal.meal_id in covered_meal_ids:
+            try:
+                if meal.status not in _ACTIVE_STATUSES:
                     continue
-                result[local_date].append(_build_hydration_activity(meal, language))
-            else:
-                result[local_date].append(_build_meal_activity(meal, language))
+                if not meal.created_at:
+                    continue
+                local_date = meal.created_at.astimezone(tz).date().isoformat()
+                if local_date not in result:
+                    result[local_date] = []
+                if meal.meal_type == "hydration":
+                    if meal.meal_id in covered_meal_ids:
+                        continue
+                    result[local_date].append(_build_hydration_activity(meal, language))
+                else:
+                    result[local_date].append(_build_meal_activity(meal, language))
+            except Exception:
+                logger.exception(
+                    "Skipping bulk meal activity for meal_id=%s",
+                    getattr(meal, "meal_id", None),
+                )
 
         for entry in hydration_entries:
-            local_date = entry.logged_at.astimezone(tz).date().isoformat()
-            if local_date not in result:
-                result[local_date] = []
-            result[local_date].append(_build_hydration_entry_activity(entry, language))
+            try:
+                if not entry.logged_at:
+                    continue
+                local_date = entry.logged_at.astimezone(tz).date().isoformat()
+                if local_date not in result:
+                    result[local_date] = []
+                result[local_date].append(
+                    _build_hydration_entry_activity(entry, language)
+                )
+            except Exception:
+                logger.exception(
+                    "Skipping bulk hydration entry activity for entry_id=%s",
+                    getattr(entry, "id", None),
+                )
 
         return result

--- a/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
+++ b/src/app/handlers/query_handlers/get_nutrition_bulk_query_handler.py
@@ -151,49 +151,55 @@ class GetNutritionBulkQueryHandler(EventHandler[GetNutritionBulkQuery, dict[str,
 
             weekly_summary = None
             if weekly_budget and weekly_budget.target_revision == target_revision:
-                base_daily = target_calories or (weekly_budget.target_calories / 7)
-                effective = (
-                    await WeeklyBudgetService.get_effective_adjusted_daily_async(
-                        uow=uow,
-                        user_id=query.user_id,
-                        week_start=week_start,
-                        target_date=today,
-                        weekly_budget=weekly_budget,
-                        base_daily_cal=base_daily,
-                        base_daily_protein=(target_macros or {}).get("protein", 70),
-                        base_daily_carbs=(target_macros or {}).get("carbs", 200),
-                        base_daily_fat=(target_macros or {}).get("fat", 70),
-                        bmr=bmr,
-                        user_timezone=user_tz_str,
+                try:
+                    base_daily = target_calories or (weekly_budget.target_calories / 7)
+                    effective = (
+                        await WeeklyBudgetService.get_effective_adjusted_daily_async(
+                            uow=uow,
+                            user_id=query.user_id,
+                            week_start=week_start,
+                            target_date=today,
+                            weekly_budget=weekly_budget,
+                            base_daily_cal=base_daily,
+                            base_daily_protein=(target_macros or {}).get("protein", 70),
+                            base_daily_carbs=(target_macros or {}).get("carbs", 200),
+                            base_daily_fat=(target_macros or {}).get("fat", 70),
+                            bmr=bmr,
+                            user_timezone=user_tz_str,
+                        )
                     )
-                )
-                adjusted = effective.adjusted
-                adjusted_macros = TdeeCalculationService.apply_adjusted_macro_policy(
-                    adjusted.calories,
-                    MacroTargets(
-                        calories=adjusted.calories,
-                        protein=adjusted.protein,
-                        carbs=adjusted.carbs,
-                        fat=adjusted.fat,
-                    ),
-                    macro_preset,
-                    is_custom,
-                )
-                consumed = effective.consumed_total
-                weekly_summary = {
-                    "week_start_date": week_start.isoformat(),
-                    "target_calories": weekly_budget.target_calories,
-                    "consumed_calories": round(consumed["calories"], 1),
-                    "remaining_calories": round(
-                        weekly_budget.target_calories - consumed["calories"], 1
-                    ),
-                    "adjusted_daily_calories": adjusted_macros.calories,
-                    "adjusted_daily_protein": adjusted_macros.protein,
-                    "adjusted_daily_carbs": adjusted_macros.carbs,
-                    "adjusted_daily_fat": adjusted_macros.fat,
-                    "remaining_days": adjusted.remaining_days,
-                    "target_revision": weekly_budget.target_revision,
-                }
+                    adjusted = effective.adjusted
+                    adjusted_macros = TdeeCalculationService.apply_adjusted_macro_policy(
+                        adjusted.calories,
+                        MacroTargets(
+                            calories=adjusted.calories,
+                            protein=adjusted.protein,
+                            carbs=adjusted.carbs,
+                            fat=adjusted.fat,
+                        ),
+                        macro_preset,
+                        is_custom,
+                    )
+                    consumed = effective.consumed_total
+                    weekly_summary = {
+                        "week_start_date": week_start.isoformat(),
+                        "target_calories": weekly_budget.target_calories,
+                        "consumed_calories": round(consumed["calories"], 1),
+                        "remaining_calories": round(
+                            weekly_budget.target_calories - consumed["calories"], 1
+                        ),
+                        "adjusted_daily_calories": adjusted_macros.calories,
+                        "adjusted_daily_protein": adjusted_macros.protein,
+                        "adjusted_daily_carbs": adjusted_macros.carbs,
+                        "adjusted_daily_fat": adjusted_macros.fat,
+                        "remaining_days": adjusted.remaining_days,
+                        "target_revision": weekly_budget.target_revision,
+                    }
+                except Exception:
+                    logger.exception(
+                        "Weekly budget summary failed for user %s; continuing without it",
+                        query.user_id,
+                    )
             elif weekly_budget:
                 logger.warning("Refusing stale weekly target row for user %s", query.user_id)
 

--- a/src/app/handlers/query_handlers/get_popular_staples_query_handler.py
+++ b/src/app/handlers/query_handlers/get_popular_staples_query_handler.py
@@ -1,0 +1,134 @@
+"""Load curated popular staples from food_reference (no FatSecret)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from src.api.mappers.food_reference_display_name import (
+    resolve_food_reference_display_name,
+)
+from src.app.events.base import EventHandler, handles
+from src.app.queries.food.get_popular_staples_query import (
+    POPULAR_STAPLE_FOOD_REFERENCE_IDS,
+    GetPopularStaplesQuery,
+)
+from src.domain.constants.languages import normalize_language
+from src.domain.ports.food_mapping_service_port import FoodMappingServicePort
+from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
+
+logger = logging.getLogger(__name__)
+
+
+@handles(GetPopularStaplesQuery)
+class GetPopularStaplesQueryHandler(
+    EventHandler[GetPopularStaplesQuery, dict[str, Any]]
+):
+    """Return fixed food_reference staples in curated order."""
+
+    def __init__(
+        self,
+        mapping_service: FoodMappingServicePort,
+        load_by_ids: Callable[[list[int]], Any],
+    ):
+        self.mapping_service = mapping_service
+        self.load_by_ids = load_by_ids
+
+    async def handle(self, event: GetPopularStaplesQuery) -> dict[str, Any]:
+        language = normalize_language(event.language)
+        try:
+            rows = await self.load_by_ids(list(POPULAR_STAPLE_FOOD_REFERENCE_IDS))
+        except Exception:
+            logger.warning("popular staples load failed", exc_info=True)
+            return {"results": [], "total": 0}
+
+        by_id = {
+            int(row["id"]): row
+            for row in rows
+            if isinstance(row, dict) and row.get("id") is not None
+        }
+        mapped: list[dict[str, Any]] = []
+        for ref_id in POPULAR_STAPLE_FOOD_REFERENCE_IDS:
+            row = by_id.get(ref_id)
+            if row is None:
+                continue
+            raw = self._to_raw(row, language=language)
+            try:
+                mapped.append(self.mapping_service.map_search_item(raw))
+            except NutritionIntegrityError:
+                logger.info(
+                    "popular staple skipped by integrity",
+                    extra={"food_reference_id": ref_id},
+                )
+            except Exception:
+                logger.warning(
+                    "popular staple map failed",
+                    extra={"food_reference_id": ref_id},
+                    exc_info=True,
+                )
+
+        return {"results": mapped, "total": len(mapped)}
+
+    def _to_raw(self, row: dict[str, Any], *, language: str) -> dict[str, Any]:
+        display_name = resolve_food_reference_display_name(row, language)
+        allowed_units = self._localize_units(
+            row.get("allowed_units") or [],
+            language=language,
+        )
+        return {
+            "source": "food_reference",
+            "food_reference_id": row["id"],
+            "origin": "local",
+            "source_namespace": row.get("source_namespace") or "food_reference",
+            "source_food_id": row.get("source_food_id") or str(row["id"]),
+            "food_id": f"food_reference:{row['id']}",
+            "description": display_name,
+            "name": display_name,
+            "name_vi": row.get("name_vi"),
+            "brand": row.get("brand"),
+            "provider_source": row.get("source"),
+            "is_verified": row.get("is_verified"),
+            "serving_description": row.get("serving_size"),
+            "allowed_units": allowed_units,
+            "protein_100g": row.get("protein_100g"),
+            "carbs_100g": row.get("carbs_100g"),
+            "fat_100g": row.get("fat_100g"),
+            "fiber_100g": row.get("fiber_100g"),
+            "sugar_100g": row.get("sugar_100g"),
+        }
+
+    @staticmethod
+    def _localize_units(units: Any, *, language: str) -> list[dict[str, Any]]:
+        if not isinstance(units, list):
+            return []
+        keep_localized = language == "vi"
+        cleaned: list[dict[str, Any]] = []
+        for raw in units:
+            if not isinstance(raw, dict):
+                continue
+            unit = dict(raw)
+            unit = GetPopularStaplesQueryHandler._normalize_ml_portion(unit)
+            if not keep_localized:
+                unit.pop("display_description", None)
+            cleaned.append(unit)
+        return cleaned
+
+    @staticmethod
+    def _normalize_ml_portion(unit: dict[str, Any]) -> dict[str, Any]:
+        """Treat provider ml rows with ~100g weight as a 100 ml portion."""
+        name = str(unit.get("unit") or "").strip().lower()
+        if name != "ml":
+            return unit
+        try:
+            grams = float(unit.get("gram_weight") or 0)
+        except (TypeError, ValueError):
+            return unit
+        description = str(unit.get("description") or "").strip().lower()
+        if grams > 2.5 and (
+            not description or description in {"ml", "1 ml"} or "100" not in description
+        ):
+            fixed = dict(unit)
+            fixed["description"] = "100 ml"
+            return fixed
+        return unit

--- a/src/app/handlers/query_handlers/get_popular_staples_query_handler.py
+++ b/src/app/handlers/query_handlers/get_popular_staples_query_handler.py
@@ -125,9 +125,8 @@ class GetPopularStaplesQueryHandler(
         except (TypeError, ValueError):
             return unit
         description = str(unit.get("description") or "").strip().lower()
-        if grams > 2.5 and (
-            not description or description in {"ml", "1 ml"} or "100" not in description
-        ):
+        # Only rewrite empty/trivial labels — keep explicit portions like "250 ml".
+        if grams > 2.5 and (not description or description in {"ml", "1 ml"}):
             fixed = dict(unit)
             fixed["description"] = "100 ml"
             return fixed

--- a/src/app/queries/food/get_popular_staples_query.py
+++ b/src/app/queries/food/get_popular_staples_query.py
@@ -1,0 +1,14 @@
+"""Query for curated popular staple foods from food_reference."""
+
+from dataclasses import dataclass
+
+
+# Curated food_reference primary keys (beef, pork, white rice, egg, whole milk).
+POPULAR_STAPLE_FOOD_REFERENCE_IDS: tuple[int, ...] = (205, 294, 348, 363, 440)
+
+
+@dataclass(frozen=True)
+class GetPopularStaplesQuery:
+    """Load fixed staple foods for the catalog popular list."""
+
+    language: str = "en"

--- a/src/infra/mappers/meal_mapper.py
+++ b/src/infra/mappers/meal_mapper.py
@@ -43,14 +43,17 @@ _UNHYDRATABLE_READY_MEAL_ERRORS = {
 
 
 def _nutrition_override_from_orm(value: dict | None) -> NutritionOverride | None:
-    if not value:
+    if not value or not isinstance(value, dict):
         return None
-    return NutritionOverride(
-        calories=float(value["calories"]),
-        protein=float(value["protein"]),
-        carbs=float(value["carbs"]),
-        fat=float(value["fat"]),
-    )
+    try:
+        return NutritionOverride(
+            calories=float(value["calories"]),
+            protein=float(value["protein"]),
+            carbs=float(value["carbs"]),
+            fat=float(value["fat"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def _to_naive_utc(dt: datetime | None) -> datetime | None:

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -90,6 +90,22 @@ class AsyncFoodReferenceRepository:
         model = result.scalar_one_or_none()
         return food_reference_model_to_dict(model) if model else None
 
+    async def get_by_ids(self, ref_ids: list[int]) -> list[dict[str, Any]]:
+        """Load verified public references; caller reorders as needed."""
+        ids = sorted({int(value) for value in ref_ids})
+        if not ids:
+            return []
+        stmt = (
+            select(FoodReferenceModel)
+            .where(FoodReferenceModel.id.in_(ids))
+            .where(self._integrity_repository.public_eligibility_clause())
+            .options(*_FOOD_REFERENCE_LOAD_OPTIONS)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            food_reference_model_to_dict(model) for model in result.scalars().all()
+        ]
+
     async def get_nutrition_projection(
         self,
         food_reference_id: int,

--- a/tests/unit/api/test_event_bus_dependency_singletons.py
+++ b/tests/unit/api/test_event_bus_dependency_singletons.py
@@ -78,13 +78,14 @@ def test_get_food_search_event_bus_is_singleton(monkeypatch):
 
     # Patch handlers to avoid constructing real ones
     monkeypatch.setattr(mod, "SearchFoodsQueryHandler", lambda *a, **k: object())
+    monkeypatch.setattr(mod, "GetPopularStaplesQueryHandler", lambda *a, **k: object())
     monkeypatch.setattr(mod, "GetFoodDetailsQueryHandler", lambda *a, **k: object())
     monkeypatch.setattr(mod, "LookupBarcodeQueryHandler", lambda *a, **k: object())
 
     bus1 = mod.get_food_search_event_bus()
     bus2 = mod.get_food_search_event_bus()
     assert bus1 is bus2
-    assert len(bus1.registered) == 3
+    assert len(bus1.registered) == 4
 
 
 def test_get_configured_event_bus_is_singleton(monkeypatch):

--- a/tests/unit/api/test_meal_mapper.py
+++ b/tests/unit/api/test_meal_mapper.py
@@ -1540,6 +1540,24 @@ class TestMealMapper:
         with pytest.raises(Exception, match="User profile not found"):
             MealMapper.to_daily_nutrition_response(daily_macros_data)
 
+    def test_to_daily_nutrition_response_missing_target_macros(self):
+        """Calories without macros must not 500 — treat macros as zero."""
+        daily_macros_data = {
+            "target_calories": 2000.0,
+            "total_calories": 500.0,
+            "total_protein": 40.0,
+            "total_carbs": 50.0,
+            "total_fat": 10.0,
+        }
+
+        result = MealMapper.to_daily_nutrition_response(daily_macros_data)
+
+        assert result.target_calories == 2000.0
+        assert result.target_macros.protein == 0.0
+        assert result.target_macros.carbs == 0.0
+        assert result.target_macros.fat == 0.0
+        assert result.remaining_calories == 1500.0
+
     def test_to_daily_nutrition_response_over_target(self):
         """Test when consumed calories exceed target."""
         daily_macros_data = {

--- a/tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py
@@ -98,3 +98,20 @@ async def test_popular_staples_strip_vi_labels_for_english():
         if unit["unit"] == "oz, boneless, cooked"
     )
     assert "display_description" not in oz
+
+
+def test_normalize_ml_portion_only_rewrites_trivial_labels():
+    normalize = GetPopularStaplesQueryHandler._normalize_ml_portion
+
+    assert normalize(
+        {"unit": "ml", "gram_weight": 103.133, "description": "ml"}
+    )["description"] == "100 ml"
+    assert normalize(
+        {"unit": "ml", "gram_weight": 103.133, "description": "1 ml"}
+    )["description"] == "100 ml"
+    assert normalize(
+        {"unit": "ml", "gram_weight": 250.0, "description": "250 ml"}
+    )["description"] == "250 ml"
+    assert normalize(
+        {"unit": "ml", "gram_weight": 1.0, "description": "ml"}
+    )["description"] == "ml"

--- a/tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py
@@ -1,0 +1,100 @@
+"""Unit tests for curated popular staples query handler."""
+
+import pytest
+
+from src.app.handlers.query_handlers.get_popular_staples_query_handler import (
+    GetPopularStaplesQueryHandler,
+)
+from src.app.queries.food.get_popular_staples_query import (
+    POPULAR_STAPLE_FOOD_REFERENCE_IDS,
+    GetPopularStaplesQuery,
+)
+from src.domain.services.food_mapping_service import FoodMappingService
+
+
+def _row(ref_id: int, name: str, name_vi: str | None = None) -> dict:
+    return {
+        "id": ref_id,
+        "name": name,
+        "name_vi": name_vi,
+        "brand": None,
+        "source": "fatsecret",
+        "source_namespace": "fatsecret",
+        "source_food_id": str(ref_id),
+        "is_verified": True,
+        "serving_size": None,
+        "protein_100g": 10.0,
+        "carbs_100g": 0.0,
+        "fat_100g": 5.0,
+        "fiber_100g": 0.0,
+        "sugar_100g": 0.0,
+        "allowed_units": [
+            {
+                "unit": "g",
+                "gram_weight": 1.0,
+                "description": "1 g",
+            },
+            {
+                "unit": "oz, boneless, cooked",
+                "gram_weight": 28.35,
+                "description": "oz, boneless, cooked",
+                "display_description": "Oz, không xương, đã nấu",
+            },
+            {
+                "unit": "ml",
+                "gram_weight": 103.133,
+                "description": "ml",
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_popular_staples_preserve_order_and_localize_vi():
+    rows = [
+        _row(205, "Beef", "Thịt bò"),
+        _row(294, "Pork", "Thịt lợn"),
+        _row(348, "White Rice", "Cơm"),
+        _row(363, "Egg", "Trứng"),
+        _row(440, "Whole Milk", "Sữa tươi nguyên kem"),
+    ]
+
+    async def load(_ids):
+        return rows
+
+    handler = GetPopularStaplesQueryHandler(FoodMappingService(), load)
+    result = await handler.handle(GetPopularStaplesQuery(language="vi"))
+
+    assert result["total"] == 5
+    assert [item["food_reference_id"] for item in result["results"]] == list(
+        POPULAR_STAPLE_FOOD_REFERENCE_IDS
+    )
+    assert [item["name"] for item in result["results"]] == [
+        "Thịt bò",
+        "Thịt lợn",
+        "Cơm",
+        "Trứng",
+        "Sữa tươi nguyên kem",
+    ]
+    beef_units = result["results"][0]["allowed_units"]
+    oz = next(unit for unit in beef_units if unit["unit"] == "oz, boneless, cooked")
+    assert oz["display_description"] == "Oz, không xương, đã nấu"
+    ml = next(unit for unit in beef_units if unit["unit"] == "ml")
+    assert ml["description"] == "100 ml"
+
+
+@pytest.mark.asyncio
+async def test_popular_staples_strip_vi_labels_for_english():
+    async def load(_ids):
+        return [_row(205, "Beef", "Thịt bò")]
+
+    handler = GetPopularStaplesQueryHandler(FoodMappingService(), load)
+    result = await handler.handle(GetPopularStaplesQuery(language="en"))
+
+    assert result["results"][0]["name"] == "Beef"
+    oz = next(
+        unit
+        for unit in result["results"][0]["allowed_units"]
+        if unit["unit"] == "oz, boneless, cooked"
+    )
+    assert "display_description" not in oz


### PR DESCRIPTION
## Summary
- Add `GET /v1/foods/popular-staples` for curated beef/pork/rice/egg/milk from `food_reference` (no FatSecret on open)
- Backfill Vietnamese staple serving labels via migration `20260823000002`
- Harden meal/bulk mappers against null `target_macros` / bad activity rows

## Test plan
- [ ] `pytest tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py`
- [ ] `pytest tests/unit/api/test_meal_mapper.py`
- [ ] Call `GET /v1/foods/popular-staples` with `Accept-Language: vi` and confirm 5 staples + localized `display_description`
- [ ] Run migration `20260823000002` on staging and spot-check beef/pork oz/cup `name_vi`


Made with [Cursor](https://cursor.com)