### PR TITLE
perf(foods): stage FatSecret search (no N× food.get fan-out)

### DIFF
--- a/src/api/dependencies/event_bus.py
+++ b/src/api/dependencies/event_bus.py
@@ -135,6 +135,7 @@ from src.app.handlers.query_handlers import (
     GetDailyMacrosQueryHandler,
     GetDailyMovementQueryHandler,
     GetFoodDetailsQueryHandler,
+    GetProviderFoodDetailsQueryHandler,
     GetPopularStaplesQueryHandler,
     GetJourneyProgressQueryHandler,
     GetMealByIdQueryHandler,
@@ -178,6 +179,9 @@ from src.app.handlers.query_handlers.list_logged_catalog_meals_query_handler imp
 from src.app.queries.activity import GetBulkActivitiesQuery, GetDailyActivitiesQuery
 from src.app.queries.cheat_day import GetCheatDaysQuery
 from src.app.queries.food.get_food_details_query import GetFoodDetailsQuery
+from src.app.queries.food.get_provider_food_details_query import (
+    GetProviderFoodDetailsQuery,
+)
 from src.app.queries.food.get_popular_staples_query import GetPopularStaplesQuery
 from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 from src.app.queries.food.search_foods_query import SearchFoodsQuery
@@ -357,6 +361,15 @@ def get_food_search_event_bus() -> EventBus:
         GetFoodDetailsQuery,
         GetFoodDetailsQueryHandler(
             food_data_service, food_cache_service, food_mapping_service
+        ),
+    )
+    event_bus.register_handler(
+        GetProviderFoodDetailsQuery,
+        GetProviderFoodDetailsQueryHandler(
+            food_mapping_service,
+            fat_secret_service=fat_secret_service,
+            uow_factory=AsyncUnitOfWork,
+            cache_service=food_cache_service,
         ),
     )
     event_bus.register_handler(
@@ -619,6 +632,15 @@ def get_configured_event_bus() -> EventBus:
         GetFoodDetailsQuery,
         GetFoodDetailsQueryHandler(
             food_data_service, food_cache_service, food_mapping_service
+        ),
+    )
+    event_bus.register_handler(
+        GetProviderFoodDetailsQuery,
+        GetProviderFoodDetailsQueryHandler(
+            food_mapping_service,
+            fat_secret_service=fat_secret_service,
+            uow_factory=AsyncUnitOfWork,
+            cache_service=food_cache_service,
         ),
     )
 

--- a/src/api/routes/v1/foods.py
+++ b/src/api/routes/v1/foods.py
@@ -13,6 +13,9 @@ from src.api.middleware.accept_language import get_request_language
 from src.api.middleware.rate_limit import limiter
 from src.api.schemas.response.barcode_product_response import BarcodeProductResponse
 from src.app.queries.food.get_food_details_query import GetFoodDetailsQuery
+from src.app.queries.food.get_provider_food_details_query import (
+    GetProviderFoodDetailsQuery,
+)
 from src.app.queries.food.lookup_barcode_query import LookupBarcodeQuery
 from src.app.queries.food.search_foods_query import SearchFoodsQuery
 from src.domain.exceptions.barcode_exceptions import InvalidBarcodeError
@@ -23,6 +26,7 @@ router = APIRouter(prefix="/v1/foods", tags=["Foods"])
 FOOD_SEARCH_LIMIT = "30/minute"
 FOOD_AUTOCOMPLETE_LIMIT = "60/minute"
 FOOD_DETAILS_LIMIT = "30/minute"
+FOOD_PROVIDER_DETAILS_LIMIT = "60/minute"
 FOOD_BARCODE_LIMIT = "20/minute"
 FOOD_POPULAR_STAPLES_LIMIT = "60/minute"
 
@@ -74,6 +78,31 @@ async def autocomplete_foods(
         autocomplete=True,
     )
     return await event_bus.send(query)
+
+
+@router.get("/provider/{namespace}/{source_food_id}/details")
+@limiter.limit(FOOD_PROVIDER_DETAILS_LIMIT)
+async def get_provider_food_details(
+    request: Request,
+    namespace: str,
+    source_food_id: str,
+    _: str = Depends(get_current_user_id),
+):
+    """Resolve one provider food (FatSecret) after search select — single food.get."""
+    event_bus = get_food_search_event_bus()
+    language = get_request_language(request)
+    try:
+        return await event_bus.send(
+            GetProviderFoodDetailsQuery(
+                source_namespace=namespace,
+                source_food_id=source_food_id,
+                language=language,
+            )
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/{fdc_id}/details")

--- a/src/app/handlers/command_handlers/meal_text_parsing_utils.py
+++ b/src/app/handlers/command_handlers/meal_text_parsing_utils.py
@@ -8,7 +8,17 @@ import logging
 import re
 from typing import Any
 
+from src.domain.services.fatsecret_description_nutrition import (
+    parse_fatsecret_nutrition,
+)
+
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "extract_json_from_response",
+    "extract_usda_nutrition",
+    "parse_fatsecret_nutrition",
+]
 
 
 def extract_json_from_response(content: str) -> list[dict[str, Any]]:
@@ -88,37 +98,3 @@ def extract_usda_nutrition(nutrients: list[dict[str, Any]]) -> dict[str, float]:
         elif nutrient_id in (204, 1004):  # Fat
             result["fat"] = float(value)
     return result
-
-
-def parse_fatsecret_nutrition(food: dict[str, Any]) -> dict[str, float]:
-    """Parse per-100g nutrition from fatsecret food_description field.
-
-    fatsecret format: 'Per 100g - Calories: 155kcal | Fat: 11g | Carbs: 1.1g | Protein: 13g'
-    """
-    desc = food.get("food_description", "")
-    if not desc:
-        return {}
-    result: dict[str, float] = {}
-    try:
-        for part in desc.split("|"):
-            part = part.strip().lower()
-            if "calories" in part or "cal" in part:
-                val = re.search(r"([\d.]+)", part)
-                if val:
-                    result["calories"] = float(val.group(1))
-            elif "fat" in part:
-                val = re.search(r"([\d.]+)", part)
-                if val:
-                    result["fat"] = float(val.group(1))
-            elif "carb" in part:
-                val = re.search(r"([\d.]+)", part)
-                if val:
-                    result["carbs"] = float(val.group(1))
-            elif "protein" in part:
-                val = re.search(r"([\d.]+)", part)
-                if val:
-                    result["protein"] = float(val.group(1))
-    except Exception as e:
-        logger.debug(f"Could not parse fatsecret nutrition: {e}")
-        return {}
-    return result if result else {}

--- a/src/app/handlers/query_handlers/__init__.py
+++ b/src/app/handlers/query_handlers/__init__.py
@@ -17,6 +17,9 @@ from .get_daily_macros_query_handler import GetDailyMacrosQueryHandler
 from .get_daily_movement_query_handler import GetDailyMovementQueryHandler
 from .get_drink_catalog_query_handler import GetDrinkCatalogQueryHandler
 from .get_food_details_query_handler import GetFoodDetailsQueryHandler
+from .get_provider_food_details_query_handler import (
+    GetProviderFoodDetailsQueryHandler,
+)
 from .get_popular_staples_query_handler import GetPopularStaplesQueryHandler
 from .get_journey_progress_query_handler import GetJourneyProgressQueryHandler
 
@@ -59,6 +62,7 @@ __all__ = [
     "SearchFoodsQueryHandler",
     "GetPopularStaplesQueryHandler",
     "GetFoodDetailsQueryHandler",
+    "GetProviderFoodDetailsQueryHandler",
     "LookupBarcodeQueryHandler",
     # Meal
     "GetMealByIdQueryHandler",

--- a/src/app/handlers/query_handlers/get_provider_food_details_query_handler.py
+++ b/src/app/handlers/query_handlers/get_provider_food_details_query_handler.py
@@ -11,8 +11,8 @@ from src.app.queries.food.get_provider_food_details_query import (
     GetProviderFoodDetailsQuery,
 )
 from src.domain.cache.cache_keys import CacheKeys
+from src.domain.constants.fatsecret_locale import LANGUAGE_TO_REGION
 from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
-from src.infra.adapters.fat_secret_service import LANGUAGE_TO_REGION
 from src.observability import distribution_metric, increment_metric
 
 logger = logging.getLogger(__name__)

--- a/src/app/handlers/query_handlers/get_provider_food_details_query_handler.py
+++ b/src/app/handlers/query_handlers/get_provider_food_details_query_handler.py
@@ -1,0 +1,171 @@
+"""Resolve a single FatSecret (provider) food via food.get.v5 on select."""
+
+from __future__ import annotations
+
+import logging
+from time import perf_counter
+from typing import Any
+
+from src.app.events.base import EventHandler, handles
+from src.app.queries.food.get_provider_food_details_query import (
+    GetProviderFoodDetailsQuery,
+)
+from src.domain.cache.cache_keys import CacheKeys
+from src.domain.services.nutrition_integrity_policy import NutritionIntegrityError
+from src.infra.adapters.fat_secret_service import LANGUAGE_TO_REGION
+from src.observability import distribution_metric, increment_metric
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_NAMESPACES = frozenset({"fatsecret"})
+
+
+@handles(GetProviderFoodDetailsQuery)
+class GetProviderFoodDetailsQueryHandler(
+    EventHandler[GetProviderFoodDetailsQuery, dict[str, Any]]
+):
+    """Fetch full provider nutrition for one selected search candidate."""
+
+    def __init__(
+        self,
+        mapping_service,
+        fat_secret_service: Any | None = None,
+        uow_factory: Any | None = None,
+        cache_service: Any | None = None,
+    ):
+        self.mapping_service = mapping_service
+        self.fat_secret_service = fat_secret_service
+        self.uow_factory = uow_factory
+        self.cache_service = cache_service
+
+    async def handle(self, event: GetProviderFoodDetailsQuery) -> dict[str, Any]:
+        started = perf_counter()
+        namespace = (event.source_namespace or "").strip().lower()
+        source_food_id = str(event.source_food_id or "").strip()
+        if namespace not in SUPPORTED_NAMESPACES or not source_food_id:
+            self._record(started, status="invalid")
+            raise ValueError("unsupported provider food identity")
+
+        if self.fat_secret_service is None:
+            self._record(started, status="unavailable")
+            raise LookupError("fatsecret provider is not configured")
+
+        language = event.language or "en"
+        region = LANGUAGE_TO_REGION.get(language, "US")
+        detail_language = language if language in LANGUAGE_TO_REGION else "en"
+        cache_id = f"provider:{namespace}:{source_food_id}:{detail_language}"
+
+        cached = await self._read_cache(cache_id)
+        if cached is not None:
+            mapped = self._map_item(cached)
+            if mapped is not None:
+                self._record(started, status="cache")
+                return mapped
+
+        details = await self.fat_secret_service.get_food_details(
+            source_food_id,
+            region=region,
+            language=detail_language,
+        )
+        if not details:
+            self._record(started, status="empty")
+            raise LookupError("provider food not found")
+
+        details.setdefault("source", "fatsecret")
+        details.setdefault("source_namespace", "fatsecret")
+        details.setdefault("source_food_id", source_food_id)
+        details.setdefault("food_id", source_food_id)
+        details.setdefault("origin", "provider")
+
+        if event.adopt:
+            await self._adopt(details, language=language)
+
+        mapped = self._map_item(details)
+        if mapped is None:
+            self._record(started, status="rejected")
+            raise LookupError("provider food failed nutrition integrity")
+
+        await self._write_cache(cache_id, details)
+        self._record(started, status="success")
+        return mapped
+
+    def _map_item(self, item: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            mapped = self.mapping_service.map_search_item(item)
+        except NutritionIntegrityError as exc:
+            logger.info(
+                "provider food details rejected by integrity: %s",
+                exc.result.reason_code,
+            )
+            return None
+        if item.get("food_reference_id") is not None:
+            mapped["food_reference_id"] = item["food_reference_id"]
+        return mapped
+
+    async def _adopt(self, item: dict[str, Any], *, language: str) -> None:
+        if self.uow_factory is None:
+            return
+        if item.get("metric_serving_amount") is None:
+            return
+        if not all(
+            item.get(field) is not None
+            for field in ("protein_100g", "carbs_100g", "fat_100g")
+        ):
+            return
+        display_name = str(item.get("description") or item.get("name") or "")
+        english_name = str(item.get("canonical_name") or display_name)
+        try:
+            async with self.uow_factory() as uow:
+                adopted = await uow.food_references.adopt_provider_food(
+                    item.get("source_namespace") or "fatsecret",
+                    str(item.get("source_food_id") or item.get("food_id")),
+                    english_name,
+                    {
+                        "protein_100g": item.get("protein_100g"),
+                        "carbs_100g": item.get("carbs_100g"),
+                        "fat_100g": item.get("fat_100g"),
+                        "fiber_100g": item.get("fiber_100g") or 0,
+                        "sugar_100g": item.get("sugar_100g") or 0,
+                    },
+                    item.get("allowed_units"),
+                    language,
+                    display_name,
+                )
+            item["food_reference_id"] = adopted.get("id")
+        except Exception:
+            logger.warning("provider food adopt failed", exc_info=True)
+
+    async def _read_cache(self, cache_id: str) -> dict[str, Any] | None:
+        redis = getattr(self.cache_service, "cache_service", None)
+        if redis is None:
+            return None
+        try:
+            cache_key, _ = CacheKeys.food_details(cache_id)
+            return await redis.get_json(cache_key)
+        except Exception:
+            logger.warning("provider food cache read failed", exc_info=True)
+            return None
+
+    async def _write_cache(self, cache_id: str, payload: dict[str, Any]) -> None:
+        redis = getattr(self.cache_service, "cache_service", None)
+        if redis is None:
+            return
+        try:
+            cache_key, default_ttl = CacheKeys.food_details(cache_id)
+            await redis.set_json(cache_key, payload, default_ttl)
+        except Exception:
+            logger.warning("provider food cache write failed", exc_info=True)
+
+    def _record(self, started: float, *, status: str) -> None:
+        attributes = {
+            "operation": "provider_details",
+            "source": "fatsecret",
+            "status": status,
+        }
+        distribution_metric(
+            "food_search.operation.latency_ms",
+            (perf_counter() - started) * 1000,
+            unit="millisecond",
+            attributes=attributes,
+        )
+        increment_metric("food_search.requests", attributes=attributes)

--- a/src/app/handlers/query_handlers/search_foods_query_handler.py
+++ b/src/app/handlers/query_handlers/search_foods_query_handler.py
@@ -146,8 +146,11 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
                 )
             else:
                 try:
-                    fs_results = await self.fat_secret_service.search_foods(
-                        event.query, max_results=remaining_limit
+                    # Candidates only — never fan out food.get.v5 per hit.
+                    # Detail enrichment happens on provider details / select.
+                    fs_results = await self._search_provider_candidates(
+                        event.query,
+                        remaining_limit,
                     )
                     if not event.autocomplete:
                         await self._adopt_provider_hits(fs_results, locale="en")
@@ -263,6 +266,10 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
             return False
         if not (item.get("source_food_id") or item.get("food_id")):
             return False
+        # Search-description macros lack metric_serving_amount; only adopt
+        # fully resolved food.get.v5 (or servings-embedded) hits.
+        if item.get("metric_serving_amount") is None:
+            return False
         return all(
             item.get(field) is not None
             for field in ("protein_100g", "carbs_100g", "fat_100g")
@@ -276,9 +283,7 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
     ) -> list[dict[str, Any]]:
         """Acquire canonical provider data for later locale presentation."""
         try:
-            results = await self.fat_secret_service.search_foods(
-                query, max_results=limit
-            )
+            results = await self._search_provider_candidates(query, limit)
             if results:
                 for item in results:
                     english = str(item.get("description") or item.get("name") or "")
@@ -290,6 +295,27 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
         except Exception:
             logger.warning("fatsecret canonical search failed", exc_info=True)
         return local_raw
+
+    async def _search_provider_candidates(
+        self, query: str, limit: int
+    ) -> list[dict[str, Any]]:
+        """FatSecret search without per-hit detail fetches."""
+        from inspect import isawaitable
+
+        service = self.fat_secret_service
+        if service is None:
+            return []
+        search_candidates = getattr(service, "search_food_candidates", None)
+        if callable(search_candidates):
+            result = search_candidates(query, max_results=limit)
+            if isawaitable(result):
+                resolved = await result
+                if isinstance(resolved, list):
+                    return resolved
+            elif isinstance(result, list):
+                return result
+        # Test doubles / older adapters may only expose search_foods.
+        return await service.search_foods(query, max_results=limit)
 
     async def _canonical_query(self, query: str, language: str) -> str:
         if language == "en" or self.translation_service is None:
@@ -459,7 +485,8 @@ class SearchFoodsQueryHandler(EventHandler[SearchFoodsQuery, dict[str, Any]]):
     def _cache_key(query: str, language: str) -> str:
         normalized = re.sub(r"\s+", " ", query.strip().lower())
         digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-        return f"food-search:v2:{language}:{digest}"
+        # v3: candidate-only FatSecret payloads (no per-hit food.get.v5).
+        return f"food-search:v3:{language}:{digest}"
 
     def _source_label(self, local_count: int, result_count: int) -> str:
         if local_count and result_count > local_count:

--- a/src/app/queries/food/get_provider_food_details_query.py
+++ b/src/app/queries/food/get_provider_food_details_query.py
@@ -1,0 +1,13 @@
+"""Query to resolve one provider food (e.g. FatSecret) after search select."""
+
+from dataclasses import dataclass
+
+from src.app.events.base import Query
+
+
+@dataclass
+class GetProviderFoodDetailsQuery(Query):
+    source_namespace: str
+    source_food_id: str
+    language: str = "en"
+    adopt: bool = True

--- a/src/domain/cache/cache_keys.py
+++ b/src/domain/cache/cache_keys.py
@@ -17,7 +17,8 @@ class CacheKeys:
     # Bumped when search-time catalog adoption changes what a cached search
     # result contains (e.g. adding food_reference_id to provider hits), so
     # stale pre-adoption entries expire instead of serving thin ids forever.
-    CATALOG_ADOPT_CACHE_VERSION = "catalog_adopt_v1"
+    # v2: candidate-only FatSecret search (no N× food.get.v5 enrichment).
+    CATALOG_ADOPT_CACHE_VERSION = "catalog_adopt_v2"
 
     TTL_10_MIN = 600
     TTL_5_MIN = 300

--- a/src/domain/constants/fatsecret_locale.py
+++ b/src/domain/constants/fatsecret_locale.py
@@ -1,0 +1,11 @@
+"""FatSecret locale helpers shared by search and provider-detail flows."""
+
+LANGUAGE_TO_REGION = {
+    "vi": "VN",
+    "en": "US",
+    "es": "ES",
+    "fr": "FR",
+    "de": "DE",
+    "ja": "JP",
+    "zh": "CN",
+}

--- a/src/domain/services/fatsecret_description_nutrition.py
+++ b/src/domain/services/fatsecret_description_nutrition.py
@@ -1,0 +1,83 @@
+"""Parse FatSecret search ``food_description`` strings into per-100g macros.
+
+Search responses often include a description like:
+``Per 100g - Calories: 155kcal | Fat: 11g | Carbs: 1.1g | Protein: 13g``
+
+This is display-quality for list results. Authoritative per-100g + servings
+still come from ``food.get.v5`` on select.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_PER_100G_HINT = re.compile(r"per\s*100\s*g", re.IGNORECASE)
+
+
+def parse_fatsecret_nutrition(food: dict[str, Any]) -> dict[str, float]:
+    """Parse calories/protein/carbs/fat from a FatSecret food_description field."""
+    desc = str(food.get("food_description") or "")
+    if not desc:
+        return {}
+    result: dict[str, float] = {}
+    try:
+        for part in desc.split("|"):
+            part = part.strip().lower()
+            if "calories" in part or (
+                "cal" in part and "carb" not in part and "protein" not in part
+            ):
+                val = re.search(r"(?:calories|cal(?:ories)?)\s*[:=]?\s*([\d.]+)", part)
+                if not val:
+                    val = re.search(r"([\d.]+)\s*kcal", part)
+                if val:
+                    result["calories"] = float(val.group(1))
+            elif "fat" in part:
+                val = re.search(r"fat\s*[:=]?\s*([\d.]+)", part)
+                if not val:
+                    val = re.search(r"([\d.]+)", part)
+                if val:
+                    result["fat"] = float(val.group(1))
+            elif "carb" in part:
+                val = re.search(r"carb(?:ohydrate|s)?\s*[:=]?\s*([\d.]+)", part)
+                if not val:
+                    val = re.search(r"([\d.]+)", part)
+                if val:
+                    result["carbs"] = float(val.group(1))
+            elif "protein" in part:
+                val = re.search(r"protein\s*[:=]?\s*([\d.]+)", part)
+                if not val:
+                    val = re.search(r"([\d.]+)", part)
+                if val:
+                    result["protein"] = float(val.group(1))
+    except Exception as exc:
+        logger.debug("Could not parse fatsecret nutrition: %s", type(exc).__name__)
+        return {}
+    return result
+
+
+def description_macros_as_100g(food: dict[str, Any]) -> dict[str, float]:
+    """Map description macros onto ``*_100g`` fields when description is per-100g.
+
+    Non-100g descriptions (e.g. ``Per Serving``) are ignored so we do not
+    treat serving-basis values as per-100g densities.
+    """
+    desc = str(food.get("food_description") or "")
+    if not desc or not _PER_100G_HINT.search(desc):
+        return {}
+    parsed = parse_fatsecret_nutrition(food)
+    if not parsed:
+        return {}
+    mapped: dict[str, float] = {}
+    if "calories" in parsed:
+        mapped["calories_100g"] = parsed["calories"]
+    if "protein" in parsed:
+        mapped["protein_100g"] = parsed["protein"]
+    if "carbs" in parsed:
+        mapped["carbs_100g"] = parsed["carbs"]
+    if "fat" in parsed:
+        mapped["fat_100g"] = parsed["fat"]
+    return mapped

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -13,6 +13,9 @@ from typing import Any
 
 import httpx
 
+from src.domain.services.fatsecret_description_nutrition import (
+    description_macros_as_100g,
+)
 from src.domain.services.nutrition_integrity_policy import (
     NutritionIntegrityPolicy,
     normalize_serving_options,
@@ -553,6 +556,10 @@ class FatSecretService:
         }
         if food.get("servings"):
             mapped.update(self._extract_nutrition_from_details(food))
+        elif not _has_search_macros(mapped):
+            # List-quality macros from search description only (no food.get.v5).
+            # Does not set metric_serving_amount — search adoption stays gated.
+            mapped.update(description_macros_as_100g(food))
         return mapped
 
     def _safe_float(self, value: Any) -> float | None:

--- a/src/infra/adapters/fat_secret_service.py
+++ b/src/infra/adapters/fat_secret_service.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import httpx
 
+from src.domain.constants.fatsecret_locale import LANGUAGE_TO_REGION
 from src.domain.services.fatsecret_description_nutrition import (
     description_macros_as_100g,
 )
@@ -30,17 +31,6 @@ FATSECRET_API_BASE = "https://platform.fatsecret.com/rest/server.api"
 
 # Barcode validation pattern (8-14 digits)
 BARCODE_PATTERN = re.compile(r"^\d{8,14}$")
-
-# Map language code to fatsecret region for localized search
-LANGUAGE_TO_REGION = {
-    "vi": "VN",
-    "en": "US",
-    "es": "ES",
-    "fr": "FR",
-    "de": "DE",
-    "ja": "JP",
-    "zh": "CN",
-}
 
 
 def _has_search_macros(food: dict[str, Any]) -> bool:

--- a/tests/unit/api/test_event_bus_dependency_singletons.py
+++ b/tests/unit/api/test_event_bus_dependency_singletons.py
@@ -80,12 +80,15 @@ def test_get_food_search_event_bus_is_singleton(monkeypatch):
     monkeypatch.setattr(mod, "SearchFoodsQueryHandler", lambda *a, **k: object())
     monkeypatch.setattr(mod, "GetPopularStaplesQueryHandler", lambda *a, **k: object())
     monkeypatch.setattr(mod, "GetFoodDetailsQueryHandler", lambda *a, **k: object())
+    monkeypatch.setattr(
+        mod, "GetProviderFoodDetailsQueryHandler", lambda *a, **k: object()
+    )
     monkeypatch.setattr(mod, "LookupBarcodeQueryHandler", lambda *a, **k: object())
 
     bus1 = mod.get_food_search_event_bus()
     bus2 = mod.get_food_search_event_bus()
     assert bus1 is bus2
-    assert len(bus1.registered) == 4
+    assert len(bus1.registered) == 5
 
 
 def test_get_configured_event_bus_is_singleton(monkeypatch):

--- a/tests/unit/domain/cache/test_food_search_cache_version.py
+++ b/tests/unit/domain/cache/test_food_search_cache_version.py
@@ -17,5 +17,5 @@ def test_food_search_cache_namespace_includes_generation_after_integrity_transit
 
     assert (
         key
-        == "food:search:v3:catalog_adopt_v1:nutrition_integrity_v1:generation:12:rice"
+        == "food:search:v3:catalog_adopt_v2:nutrition_integrity_v1:generation:12:rice"
     )

--- a/tests/unit/domain/services/test_fatsecret_description_nutrition.py
+++ b/tests/unit/domain/services/test_fatsecret_description_nutrition.py
@@ -1,0 +1,39 @@
+"""Tests for FatSecret food_description macro parsing."""
+
+from src.domain.services.fatsecret_description_nutrition import (
+    description_macros_as_100g,
+    parse_fatsecret_nutrition,
+)
+
+
+def test_parse_skips_per_100g_prefix_digits():
+    parsed = parse_fatsecret_nutrition(
+        {
+            "food_description": (
+                "Per 100g - Calories: 155kcal | Fat: 11g | Carbs: 1.1g | Protein: 13g"
+            )
+        }
+    )
+    assert parsed == {
+        "calories": 155.0,
+        "fat": 11.0,
+        "carbs": 1.1,
+        "protein": 13.0,
+    }
+
+
+def test_description_macros_as_100g_requires_per_100g_hint():
+    assert description_macros_as_100g(
+        {
+            "food_description": (
+                "Per Serving - Calories: 200kcal | Fat: 8g | Carbs: 20g | Protein: 10g"
+            )
+        }
+    ) == {}
+    assert description_macros_as_100g(
+        {
+            "food_description": (
+                "Per 100g - Calories: 155kcal | Fat: 11g | Carbs: 1.1g | Protein: 13g"
+            )
+        }
+    )["protein_100g"] == 13.0

--- a/tests/unit/handlers/query_handlers/test_get_provider_food_details_query_handler.py
+++ b/tests/unit/handlers/query_handlers/test_get_provider_food_details_query_handler.py
@@ -1,0 +1,119 @@
+"""Tests for GetProviderFoodDetailsQueryHandler."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.app.handlers.query_handlers.get_provider_food_details_query_handler import (
+    GetProviderFoodDetailsQueryHandler,
+)
+from src.app.queries.food.get_provider_food_details_query import (
+    GetProviderFoodDetailsQuery,
+)
+
+
+class _FakeFoodReferenceRepo:
+    def __init__(self):
+        self.calls = []
+
+    async def adopt_provider_food(self, *args):
+        self.calls.append(args)
+        return {"id": 42}
+
+
+class _FakeUow:
+    def __init__(self, repo):
+        self.food_references = repo
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeUowFactory:
+    def __init__(self, repo):
+        self.repo = repo
+
+    def __call__(self):
+        return _FakeUow(self.repo)
+
+
+@pytest.mark.asyncio
+async def test_provider_details_fetches_and_maps_one_food():
+    fat_secret = MagicMock()
+    fat_secret.get_food_details = AsyncMock(
+        return_value={
+            "description": "Chicken Breast",
+            "source": "fatsecret",
+            "source_namespace": "fatsecret",
+            "source_food_id": "123",
+            "food_id": "123",
+            "protein_100g": 31.0,
+            "carbs_100g": 0.0,
+            "fat_100g": 3.6,
+            "metric_serving_amount": 100.0,
+            "allowed_units": [
+                {"unit": "g", "gram_weight": 1.0, "description": "1 g"},
+            ],
+        }
+    )
+    mapping = MagicMock()
+    mapping.map_search_item.side_effect = lambda item: {
+        **item,
+        "name": item.get("description"),
+        "origin": "provider",
+    }
+    repo = _FakeFoodReferenceRepo()
+
+    handler = GetProviderFoodDetailsQueryHandler(
+        mapping_service=mapping,
+        fat_secret_service=fat_secret,
+        uow_factory=_FakeUowFactory(repo),
+    )
+
+    result = await handler.handle(
+        GetProviderFoodDetailsQuery(
+            source_namespace="fatsecret",
+            source_food_id="123",
+            language="en",
+        )
+    )
+
+    fat_secret.get_food_details.assert_awaited_once()
+    assert result["name"] == "Chicken Breast"
+    assert result["food_reference_id"] == 42
+    assert len(repo.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_details_rejects_unknown_namespace():
+    handler = GetProviderFoodDetailsQueryHandler(
+        mapping_service=MagicMock(),
+        fat_secret_service=MagicMock(),
+    )
+    with pytest.raises(ValueError):
+        await handler.handle(
+            GetProviderFoodDetailsQuery(
+                source_namespace="usda",
+                source_food_id="1",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_provider_details_missing_food_raises_lookup():
+    fat_secret = MagicMock()
+    fat_secret.get_food_details = AsyncMock(return_value=None)
+    handler = GetProviderFoodDetailsQueryHandler(
+        mapping_service=MagicMock(),
+        fat_secret_service=fat_secret,
+    )
+    with pytest.raises(LookupError):
+        await handler.handle(
+            GetProviderFoodDetailsQuery(
+                source_namespace="fatsecret",
+                source_food_id="missing",
+            )
+        )

--- a/tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py
+++ b/tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py
@@ -222,7 +222,7 @@ async def test_non_english_search_translates_query_and_only_full_results_are_cac
     ]
     fat_secret.search_foods.assert_awaited_once_with("rice", max_results=20)
     cache.cache_search.assert_awaited_once()
-    assert cache.cache_search.call_args.args[0].startswith("food-search:v2:vi:")
+    assert cache.cache_search.call_args.args[0].startswith("food-search:v3:vi:")
 
 
 @pytest.mark.asyncio
@@ -448,6 +448,7 @@ async def test_detailed_fatsecret_hit_is_adopted_and_mapped_with_food_reference_
                 "fat_100g": 3.6,
                 "fiber_100g": 0.0,
                 "sugar_100g": 0.0,
+                "metric_serving_amount": 100.0,
                 "allowed_units": [
                     {"unit": "g", "gram_weight": 100.0, "description": "100 g"}
                 ],
@@ -528,6 +529,84 @@ async def test_autocomplete_search_never_adopts():
 
 
 @pytest.mark.asyncio
+async def test_search_description_macros_without_metric_are_not_adopted():
+    """List-quality description macros must not adopt into the catalog."""
+    cache = MagicMock()
+    cache.get_cached_search = AsyncMock(return_value=None)
+    cache.cache_search = AsyncMock()
+    fat_secret = MagicMock()
+    fat_secret.search_food_candidates = AsyncMock(
+        return_value=[
+            {
+                "description": "Chicken Breast",
+                "source": "fatsecret",
+                "source_namespace": "fatsecret",
+                "source_food_id": "55",
+                "food_id": "55",
+                "protein_100g": 31.0,
+                "carbs_100g": 0.0,
+                "fat_100g": 3.6,
+            }
+        ]
+    )
+    mapping = MagicMock()
+    mapping.map_search_item.side_effect = lambda item: dict(item)
+    repo = _FakeFoodReferenceRepo()
+    uow_factory = _FakeUowFactory(repo)
+
+    handler = SearchFoodsQueryHandler(
+        cache_service=cache,
+        mapping_service=mapping,
+        fat_secret_service=fat_secret,
+        local_search=AsyncMock(return_value=[]),
+        uow_factory=uow_factory,
+    )
+
+    result = await handler.handle(
+        SearchFoodsQuery(query="chicken", language="en", limit=5)
+    )
+
+    assert repo.calls == []
+    assert "food_reference_id" not in result["results"][0]
+    fat_secret.search_food_candidates.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_search_prefers_candidates_over_enriched_search_foods():
+    """Search UI path must call candidates (no N× food.get fan-out)."""
+    cache = MagicMock()
+    cache.get_cached_search = AsyncMock(return_value=None)
+    cache.cache_search = AsyncMock()
+    fat_secret = MagicMock()
+    fat_secret.search_food_candidates = AsyncMock(
+        return_value=[
+            {
+                "description": "Rice",
+                "source": "fatsecret",
+                "source_namespace": "fatsecret",
+                "source_food_id": "1",
+                "food_id": "1",
+            }
+        ]
+    )
+    fat_secret.search_foods = AsyncMock(return_value=[])
+    mapping = MagicMock()
+    mapping.map_search_item.side_effect = lambda item: dict(item)
+
+    handler = SearchFoodsQueryHandler(
+        cache_service=cache,
+        mapping_service=mapping,
+        fat_secret_service=fat_secret,
+        local_search=AsyncMock(return_value=[]),
+    )
+
+    await handler.handle(SearchFoodsQuery(query="rice", language="en", limit=5))
+
+    fat_secret.search_food_candidates.assert_awaited_once_with("rice", max_results=5)
+    fat_secret.search_foods.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_thin_provider_hit_without_macros_is_not_adopted():
     """A candidate with no durable macros must not trigger an adopt write."""
     cache = MagicMock()
@@ -585,6 +664,7 @@ async def test_localized_search_adopts_before_translation_overwrites_name():
                 "protein_100g": 6.0,
                 "carbs_100g": 10.0,
                 "fat_100g": 2.0,
+                "metric_serving_amount": 100.0,
             }
         ]
     )

--- a/tests/unit/infra/adapters/test_fat_secret_service.py
+++ b/tests/unit/infra/adapters/test_fat_secret_service.py
@@ -407,3 +407,38 @@ async def test_fatsecret_barcode_lookup_uses_method_based_endpoint():
         "gram_weight": 1.0,
         "description": "1 g",
     }
+
+
+@pytest.mark.unit
+def test_map_search_result_parses_per_100g_description():
+    service = FatSecretService("client", "secret")
+    mapped = service._map_search_result(
+        {
+            "food_id": "1",
+            "food_name": "Egg",
+            "food_description": (
+                "Per 100g - Calories: 155kcal | Fat: 11g | Carbs: 1.1g | Protein: 13g"
+            ),
+        }
+    )
+    assert mapped["protein_100g"] == 13.0
+    assert mapped["carbs_100g"] == 1.1
+    assert mapped["fat_100g"] == 11.0
+    assert mapped["calories_100g"] == 155.0
+    assert mapped.get("metric_serving_amount") is None
+
+
+@pytest.mark.unit
+def test_map_search_result_ignores_per_serving_description_as_100g():
+    service = FatSecretService("client", "secret")
+    mapped = service._map_search_result(
+        {
+            "food_id": "1",
+            "food_name": "Bar",
+            "food_description": (
+                "Per Serving - Calories: 200kcal | Fat: 8g | Carbs: 20g | Protein: 10g"
+            ),
+        }
+    )
+    assert mapped.get("protein_100g") is None
+    assert mapped.get("calories_100g") is None


### PR DESCRIPTION
## Summary
- Food search/autocomplete uses `search_food_candidates` only (one FatSecret search call).
- Parses `Per 100g` `food_description` macros for list display; does not adopt thin hits into catalog.
- Adds `GET /v1/foods/provider/{namespace}/{source_food_id}/details` for a single `food.get.v5` on select.
- Bumps search cache to v3 / `catalog_adopt_v2`.

## Test plan
- [ ] Unit: `pytest tests/unit/handlers/query_handlers/test_search_foods_partial_cache.py tests/unit/handlers/query_handlers/test_get_provider_food_details_query_handler.py tests/unit/infra/adapters/test_fat_secret_service.py tests/unit/domain/services/test_fatsecret_description_nutrition.py`
- [ ] Manual: type a FatSecret food query → results appear without multi-second wait
- [ ] Manual: tap a result → details/servings load; logging macros look correct
- [ ] Manual: non-English search still returns localized names


Made with [Cursor](https://cursor.com)