### PR TITLE
feat(meals): persist client meal and item UUIDs on create

### DIFF
--- a/docs/decisions/260826-client-stable-meal-and-item-ids.md
+++ b/docs/decisions/260826-client-stable-meal-and-item-ids.md
@@ -1,0 +1,90 @@
+# Client-Stable Meal and Item IDs
+
+**Status:** Accepted  
+**Date:** 2026-08-26  
+**Scope:** Manual and parse-text meal create, edit-add ingredient identity, and mobile optimistic create/edit convergence.
+
+## Context
+
+Manual and parse-text create used server-minted meal and food-item primary keys.
+Mobile promoted `localId` → `serverId` after create and remapped ingredient ids
+when the server returned different PKs. That forced add/remove outboxes, alias
+merge on Home, and snap-back when users edited the plate before create ack.
+
+Photo, scan, and hydration create paths were already server-minted and unrelated
+to parse/cart identity. Durable write operation identity (`Idempotency-Key`) is
+documented separately in
+`backend/docs/decisions/260811-durable-write-contract.md`.
+
+Calories-from-macros remains unchanged: macros are source of truth; backend
+derives calories (`tdee_service.py`, meal nutrition paths).
+
+## Decision
+
+### Create (manual / parse-text)
+
+1. **Optional client UUIDs are server PKs.** `CreateManualMealFromFoodsRequest`
+   accepts optional `meal_id` and per-item `id`. When present and valid, the
+   handler **INSERT**s those values as primary keys — no upsert, no remint.
+2. **Omit → mint.** Missing or blank ids are replaced with server-generated
+   UUID v4 (`client_resource_id.resolve_client_meal_id`, item id mint in create
+   handler). Legacy clients that omit ids keep working.
+3. **INSERT-only conflicts → 409.** If a requested meal id already exists:
+   same user → `409` `CLIENT_MEAL_ID_CONFLICT`; another user → `409`
+   `CLIENT_MEAL_ID_CONFLICT` (wrong account). Never attach an existing row.
+4. **Payload shape errors → 400.** Duplicate item ids in one create payload →
+   `400` `DUPLICATE_CLIENT_ITEM_ID`. Non-UUID `meal_id` or item `id` →
+   `400` `INVALID_CLIENT_RESOURCE_ID`. Request schema validators live on
+   `CreateManualMealFromFoodsRequest`; handler checks in
+   `client_resource_id.py`.
+5. **Idempotency-Key stays operation identity.** Header fingerprint replay is
+   unchanged (`260811-durable-write-contract.md`). Body `meal_id` is the
+   resource primary key. Create may send the same UUID in both places; the
+   server evaluates them independently (replay claim vs PK reservation).
+6. **Photo / scan / hydration unchanged.** Those flows do not accept client
+   meal or item PKs; ids remain server-minted. Do not unify with manual/parse.
+
+### Edit-add
+
+7. **Honor client item id on add.** `AddFoodItemStrategy._resolve_add_item_id`
+   uses `change.id` when it is a valid UUID and the id is unused on the meal;
+   mint only when omitted. Invalid UUID → reject. Re-adding the same id on the
+   same meal is idempotent update semantics (existing row wins).
+
+### Mobile contract (pointer)
+
+8. Mobile sends cart item UUIDs from parse/search and uses Save `operationId`
+   as create `meal_id`. After create ack: tombstone → DELETE; else if the
+   local plate is dirty → one PUT of the current plate; else apply create body
+   (same ids). No food-item remap or add/remove outbox for new creates.
+   Authoritative detail: `mobile/docs/decisions/reliable-write-contract.md` and
+   `mobile/docs/architecture.md` (Caching intent).
+
+## Consequences
+
+Positive:
+
+- Optimistic create/edit uses one id end-to-end; no promote/remap race on Home
+  or edit.
+- Rapid edit during in-flight create converges with a single diff PUT, not an
+  outbox of per-item adds/removes.
+- PK conflicts are explicit (`409`) instead of silent upsert corruption.
+- Photo/scan/hydration and calories-from-macros contracts stay isolated.
+
+Trade-offs:
+
+- `food_item.id` is a global PK; clients must not reuse ids across meals.
+- Expand/contract: older cache rows may still have `localId != serverId`; dual-read
+  remains for one release.
+- `MealWriteCoordinator.automaticMutationReplayEnabled` stays **false**; ambiguous
+  transport is persisted, not auto-retried.
+
+## Validation
+
+Evidence:
+
+- `backend/src/app/handlers/command_handlers/client_resource_id.py`
+- `backend/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py`
+- `backend/src/domain/strategies/meal_edit_strategies.py` (`_resolve_add_item_id`)
+- `backend/tests/unit/domain/test_meal_edit_strategies.py` (`test_add_keeps_client_item_id`)
+- `mobile/test/features/meal_edit/application/providers/meal_edit_promote_after_create_test.dart`

--- a/src/api/routes/v1/meals_manual_text.py
+++ b/src/api/routes/v1/meals_manual_text.py
@@ -162,6 +162,7 @@ async def create_manual_meal(
                 )
             items.append(
                 ManualMealItem(
+                    id=i.id,
                     fdc_id=i.fdc_id,
                     name=i.name,
                     quantity=i.quantity,
@@ -197,6 +198,7 @@ async def create_manual_meal(
             user_id=user_id,
             items=items,
             dish_name=payload.dish_name,
+            meal_id=payload.meal_id,
             meal_type=payload.meal_type,
             target_date=target_date,
             source=payload.source,

--- a/src/api/schemas/request/meal_requests.py
+++ b/src/api/schemas/request/meal_requests.py
@@ -2,6 +2,7 @@
 Meal-related request DTOs.
 """
 
+import uuid
 import warnings
 from datetime import datetime
 from typing import Any, Literal, Optional
@@ -203,12 +204,29 @@ class ServingUnitRequest(BaseModel):
     description: str = Field("", max_length=200)
 
 
+def _validate_optional_client_uuid(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    try:
+        return str(uuid.UUID(trimmed))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a valid UUID") from exc
+
+
 class ManualMealItemRequest(BaseModel):
     """Single selected food item with portion to create a manual meal.
 
     Supports both USDA foods (via fdc_id) and custom foods (via name + custom_nutrition).
     """
 
+    id: Optional[str] = Field(
+        None,
+        max_length=36,
+        description="Client-assigned food item UUID; server mints when omitted",
+    )
     fdc_id: Optional[int] = Field(
         None, description="USDA FDC ID (required for USDA foods)"
     )
@@ -252,11 +270,21 @@ class ManualMealItemRequest(BaseModel):
         description="Custom nutrition data for non-USDA foods",
     )
 
+    @field_validator("id")
+    @classmethod
+    def validate_item_id_uuid(cls, value: str | None) -> str | None:
+        return _validate_optional_client_uuid(value, field="item id")
+
 
 class CreateManualMealFromFoodsRequest(BaseModel):
     """Create a manual meal from selected USDA foods with portions."""
 
     dish_name: str = Field(..., min_length=1, max_length=200)
+    meal_id: Optional[str] = Field(
+        None,
+        max_length=36,
+        description="Client-assigned meal UUID; server mints when omitted",
+    )
     items: list[ManualMealItemRequest] = Field(..., min_items=1, max_length=50)
     nutrition_contract_version: Optional[int] = Field(
         None, description="Versioned authoritative nutrition save contract"
@@ -271,6 +299,21 @@ class CreateManualMealFromFoodsRequest(BaseModel):
         None, description="Meal source: scanner, prompt, food_search, manual"
     )
     emoji: Optional[str] = Field(None, description="AI-assigned dish emoji")
+
+    @field_validator("meal_id")
+    @classmethod
+    def validate_meal_id_uuid(cls, value: str | None) -> str | None:
+        return _validate_optional_client_uuid(value, field="meal_id")
+
+    @model_validator(mode="after")
+    def validate_unique_item_ids(self) -> "CreateManualMealFromFoodsRequest":
+        seen: set[str] = set()
+        for item in self.items:
+            if item.id and item.id in seen:
+                raise ValueError("duplicate item ids in request")
+            if item.id:
+                seen.add(item.id)
+        return self
 
     @model_validator(mode="after")
     def validate_custom_nutrition_bounds(self):

--- a/src/app/commands/meal/create_manual_meal_command.py
+++ b/src/app/commands/meal/create_manual_meal_command.py
@@ -25,6 +25,7 @@ class CustomNutrition:
 class ManualMealItem:
     """Manual meal item - either USDA (fdc_id) or custom (name + nutrition)."""
 
+    id: Optional[str] = None
     fdc_id: Optional[int] = None
     name: Optional[str] = None
     quantity: float = 1.0  # in grams or unit-specified grams base
@@ -45,6 +46,7 @@ class CreateManualMealCommand(Command):
     user_id: str
     items: List[ManualMealItem]
     dish_name: str
+    meal_id: Optional[str] = None
     meal_type: Optional[str] = None
     target_date: Optional[date] = None
     source: Optional[str] = None  # scanner, prompt, food_search, manual

--- a/src/app/handlers/command_handlers/client_resource_id.py
+++ b/src/app/handlers/command_handlers/client_resource_id.py
@@ -1,0 +1,70 @@
+"""Validate and resolve client-supplied meal and food-item UUIDs."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from uuid import uuid4
+
+from src.api.exceptions import ConflictException, ValidationException
+from src.domain.ports.meal_repository_port import MealRepositoryPort
+
+
+def parse_optional_client_uuid(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    try:
+        return str(uuid.UUID(trimmed))
+    except ValueError as exc:
+        raise ValidationException(
+            f"Invalid {field}: must be a UUID",
+            error_code="INVALID_CLIENT_RESOURCE_ID",
+            details={field: value},
+        ) from exc
+
+
+def assert_unique_command_item_ids(items: Iterable) -> None:
+    seen: set[str] = set()
+    for item in items:
+        raw_id = getattr(item, "id", None)
+        if not raw_id:
+            continue
+        parsed = parse_optional_client_uuid(raw_id, field="item id")
+        assert parsed is not None
+        if parsed in seen:
+            raise ValidationException(
+                "Duplicate food item ids in request",
+                error_code="DUPLICATE_CLIENT_ITEM_ID",
+            )
+        seen.add(parsed)
+
+
+async def resolve_client_meal_id(
+    *,
+    requested_meal_id: str | None,
+    user_id: str,
+    meal_repo: MealRepositoryPort,
+) -> str:
+    meal_id = parse_optional_client_uuid(requested_meal_id, field="meal_id")
+    if meal_id is None:
+        return str(uuid4())
+
+    existing = await meal_repo.find_by_id(meal_id)
+    if existing is None:
+        return meal_id
+
+    if existing.user_id != user_id:
+        raise ConflictException(
+            "Meal id is already in use by another account",
+            error_code="CLIENT_MEAL_ID_CONFLICT",
+            details={"meal_id": meal_id},
+        )
+
+    raise ConflictException(
+        "Meal id already exists",
+        error_code="CLIENT_MEAL_ID_CONFLICT",
+        details={"meal_id": meal_id},
+    )

--- a/src/app/handlers/command_handlers/create_manual_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/create_manual_meal_command_handler.py
@@ -9,9 +9,15 @@ from datetime import timedelta
 from typing import Any
 from uuid import uuid4
 
+from sqlalchemy.exc import IntegrityError
+
 from src.api.exceptions import ConflictException, ValidationException
 from src.app.commands.meal.create_manual_meal_command import CreateManualMealCommand
 from src.app.events.base import EventHandler
+from src.app.handlers.command_handlers.client_resource_id import (
+    assert_unique_command_item_ids,
+    resolve_client_meal_id,
+)
 from src.app.services.cache_invalidation_service import CacheInvalidationService
 from src.app.services.manual_meal_nutrition_resolver import (
     ManualMealNutritionResolver,
@@ -145,9 +151,7 @@ class CreateManualMealCommandHandler(EventHandler[CreateManualMealCommand, Any])
 
         try:
             items_needing_resolution = [
-                item
-                for item in event.items
-                if not self._is_prepared_nutrition(item)
+                item for item in event.items if not self._is_prepared_nutrition(item)
             ]
             if items_needing_resolution:
                 async with self.uow_factory() as resolve_uow:
@@ -261,6 +265,7 @@ class CreateManualMealCommandHandler(EventHandler[CreateManualMealCommand, Any])
         revalidate_local=True,
     ):
         items = resolved_items or event.items
+        assert_unique_command_item_ids(items)
         if event.nutrition_contract_version == 2 and resolved_items is None:
             if uow is None or not getattr(uow, "food_references", None):
                 raise ValueError(
@@ -302,8 +307,14 @@ class CreateManualMealCommandHandler(EventHandler[CreateManualMealCommand, Any])
             else:
                 source = "manual"
 
+        meal_id = await resolve_client_meal_id(
+            requested_meal_id=event.meal_id,
+            user_id=event.user_id,
+            meal_repo=meal_repo,
+        )
+
         meal = Meal(
-            meal_id=str(uuid4()),
+            meal_id=meal_id,
             user_id=event.user_id,
             status=MealStatus.READY,
             created_at=meal_datetime,
@@ -321,7 +332,13 @@ class CreateManualMealCommandHandler(EventHandler[CreateManualMealCommand, Any])
             source=source,
         )
 
-        saved_meal = await meal_repo.save(meal)
+        try:
+            saved_meal = await meal_repo.save(meal)
+        except IntegrityError as exc:
+            raise ConflictException(
+                "A client-supplied id is already in use",
+                error_code="CLIENT_RESOURCE_ID_CONFLICT",
+            ) from exc
         if uow is None:
             # injected meal_repository path: invalidate here as there is no outer UoW block
             if self.cache_invalidation:

--- a/src/app/handlers/command_handlers/create_manual_meal_command_handler.py
+++ b/src/app/handlers/command_handlers/create_manual_meal_command_handler.py
@@ -333,7 +333,7 @@ class CreateManualMealCommandHandler(EventHandler[CreateManualMealCommand, Any])
         )
 
         try:
-            saved_meal = await meal_repo.save(meal)
+            saved_meal = await meal_repo.insert(meal)
         except IntegrityError as exc:
             raise ConflictException(
                 "A client-supplied id is already in use",

--- a/src/domain/ports/meal_repository_port.py
+++ b/src/domain/ports/meal_repository_port.py
@@ -24,6 +24,10 @@ class MealRepositoryPort(ABC):
         """
         pass
 
+    async def insert(self, meal: Meal) -> Meal:
+        """Insert a new meal row. Must not UPDATE an existing primary key."""
+        return await self.save(meal)
+
     @abstractmethod
     async def find_by_id(self, meal_id: str, projection: Any = None) -> Meal | None:
         """

--- a/src/domain/services/nutrition_calculation_service.py
+++ b/src/domain/services/nutrition_calculation_service.py
@@ -605,7 +605,7 @@ class NutritionCalculationService:
         Aggregate nutrition from command items with custom_nutrition.
         Returns (Nutrition, list[FoodItem]). Items without custom_nutrition are skipped.
         """
-        from uuid import uuid4
+        from uuid import UUID, uuid4
 
         food_items = []
         total_protein = total_carbs = total_fat = 0.0
@@ -646,9 +646,17 @@ class NutritionCalculationService:
             total_fat += fat
             total_fiber += fiber
             total_sugar += sugar
+            raw_item_id = getattr(item, "id", None)
+            if raw_item_id:
+                try:
+                    food_item_id = str(UUID(str(raw_item_id)))
+                except ValueError as exc:
+                    raise ValueError("item id must be a valid UUID") from exc
+            else:
+                food_item_id = str(uuid4())
             food_items.append(
                 FoodItem(
-                    id=uuid4(),
+                    id=food_item_id,
                     name=item_name,
                     quantity=item.quantity,
                     unit=item.unit,

--- a/src/domain/strategies/meal_edit_strategies.py
+++ b/src/domain/strategies/meal_edit_strategies.py
@@ -382,6 +382,15 @@ class UpdateFoodItemStrategy(FoodItemChangeStrategy):
         )
 
 
+def _resolve_add_item_id(change: FoodItemChange) -> str:
+    if not change.id:
+        return str(uuid.uuid4())
+    try:
+        return str(uuid.UUID(change.id))
+    except ValueError as exc:
+        raise ValueError("item id must be a valid UUID") from exc
+
+
 class AddFoodItemStrategy(FoodItemChangeStrategy):
     """Strategy for adding a new food item."""
 
@@ -395,7 +404,7 @@ class AddFoodItemStrategy(FoodItemChangeStrategy):
         self, food_items_dict: dict[str, FoodItem], change: FoodItemChange
     ) -> None:
         """Add new food item to dictionary."""
-        new_item_id = str(uuid.uuid4())
+        new_item_id = _resolve_add_item_id(change)
 
         # Try to get nutrition from various sources
         quantity = change.quantity or 100

--- a/src/infra/repositories/meal_repository_async.py
+++ b/src/infra/repositories/meal_repository_async.py
@@ -143,18 +143,20 @@ class AsyncMealRepository(MealRepositoryPort):
             return await self._reload_meal_domain(
                 meal.meal_id, fallback_image=meal.image
             )
-        else:
-            db_meal = meal_domain_to_orm(meal)
-            if meal.image:
-                db_image = await self._upsert_meal_image(meal.image)
-                db_meal.image_id = str(meal.image.image_id)
-                db_meal.image = db_image
+        return await self.insert(meal)
 
-            self.session.add(db_meal)
-            await self.session.flush()
-            return await self._reload_meal_domain(
-                db_meal.meal_id, fallback_image=meal.image
-            )
+    async def insert(self, meal: Meal) -> Meal:
+        db_meal = meal_domain_to_orm(meal)
+        if meal.image:
+            db_image = await self._upsert_meal_image(meal.image)
+            db_meal.image_id = str(meal.image.image_id)
+            db_meal.image = db_image
+
+        self.session.add(db_meal)
+        await self.session.flush()
+        return await self._reload_meal_domain(
+            db_meal.meal_id, fallback_image=meal.image
+        )
 
     async def find_by_id(
         self, meal_id: str, projection: MealProjection = MealProjection.FULL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -541,6 +541,9 @@ class AsyncTestMealRepository:
     async def save(self, *args, **kwargs):
         return self._repo.save(*args, **kwargs)
 
+    async def insert(self, *args, **kwargs):
+        return self._repo.save(*args, **kwargs)
+
     async def delete(self, *args, **kwargs):
         return self._repo.delete(*args, **kwargs)
 

--- a/tests/fixtures/fakes/fake_meal_repository.py
+++ b/tests/fixtures/fakes/fake_meal_repository.py
@@ -3,6 +3,8 @@
 from datetime import date
 from typing import Any, List, Optional
 
+from sqlalchemy.exc import IntegrityError
+
 from src.domain.model.meal import Meal, MealStatus
 from src.domain.ports.meal_repository_port import MealRepositoryPort
 
@@ -17,6 +19,11 @@ class FakeMealRepository(MealRepositoryPort):
         """Save a meal to in-memory storage."""
         self._meals[meal.meal_id] = meal
         return meal
+
+    async def insert(self, meal: Meal) -> Meal:
+        if meal.meal_id in self._meals:
+            raise IntegrityError("insert", {}, Exception("duplicate meal_id"))
+        return await self.save(meal)
 
     async def find_by_id(self, meal_id: str, projection: Any = None) -> Optional[Meal]:
         """Find a meal by ID."""

--- a/tests/integration/test_manual_meal_with_target_date.py
+++ b/tests/integration/test_manual_meal_with_target_date.py
@@ -63,6 +63,7 @@ async def test_manual_meal_created_with_target_date():
         return meal
 
     mock_meal_repo.save = save_meal
+    mock_meal_repo.insert = save_meal
 
     # Create handler
     handler = CreateManualMealCommandHandler(
@@ -190,6 +191,7 @@ async def test_manual_meal_without_target_date_uses_current_date():
         return meal
 
     mock_meal_repo.save = save_meal
+    mock_meal_repo.insert = save_meal
 
     handler = CreateManualMealCommandHandler(
         meal_repository=mock_meal_repo,

--- a/tests/unit/api/test_meal_edit_requests.py
+++ b/tests/unit/api/test_meal_edit_requests.py
@@ -368,6 +368,99 @@ class TestCreateManualMealFromFoodsRequest:
                 ],
             )
 
+    def test_accepts_client_meal_and_item_ids(self):
+        meal_id = "550e8400-e29b-41d4-a716-446655440010"
+        item_id = "550e8400-e29b-41d4-a716-446655440011"
+        request = CreateManualMealFromFoodsRequest(
+            dish_name="Client ids",
+            meal_id=meal_id,
+            items=[
+                {
+                    "id": item_id,
+                    "name": "Rice",
+                    "quantity": 100.0,
+                    "unit": "g",
+                    "custom_nutrition": {
+                        "protein_per_100g": 2.7,
+                        "carbs_per_100g": 28.0,
+                        "fat_per_100g": 0.3,
+                    },
+                }
+            ],
+        )
+
+        assert request.meal_id == meal_id
+        assert request.items[0].id == item_id
+
+    def test_rejects_invalid_meal_id(self):
+        with pytest.raises(ValidationError, match="meal_id must be a valid UUID"):
+            CreateManualMealFromFoodsRequest(
+                dish_name="Bad meal id",
+                meal_id="not-a-uuid",
+                items=[
+                    {
+                        "name": "Rice",
+                        "quantity": 100.0,
+                        "unit": "g",
+                        "custom_nutrition": {
+                            "protein_per_100g": 2.7,
+                            "carbs_per_100g": 28.0,
+                            "fat_per_100g": 0.3,
+                        },
+                    }
+                ],
+            )
+
+    def test_rejects_invalid_item_id(self):
+        with pytest.raises(ValidationError, match="item id must be a valid UUID"):
+            CreateManualMealFromFoodsRequest(
+                dish_name="Bad item id",
+                items=[
+                    {
+                        "id": "not-a-uuid",
+                        "name": "Rice",
+                        "quantity": 100.0,
+                        "unit": "g",
+                        "custom_nutrition": {
+                            "protein_per_100g": 2.7,
+                            "carbs_per_100g": 28.0,
+                            "fat_per_100g": 0.3,
+                        },
+                    }
+                ],
+            )
+
+    def test_rejects_duplicate_item_ids(self):
+        item_id = "550e8400-e29b-41d4-a716-446655440012"
+        with pytest.raises(ValidationError, match="duplicate item ids"):
+            CreateManualMealFromFoodsRequest(
+                dish_name="Duplicate ids",
+                items=[
+                    {
+                        "id": item_id,
+                        "name": "Rice",
+                        "quantity": 100.0,
+                        "unit": "g",
+                        "custom_nutrition": {
+                            "protein_per_100g": 2.7,
+                            "carbs_per_100g": 28.0,
+                            "fat_per_100g": 0.3,
+                        },
+                    },
+                    {
+                        "id": item_id,
+                        "name": "Chicken",
+                        "quantity": 100.0,
+                        "unit": "g",
+                        "custom_nutrition": {
+                            "protein_per_100g": 31.0,
+                            "carbs_per_100g": 0.0,
+                            "fat_per_100g": 3.6,
+                        },
+                    },
+                ],
+            )
+
 
 @pytest.mark.unit
 class TestEditMealIngredientsRequest:

--- a/tests/unit/app/handlers/test_edit_meal_v2_authority.py
+++ b/tests/unit/app/handlers/test_edit_meal_v2_authority.py
@@ -16,6 +16,8 @@ from src.domain.model.meal.food_item_change import (
 from src.domain.model.meal.meal import MealStatus
 from src.domain.model.nutrition import FoodItem, Macros
 
+_CLIENT_ADD_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+
 
 class _References:
     async def get_nutrition_projection(self, food_reference_id):
@@ -52,7 +54,7 @@ async def test_v2_add_allows_client_generated_id_not_owned_by_meal():
     )
     change = FoodItemChange(
         action="add",
-        id="client-generated-id",
+        id=_CLIENT_ADD_ID,
         name="Rau Xao",
         quantity=100,
         unit="g",
@@ -76,10 +78,10 @@ async def test_v2_add_allows_client_generated_id_not_owned_by_meal():
     )
     updated = await handler._apply_food_item_changes([current], prepared)
 
-    assert prepared[0].id == "client-generated-id"
+    assert prepared[0].id == _CLIENT_ADD_ID
     assert len(updated) == 2
     added = next(item for item in updated if item.name == "Rau Xao")
-    assert added.id != change.id
+    assert added.id == change.id
     uuid.UUID(added.id)
     assert added.source_kind == "custom"
     assert added.macros.protein == pytest.approx(2)
@@ -96,7 +98,7 @@ async def test_v2_add_without_origin_is_rejected_before_id_lookup():
     )
     change = FoodItemChange(
         action="add",
-        id="client-generated-id",
+        id=_CLIENT_ADD_ID,
         name="Rau Xao",
         quantity=100,
         unit="g",
@@ -309,7 +311,7 @@ async def test_v2_item_override_allows_add_action_in_handler(clear_override):
     )
     change = FoodItemChange(
         action="add",
-        id="client-generated-id",
+        id=_CLIENT_ADD_ID,
         name="Rau xao",
         quantity=100,
         unit="g",
@@ -475,7 +477,7 @@ async def test_v2_add_by_fatsecret_id_adopts_once_not_search():
     )
     change = FoodItemChange(
         action="add",
-        id="client-generated-id",
+        id=_CLIENT_ADD_ID,
         name="Thịt bò",
         quantity=60,
         unit="g",
@@ -543,7 +545,7 @@ async def test_v2_add_by_food_reference_id_never_calls_provider():
     )
     change = FoodItemChange(
         action="add",
-        id="client-generated-id",
+        id=_CLIENT_ADD_ID,
         origin="local",
         food_reference_id=42,
         quantity=100,

--- a/tests/unit/domain/test_meal_edit_strategies.py
+++ b/tests/unit/domain/test_meal_edit_strategies.py
@@ -535,6 +535,89 @@ class TestAddFoodItemStrategy:
     """Tests for AddFoodItemStrategy."""
 
     @pytest.mark.asyncio
+    async def test_add_keeps_client_item_id(self):
+        mock_nutrition_service = Mock()
+        strategy = AddFoodItemStrategy(mock_nutrition_service, food_service=None)
+        client_item_id = "550e8400-e29b-41d4-a716-446655440020"
+
+        change = FoodItemChange(
+            action="add",
+            id=client_item_id,
+            name="Custom Food",
+            quantity=150.0,
+            unit="g",
+            custom_nutrition=CustomNutritionData(
+                calories_per_100g=250.0,
+                protein_per_100g=20.0,
+                carbs_per_100g=30.0,
+                fat_per_100g=10.0,
+            ),
+        )
+
+        food_items_dict = {}
+        await strategy.apply(food_items_dict, change)
+
+        assert client_item_id in food_items_dict
+        assert food_items_dict[client_item_id].id == client_item_id
+
+    @pytest.mark.asyncio
+    async def test_add_rejects_invalid_client_item_id(self):
+        strategy = AddFoodItemStrategy(Mock(), food_service=None)
+        change = FoodItemChange(
+            action="add",
+            id="not-a-uuid",
+            name="Custom Food",
+            quantity=100.0,
+            unit="g",
+            custom_nutrition=CustomNutritionData(
+                calories_per_100g=100.0,
+                protein_per_100g=10.0,
+                carbs_per_100g=10.0,
+                fat_per_100g=5.0,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="item id must be a valid UUID"):
+            await strategy.apply({}, change)
+
+    @pytest.mark.asyncio
+    async def test_add_with_existing_same_meal_id_is_idempotent(self):
+        mock_nutrition_service = Mock()
+        strategy = AddFoodItemStrategy(mock_nutrition_service, food_service=None)
+        client_item_id = "550e8400-e29b-41d4-a716-446655440021"
+        food_items_dict = {
+            client_item_id: FoodItem(
+                id=client_item_id,
+                name="Old Name",
+                quantity=100.0,
+                unit="g",
+                macros=Macros(protein=10.0, carbs=10.0, fat=5.0),
+            )
+        }
+
+        change = FoodItemChange(
+            action="add",
+            id=client_item_id,
+            name="Updated Name",
+            quantity=150.0,
+            unit="g",
+            custom_nutrition=CustomNutritionData(
+                calories_per_100g=200.0,
+                protein_per_100g=20.0,
+                carbs_per_100g=20.0,
+                fat_per_100g=10.0,
+            ),
+        )
+
+        await strategy.apply(food_items_dict, change)
+
+        assert len(food_items_dict) == 1
+        updated = food_items_dict[client_item_id]
+        assert updated.id == client_item_id
+        assert updated.name == "Updated Name"
+        assert updated.quantity == 150.0
+
+    @pytest.mark.asyncio
     async def test_add_with_custom_nutrition(self):
         """Test adding food item with custom nutrition data."""
         # Arrange

--- a/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from src.api.exceptions import ConflictException, ValidationException
 from src.app.commands.meal.create_manual_meal_command import (
@@ -39,6 +40,9 @@ class _FakeMeals:
         self.saved_meals.append(meal)
         return meal
 
+    async def insert(self, meal):
+        return await self.save(meal)
+
     async def find_by_id(self, meal_id):
         return self._existing_by_id.get(meal_id)
 
@@ -62,6 +66,9 @@ class _FakeUow:
 
 class _PreparedV2Meals:
     async def save(self, meal):
+        return meal
+
+    async def insert(self, meal):
         return meal
 
 
@@ -259,6 +266,28 @@ async def test_create_rejects_existing_same_user_meal_id_without_replay():
 
     with pytest.raises(ConflictException, match="already exists"):
         await handler.handle(cmd)
+
+
+@pytest.mark.asyncio
+async def test_create_insert_integrity_error_maps_to_conflict():
+    uow = _FakeUow(_make_meal())
+
+    async def _insert(_meal):
+        raise IntegrityError("INSERT", {}, Exception("duplicate meal_id"))
+
+    uow.meals.insert = _insert
+    handler = CreateManualMealCommandHandler(uow=uow)
+    cmd = CreateManualMealCommand(
+        user_id=_UUID_1,
+        meal_id=_CLIENT_MEAL_ID,
+        items=_make_command().items,
+        dish_name="Rice Bowl",
+        source="manual",
+    )
+
+    with pytest.raises(ConflictException, match="already in use") as exc_info:
+        await handler.handle(cmd)
+    assert exc_info.value.error_code == "CLIENT_RESOURCE_ID_CONFLICT"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
+++ b/tests/unit/handlers/command_handlers/test_create_manual_meal_command_handler.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.api.exceptions import ValidationException
+from src.api.exceptions import ConflictException, ValidationException
 from src.app.commands.meal.create_manual_meal_command import (
     CreateManualMealCommand,
     CustomNutrition,
@@ -32,9 +32,15 @@ from src.app.services.cache_invalidation_service import CacheInvalidationService
 class _FakeMeals:
     def __init__(self, fake_meal):
         self._meal = fake_meal
+        self.saved_meals = []
+        self._existing_by_id = {}
 
     async def save(self, meal):
-        return self._meal
+        self.saved_meals.append(meal)
+        return meal
+
+    async def find_by_id(self, meal_id):
+        return self._existing_by_id.get(meal_id)
 
 
 class _FakeUsers:
@@ -88,6 +94,9 @@ def _make_meal():
 
 _UUID_1 = "550e8400-e29b-41d4-a716-446655440001"
 _UUID_2 = "550e8400-e29b-41d4-a716-446655440002"
+_CLIENT_MEAL_ID = "550e8400-e29b-41d4-a716-446655440010"
+_CLIENT_ITEM_ID = "550e8400-e29b-41d4-a716-446655440011"
+_OTHER_USER_ID = "550e8400-e29b-41d4-a716-446655440099"
 
 
 def _make_command(user_id: str = _UUID_1) -> CreateManualMealCommand:
@@ -138,8 +147,9 @@ async def test_handler_timing_logs_show_cache_delay(caplog):
 
     cache_svc = CacheInvalidationService(cache=slow_cache)
     fake_meal = _make_meal()
+    uow = _FakeUow(fake_meal)
     handler = CreateManualMealCommandHandler(
-        uow=_FakeUow(fake_meal),
+        uow=uow,
         cache_invalidation=cache_svc,
     )
 
@@ -164,7 +174,163 @@ async def test_handler_timing_logs_show_cache_delay(caplog):
     )
 
     # Result is the saved meal
-    assert result is fake_meal
+    assert result.meal_id is not None
+    assert uow.meals.saved_meals
+
+
+@pytest.mark.asyncio
+async def test_create_persists_client_meal_and_item_ids():
+    uow = _FakeUow(_make_meal())
+    handler = CreateManualMealCommandHandler(uow=uow)
+    cmd = CreateManualMealCommand(
+        user_id=_UUID_1,
+        meal_id=_CLIENT_MEAL_ID,
+        items=[
+            ManualMealItem(
+                id=_CLIENT_ITEM_ID,
+                name="Rice",
+                quantity=100.0,
+                unit="g",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=130.0,
+                    protein_per_100g=2.7,
+                    carbs_per_100g=28.0,
+                    fat_per_100g=0.3,
+                ),
+            )
+        ],
+        dish_name="Rice Bowl",
+        source="manual",
+    )
+
+    meal = await handler.handle(cmd)
+
+    assert meal.meal_id == _CLIENT_MEAL_ID
+    assert meal.nutrition.food_items[0].id == _CLIENT_ITEM_ID
+
+
+@pytest.mark.asyncio
+async def test_create_without_client_ids_mints_valid_uuids():
+    uow = _FakeUow(_make_meal())
+    handler = CreateManualMealCommandHandler(uow=uow)
+    cmd = _make_command()
+
+    meal = await handler.handle(cmd)
+
+    import uuid
+
+    uuid.UUID(meal.meal_id)
+    uuid.UUID(meal.nutrition.food_items[0].id)
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_other_users_meal_id():
+    existing = MagicMock()
+    existing.user_id = _OTHER_USER_ID
+    uow = _FakeUow(_make_meal())
+    uow.meals._existing_by_id[_CLIENT_MEAL_ID] = existing
+    handler = CreateManualMealCommandHandler(uow=uow)
+    cmd = CreateManualMealCommand(
+        user_id=_UUID_1,
+        meal_id=_CLIENT_MEAL_ID,
+        items=_make_command().items,
+        dish_name="Rice Bowl",
+        source="manual",
+    )
+
+    with pytest.raises(ConflictException, match="another account"):
+        await handler.handle(cmd)
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_existing_same_user_meal_id_without_replay():
+    existing = MagicMock()
+    existing.user_id = _UUID_1
+    uow = _FakeUow(_make_meal())
+    uow.meals._existing_by_id[_CLIENT_MEAL_ID] = existing
+    handler = CreateManualMealCommandHandler(uow=uow)
+    cmd = CreateManualMealCommand(
+        user_id=_UUID_1,
+        meal_id=_CLIENT_MEAL_ID,
+        items=_make_command().items,
+        dish_name="Rice Bowl",
+        source="manual",
+    )
+
+    with pytest.raises(ConflictException, match="already exists"):
+        await handler.handle(cmd)
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_duplicate_item_ids_in_command():
+    handler = CreateManualMealCommandHandler(uow=_FakeUow(_make_meal()))
+    cmd = CreateManualMealCommand(
+        user_id=_UUID_1,
+        items=[
+            ManualMealItem(
+                id=_CLIENT_ITEM_ID,
+                name="Rice",
+                quantity=100.0,
+                unit="g",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=130.0,
+                    protein_per_100g=2.7,
+                    carbs_per_100g=28.0,
+                    fat_per_100g=0.3,
+                ),
+            ),
+            ManualMealItem(
+                id=_CLIENT_ITEM_ID,
+                name="Chicken",
+                quantity=100.0,
+                unit="g",
+                custom_nutrition=CustomNutrition(
+                    calories_per_100g=165.0,
+                    protein_per_100g=31.0,
+                    carbs_per_100g=0.0,
+                    fat_per_100g=3.6,
+                ),
+            ),
+        ],
+        dish_name="Combo",
+        source="manual",
+    )
+
+    with pytest.raises(ValidationException, match="Duplicate food item ids"):
+        await handler.handle(cmd)
+
+
+@pytest.mark.asyncio
+async def test_v2_idempotent_replay_returns_existing_meal_without_conflict():
+    existing_meal = MagicMock()
+    existing_meal.meal_id = _CLIENT_MEAL_ID
+    existing_meal.user_id = _UUID_1
+    replay_uow = _PreparedV2Uow()
+    replay_uow.meals.find_by_id = AsyncMock(return_value=existing_meal)
+    handler = CreateManualMealCommandHandler(
+        uow=_PreparedV2Uow(),
+        uow_factory=lambda: replay_uow,
+        nutrition_resolver=MagicMock(),
+    )
+    handler._reserve_v2_write_short = AsyncMock(
+        return_value=SimpleNamespace(
+            state="replay",
+            target_meal_id=_CLIENT_MEAL_ID,
+        )
+    )
+    cmd = CreateManualMealCommand(
+        user_id=_UUID_1,
+        meal_id=_CLIENT_MEAL_ID,
+        items=_make_command().items,
+        dish_name="Rice Bowl",
+        nutrition_contract_version=2,
+        idempotency_key="write-replay",
+        request_fingerprint="fingerprint-replay",
+    )
+
+    meal = await handler.handle(cmd)
+
+    assert meal is existing_meal
 
 
 @pytest.mark.asyncio
@@ -422,7 +588,7 @@ async def test_handler_timing_logs_fast_cache(caplog):
         "No 'manual_save handler timing' log found — instrumentation missing."
     )
 
-    assert result is fake_meal
+    assert result.meal_id is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/infra/test_food_database.py
+++ b/tests/unit/infra/test_food_database.py
@@ -92,6 +92,9 @@ class InMemoryMealRepository:
         self._store[meal.meal_id] = meal
         return meal
 
+    async def insert(self, meal):
+        return await self.save(meal)
+
     async def find_by_id(self, meal_id: str):
         return self._store.get(meal_id)
 


### PR DESCRIPTION
## Summary
- Accept optional `meal_id` and per-item `id` on manual/parse create; INSERT those UUIDs as PKs (omit still mints for old clients).
- Never upsert: other-user / already-used meal id → 409; duplicate/non-UUID ids → 400.
- Edit-add honors `change.id` when the UUID is unused on the meal.

Pairs with mobile PR `feat/client-stable-meal-and-item-ids` (dirty plate + tombstone-wins). Ship backend first or same release train — mobile will PUT client meal UUIDs.

ADR: `docs/decisions/260826-client-stable-meal-and-item-ids.md`

## Test plan
- [ ] Unit: persist client `meal_id` and item ids; omit still mints
- [ ] Unit: other user’s `meal_id` → 409; duplicate item ids → 400; invalid UUID → 400
- [ ] Unit: edit-add keeps `change.id` when valid
- [ ] Photo/scan/hydration create still server-mints ids
- [ ] Idempotency-Key replay still returns the existing meal (header vs body stay independent)


Made with [Cursor](https://cursor.com)