### PR TITLE
fix: preserve calories from parsed text items

### DIFF
--- a/src/api/routes/v1/meals_route_helpers.py
+++ b/src/api/routes/v1/meals_route_helpers.py
@@ -71,7 +71,7 @@ def parsed_food_item_to_response(item) -> ParsedFoodItem:
         name=item.name,
         quantity=item.quantity,
         unit=item.unit,
-        calories=MacrosModel(
+        calories=item.calories if getattr(item, "calories", None) is not None else MacrosModel(
             protein=item.protein,
             carbs=item.carbs,
             fat=item.fat,

--- a/src/app/handlers/command_handlers/parse_meal_text_handler.py
+++ b/src/app/handlers/command_handlers/parse_meal_text_handler.py
@@ -282,6 +282,7 @@ class ParseMealTextHandler(
                 fat=item.get("fat", 0),
                 fiber=item.get("fiber", 0),
                 sugar=item.get("sugar", 0),
+                calories=item.get("calories"),
                 data_source=item.get("data_source"),
                 fdc_id=item.get("fdc_id"),
                 allowed_units=item.get("allowed_units")

--- a/src/app/schemas/meal_schemas.py
+++ b/src/app/schemas/meal_schemas.py
@@ -19,6 +19,7 @@ class ParsedFoodItemDto:
     fat: float
     fiber: float = 0.0
     sugar: float = 0.0
+    calories: float | None = None
     data_source: str | None = None
     fdc_id: int | None = None
     allowed_units: list[dict[str, Any]] | None = None


### PR DESCRIPTION
Fixes an issue where `kcal` values generated by the AI parse text were overwritten with macro-derived values on response serialization, causing inconsistencies between the parsed values and the values shown when the meal is opened.

---
*PR created automatically by Jules for task [18029500415029016691](https://jules.google.com/task/18029500415029016691) started by @phuoctung28*