### PR TITLE
fix(foods): resolve popular staples by FatSecret source ids

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -267,10 +267,10 @@ async def _search_local_food_references(
 
 
 async def _load_popular_staple_food_references(
-    ref_ids: list[int],
+    identities: list[tuple[str, str]],
 ) -> list[dict]:
     async with AsyncUnitOfWork() as uow:
-        return await uow.food_references.get_by_ids(ref_ids)
+        return await uow.food_references.get_by_source_identities(identities)
 
 
 async def _food_integrity_cache_context() -> dict[str, int | str]:

--- a/src/app/handlers/query_handlers/get_popular_staples_query_handler.py
+++ b/src/app/handlers/query_handlers/get_popular_staples_query_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 from typing import Any
 
 from src.api.mappers.food_reference_display_name import (
@@ -11,7 +11,7 @@ from src.api.mappers.food_reference_display_name import (
 )
 from src.app.events.base import EventHandler, handles
 from src.app.queries.food.get_popular_staples_query import (
-    POPULAR_STAPLE_FOOD_REFERENCE_IDS,
+    POPULAR_STAPLE_SOURCE_IDENTITIES,
     GetPopularStaplesQuery,
 )
 from src.domain.constants.languages import normalize_language
@@ -19,6 +19,10 @@ from src.domain.ports.food_mapping_service_port import FoodMappingServicePort
 from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
 
 logger = logging.getLogger(__name__)
+
+LoadBySourceIdentities = Callable[
+    [list[tuple[str, str]]], Awaitable[list[dict[str, Any]]]
+]
 
 
 @handles(GetPopularStaplesQuery)
@@ -30,27 +34,31 @@ class GetPopularStaplesQueryHandler(
     def __init__(
         self,
         mapping_service: FoodMappingServicePort,
-        load_by_ids: Callable[[list[int]], Any],
+        load_by_source_identities: LoadBySourceIdentities,
     ):
         self.mapping_service = mapping_service
-        self.load_by_ids = load_by_ids
+        self.load_by_source_identities = load_by_source_identities
 
     async def handle(self, event: GetPopularStaplesQuery) -> dict[str, Any]:
         language = normalize_language(event.language)
+        identities = list(POPULAR_STAPLE_SOURCE_IDENTITIES)
         try:
-            rows = await self.load_by_ids(list(POPULAR_STAPLE_FOOD_REFERENCE_IDS))
+            rows = await self.load_by_source_identities(identities)
         except Exception:
             logger.warning("popular staples load failed", exc_info=True)
             return {"results": [], "total": 0}
 
-        by_id = {
-            int(row["id"]): row
+        by_identity = {
+            (
+                str(row.get("source_namespace") or ""),
+                str(row.get("source_food_id") or ""),
+            ): row
             for row in rows
-            if isinstance(row, dict) and row.get("id") is not None
+            if isinstance(row, dict)
         }
         mapped: list[dict[str, Any]] = []
-        for ref_id in POPULAR_STAPLE_FOOD_REFERENCE_IDS:
-            row = by_id.get(ref_id)
+        for namespace, food_id in identities:
+            row = by_identity.get((namespace, food_id))
             if row is None:
                 continue
             raw = self._to_raw(row, language=language)
@@ -59,12 +67,18 @@ class GetPopularStaplesQueryHandler(
             except NutritionIntegrityError:
                 logger.info(
                     "popular staple skipped by integrity",
-                    extra={"food_reference_id": ref_id},
+                    extra={
+                        "source_namespace": namespace,
+                        "source_food_id": food_id,
+                    },
                 )
             except Exception:
                 logger.warning(
                     "popular staple map failed",
-                    extra={"food_reference_id": ref_id},
+                    extra={
+                        "source_namespace": namespace,
+                        "source_food_id": food_id,
+                    },
                     exc_info=True,
                 )
 

--- a/src/app/queries/food/get_popular_staples_query.py
+++ b/src/app/queries/food/get_popular_staples_query.py
@@ -2,9 +2,16 @@
 
 from dataclasses import dataclass
 
-
-# Curated food_reference primary keys (beef, pork, white rice, egg, whole milk).
-POPULAR_STAPLE_FOOD_REFERENCE_IDS: tuple[int, ...] = (205, 294, 348, 363, 440)
+# Stable FatSecret identities (beef, pork, white rice, egg, whole milk).
+# Do not key staples by auto-increment food_reference PKs — those diverge
+# across local/staging/prod. Verified via FatSecret food.get.v5 2026-08-25.
+POPULAR_STAPLE_SOURCE_IDENTITIES: tuple[tuple[str, str], ...] = (
+    ("fatsecret", "1350"),
+    ("fatsecret", "1421"),
+    ("fatsecret", "4501"),
+    ("fatsecret", "3092"),
+    ("fatsecret", "794"),
+)
 
 
 @dataclass(frozen=True)

--- a/src/domain/ports/food_reference_repository_port.py
+++ b/src/domain/ports/food_reference_repository_port.py
@@ -105,6 +105,12 @@ class FoodReferenceRepositoryPort(Protocol):
     ) -> dict[str, Any] | None:
         """Return the food-reference row already tagged with this provider id."""
 
+    async def get_by_source_identities(
+        self,
+        identities: list[tuple[str, str]],
+    ) -> list[dict[str, Any]]:
+        """Load verified public references by (namespace, source_food_id)."""
+
     async def adopt_provider_food(
         self,
         namespace: str,

--- a/src/domain/services/food_mapping_service.py
+++ b/src/domain/services/food_mapping_service.py
@@ -116,13 +116,20 @@ class FoodMappingService(FoodMappingServicePort):
             fat = result.fat_100g
             fiber = result.fiber_100g
             calories = result.derived_calories_100g
+            source_namespace = str(item.get("source_namespace") or "").strip()
+            source_food_id = item.get("source_food_id")
+            if not source_namespace or source_namespace == "food_reference":
+                source_namespace = "food_reference"
+                source_food_id = str(food_reference_id)
+            else:
+                source_food_id = str(source_food_id or food_reference_id)
             return {
                 "fdc_id": None,
                 "food_id": expected_alias,
                 "food_reference_id": food_reference_id,
                 "origin": "local",
-                "source_namespace": "food_reference",
-                "source_food_id": str(food_reference_id),
+                "source_namespace": source_namespace,
+                "source_food_id": source_food_id,
                 "name": item.get("description"),
                 "brand": item.get("brand"),
                 "data_type": "food_reference",

--- a/src/infra/repositories/food_reference_repository_async.py
+++ b/src/infra/repositories/food_reference_repository_async.py
@@ -106,6 +106,35 @@ class AsyncFoodReferenceRepository:
             food_reference_model_to_dict(model) for model in result.scalars().all()
         ]
 
+    async def get_by_source_identities(
+        self, identities: list[tuple[str, str]]
+    ) -> list[dict[str, Any]]:
+        """Load verified public references by provider identity; caller reorders."""
+        cleaned = [
+            (str(namespace).strip(), str(food_id).strip())
+            for namespace, food_id in identities
+            if str(namespace).strip() and str(food_id).strip()
+        ]
+        if not cleaned:
+            return []
+        clauses = [
+            and_(
+                FoodReferenceModel.source_namespace == namespace,
+                FoodReferenceModel.source_food_id == food_id,
+            )
+            for namespace, food_id in cleaned
+        ]
+        stmt = (
+            select(FoodReferenceModel)
+            .where(or_(*clauses))
+            .where(self._integrity_repository.public_eligibility_clause())
+            .options(*_FOOD_REFERENCE_LOAD_OPTIONS)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            food_reference_model_to_dict(model) for model in result.scalars().all()
+        ]
+
     async def get_nutrition_projection(
         self,
         food_reference_id: int,

--- a/tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py
@@ -6,13 +6,19 @@ from src.app.handlers.query_handlers.get_popular_staples_query_handler import (
     GetPopularStaplesQueryHandler,
 )
 from src.app.queries.food.get_popular_staples_query import (
-    POPULAR_STAPLE_FOOD_REFERENCE_IDS,
+    POPULAR_STAPLE_SOURCE_IDENTITIES,
     GetPopularStaplesQuery,
 )
 from src.domain.services.food_mapping_service import FoodMappingService
 
 
-def _row(ref_id: int, name: str, name_vi: str | None = None) -> dict:
+def _row(
+    ref_id: int,
+    name: str,
+    *,
+    source_food_id: str,
+    name_vi: str | None = None,
+) -> dict:
     return {
         "id": ref_id,
         "name": name,
@@ -20,7 +26,7 @@ def _row(ref_id: int, name: str, name_vi: str | None = None) -> dict:
         "brand": None,
         "source": "fatsecret",
         "source_namespace": "fatsecret",
-        "source_food_id": str(ref_id),
+        "source_food_id": source_food_id,
         "is_verified": True,
         "serving_size": None,
         "protein_100g": 10.0,
@@ -52,23 +58,33 @@ def _row(ref_id: int, name: str, name_vi: str | None = None) -> dict:
 @pytest.mark.asyncio
 async def test_popular_staples_preserve_order_and_localize_vi():
     rows = [
-        _row(205, "Beef", "Thịt bò"),
-        _row(294, "Pork", "Thịt lợn"),
-        _row(348, "White Rice", "Cơm"),
-        _row(363, "Egg", "Trứng"),
-        _row(440, "Whole Milk", "Sữa tươi nguyên kem"),
+        _row(1933, "Beef", source_food_id="1350", name_vi="Thịt bò"),
+        _row(1934, "Pork", source_food_id="1421", name_vi="Thịt lợn"),
+        _row(1885, "White Rice", source_food_id="4501", name_vi="Cơm"),
+        _row(1887, "Egg", source_food_id="3092", name_vi="Trứng"),
+        _row(1886, "Whole Milk", source_food_id="794", name_vi="Sữa tươi nguyên kem"),
     ]
 
-    async def load(_ids):
+    async def load(_identities):
         return rows
 
     handler = GetPopularStaplesQueryHandler(FoodMappingService(), load)
     result = await handler.handle(GetPopularStaplesQuery(language="vi"))
 
     assert result["total"] == 5
-    assert [item["food_reference_id"] for item in result["results"]] == list(
-        POPULAR_STAPLE_FOOD_REFERENCE_IDS
-    )
+    assert [item["source_food_id"] for item in result["results"]] == [
+        food_id for _, food_id in POPULAR_STAPLE_SOURCE_IDENTITIES
+    ]
+    assert [item["source_namespace"] for item in result["results"]] == [
+        "fatsecret"
+    ] * 5
+    assert [item["food_reference_id"] for item in result["results"]] == [
+        1933,
+        1934,
+        1885,
+        1887,
+        1886,
+    ]
     assert [item["name"] for item in result["results"]] == [
         "Thịt bò",
         "Thịt lợn",
@@ -85,8 +101,8 @@ async def test_popular_staples_preserve_order_and_localize_vi():
 
 @pytest.mark.asyncio
 async def test_popular_staples_strip_vi_labels_for_english():
-    async def load(_ids):
-        return [_row(205, "Beef", "Thịt bò")]
+    async def load(_identities):
+        return [_row(1933, "Beef", source_food_id="1350", name_vi="Thịt bò")]
 
     handler = GetPopularStaplesQueryHandler(FoodMappingService(), load)
     result = await handler.handle(GetPopularStaplesQuery(language="en"))


### PR DESCRIPTION
## Summary
- Popular staples are resolved by stable FatSecret `(namespace, source_food_id)` identities instead of brittle `food_reference` PKs that diverge across local/staging/prod.
- Adds `get_by_source_identities` and preserves FatSecret `source_*` on mapped catalog search hits so clients can match staples correctly.
- Fixes the bug where prefetch showed Beef/Pork/Rice/Egg/Milk but saved meals reopened as unrelated catalog foods.

## Test plan
- [x] `pytest tests/unit/handlers/query_handlers/test_get_popular_staples_query_handler.py`
- [x] Related food-mapping unit tests
- [ ] `GET /v1/foods/popular-staples` on staging returns Beef/Pork/White Rice/Egg/Whole Milk with correct `food_reference_id`s
- [ ] Create meal from staples → after durable save, reopen shows the same foods


Made with [Cursor](https://cursor.com)